### PR TITLE
Fix write uninitialized buffer issue by valgrind

### DIFF
--- a/src/parser/type/complex/embedding_type.h
+++ b/src/parser/type/complex/embedding_type.h
@@ -25,8 +25,8 @@ enum EmbeddingDataType : int8_t { kElemBit, kElemInt8, kElemInt16, kElemInt32, k
 
 struct EmbeddingType {
 public:
-    char *ptr = nullptr;
-    const bool new_allocated_;
+    char *ptr{};
+    const bool new_allocated_{};
 
     static size_t embedding_type_width[];
 

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -31,6 +31,19 @@ class Txn;
 class SegmentEntry;
 class DataBlock;
 
+#pragma pack(4)
+struct CreateField {
+//    CreateField(TxnTimeStamp create_ts, i32 row_count) : create_ts_(create_ts), row_count_(row_count) {}
+
+    TxnTimeStamp create_ts_{};
+    i32 row_count_{};
+
+    bool operator==(const CreateField &rhs) const { return create_ts_ == rhs.create_ts_ && row_count_ == rhs.row_count_; }
+
+    bool operator!=(const CreateField &rhs) const { return !(*this == rhs); }
+};
+#pragma pack()
+
 export struct BlockVersion {
     constexpr static String PATH = "version";
 
@@ -41,8 +54,8 @@ export struct BlockVersion {
     void LoadFromFile(const String &version_path);
     void SaveToFile(const String &version_path);
 
-    Vector<Pair<TxnTimeStamp, i32>> created_{}; // second field width is same as timestamp, otherwise Valgrind will issue BlockVersion::SaveToFile has
-                                                // risk to write uninitialized buffer. (ts, rows)
+    Vector<CreateField> created_{}; // second field width is same as timestamp, otherwise Valgrind will issue BlockVersion::SaveToFile has
+                                    // risk to write uninitialized buffer. (ts, rows)
     Vector<TxnTimeStamp> deleted_{};
 };
 
@@ -119,9 +132,7 @@ public:
 
     const String &DirPath() { return *base_dir_; }
 
-    String VersionFilePath() {
-        return LocalFileSystem::ConcatenateFilePath(*base_dir_, BlockVersion::PATH);
-    }
+    String VersionFilePath() { return LocalFileSystem::ConcatenateFilePath(*base_dir_, BlockVersion::PATH); }
 
 private:
     static SharedPtr<String> DetermineDir(const String &parent_dir, u64 block_id);

--- a/src/storage/meta/entry/table_collection_entry.cpp
+++ b/src/storage/meta/entry/table_collection_entry.cpp
@@ -340,9 +340,9 @@ UniquePtr<String> TableCollectionEntry::ImportSegment(TableCollectionEntry *tabl
         row_count += block_entry->row_count_;
         block_entry->block_version_->created_.emplace_back(commit_ts, block_entry->row_count_);
     }
-    table_entry->row_count_ += row_count;
 
     UniqueLock<RWMutex> rw_locker(table_entry->rw_locker_);
+    table_entry->row_count_ += row_count;
     table_entry->segment_map_.emplace(segment->segment_id_, Move(segment));
     return nullptr;
 }


### PR DESCRIPTION
### What problem does this PR solve?
When system checkpoint the meta, valgrind will issue warning: "Syscall param writev(vector[...]) points to uninitialised byte(s)"

After investigation, this warning is caused by: Pair<TxnTimestamp, i32> construction in heap. Since TxnTimestamp is u64, the whole pair structure will hold 8*2 = 16 Bytes. But only 4*3 Bytes are initialized, which 4 left are uninitialized. When flush the buffer to disk, valgrind will issue the fault.

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer