### PR TITLE
Refactor code and enhance functionality for wal recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ cmake-build-debug-gcc/**
 cmake-build-release/**
 cmake-build-release-clang/**
 cmake-build-release-gcc/**
+cmake-build-debug-**
 Infinity.xml
 
 # OSX dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ message(STATUS "Branch name = ${GIT_BRANCH_NAME}")
 execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD OUTPUT_VARIABLE GIT_COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "Commit-id = ${GIT_COMMIT_ID}")
 
+
 set(TEST_DATA_PATH ${CMAKE_SOURCE_DIR}/test/data)
 set(CSV_DATA_PATH ${CMAKE_SOURCE_DIR}/third_party/zsv/data)
 

--- a/src/executor/operator/physical_import.cpp
+++ b/src/executor/operator/physical_import.cpp
@@ -43,6 +43,9 @@ import infinity_exception;
 import table_collection_entry;
 import segment_entry;
 import zsv;
+#include "statement/statement_common.h"
+#include "type/info/embedding_info.h"
+#include "type/info/varchar_info.h"
 
 module physical_import;
 
@@ -152,31 +155,14 @@ void PhysicalImport::ImportFVECS(QueryContext *query_context, ImportInputState *
 
         row_idx++;
         if (row_idx == vector_n) {
-            for (auto &block_entry : segment_entry->block_entries_) {
-                BlockEntry::FlushData(block_entry.get(), block_entry->row_count_);
-            }
-            txn->AddWalCmd(MakeShared<WalCmdImport>(db_name,
-                                                    table_name,
-                                                    *segment_entry->segment_dir_,
-                                                    segment_entry->segment_id_,
-                                                    segment_entry->block_entries_.size()));
-            txn_store->Import(segment_entry);
+            SaveSegmentData(txn, segment_entry, db_name, table_name);
             break;
         }
         if (SegmentEntry::Room(segment_entry.get()) <= 0) {
-            for (auto &block_entry : segment_entry->block_entries_) {
-                BlockEntry::FlushData(block_entry.get(), block_entry->row_count_);
-            }
-            txn->AddWalCmd(MakeShared<WalCmdImport>(db_name,
-                                                    table_name,
-                                                    *segment_entry->segment_dir_,
-                                                    segment_entry->segment_id_,
-                                                    segment_entry->block_entries_.size()));
-            txn_store->Import(segment_entry);
+            SaveSegmentData(txn, segment_entry, db_name, table_name);
+
             segment_id = TableCollectionEntry::GetNextSegmentID(table_collection_entry_);
-            segment_entry = SegmentEntry::MakeNewSegmentEntry(table_collection_entry_,
-                                                              segment_id,
-                                                              query_context->GetTxn()->GetBufferMgr());
+            segment_entry = SegmentEntry::MakeNewSegmentEntry(table_collection_entry_, segment_id, query_context->GetTxn()->GetBufferMgr());
 
             last_block_entry = segment_entry->block_entries_.back().get();
             object_handle = ObjectHandle(last_block_entry->columns_[0]->buffer_handle_);
@@ -226,16 +212,7 @@ void PhysicalImport::ImportCSV(QueryContext *query_context, ImportInputState *in
     if (parser_context->segment_entry_->row_count_ > 0) {
         const String &db_name = *TableCollectionEntry::GetDBEntry(table_collection_entry_)->db_name_;
         const String &table_name = *table_collection_entry_->table_collection_name_;
-        for (auto &block_entry : parser_context->segment_entry_->block_entries_) {
-            BlockEntry::FlushData(block_entry.get(), block_entry->row_count_);
-        }
-        parser_context->txn_->AddWalCmd(MakeShared<WalCmdImport>(db_name,
-                                                                table_name,
-                                                                *parser_context->segment_entry_->segment_dir_,
-                                                                parser_context->segment_entry_->segment_id_,
-                                                                parser_context->segment_entry_->block_entries_.size()));
-        auto txn_store = parser_context->txn_->GetTxnTableStore(table_name);
-        txn_store->Import(parser_context->segment_entry_);
+        SaveSegmentData(parser_context->txn_, parser_context->segment_entry_, db_name, table_name);
     }
     fclose(fp);
 
@@ -345,20 +322,8 @@ void PhysicalImport::CSVRowHandler(void *context) {
     const String &table_name = *table->table_collection_name_;
     // we have already used all space of the segment
     if (SegmentEntry::Room(segment_entry.get()) <= 0) {
-        // add to txn_store
-        for (auto &block_entry : segment_entry->block_entries_) {
-            BlockEntry::FlushData(block_entry.get(), block_entry->row_count_);
-        }
-        txn->AddWalCmd(MakeShared<WalCmdImport>(db_name,
-                                                table_name,
-                                                *segment_entry->segment_dir_,
-                                                segment_entry->segment_id_,
-                                                segment_entry->block_entries_.size()));
-        txn_store->Import(segment_entry);
-
-        // create new segment entry
-        parser_context->segment_entry_ =
-            SegmentEntry::MakeNewSegmentEntry(table, txn->TxnID(), txn->GetBufferMgr());
+        SaveSegmentData(txn, segment_entry, db_name, table_name);
+        parser_context->segment_entry_ = SegmentEntry::MakeNewSegmentEntry(table, txn->TxnID(), txn->GetBufferMgr());
         segment_entry = parser_context->segment_entry_;
     }
 
@@ -470,6 +435,31 @@ void PhysicalImport::CSVRowHandler(void *context) {
     ++last_block_entry->row_count_;
     ++segment_entry->row_count_;
     ++parser_context->row_count_;
+}
+void PhysicalImport::SaveSegmentData(Txn *txn, SharedPtr<SegmentEntry> &segment_entry, const String &db_name, const String &table_name) {
+    Vector<i32> block_row_counts;
+
+    block_row_counts.reserve(segment_entry->block_entries_.size());
+    for (auto &block_entry : segment_entry->block_entries_) {
+        BlockEntry::FlushData(block_entry.get(), block_entry->row_count_);
+        auto size = std::max(segment_entry->block_entries_.size(), static_cast<SizeT>(block_entry->block_id_ + 1));
+        block_row_counts.resize(size);
+        block_row_counts[block_entry->block_id_] = block_entry->row_count_;
+    }
+
+    LOG_TRACE(Format("Block rows count {}", block_row_counts.size()));
+    for (int i = 0; i < block_row_counts.size(); ++i) {
+        LOG_TRACE(Format("Block {} rows count {}", i, block_row_counts[i]));
+    }
+
+    txn->AddWalCmd(MakeShared<WalCmdImport>(db_name,
+                                            table_name,
+                                            *segment_entry->segment_dir_,
+                                            segment_entry->segment_id_,
+                                            segment_entry->block_entries_.size(),
+                                            block_row_counts));
+
+    txn->GetTxnTableStore(table_name)->Import(segment_entry);
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_import.cppm
+++ b/src/executor/operator/physical_import.cppm
@@ -18,6 +18,7 @@ import zsv;
 
 export module physical_import;
 
+
 namespace infinity {
 
 // class TableCollectionEntry;
@@ -77,6 +78,8 @@ public:
     inline bool header() const { return header_; }
 
     inline char delimiter() const { return delimiter_; }
+
+    static void SaveSegmentData(Txn *txn, SharedPtr<SegmentEntry> &segment_entry, const String &db_name, const String &table_name);
 
 private:
     static void CSVHeaderHandler(void *);

--- a/src/storage/buffer/buffer_handle.cpp
+++ b/src/storage/buffer/buffer_handle.cpp
@@ -101,7 +101,6 @@ void *BufferHandle::LoadData() {
                     }
                 }
             }
-
             case BufferStatus::kFreed: {
                 if (reference_count_ != 0 || data_ != nullptr) {
                     LOG_ERROR("Error happened when buffer with freed status.");
@@ -458,11 +457,6 @@ void BufferHandle::WriteFile(SizeT buffer_length) {
         fs.CreateDirectory(to_write_path);
     }
 
-    if (fs.Exists(to_write_file)) {
-        String err_msg = Format("File {} was already been created before.", to_write_file);
-        LOG_ERROR(err_msg);
-        Error<StorageException>(err_msg, __FILE_NAME__, __LINE__);
-    }
 
     u8 flags = FileFlags::WRITE_FLAG | FileFlags::CREATE_FLAG;
     file_handler_ = fs.OpenFile(to_write_file, flags, FileLockType::kWriteLock);

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -87,6 +87,8 @@ BufferHandle *BufferManager::GetBufferHandle(const SharedPtr<String> &file_dir, 
             iter.first->second.current_dir_ = file_dir;
             iter.first->second.file_name_ = filename;
             iter.first->second.buffer_type_ = buffer_type;
+            // FIXME: need to remove the buffer size
+            iter.first->second.buffer_size_ = DEFAULT_VECTOR_SIZE * 8;
 
             return &(iter.first->second);
         }

--- a/src/storage/meta/entry/block_column_entry.cppm
+++ b/src/storage/meta/entry/block_column_entry.cppm
@@ -28,7 +28,7 @@ public:
     const BlockEntry *block_entry_{nullptr};
     u64 column_id_{};
     SharedPtr<DataType> column_type_{};
-    BufferHandle *buffer_handle_{};
+    BufferHandle *buffer_handle_{nullptr};
 
     const SharedPtr<String> base_dir_{};
     SharedPtr<String> file_name_{};
@@ -36,7 +36,7 @@ public:
     UniquePtr<OutlineInfo> outline_info_{};
 
 public:
-    static UniquePtr<BlockColumnEntry> MakeNewBlockColumnEntry(const BlockEntry *block_entry, u64 column_id, BufferManager *buffer_manager);
+    static UniquePtr<BlockColumnEntry> MakeNewBlockColumnEntry(const BlockEntry *block_entry, u64 column_id, BufferManager *buffer_manager,bool is_replay=false);
 
     static ColumnBuffer GetColumnData(BlockColumnEntry *column_data_entry, BufferManager *buffer_manager);
 

--- a/src/storage/meta/entry/db_entry.cppm
+++ b/src/storage/meta/entry/db_entry.cppm
@@ -14,6 +14,7 @@ import table_collection_detail;
 import table_collection_meta;
 import buffer_manager;
 import txn_manager;
+#include "statement/extra/extra_ddl_info.h"
 
 export module db_entry;
 

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -46,9 +46,7 @@ UniquePtr<SegmentVersion> SegmentVersion::Deserialize(const Json &table_entry_js
 
 SegmentEntry::SegmentEntry(const TableCollectionEntry *table_entry) : BaseEntry(EntryType::kSegment), table_entry_(table_entry) {}
 
-SharedPtr<SegmentEntry>
-SegmentEntry::MakeNewSegmentEntry(const TableCollectionEntry *table_entry, u64 segment_id, BufferManager *buffer_mgr, bool is_new) {
-
+SharedPtr<SegmentEntry> SegmentEntry::MakeNewSegmentEntry(const TableCollectionEntry *table_entry, u64 segment_id, BufferManager *buffer_mgr) {
     SharedPtr<SegmentEntry> new_entry = MakeShared<SegmentEntry>(table_entry);
     new_entry->row_count_ = 0;
     new_entry->row_capacity_ = DEFAULT_SEGMENT_CAPACITY;
@@ -60,10 +58,25 @@ SegmentEntry::MakeNewSegmentEntry(const TableCollectionEntry *table_entry, u64 s
     new_entry->column_count_ = table_ptr->columns_.size();
 
     new_entry->segment_dir_ = SegmentEntry::DetermineSegFilename(*table_entry->table_entry_dir_, segment_id);
-    if (new_entry->block_entries_.empty() && is_new) {
+    if (new_entry->block_entries_.empty()) {
         new_entry->block_entries_.emplace_back(
             MakeUnique<BlockEntry>(new_entry.get(), new_entry->block_entries_.size(), 0, new_entry->column_count_, buffer_mgr));
     }
+    return new_entry;
+}
+
+SharedPtr<SegmentEntry>
+SegmentEntry::MakeReplaySegmentEntry(const TableCollectionEntry *table_entry, u64 segment_id, SharedPtr<String> segment_dir, TxnTimeStamp commit_ts) {
+
+    auto new_entry = MakeShared<SegmentEntry>(table_entry);
+    new_entry->row_capacity_ = DEFAULT_SEGMENT_CAPACITY;
+    new_entry->segment_id_ = segment_id;
+    new_entry->min_row_ts_ = commit_ts;
+    new_entry->max_row_ts_ = commit_ts;
+
+    const auto *table_ptr = (const TableCollectionEntry *)table_entry;
+    new_entry->column_count_ = table_ptr->columns_.size();
+    new_entry->segment_dir_ = std::move(segment_dir);
     return new_entry;
 }
 
@@ -98,7 +111,7 @@ int SegmentEntry::AppendData(SegmentEntry *segment_entry, Txn *txn_ptr, AppendSt
             i16 range_block_start_row = last_block_entry->row_count_;
 
             i16 actual_appended =
-                BlockEntry::AppendData(last_block_entry, txn_ptr, input_block, append_state_ptr->current_block_offset_, to_append_rows);
+                BlockEntry::AppendData(last_block_entry, txn_ptr, input_block, append_state_ptr->current_block_offset_, to_append_rows, buffer_mgr);
 
             append_state_ptr->append_ranges_.emplace_back(range_segment_id, range_block_id, range_block_start_row, actual_appended);
 
@@ -262,14 +275,27 @@ Json SegmentEntry::Serialize(SegmentEntry *segment_entry, TxnTimeStamp max_commi
         json_res["deleted"] = segment_entry->deleted_;
         json_res["row_count"] = segment_entry->row_count_;
         for (auto &block_entry : segment_entry->block_entries_) {
-            if (max_commit_ts > block_entry->checkpoint_ts_)
+            if (is_full_checkpoint || max_commit_ts > block_entry->checkpoint_ts_) {
                 block_entries.push_back((BlockEntry *)block_entry.get());
+            }
         }
     }
     for (BlockEntry *block_entry : block_entries) {
+        LOG_TRACE(Format("Before Flush: block_entry checkpoint ts: {}, min_row_ts: {}, max_row_ts: {} || max_commit_ts: {}",
+                         block_entry->checkpoint_ts_,
+                         block_entry->min_row_ts_,
+                         block_entry->max_row_ts_,
+                         max_commit_ts));
         BlockEntry::Flush(block_entry, max_commit_ts);
-        if (!is_full_checkpoint && block_entry->checkpoint_ts_ != max_commit_ts)
+        LOG_TRACE(Format("Finish Flush: block_entry checkpoint ts: {}, min_row_ts: {}, max_row_ts: {} || max_commit_ts: {}",
+                         block_entry->checkpoint_ts_,
+                         block_entry->min_row_ts_,
+                         block_entry->max_row_ts_,
+                         max_commit_ts));
+        // WARNING: this operation may influence data visibility
+        if (!is_full_checkpoint && block_entry->checkpoint_ts_ != max_commit_ts) {
             continue;
+        }
         json_res["block_entries"].emplace_back(BlockEntry::Serialize(block_entry, max_commit_ts));
     }
     for (const auto &[_index_name, index_entry] : segment_entry->index_entry_map_) {
@@ -296,10 +322,13 @@ SharedPtr<SegmentEntry> SegmentEntry::Deserialize(const Json &segment_entry_json
     if (segment_entry_json.contains("block_entries")) {
         for (const auto &block_json : segment_entry_json["block_entries"]) {
             UniquePtr<BlockEntry> block_entry = BlockEntry::Deserialize(block_json, segment_entry.get(), buffer_mgr);
-            segment_entry->block_entries_.reserve(block_entry->block_id_ + 1);
-            segment_entry->block_entries_[block_entry->block_id_] = Move(block_entry);
+            auto block_entries_size = segment_entry->block_entries_.size();
+            segment_entry->block_entries_.resize(Max(block_entries_size, static_cast<SizeT>(block_entry->block_id_ + 1)));
+            segment_entry->block_entries_[block_entry->block_id_] = std::move(block_entry);
         }
     }
+    LOG_TRACE(Format("Segment: {}, Block count: {}", segment_entry->segment_id_, segment_entry->block_entries_.size()));
+
     if (segment_entry_json.contains("index_entries")) {
         for (const auto &index_json : segment_entry_json["index_entries"]) {
             SharedPtr<IndexEntry> index_entry = IndexEntry::Deserialize(index_json, segment_entry.get(), buffer_mgr);

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -21,13 +21,13 @@ export module segment_entry;
 
 namespace infinity {
 
-//class BufferManager;
+// class BufferManager;
 //
-//class Txn;
+// class Txn;
 //
 class TableCollectionEntry;
 //
-//class IndexDef;
+// class IndexDef;
 //
 export class SegmentEntry;
 
@@ -74,8 +74,10 @@ public:
     HashMap<String, SharedPtr<IndexEntry>> index_entry_map_{};
 
 public:
+    static SharedPtr<SegmentEntry> MakeNewSegmentEntry(const TableCollectionEntry *table_entry, u64 segment_id, BufferManager *buffer_mgr);
+
     static SharedPtr<SegmentEntry>
-    MakeNewSegmentEntry(const TableCollectionEntry *table_entry, u64 segment_id, BufferManager *buffer_mgr, bool is_new = true);
+    MakeReplaySegmentEntry(const TableCollectionEntry *table_entry, u64 segment_id, SharedPtr<String> segment_dir, TxnTimeStamp commit_ts);
 
     static int AppendData(SegmentEntry *segment_entry, Txn *txn_ptr, AppendState *append_state_ptr, BufferManager *buffer_mgr);
 

--- a/src/storage/meta/entry/table_collecton_entry.cpp
+++ b/src/storage/meta/entry/table_collecton_entry.cpp
@@ -288,8 +288,8 @@ UniquePtr<String> TableCollectionEntry::ImportSegment(TableCollectionEntry *tabl
     for (auto &block_entry : segment->block_entries_) {
         block_entry->min_row_ts_ = commit_ts;
         block_entry->max_row_ts_ = commit_ts;
-        block_entry->checkpoint_ts_ = commit_ts;
-        block_entry->block_version_->created_.push_back({commit_ts, block_entry->row_count_});
+        // ATTENTION: Do not modify the block_entry checkpoint_ts_
+        block_entry->block_version_->created_.emplace_back(commit_ts, block_entry->row_count_);
     }
 
     UniqueLock<RWMutex> rw_locker(table_entry->rw_locker_);

--- a/src/storage/meta/table_collection_meta.cpp
+++ b/src/storage/meta/table_collection_meta.cpp
@@ -195,7 +195,7 @@ EntryResult TableCollectionMeta::DropNewEntry(TableCollectionMeta *table_meta,
         return {nullptr, MakeUnique<String>("No valid table entry.")};
     }
 
-    TableCollectionEntry *header_table_entry = (TableCollectionEntry *)header_base_entry;
+    auto *header_table_entry = (TableCollectionEntry *)header_base_entry;
     if (header_table_entry->commit_ts_ < UNCOMMIT_TS) {
         // Committed
         if (begin_ts > header_table_entry->commit_ts_) {
@@ -278,7 +278,7 @@ EntryResult TableCollectionMeta::GetEntry(TableCollectionMeta *table_meta, u64 t
 
     for (const auto &table_entry : table_meta->entry_list_) {
         if (table_entry->entry_type_ == EntryType::kDummy) {
-            LOG_TRACE("No valid table entry.");
+            LOG_TRACE("No valid table entry. dummy entry");
             return {nullptr, MakeUnique<String>("No valid table entry.")};
         }
 

--- a/src/storage/txn/txn.cppm
+++ b/src/storage/txn/txn.cppm
@@ -19,6 +19,7 @@ import txn_context;
 import wal_entry;
 import txn_store;
 import index_def_entry;
+#include "statement/extra/extra_ddl_info.h"
 
 export module txn;
 

--- a/src/storage/wal/wal_entry.cppm
+++ b/src/storage/wal/wal_entry.cppm
@@ -15,9 +15,9 @@ import index_def;
 
 namespace infinity {
 
-//class TableDef;
+// class TableDef;
 //
-//class DataBlock;
+// class DataBlock;
 
 export enum class WalCommandType : i8 {
     INVALID = 0,
@@ -44,6 +44,7 @@ export enum class WalCommandType : i8 {
     CHECKPOINT = 99,
 };
 
+// WalCommandType -> String
 export struct WalCmd {
     virtual ~WalCmd() = default;
 
@@ -57,6 +58,8 @@ export struct WalCmd {
     virtual void WriteAdv(char *&ptr) const = 0;
     // Read from a serialized version
     static SharedPtr<WalCmd> ReadAdv(char *&ptr, i32 max_bytes);
+
+    static String WalCommandTypeToString(WalCommandType type);
 };
 
 export struct WalCmdCreateDatabase : public WalCmd {
@@ -149,9 +152,9 @@ export struct WalCmdDropIndex : public WalCmd {
 };
 
 export struct WalCmdImport : public WalCmd {
-    WalCmdImport(String db_name_, String table_name_, String segment_dir_, i32 segment_id_, i32 block_entries_size_)
+    WalCmdImport(String db_name_, String table_name_, String segment_dir_, i32 segment_id_, i32 block_entries_size_, Vector<i32> &row_counts_)
         : db_name(Move(db_name_)), table_name(Move(table_name_)), segment_dir(Move(segment_dir_)), segment_id(segment_id_),
-          block_entries_size(block_entries_size_) {}
+          block_entries_size(block_entries_size_), row_counts_(row_counts_) {}
 
     WalCommandType GetType() override { return WalCommandType::IMPORT; }
     bool operator==(const WalCmd &other) const override;
@@ -163,6 +166,8 @@ export struct WalCmdImport : public WalCmd {
     String segment_dir;
     i32 segment_id;
     i32 block_entries_size;
+    // row_counts_[i] means the number of rows in the i-th block entry
+    Vector<i32> row_counts_;
 };
 
 export struct WalCmdAppend : public WalCmd {
@@ -240,6 +245,8 @@ export struct WalEntry : WalEntryHeader {
     [[nodiscard]] bool IsCheckPoint() const;
 
     [[nodiscard]] bool IsFullCheckPoint() const;
+
+    [[nodiscard]] String ToString() const;
 };
 
 export class WalEntryIterator {

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -110,10 +110,12 @@ private:
 
     // Only Checkpoint thread access following members
     TxnTimeStamp ckp_commit_ts_{};
+    TxnTimeStamp full_ckp_commit_ts_{};
     i64 full_ckp_wal_size_;
     i64 full_ckp_when_;
     i64 delta_ckp_wal_size_;
     i64 delta_ckp_when_;
+
     Vector<String> wal_list_;
 };
 

--- a/src/unit_test/storage/wal/wal_entry.cpp
+++ b/src/unit_test/storage/wal/wal_entry.cpp
@@ -61,7 +61,9 @@ void MockWalFile(const String &wal_file_path = "/tmp/infinity/wal/wal.log") {
         auto entry = MakeShared<WalEntry>();
         entry->cmds.push_back(MakeShared<WalCmdCreateDatabase>("default2"));
         entry->cmds.push_back(MakeShared<WalCmdCreateTable>("default", MockTableDesc2()));
-        entry->cmds.push_back(MakeShared<WalCmdImport>("default", "tbl1", "/tmp/infinity/data/default/txn_66/tbl1/ENkJMWTQ8N_seg_0", 0, 3));
+        Vector<i32> row_counts{1, 2, 3};
+        entry->cmds.push_back(
+            MakeShared<WalCmdImport>("default", "tbl1", "/tmp/infinity/data/default/txn_66/tbl1/ENkJMWTQ8N_seg_0", 0, 3, row_counts));
 
         auto data_block = DataBlock::Make();
         Vector<SharedPtr<DataType>> column_types;
@@ -141,7 +143,8 @@ TEST_F(WalEntryTest, ReadWrite) {
     entry->cmds.push_back(MakeShared<WalCmdDropDatabase>("db1"));
     entry->cmds.push_back(MakeShared<WalCmdCreateTable>("db1", MockTableDesc2()));
     entry->cmds.push_back(MakeShared<WalCmdDropTable>("db1", "tbl1"));
-    entry->cmds.push_back(MakeShared<WalCmdImport>("db1", "tbl1", "/tmp/infinity/data/default/txn_66/tbl1/ENkJMWTQ8N_seg_0", 0, 3));
+    Vector<i32> row_counts{1, 2, 3};
+    entry->cmds.push_back(MakeShared<WalCmdImport>("db1", "tbl1", "/tmp/infinity/data/default/txn_66/tbl1/ENkJMWTQ8N_seg_0", 0, 3, row_counts));
 
     auto index_def = IVFFlatIndexDef::Make(MakeShared<String>("idx1"),
                                            Vector<String>{"col1", "col2"},

--- a/src/unit_test/storage/wal/wal_replay.cpp
+++ b/src/unit_test/storage/wal/wal_replay.cpp
@@ -21,14 +21,14 @@ import table_collection_entry;
 import wal_entry;
 import infinity_exception;
 import infinity_assert;
+import column_vector;
+import physical_import;
+import txn;
 
 class WalReplayTest : public BaseTest {
     void SetUp() override { system("rm -rf /tmp/infinity"); }
 
-    void TearDown() override {
-        system("tree  /tmp/infinity");
-        system("rm -rf /tmp/infinity");
-    }
+    void TearDown() override { system("tree  /tmp/infinity"); }
 };
 
 using namespace infinity;
@@ -354,6 +354,7 @@ TEST_F(WalReplayTest, WalReplayAppend) {
             UniquePtr<MetaTableState> read_table_meta = MakeUnique<MetaTableState>();
 
             txn->GetMetaTableState(read_table_meta.get(), "default", "tbl4", column_ids);
+            EXPECT_EQ(read_table_meta->segment_map_.size(), 1);
 
             EXPECT_EQ(read_table_meta->local_blocks_.size(), 0);
             EXPECT_EQ(read_table_meta->segment_map_.size(), 1);
@@ -449,111 +450,107 @@ TEST_F(WalReplayTest, WalReplayImport) {
             EXPECT_NE(result.entry_, nullptr);
             txn->CommitTxn();
         }
+
+        auto tbl2_def = MakeUnique<TableDef>(MakeShared<String>("default"), MakeShared<String>("tbl2"), columns);
+        auto *txn2 = txn_mgr->CreateTxn();
+        txn2->BeginTxn();
+        auto result2 = txn2->CreateTable("default", Move(tbl2_def), ConflictType::kIgnore);
+        EXPECT_NE(result2.entry_, nullptr);
+        txn2->CommitTxn();
+
+        TxnTimeStamp tx4_commit_ts = txn2->CommitTS();
         {
-            auto tbl2_def = MakeUnique<TableDef>(MakeShared<String>("default"), MakeShared<String>("tbl2"), columns);
-            auto *txn2 = txn_mgr->CreateTxn();
-            txn2->BeginTxn();
-            auto result3 = txn2->CreateTable("default", Move(tbl2_def), ConflictType::kIgnore);
-            EXPECT_NE(result3.entry_, nullptr);
-            txn2->CommitTxn();
+            auto txn = txn_mgr->CreateTxn();
+            txn->BeginTxn();
+            txn->Checkpoint(tx4_commit_ts, true);
+            txn->CommitTxn();
         }
 
         {
-            auto *txn3 = txn_mgr->CreateTxn();
+            auto *txn = txn_mgr->CreateTxn();
             auto tbl3_def = MakeUnique<TableDef>(MakeShared<String>("default"), MakeShared<String>("tbl3"), columns);
 
-            txn3->BeginTxn();
-            auto result3 = txn3->CreateTable("default", Move(tbl3_def), ConflictType::kIgnore);
+            txn->BeginTxn();
+            auto result3 = txn->CreateTable("default", Move(tbl3_def), ConflictType::kIgnore);
             EXPECT_NE(result3.entry_, nullptr);
-            txn3->CommitTxn();
+            txn->CommitTxn();
         }
 
-        auto *txn4 = txn_mgr->CreateTxn();
-
         {
+            auto txn4 = txn_mgr->CreateTxn();
             txn4->BeginTxn();
 
             TableCollectionEntry *table_collection_entry = nullptr;
-            txn4->GetTableEntry("default", "tbl1", table_collection_entry);
+            auto table_collection_entry_result = txn4->GetTableEntry("default", "tbl1", table_collection_entry);
             EXPECT_NE(table_collection_entry, nullptr);
+            const String &db_name = *TableCollectionEntry::GetDBEntry(table_collection_entry)->db_name_;
+            const String &table_name = *table_collection_entry->table_collection_name_;
+            u64 segment_id = TableCollectionEntry::GetNextSegmentID(table_collection_entry);
+            EXPECT_EQ(segment_id, 0);
+            auto segment_entry = SegmentEntry::MakeNewSegmentEntry(table_collection_entry, segment_id, buffer_manager);
+            EXPECT_EQ(segment_entry->segment_id_, 0);
+            auto last_block_entry = segment_entry->block_entries_.back().get();
             txn4->AddTxnTableStore("tbl1", MakeUnique<TxnTableStore>("tbl1", table_collection_entry, txn4));
 
-            TxnTableStore *txn_store = txn4->GetTxnTableStore("tbl1");
-            EXPECT_NE(txn_store, nullptr);
-
-            u64 segment_id = TableCollectionEntry::GetNextSegmentID(table_collection_entry);
-            auto segment_entry = SegmentEntry::MakeNewSegmentEntry(table_collection_entry, segment_id, buffer_manager);
-
-            // process segment entry
-
-            BlockEntry *last_block_entry = segment_entry->block_entries_.back().get();
-
-            SizeT need_write_row = 1;
-            Vector<StringView> write_data{"1", "22", "3.33"};
-            for (SizeT column_idx = 0; column_idx < /*column_count*/ 3; ++column_idx) {
-                BlockColumnEntry *block_column_entry = last_block_entry->columns_[column_idx].get();
-                auto column_type = block_column_entry->column_type_.get();
-                SizeT dst_offset = need_write_row * column_type->Size();
-                // test data
-                // 1 22 3.33
-                switch (column_type->type()) {
-                    case kBoolean: {
-                        AppendSimpleData<BooleanT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kTinyInt: {
-                        AppendSimpleData<TinyIntT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kSmallInt: {
-                        AppendSimpleData<SmallIntT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kInteger: {
-                        AppendSimpleData<IntegerT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kBigInt: {
-                        AppendSimpleData<BigIntT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kFloat: {
-                        AppendSimpleData<FloatT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kDouble: {
-                        AppendSimpleData<DoubleT>(block_column_entry, write_data[column_idx], dst_offset);
-                        break;
-                    }
-                    case kMissing:
-                    case kInvalid: {
-                        Error<ExecutorException>("Invalid data type", __FILE_NAME__, __LINE__);
-                    }
-                    default: {
-                        Error<NotImplementException>("Not supported now in append data in column", __FILE_NAME__, __LINE__);
-                    }
-                }
+            Vector<SharedPtr<ColumnVector>> columns_vector;
+            {
+                SharedPtr<ColumnVector> column_vector = ColumnVector::Make(MakeShared<DataType>(LogicalType::kTinyInt));
+                column_vector->Initialize();
+                Value v = Value::MakeTinyInt(static_cast<TinyIntT>(1));
+                column_vector->AppendValue(v);
+                columns_vector.push_back(column_vector);
+            }
+            {
+                SharedPtr<ColumnVector> column = ColumnVector::Make(MakeShared<DataType>(LogicalType::kBigInt));
+                column->Initialize();
+                Value v = Value::MakeBigInt(static_cast<BigIntT>(22));
+                column->AppendValue(v);
+                columns_vector.push_back(column);
+            }
+            {
+                SharedPtr<ColumnVector> column = ColumnVector::Make(MakeShared<DataType>(LogicalType::kDouble));
+                column->Initialize();
+                Value v = Value::MakeDouble(static_cast<DoubleT>(f64(3)) + 0.33f);
+                column->AppendValue(v);
+                columns_vector.push_back(column);
             }
 
-            ++last_block_entry->row_count_;
-            ++segment_entry->row_count_;
+            {
+                auto block_column_entry1 = last_block_entry->columns_[0].get();
+                auto column_type1 = block_column_entry1->column_type_.get();
+                EXPECT_EQ(column_type1->type(), LogicalType::kTinyInt);
+                SizeT data_type_size = columns_vector[0]->data_type_size_;
+                EXPECT_EQ(data_type_size, 1);
+                ptr_t src_ptr = columns_vector[0].get()->data();
+                SizeT data_size = 1 * data_type_size;
+                BlockColumnEntry::AppendRaw(block_column_entry1, 0, src_ptr, data_size);
+            }
+            {
+                auto block_column_entry2 = last_block_entry->columns_[1].get();
+                auto column_type2 = block_column_entry2->column_type_.get();
+                EXPECT_EQ(column_type2->type(), LogicalType::kBigInt);
+                SizeT data_type_size = columns_vector[1]->data_type_size_;
+                EXPECT_EQ(data_type_size, 8);
+                ptr_t src_ptr = columns_vector[1].get()->data();
+                SizeT data_size = 1 * data_type_size;
+                BlockColumnEntry::AppendRaw(block_column_entry2, 0, src_ptr, data_size);
+            }
+            {
+                auto block_column_entry3 = last_block_entry->columns_[2].get();
+                auto column_type3 = block_column_entry3->column_type_.get();
+                EXPECT_EQ(column_type3->type(), LogicalType::kDouble);
+                SizeT data_type_size = columns_vector[2]->data_type_size_;
+                EXPECT_EQ(data_type_size, 8);
+                ptr_t src_ptr = columns_vector[2].get()->data();
+                SizeT data_size = 1 * data_type_size;
+                BlockColumnEntry::AppendRaw(block_column_entry3, 0, src_ptr, data_size);
+            }
 
-            txn4->AddWalCmd(MakeShared<WalCmdImport>("default",
-                                                     "tbl1",
-                                                     *segment_entry->segment_dir_,
-                                                     segment_entry->segment_id_,
-                                                     segment_entry->block_entries_.size()));
-            txn_store->Import(segment_entry);
+            last_block_entry->row_count_ = 1;
+            segment_entry->row_count_ = 1;
+
+            PhysicalImport::SaveSegmentData(txn4, segment_entry, "default", "tbl1");
             txn4->CommitTxn();
-        }
-
-        i64 tx4_commit_ts = txn4->CommitTS();
-
-        {
-            auto *txn6 = txn_mgr->CreateTxn();
-            txn6->BeginTxn();
-            txn6->Checkpoint(tx4_commit_ts, true);
-            txn6->CommitTxn();
         }
 
         infinity::Infinity::instance().UnInit();
@@ -572,71 +569,42 @@ TEST_F(WalReplayTest, WalReplayImport) {
         TxnManager *txn_mgr = storage->txn_manager();
         BufferManager *buffer_manager = storage->buffer_manager();
 
-        Vector<SharedPtr<ColumnDef>> columns;
         {
-            i64 column_id = 0;
-            {
-                HashSet<ConstraintType> constraints;
-                constraints.insert(ConstraintType::kUnique);
-                constraints.insert(ConstraintType::kNotNull);
-                auto column_def_ptr =
-                    MakeShared<ColumnDef>(column_id++, MakeShared<DataType>(DataType(LogicalType::kTinyInt)), "tiny_int_col", constraints);
-                columns.emplace_back(column_def_ptr);
-            }
-        }
-        {
-            auto tbl5_def = MakeUnique<TableDef>(MakeShared<String>("default"), MakeShared<String>("tbl5"), columns);
-            auto *txn = txn_mgr->CreateTxn();
-            txn->BeginTxn();
-            auto result = txn->CreateTable("default", Move(tbl5_def), ConflictType::kIgnore);
-            EXPECT_NE(result.entry_, nullptr);
-            txn->CommitTxn();
-        }
-        {
-            auto *txn = txn_mgr->CreateTxn();
+            auto txn = txn_mgr->CreateTxn();
             txn->BeginTxn();
             Vector<ColumnID> column_ids{0, 1, 2};
-            UniquePtr<MetaTableState> read_table_meta = MakeUnique<MetaTableState>();
+            TableCollectionEntry *table_collection_entry = nullptr;
+            txn->GetTableEntry("default", "tbl1", table_collection_entry);
+            EXPECT_NE(table_collection_entry, nullptr);
+            auto segment_entry = table_collection_entry->segments_[0].get();
+            EXPECT_EQ(segment_entry->segment_id_, 0);
+            auto block_id = segment_entry->block_entries_[0]->block_id_;
+            EXPECT_EQ(block_id, 0);
+            auto block_entry = segment_entry->block_entries_[0].get();
+            EXPECT_EQ(block_entry->row_count_, 1);
 
-            txn->GetMetaTableState(read_table_meta.get(), "default", "tbl1", column_ids);
+            BlockColumnEntry *column0 = block_entry->columns_[0].get();
+            BlockColumnEntry *column1 = block_entry->columns_[1].get();
+            BlockColumnEntry *column2 = block_entry->columns_[2].get();
 
-            EXPECT_EQ(read_table_meta->local_blocks_.size(), 0);
-            EXPECT_EQ(read_table_meta->segment_map_.size(), 1);
-            for (const auto &segment_pair : read_table_meta->segment_map_) {
-                EXPECT_EQ(segment_pair.first, 0);
-                EXPECT_NE(segment_pair.second.segment_entry_, nullptr);
-                for (const auto &block_pair : segment_pair.second.block_map_) {
-                    EXPECT_NE(block_pair.second.block_entry_, nullptr);
+            ColumnBuffer col0_obj = BlockColumnEntry::GetColumnData(column0, buffer_manager);
+            col0_obj.GetAll();
+            DataType *col0_type = column0->column_type_.get();
+            i8 *col0_ptr = (i8 *)(col0_obj.GetValueAt(0, *col0_type));
+            EXPECT_EQ(*col0_ptr, (1));
 
-                    EXPECT_EQ(block_pair.second.column_data_map_.size(), 3);
-                    EXPECT_TRUE(block_pair.second.column_data_map_.contains(0));
-                    EXPECT_TRUE(block_pair.second.column_data_map_.contains(1));
-                    EXPECT_TRUE(block_pair.second.column_data_map_.contains(2));
+            ColumnBuffer col1_obj = BlockColumnEntry::GetColumnData(column1, buffer_manager);
+            DataType *col1_type = column1->column_type_.get();
+            i8 *col1_ptr = (i8 *)(col1_obj.GetValueAt(0, *col1_type));
+            EXPECT_EQ(*col1_ptr, (i64)(22));
 
-                    BlockColumnEntry *column0 = block_pair.second.column_data_map_.at(0).block_column_;
-                    BlockColumnEntry *column1 = block_pair.second.column_data_map_.at(1).block_column_;
-                    BlockColumnEntry *column2 = block_pair.second.column_data_map_.at(2).block_column_;
+            ColumnBuffer col2_obj = BlockColumnEntry::GetColumnData(column2, buffer_manager);
+            DataType *col2_type = column2->column_type_.get();
+            EXPECT_EQ(col2_type->type(), LogicalType::kDouble);
+            f64 *col2_ptr = (f64 *)(col2_obj.GetValueAt(0, *col2_type));
+            EXPECT_EQ(col2_ptr[0], (f64)(3) + 0.33f);
 
-                    SizeT row_count = block_pair.second.block_entry_->row_count_;
-                    ColumnBuffer col0_obj = BlockColumnEntry::GetColumnData(column0, buffer_manager);
-                    i8 *col0_ptr = (i8 *)(col0_obj.GetAll());
-                    for (SizeT row = 0; row < row_count; ++row) {
-                        EXPECT_EQ(col0_ptr[row], (i8)(row));
-                    }
-
-                    ColumnBuffer col1_obj = BlockColumnEntry::GetColumnData(column1, buffer_manager);
-                    i64 *col1_ptr = (i64 *)(col1_obj.GetAll());
-                    for (SizeT row = 0; row < row_count; ++row) {
-                        EXPECT_EQ(col1_ptr[row], (i64)(row));
-                    }
-
-                    ColumnBuffer col2_obj = BlockColumnEntry::GetColumnData(column2, buffer_manager);
-                    f64 *col2_ptr = (f64 *)(col2_obj.GetAll());
-                    for (SizeT row = 0; row < row_count; ++row) {
-                        EXPECT_FLOAT_EQ(col2_ptr[row], row % 8192);
-                    }
-                }
-            }
+            txn->CommitTxn();
         }
 
         infinity::Infinity::instance().UnInit();

--- a/src/unit_test/test_helper/sql_runner.cpp
+++ b/src/unit_test/test_helper/sql_runner.cpp
@@ -84,7 +84,7 @@ SharedPtr<Table> SQLRunner::Run(const String &sql_text, bool print) {
     auto plan_fragment = fragment_builder.BuildFragment(physical_plan.get());
 
     // Schedule the query pipeline
-    query_context_ptr.get()->scheduler()->Schedule(query_context_ptr.get(), plan_fragment.get());
+    query_context_ptr->scheduler()->Schedule(query_context_ptr.get(), plan_fragment.get());
 
     // Initialize query result
     QueryResult query_result;

--- a/test/sql/dql/rbo_rule/column_pruner.slt
+++ b/test/sql/dql/rbo_rule/column_pruner.slt
@@ -132,3 +132,8 @@ EXPLAIN LOGICAL SELECT Min(c1 + 1), AVG(c2) FROM t1 GROUP BY c1;
       - output columns: [c1, c2]
 
 # TODO Delete Case
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -8,24 +8,30 @@ from shutil import copyfile
 def test_process(sqllogictest_bin: str, slt_dir: str, data_dir: str, copy_dir: str):
     print("sqlllogictest-bin path is {}".format(sqllogictest_bin))
 
-    if not os.path.exists(copy_dir):
-        os.makedirs(copy_dir)
+    copy_all(data_dir, copy_dir)
 
-    for dirpath, dirnames, filenames in os.walk(data_dir):
-        for filename in filenames:
-            src_path = os.path.join(dirpath, filename)
-            dest_path = os.path.join(copy_dir, filename)
-            copyfile(src_path, dest_path)
     test_cnt = 0
     for dirpath, dirnames, filenames in os.walk(slt_dir):
         for filename in filenames:
             file = os.path.join(dirpath, filename)
             os.system(sqllogictest_bin + " " + file)
             print("Finished running test file: " + file)
-            print("----------------------------------------------------------\n")
+            print("-" * 100)
             test_cnt += 1
 
     print("Finished {} tests.".format(test_cnt))
+
+
+# copy data
+def copy_all(data_dir, copy_dir):
+    if not os.path.exists(copy_dir):
+        os.makedirs(copy_dir)
+    for dirpath, dirnames, filenames in os.walk(data_dir):
+        for filename in filenames:
+            src_path = os.path.join(dirpath, filename)
+            dest_path = os.path.join(copy_dir, filename)
+            copyfile(src_path, dest_path)
+    print("Finished copying all files.")
 
 
 # main
@@ -76,6 +82,12 @@ if __name__ == "__main__":
         type=str,
         default=copy_dir,
         dest="copy",
+    )
+    parser.add_argument(
+        "-jc",
+        "--just_copy",
+        default=copy_all(data_dir, copy_dir),
+        dest="just_copy_all_data",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
* import modules

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add more codes on third party and logger

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Transfer unit test framework, exception/config part to modules

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add Assert/Error implementation and test cases

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add more code to db_server

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Remove compilation_config.cppm and Add pg_message module

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Migrate network to modules implementation without boost connection part

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Log part is wrapped

Signed-off-by: jinhai <haijin.chn@gmail.com>

* resource manager is migrated

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add profiler and unit test

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add query context/storage/txn/connection module

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add more code about table/data_block/table_def

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Parser code is migrated and libsqlparser can be built

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Wrap parser into module

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Value is migrated

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Fix unit test compilation error

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add column vector and buffer related code

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add heap chunk unit tests

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add bitmask / bitmask buffer unit test

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add all column vector and selection unit test cases

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add parser unit test cases

Signed-off-by: jinhai <haijin.chn@gmail.com>

* More parser test cases

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Fix compilation error

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Migrate more code of data block/table/table_def

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Temp commit, can't compile successfully

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Fix above compilation failure

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add more cast function

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Finish part of logical planner

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Finish logical planner

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Bound select statement finished

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Finish storage/wal_manager

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Migrate all scalar and aggregate functions

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Finish aggregate functions registeration and table functions

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Complete query_binder migration

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Complete all expression and subquery unnest code migration

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Complete expression binder migration

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Migrate all code of storage/buffer

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Knn index code is migrated

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Complete storage meta migration

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Unmark more #if 0 covered code block

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Migrate scheduler / executor code

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Fix compilation error

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Fragment scheduler and query execution is migrated

Signed-off-by: jinhai <haijin.chn@gmail.com>

* Add lots of unit test cases

Signed-off-by: jinhai <haijin.chn@gmail.com>

* SQL file parsing ut error

Signed-off-by: jinhai <haijin.chn@gmail.com>

---------

Signed-off-by: jinhai <haijin.chn@gmail.com>### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
Refactor code and enhance functionality for segment recovery

Several modifications were made to the codebase to simplify the code and improve the readability. Furthermore, these changes also enhanced the functionality of the segment recovery process. Detailed modifications include:

1. Simplified the function to make a new segment entry and separated it into two parts: MakeNewSegmentEntry and MakeRecoverSegmentEntry.
2. Integrated a mechanism to adjust the size of the block column entry vector and removed redundant push_back calls.
3. Introduced a Include vector of row counts in the WalCmdImport to keep track of the number of rows different block entries consist.
4. Introduced logging before and after flush to trace the correctness of the flush process.
5. Fixed the logic error that failed to keep the segment_dir_ consistent after recovery.
6. Added a saveSegmentData function to clean up repeated code for saving and flushing block entries.
7. Added related information for Import and Append type WAL commands.
8. Simplified the code calling the scheduler in sql_runner.cpp.
9. Facilitated block entry construction for WAL replay, and corrected the row count during import recovery.
10. Corrected some undesired checkpoint behavior and adjusted the checkpoint timestep. Added replay logic for 'IMPORT' WAL commands.

The purpose of these changes was to keep the codebase clean and compact, as well as to ensure the correct recovery and import process, enhancing the system's reliability and easy maintenance.