### PR TITLE
Add new merge policy to iresearch

### DIFF
--- a/third_party/iresearch/core/index/index_writer.cpp
+++ b/third_party/iresearch/core/index/index_writer.cpp
@@ -1477,11 +1477,9 @@ ConsolidationResult IndexWriter::Consolidate(
     if (pending_state_.Valid()) {
       // check that we haven't added to reader cache already absent readers
       // only if we have different index meta
-      std::cout << "consolidate 1 " << std::endl;
       if (committed_reader != current_committed_reader) {
         auto begin = current_committed_reader->begin();
         auto end = current_committed_reader->end();
-        std::cout << "consolidate 2 " << std::endl;
         // pointers are different so check by name
         for (const auto* candidate : candidates) {
           if (end == std::find_if(
@@ -1525,7 +1523,6 @@ ConsolidationResult IndexWriter::Consolidate(
     } else if (committed_reader == current_committed_reader) {
       // before new transaction was started:
       // no commits happened in since consolidation was started
-      std::cout << "consolidate 3 " << std::endl;
       auto ctx = GetFlushContext();
       // lock due to context modification
       std::lock_guard ctx_lock{ctx->pending_.Mutex()};

--- a/third_party/iresearch/core/utils/index_utils.hpp
+++ b/third_party/iresearch/core/utils/index_utils.hpp
@@ -27,23 +27,6 @@
 
 namespace irs::index_utils {
 
-// merge segment if:
-//   {threshold} > segment_bytes / (all_segment_bytes / #segments)
-struct ConsolidateBytes {
-  float threshold = 0;
-};
-
-ConsolidationPolicy MakePolicy(const ConsolidateBytes& options);
-
-// merge segment if:
-//   {threshold} >= (segment_bytes + sum_of_merge_candidate_segment_bytes) /
-//   all_segment_bytes
-struct ConsolidateBytesAccum {
-  float threshold = 0;
-};
-
-ConsolidationPolicy MakePolicy(const ConsolidateBytesAccum& options);
-
 // merge first {threshold} segments
 struct ConsolidateCount {
   size_t threshold = std::numeric_limits<size_t>::max();
@@ -51,22 +34,11 @@ struct ConsolidateCount {
 
 ConsolidationPolicy MakePolicy(const ConsolidateCount& options);
 
-// merge segment if:
-//   {threshold} >= segment_docs{valid} / (all_segment_docs{valid} / #segments)
-struct ConsolidateDocsLive {
+struct ConsolidateByOrder {
   float threshold = 0;
 };
 
-ConsolidationPolicy MakePolicy(const ConsolidateDocsLive& options);
-
-// merge segment if:
-//   {threshold} > #segment_docs{valid} / (#segment_docs{valid} +
-//   #segment_docs{removed})
-struct ConsolidateDocsFill {
-  float threshold = 0;
-};
-
-ConsolidationPolicy MakePolicy(const ConsolidateDocsFill& options);
+ConsolidationPolicy MakePolicy(const ConsolidateByOrder& options);
 
 struct ConsolidateTier {
   // minimum allowed number of segments to consolidate at once

--- a/third_party/iresearch/core/utils/priority_queue.hpp
+++ b/third_party/iresearch/core/utils/priority_queue.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+namespace irs {
+
+template<class Type>
+class PriorityQueue {
+ private:
+  Type* heap_;
+  size_t size_;
+  bool own_;
+  size_t max_size_;
+
+  void UpHeap() {
+    size_t i = size_;
+    Type node = heap_[i];  // save bottom node (WAS object)
+    int32_t j = ((uint32_t)i) >> 1;
+    while (j > 0 && LessThan(node, heap_[j])) {
+      heap_[i] = heap_[j];  // shift parents down
+      i = j;
+      j = ((uint32_t)j) >> 1;
+    }
+    heap_[i] = node;  // install saved node
+  }
+  void DownHeap() {
+    size_t i = 1;
+    Type node = heap_[i];  // save top node
+    size_t j = i << 1;     // find smaller child
+    size_t k = j + 1;
+    if (k <= size_ && LessThan(heap_[k], heap_[j])) {
+      j = k;
+    }
+    while (j <= size_ && LessThan(heap_[j], node)) {
+      heap_[i] = heap_[j];  // shift up child
+      i = j;
+      j = i << 1;
+      k = j + 1;
+      if (k <= size_ && LessThan(heap_[k], heap_[j])) {
+        j = k;
+      }
+    }
+    heap_[i] = node;  // install saved node
+  }
+
+ protected:
+  PriorityQueue() {
+    size_ = 0;
+    own_ = false;
+    heap_ = NULL;
+    max_size_ = 0;
+  }
+
+  virtual bool LessThan(Type a, Type b) = 0;
+
+  void Initialize(const size_t maxSize, bool deleteOnClear) {
+    size_ = 0;
+    own_ = deleteOnClear;
+    max_size_ = maxSize;
+    size_t heapSize = max_size_ + 1;
+    heap_ = new Type[heapSize];
+  }
+
+ public:
+  virtual ~PriorityQueue() {
+    Clear();
+    delete[] heap_;
+  }
+
+  void Put(Type element) {
+    size_++;
+    heap_[size_] = element;
+    UpHeap();
+  }
+
+  bool Insert(Type element) {
+    if (size_ < max_size_) {
+      Put(element);
+      return true;
+    } else if (size_ > 0 && !LessThan(element, Top())) {
+      if (own_) {
+        delete heap_[1];
+      }
+      heap_[1] = element;
+      AdjustTop();
+      return true;
+    } else
+      return false;
+  }
+
+  Type Top() {
+    if (size_ > 0)
+      return heap_[1];
+    else
+      return NULL;
+  }
+
+  Type Pop() {
+    if (size_ > 0) {
+      Type result = heap_[1];   // save first value
+      heap_[1] = heap_[size_];  // move last to first
+
+      heap_[size_] = (Type)0;  // permit GC of objects
+      size_--;
+      DownHeap();  // adjust heap_
+      return result;
+    } else
+      return (Type)NULL;
+  }
+
+  void AdjustTop() { DownHeap(); }
+
+  size_t Size() { return size_; }
+
+  void Clear() {
+    for (size_t i = 1; i <= size_; i++) {
+      if (own_) {
+        delete heap_[i];
+      }
+    }
+    size_ = 0;
+  }
+  Type operator[](size_t pos_) { return heap_[pos_ + 1]; }
+  Type Get(size_t pos_) { return heap_[pos_ + 1]; }
+
+  void SetOwn(bool own) { own_ = own; }
+};
+
+}  // namespace irs


### PR DESCRIPTION
### What problem does this PR solve?

Add new merge policy to iresearch: 
BT policy is not used but might be adopted for future self owned inverted index.
Native policy is pretty simple, just select top three segments with least documents while keep the ordering of base doc ids of each segment. 

Currently, the memory consumption of iresearch consolidation is pretty high. 

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer