### PR TITLE
feat(wal): improve checkpoint handling and updates to transaction timestamps

### DIFF
--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -290,6 +290,8 @@ NewCatalog::SaveAsFile(const NewCatalog* catalog_ptr,
     }
     catalog_file_handler->Sync();
     catalog_file_handler->Close();
+
+    LOG_INFO("Saved catalog to: {}", file_path);
 }
 
 }

--- a/src/storage/txn/txn.h
+++ b/src/storage/txn/txn.h
@@ -177,6 +177,9 @@ public:
     void
     AddWalCmd(const SharedPtr<WalCmd>& cmd);
 
+    void 
+    Checkpoint(const TxnTimeStamp max_commit_ts);
+
 private:
     UniquePtr<String>
     GetTableEntry(const String& db_name, const String& table_name, TableCollectionEntry*& table_entry);
@@ -209,6 +212,7 @@ private:
     bool done_bottom_{false};
 
     TxnManager* txn_mgr_{};
+    bool is_checkpoint_{false};
 };
 
 }

--- a/src/storage/wal/wal_entry.h
+++ b/src/storage/wal/wal_entry.h
@@ -187,7 +187,7 @@ struct WalCmdDelete : public WalCmd {
 };
 
 struct WalCmdCheckpoint : public WalCmd {
-    WalCmdCheckpoint(int64_t max_commit_ts_) : max_commit_ts(max_commit_ts_) {}
+    WalCmdCheckpoint(int64_t max_commit_ts_, String catalog_path) : max_commit_ts_(max_commit_ts_),catalog_path_(catalog_path) {}
     virtual WalCommandType
     GetType() { return WalCommandType::CHECKPOINT; }
 
@@ -200,7 +200,8 @@ struct WalCmdCheckpoint : public WalCmd {
     virtual void
     WriteAdv(char*& buf) const;
 
-    int64_t max_commit_ts;
+    int64_t max_commit_ts_;
+    String catalog_path_;
 };
 
 struct WalEntryHeader {

--- a/src/storage/wal/wal_manager.h
+++ b/src/storage/wal/wal_manager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "common/types/alias/primitives.h"
 #include "storage/txn/txn_manager.h"
 #include "common/constants/constants.h"
 #include "wal_entry.h"
@@ -79,13 +80,16 @@ private:
     std::ofstream ofs_;
 
     SeqGenerator lsn_gen_;
-    std::atomic<int64_t> lsn_pend_chk_;
-    int64_t lsn_done_chk_{};
+    std::atomic<TxnTimeStamp> commit_ts_pend_;
+    TxnTimeStamp commit_ts_done_{};
+
     int64_t checkpoint_ts_{};
 
     Storage* storage_;
 
     Vector<String> wal_list_;
+
+    bool wait_for_checkpoint_{false};
 };
 
 } // namespace infinity

--- a/test/unittest/storage/meta/catalog.cpp
+++ b/test/unittest/storage/meta/catalog.cpp
@@ -18,6 +18,7 @@
 class CatalogTest : public BaseTest {
     void
     SetUp() override {
+        system("rm -rf /tmp/infinity/");
         infinity::GlobalResourceUsage::Init();
         std::shared_ptr<std::string> config_path = nullptr;
         infinity::Infinity::instance().Init(config_path);
@@ -29,10 +30,7 @@ class CatalogTest : public BaseTest {
         EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
         EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
         infinity::GlobalResourceUsage::UnInit();
-
-        system("rm -rf /tmp/infinity/data/db");
-        system("rm -rf /tmp/infinity/data/catalog/*");
-        system("rm -rf /tmp/infinity/_tmp");
+        system("rm -rf /tmp/infinity/");
     }
 
 };

--- a/test/unittest/storage/wal/wal_entry.cpp
+++ b/test/unittest/storage/wal/wal_entry.cpp
@@ -95,7 +95,7 @@ TEST_F(WalEntryTest, ReadWrite) {
     entry->cmds.push_back(MakeShared<WalCmdAppend>("db1", "tbl1", data_block));
     Vector<RowID> row_ids = {RowID(1, 2)};
     entry->cmds.push_back(MakeShared<WalCmdDelete>("db1", "tbl1", row_ids));
-    entry->cmds.push_back(MakeShared<WalCmdCheckpoint>(int64_t(123)));
+    entry->cmds.push_back(MakeShared<WalCmdCheckpoint>(int64_t(123), std::string("catalog")));
 
     int32_t exp_size = entry->GetSizeInBytes();
     std::vector<char> buf(exp_size, char(0));


### PR DESCRIPTION
In wal_manager.cpp, a thread is now made to sleep until a checkpoint is completed ensuring correct join order of threads improving system stability. Also, a check has been added to ensure running_ is true before pushing an entry onto the queue. The nomenclature of several timestamp-related variables was changed to clearly denote their purpose. The added logic also removes older WAL files for efficient management of storage space. In txn.cpp, catalog storage support has been added to checkpoint thus ensuring database consistency. Simultaneously, some system setup simplification has been done in unit tests.

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer