### PR TITLE
Fix bug

### DIFF
--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -129,7 +129,7 @@ bool BufferObj::Free() {
 
 bool BufferObj::Save() {
     bool write = false;
-    rw_locker_.lock(); // This lock will be released in CloseFile()
+    rw_locker_.lock(); // This lock will be released on return if not write, otherwise released by CloseFile()
     if (type_ != BufferType::kPersistent) {
         switch (status_) {
             case BufferStatus::kLoaded:

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -128,30 +128,32 @@ bool BufferObj::Free() {
 }
 
 bool BufferObj::Save() {
+    bool write = false;
     rw_locker_.lock(); // This lock will be released in CloseFile()
-    if (type_ == BufferType::kPersistent) {
-        // No need to save because of no change happens
+    if (type_ != BufferType::kPersistent) {
+        switch (status_) {
+            case BufferStatus::kLoaded:
+            case BufferStatus::kUnloaded: {
+                file_worker_->WriteToFile(false);
+                write = true;
+                break;
+            }
+            case BufferStatus::kFreed: {
+                file_worker_->MoveFile();
+                break;
+            }
+            default: {
+                UniquePtr<String> err_msg = MakeUnique<String>("Invalid buffer status.");
+                LOG_ERROR(*err_msg);
+                Error<StorageException>(*err_msg);
+            }
+        }
+        type_ = BufferType::kPersistent;
+    }
+    if (!write) {
         rw_locker_.unlock();
-        return false;
     }
-    switch (status_) {
-        case BufferStatus::kLoaded:
-        case BufferStatus::kUnloaded: {
-            file_worker_->WriteToFile(false);
-            break;
-        }
-        case BufferStatus::kFreed: {
-            file_worker_->MoveFile();
-            break;
-        }
-        default: {
-            UniquePtr<String> err_msg = MakeUnique<String>("Invalid buffer status.");
-            LOG_ERROR(*err_msg);
-            Error<StorageException>(*err_msg);
-        }
-    }
-    type_ = BufferType::kPersistent;
-    return true;
+    return write;
 }
 
 void BufferObj::Sync() { file_worker_->Sync(); }

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -48,6 +48,13 @@ class BufferObjTest : public BaseTest {
 TEST_F(BufferObjTest, test1) {
     using namespace infinity;
 
+    auto SaveBufferObj = [](BufferObj *buffer_obj) {
+        if (buffer_obj->Save()) {
+            buffer_obj->Sync();
+            buffer_obj->CloseFile();
+        }
+    };
+
     SizeT memory_limit = 1024;
     auto temp_dir = MakeShared<String>("/tmp/infinity/spill");
     auto base_dir = MakeShared<String>("/tmp/infinity/data");
@@ -117,7 +124,7 @@ TEST_F(BufferObjTest, test1) {
     // kUnloaded, kTemp -> kFreed, kTemp
     EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
 
-    buf1->Save();
+    SaveBufferObj(buf1);
     // kFreed, kTemp -> kFreed, kPersistent
     EXPECT_EQ(buf1->type(), BufferType::kPersistent);
 
@@ -148,7 +155,7 @@ TEST_F(BufferObjTest, test1) {
         EXPECT_EQ(buf1->type(), BufferType::kEphemeral);
     }
 
-    buf1->Save();
+    SaveBufferObj(buf1);
     // kUnloadedModified, kEphemeral -> kUnloaded, kPersistent
     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
     EXPECT_EQ(buf1->type(), BufferType::kPersistent);
@@ -160,7 +167,7 @@ TEST_F(BufferObjTest, test1) {
         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
         EXPECT_EQ(buf1->type(), BufferType::kEphemeral);
 
-        buf1->Save();
+        SaveBufferObj(buf1);
         // kLoaded, kEphemeral -> kLoaded, kPersistent
         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
         EXPECT_EQ(buf1->type(), BufferType::kPersistent);
@@ -173,7 +180,7 @@ TEST_F(BufferObjTest, test1) {
 
     {
         auto handle1 = buf1->Load();
-        buf1->Save();
+        SaveBufferObj(buf1);
         // kLoaded, kEphemeral -> kLoaded, kPersistent
         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
         EXPECT_EQ(buf1->type(), BufferType::kPersistent);
@@ -186,7 +193,7 @@ TEST_F(BufferObjTest, test1) {
     { auto handle2 = buf2->Load(); }
     {
         auto handle1 = buf1->Load();
-        buf1->Save();
+        SaveBufferObj(buf1);
         // kLoaded, kPersistent -> kLoaded, kPersistent
         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
         EXPECT_EQ(buf1->type(), BufferType::kPersistent);
@@ -197,7 +204,7 @@ TEST_F(BufferObjTest, test1) {
     }
     { auto handle2 = buf2->Load(); }
     { auto handle1 = buf1->Load(); }
-    buf1->Save();
+    SaveBufferObj(buf1);
     // kUnloaded, kPersistent -> kUnloaded, kPersistent
     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
     EXPECT_EQ(buf1->type(), BufferType::kPersistent);

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -25,6 +25,8 @@ import data_file_worker;
 import global_resource_usage;
 import infinity_context;
 
+using namespace infinity;
+
 class BufferObjTest : public BaseTest {
     void SetUp() override {
         BaseTest::SetUp();
@@ -41,20 +43,19 @@ class BufferObjTest : public BaseTest {
         infinity::GlobalResourceUsage::UnInit();
         BaseTest::TearDown();
     }
-};
 
-// Test status transfer of buffer handle.
-// ?? status transfer in all
-TEST_F(BufferObjTest, test1) {
-    using namespace infinity;
-
-    auto SaveBufferObj = [](BufferObj *buffer_obj) {
+public:
+    void SaveBufferObj(BufferObj *buffer_obj) {
         if (buffer_obj->Save()) {
             buffer_obj->Sync();
             buffer_obj->CloseFile();
         }
     };
+};
 
+// Test status transfer of buffer handle.
+// ?? status transfer in all
+TEST_F(BufferObjTest, test1) {
     SizeT memory_limit = 1024;
     auto temp_dir = MakeShared<String>("/tmp/infinity/spill");
     auto base_dir = MakeShared<String>("/tmp/infinity/data");


### PR DESCRIPTION
### What problem does this PR solve?

Fix unit test fail

### What is changed and how it works?

1. Fix bufferobj unit test dead lock bug. Do not use bufferobj.Save() without following bufferobj.CloseFile()
2. Fix bufferobj move file dead lock bug. bufferobj.Save() return false if call move file.

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer