### PR TITLE
Fix ci bug

### DIFF
--- a/src/main/logger.cpp
+++ b/src/main/logger.cpp
@@ -43,6 +43,7 @@ void Logger::Initialize(const Config *config_ptr) {
     Vector<spd_sink_ptr> sinks{stdout_sinker, rotating_file_sinker};
 
     infinity_logger = MakeShared<spd_logger>("infinity", sinks.begin(), sinks.end()); // NOLINT
+    infinity_logger->set_pattern("[%H:%M:%S.%e] [%t] [%^%l%$] %v");
     RegisterLogger(infinity_logger);
 
     SetLogLevel(config_ptr->log_level());

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -56,7 +56,7 @@ BufferHandle BufferObj::Load() {
         case BufferStatus::kFreed: {
             buffer_mgr_->RequestSpace(GetBufferSize(), this);
             if (type_ != BufferType::kPersistent) {
-                LOG_WARN(Format("Load kEphemeral spill file {}/{} (Not from this address)", *file_worker_->file_dir_, *file_worker_->file_name_));
+                LOG_WARN(Format("BufferObj::Load() kEphemeral spill file {}/{} (Not from this address)", *file_worker_->file_dir_, *file_worker_->file_name_));
             }
             file_worker_->ReadFromFile(type_ != BufferType::kPersistent);
             if (type_ == BufferType::kEphemeral) {
@@ -116,7 +116,7 @@ bool BufferObj::Free() {
                     break;
                 }
                 case BufferType::kEphemeral: {
-                    LOG_WARN(Format("{}: Free kEphemeral.", *file_worker_->file_name_));
+                    LOG_WARN(Format("BufferObj::Free {}/{}: Free kEphemeral.", *file_worker_->file_dir_, *file_worker_->file_name_));
                     file_worker_->WriteToFile(true);
                     break;
                 }
@@ -142,7 +142,7 @@ bool BufferObj::Save() {
     switch (status_) {
         case BufferStatus::kLoaded:
         case BufferStatus::kUnloaded: {
-            LOG_WARN(Format("{}/{}: Save kEphemeral.", *file_worker_->file_dir_, *file_worker_->file_name_));
+            LOG_WARN(Format("BufferObj::Save() {}/{}: Save kEphemeral.", *file_worker_->file_dir_, *file_worker_->file_name_));
             file_worker_->WriteToFile(false);
             break;
         }
@@ -163,7 +163,7 @@ bool BufferObj::Save() {
 void BufferObj::Sync() { file_worker_->Sync(); }
 
 void BufferObj::CloseFile() {
-    LOG_WARN(Format("BufferObj::Close {}", *file_worker_->file_name_));
+    LOG_WARN(Format("BufferObj::CloseFile() {}/{}", *file_worker_->file_dir_, *file_worker_->file_name_));
     file_worker_->CloseFile();
     rw_locker_.unlock();
 }

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -55,9 +55,6 @@ BufferHandle BufferObj::Load() {
         }
         case BufferStatus::kFreed: {
             buffer_mgr_->RequestSpace(GetBufferSize(), this);
-            if (type_ != BufferType::kPersistent) {
-                LOG_WARN(Format("BufferObj::Load() kEphemeral spill file {}/{} (Not from this address)", *file_worker_->file_dir_, *file_worker_->file_name_));
-            }
             file_worker_->ReadFromFile(type_ != BufferType::kPersistent);
             if (type_ == BufferType::kEphemeral) {
                 type_ = BufferType::kTemp;
@@ -78,7 +75,6 @@ BufferHandle BufferObj::Load() {
 
 void BufferObj::GetMutPointer() {
     UniqueLock<RWMutex> w_locker(rw_locker_);
-    // LOG_WARN(Format("GetMutPointer of file {}/{} (Not from this address)", *file_worker_->file_dir_, *file_worker_->file_name_));
     type_ = BufferType::kEphemeral;
 }
 
@@ -116,7 +112,6 @@ bool BufferObj::Free() {
                     break;
                 }
                 case BufferType::kEphemeral: {
-                    LOG_WARN(Format("BufferObj::Free {}/{}: Free kEphemeral.", *file_worker_->file_dir_, *file_worker_->file_name_));
                     file_worker_->WriteToFile(true);
                     break;
                 }
@@ -142,7 +137,6 @@ bool BufferObj::Save() {
     switch (status_) {
         case BufferStatus::kLoaded:
         case BufferStatus::kUnloaded: {
-            LOG_WARN(Format("BufferObj::Save() {}/{}: Save kEphemeral.", *file_worker_->file_dir_, *file_worker_->file_name_));
             file_worker_->WriteToFile(false);
             break;
         }
@@ -163,7 +157,6 @@ bool BufferObj::Save() {
 void BufferObj::Sync() { file_worker_->Sync(); }
 
 void BufferObj::CloseFile() {
-    LOG_WARN(Format("BufferObj::CloseFile() {}/{}", *file_worker_->file_dir_, *file_worker_->file_name_));
     file_worker_->CloseFile();
     rw_locker_.unlock();
 }

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -97,9 +97,9 @@ void FileWorker::MoveFile() {
     if (!fs.Exists(dest_dir)) {
         fs.CreateDirectory(dest_dir);
     }
-    if (fs.Exists(dest_path)) {
-        Error<StorageException>(Format("File {} was already been created before.", dest_path));
-    }
+    // if (fs.Exists(dest_path)) {
+    //     Error<StorageException>(Format("File {} was already been created before.", dest_path));
+    // }
     fs.Rename(src_path, dest_path);
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

CI test fail.

### What is changed and how it works?

1. Add thread id in log
2. Add lock in whole process of BufferObj::Save(), BufferObj::Sync() and BufferObj::CloseFile() to avoid thread race.
3. Remove dest exist check in FileHandle::Move ()

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer