### PR TITLE
Fix ut fail on ubuntu

### DIFF
--- a/src/function/cast/float_cast.h
+++ b/src/function/cast/float_cast.h
@@ -202,7 +202,7 @@ FloatTryCastToFixlen::Run(DoubleT source, IntegerT &target) {
 template<>
 inline bool
 FloatTryCastToFixlen::Run(DoubleT source, BigIntT &target) {
-    if(source < -9223372036854775808.0f || source > 9223372036854775807.0f) {
+    if(source < -9223372036854775808.0L || source > 9223372036854775807.0L) {
         return false;
     }
     target = std::nearbyint(source);

--- a/test/unittest/function/cast/float/float_cast.cpp
+++ b/test/unittest/function/cast/float/float_cast.cpp
@@ -101,8 +101,8 @@ TEST_F(FloatCastTest, float_cast0) {
         EXPECT_EQ(source, target);
 
         source = static_cast<FloatT>(std::numeric_limits<IntegerT>::max());
-        EXPECT_FALSE(FloatTryCastToFixlen::Run(source, target));
-//        EXPECT_FLOAT_EQ(source, target);
+        EXPECT_TRUE(FloatTryCastToFixlen::Run(source, target));
+        EXPECT_FLOAT_EQ(source, target);
 
         source = static_cast<FloatT>(std::numeric_limits<IntegerT>::min());
         EXPECT_TRUE(FloatTryCastToFixlen::Run(source, target));


### PR DESCRIPTION
### What problem does this PR solve?
Fix ut fail on ubuntu


### What is changed and how it works?
```C++
// double should be L instead of f
if(source < -9223372036854775808.0L || source > 9223372036854775807.0L) {
        return false;
}
```

```C++
// Float should could cast to INT_MAX
source = static_cast<FloatT>(std::numeric_limits<IntegerT>::max());
EXPECT_TRUE(FloatTryCastToFixlen::Run(source, target));
EXPECT_FLOAT_EQ(source, target);
```
### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer