### PR TITLE
Try to fix CI bug. Add more log.

### DIFF
--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -112,6 +112,7 @@ bool BufferObj::Free() {
                     break;
                 }
                 case BufferType::kEphemeral: {
+                    LOG_WARN(Format("{}: Free kEphemeral.", *file_worker_->file_name_));
                     file_worker_->WriteToFile(true);
                     break;
                 }
@@ -136,7 +137,7 @@ bool BufferObj::Save() {
     switch (status_) {
         case BufferStatus::kLoaded:
         case BufferStatus::kUnloaded: {
-            LOG_TRACE(Format("{}: Save kEphemeral.", *file_worker_->file_name_));
+            LOG_WARN(Format("{}: Save kEphemeral.", *file_worker_->file_name_));
             file_worker_->WriteToFile(false);
             break;
         }
@@ -154,9 +155,15 @@ bool BufferObj::Save() {
     return true;
 }
 
-void BufferObj::Sync() { file_worker_->Sync(); }
+void BufferObj::Sync() {
+    UniqueLock<RWMutex> w_locker(rw_locker_);
+    file_worker_->Sync();
+}
 
-void BufferObj::CloseFile() { file_worker_->CloseFile(); }
+void BufferObj::CloseFile() {
+    UniqueLock<RWMutex> w_locker(rw_locker_);
+    file_worker_->CloseFile();
+}
 
 void BufferObj::CheckState() const {
     switch (status_) {

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -155,13 +155,10 @@ bool BufferObj::Save() {
     return true;
 }
 
-void BufferObj::Sync() {
-    UniqueLock<RWMutex> w_locker(rw_locker_);
-    file_worker_->Sync();
-}
+void BufferObj::Sync() { file_worker_->Sync(); }
 
 void BufferObj::CloseFile() {
-    UniqueLock<RWMutex> w_locker(rw_locker_);
+    LOG_WARN(Format("BufferObj::Close {}", *file_worker_->file_name_));
     file_worker_->CloseFile();
 }
 

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -61,6 +61,9 @@ void FileWorker::WriteToFile(bool to_spill) {
     }
     bool prepare_success = false;
     DeferFn defer_fn([&]() {
+        if (to_spill) {
+            LOG_WARN(Format("Write to spill file {} finished. success {}", write_path, prepare_success));
+        }
         if (!prepare_success) {
             file_handler_->Close();
             file_handler_ = nullptr;

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -208,6 +208,7 @@ void BlockColumnEntry::Flush(BlockColumnEntry *block_column_entry, SizeT) {
 //            SizeT buffer_size = row_count * column_type->Size();
             if (block_column_entry->buffer_->Save()) {
                 block_column_entry->buffer_->Sync();
+                LOG_WARN(Format("Close file {}", block_column_entry->FilePath()));
                 block_column_entry->buffer_->CloseFile();
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

CI test may crash when run insert_big_embedding test.

### What is changed and how it works?

Possible situation: the file descriptor is closed when another thread write the bufferobj to spill directory.

But such situation violate the buffer_obj status. When a thread call BufferObj::Close(), it must has called BufferObj::Save(), which holds the lock and sets the buffer_obj.type_ to kPersistent. Then when bufferobj writes to spill directory, it must be called by BufferObj::Free(), which also holds the lock.
What's more, the log shows BufferObj::Save() is never called

And add extra log for CI debug.

### Code changes

- [ ] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer