### PR TITLE
feat: add `row_count` on `table_collection_entry`

### DIFF
--- a/src/storage/meta/entry/table_collection_entry.cpp
+++ b/src/storage/meta/entry/table_collection_entry.cpp
@@ -227,6 +227,7 @@ UniquePtr<String> TableCollectionEntry::Delete(TableCollectionEntry *table_entry
 }
 
 void TableCollectionEntry::CommitAppend(TableCollectionEntry *table_entry, Txn *txn_ptr, const AppendState *append_state_ptr) {
+    SizeT row_count = 0;
     for (const auto &range : append_state_ptr->append_ranges_) {
         LOG_TRACE(Format("Commit, segment: {}, block: {} start offset: {}, count: {}",
                          range.segment_id_,
@@ -235,7 +236,9 @@ void TableCollectionEntry::CommitAppend(TableCollectionEntry *table_entry, Txn *
                          range.row_count_));
         SegmentEntry *segment_ptr = table_entry->segments_[range.segment_id_].get();
         SegmentEntry::CommitAppend(segment_ptr, txn_ptr, range.block_id_, range.start_offset_, range.row_count_);
+        row_count += range.row_count_;
     }
+    table_entry->row_count_ += row_count;
 }
 
 void TableCollectionEntry::CommitCreateIndex(TableCollectionEntry *table_entry, HashMap<String, TxnIndexStore> &txn_indexes_store_) {
@@ -254,6 +257,7 @@ void TableCollectionEntry::RollbackAppend(TableCollectionEntry *table_entry, Txn
 }
 
 void TableCollectionEntry::CommitDelete(TableCollectionEntry *table_entry, Txn *txn_ptr, const DeleteState &delete_state) {
+    SizeT row_count = 0;
     for (const auto &to_delete_seg_rows : delete_state.rows_) {
         u32 segment_id = to_delete_seg_rows.first;
         SegmentEntry *segment = TableCollectionEntry::GetSegmentByID(table_entry, segment_id);
@@ -262,7 +266,9 @@ void TableCollectionEntry::CommitDelete(TableCollectionEntry *table_entry, Txn *
         }
         const HashMap<u16, Vector<RowID>> &block_row_hashmap = to_delete_seg_rows.second;
         SegmentEntry::CommitDelete(segment, txn_ptr, block_row_hashmap);
+        row_count += block_row_hashmap.size();
     }
+    table_entry->row_count_ += row_count;
 }
 
 UniquePtr<String>
@@ -276,12 +282,16 @@ UniquePtr<String> TableCollectionEntry::ImportSegment(TableCollectionEntry *tabl
     TxnTimeStamp commit_ts = txn_ptr->CommitTS();
     segment->min_row_ts_ = commit_ts;
     segment->max_row_ts_ = commit_ts;
+
+    SizeT row_count = 0;
     for (auto &block_entry : segment->block_entries_) {
         block_entry->min_row_ts_ = commit_ts;
         block_entry->max_row_ts_ = commit_ts;
         // ATTENTION: Do not modify the block_entry checkpoint_ts_
+        row_count += block_entry->row_count_;
         block_entry->block_version_->created_.emplace_back(commit_ts, block_entry->row_count_);
     }
+    table_entry->row_count_ += row_count;
 
     UniqueLock<RWMutex> rw_locker(table_entry->rw_locker_);
     table_entry->segments_.emplace(segment->segment_id_, Move(segment));
@@ -328,7 +338,7 @@ Json TableCollectionEntry::Serialize(TableCollectionEntry *table_entry, TxnTimeS
         json_res["table_entry_dir"] = *table_entry->table_entry_dir_;
         json_res["table_name"] = *table_entry->table_collection_name_;
         json_res["table_entry_type"] = table_entry->table_collection_type_;
-        json_res["row_count"] = table_entry->row_count_;
+        json_res["row_count"] = table_entry->row_count_.load();
         json_res["begin_ts"] = table_entry->begin_ts_;
         json_res["commit_ts"] = table_entry->commit_ts_.load();
         json_res["txn_id"] = table_entry->txn_id_.load();

--- a/src/storage/meta/entry/table_collection_entry.cppm
+++ b/src/storage/meta/entry/table_collection_entry.cppm
@@ -132,7 +132,7 @@ public:
     TableCollectionMeta *table_collection_meta_{};
 
     // From data table
-    SizeT row_count_{};
+    Atomic<SizeT> row_count_{};
     HashMap<u32, SharedPtr<SegmentEntry>> segments_{};
     SegmentEntry *unsealed_segment_{};
     atomic_u32 next_segment_id_{};

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -78,7 +78,6 @@ void Storage::Init() {
 
 void Storage::UnInit() {
     Printf("Shutdown storage ...\n");
-    txn_mgr_->Stop();
     wal_mgr_->Stop();
 
     txn_mgr_.reset();

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -141,8 +141,7 @@ void WalManager::Stop() {
     // pop all the entries in the queue. and notify the condition variable.
     std::lock_guard guard(mutex_);
     for (const auto &entry : que_) {
-        auto wal_entry = que_.front();
-        Txn *txn = txn_mgr->GetTxn(wal_entry->txn_id);
+        Txn *txn = txn_mgr->GetTxn(entry->txn_id);
         if (txn != nullptr) {
             txn->CancelCommitBottom();
         }


### PR DESCRIPTION
### What problem does this PR solve?

``` shell
kould=> show tables;
 database |         table          | type  | column_count | row_count | segment_count | block_count | segment_capacity 
----------+------------------------+-------+--------------+-----------+---------------+-------------+------------------
 default  | test_index             | Table |            1 |      1000 |             1 |           1 |            16384
 default  | test_knn_hnsw_ip       | Table |            2 |        24 |             3 |           3 |            16384
 default  | test_knn_ip            | Table |            2 |        24 |             3 |           3 |            16384
 default  | test_annivfflat        | Table |            1 |      1000 |             1 |           1 |            16384
 default  | test_knn_l2            | Table |            2 |        24 |             3 |           3 |            16384
 default  | test_knn_annivfflat_ip | Table |            2 |        24 |             3 |           3 |            16384
 default  | test_knn_hnsw_l2       | Table |            2 |        24 |             3 |           3 |            16384
 default  | test_hnsw              | Table |            1 |      1000 |             1 |           1 |            16384
 default  | test_knn_annivfflat_l2 | Table |            2 |        24 |             3 |           3 |            16384
(9 rows)

```

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer