### PR TITLE
Build KNN index in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ parser.output
 #query_parser.h
 #query_parser.cpp
 
+test/data/csv/test_sort.csv
+test/sql/dql/sort.slt
 test/data/csv/*big*.csv
 test/sql/**/*big*.slt
 test/data/fvecs/

--- a/benchmark/local_infinity/knn/knn_import_benchmark.cpp
+++ b/benchmark/local_infinity/knn/knn_import_benchmark.cpp
@@ -37,16 +37,11 @@ import query_result;
 
 using namespace infinity;
 
-int main(int argc, char *argv[]) {
-    if (argc != 2) {
-        std::cout << "import sift or gist" << std::endl;
-        return 1;
-    }
+int main() {
     bool sift = true;
-    if (strcmp(argv[1], "sift") && strcmp(argv[1], "gist")) {
-        return 1;
-    }
-    sift = strcmp(argv[1], "sift") == 0;
+    int M = 16;
+    int ef_construct = 200;
+    std::cout << "benchmark: " << (sift ? "sift" : "gist") << std::endl;
 
     std::string data_path = "/tmp/infinity";
 
@@ -75,13 +70,14 @@ int main(int argc, char *argv[]) {
         if (sift) {
             col1_type = std::make_shared<DataType>(LogicalType::kEmbedding, std::make_shared<EmbeddingInfo>(EmbeddingDataType::kElemFloat, 128));
             base_path += "/benchmark/sift_1m/sift_base.fvecs";
-            table_name = "sift_benchmark";
+            table_name = "sift_benchmark_M" + std::to_string(M) + "_ef" + std::to_string(ef_construct);
         } else {
             col1_type = std::make_shared<DataType>(LogicalType::kEmbedding, std::make_shared<EmbeddingInfo>(EmbeddingDataType::kElemFloat, 960));
             base_path += "/benchmark/gist_1m/gist_base.fvecs";
-            table_name = "gist_benchmark";
+            table_name = "gist_benchmark_M" + std::to_string(M) + "_ef" + std::to_string(ef_construct);
         }
         std::cout << "Import from: " << base_path << std::endl;
+        std::cout << "table_name: " << table_name << std::endl;
 
         std::string col1_name = "col1";
         auto col1_def = std::make_unique<ColumnDef>(0, col1_type, col1_name, std::unordered_set<ConstraintType>());
@@ -123,8 +119,8 @@ int main(int argc, char *argv[]) {
 
             {
                 auto index_param_list = new std::vector<InitParameter *>();
-                index_param_list->emplace_back(new InitParameter("M", std::to_string(16)));
-                index_param_list->emplace_back(new InitParameter("ef_construction", std::to_string(200)));
+                index_param_list->emplace_back(new InitParameter("M", std::to_string(M)));
+                index_param_list->emplace_back(new InitParameter("ef_construction", std::to_string(ef_construct)));
                 index_param_list->emplace_back(new InitParameter("ef", std::to_string(200)));
                 index_param_list->emplace_back(new InitParameter("metric", "l2"));
                 index_param_list->emplace_back(new InitParameter("encode", "lvq"));

--- a/benchmark/local_infinity/knn/knn_query_benchmark.cpp
+++ b/benchmark/local_infinity/knn/knn_query_benchmark.cpp
@@ -84,24 +84,18 @@ inline void ParallelFor(size_t start, size_t end, size_t numThreads, Function fn
     }
 }
 
-int main(int argc, char *argv[]) {
-    if (argc != 3) {
-        std::cout << "query gist/sift ef=?" << std::endl;
-        return 1;
-    }
+int main() {
     bool sift = true;
-    if (strcmp(argv[1], "sift") && strcmp(argv[1], "gist")) {
-        return 1;
-    }
-    sift = strcmp(argv[1], "sift") == 0;
-    size_t ef = std::stoull(argv[2]);
-
+    int ef = 100;
+    int M = 16;
+    int ef_construct = 200;
     size_t thread_num = 1;
-    size_t total_times = 1;
-    std::cout << "Please input thread_num, 0 means use all resources:" << std::endl;
-    std::cin >> thread_num;
-    std::cout << "Please input total_times:" << std::endl;
-    std::cin >> total_times;
+    size_t total_times = 3;
+
+    std::cout << "benchmark: " << (sift ? "sift" : "gist") << std::endl;
+    std::cout << "ef: " << ef << std::endl;
+    std::cout << "thread_n: " << thread_num << std::endl;
+    std::cout << "total_times: " << total_times << std::endl;
 
     std::string path = "/tmp/infinity";
     LocalFileSystem fs;
@@ -123,15 +117,16 @@ int main(int argc, char *argv[]) {
         dimension = 128;
         query_path += "/benchmark/sift_1m/sift_query.fvecs";
         groundtruth_path += "/benchmark/sift_1m/sift_groundtruth.ivecs";
-        table_name = "sift_benchmark";
+        table_name = "sift_benchmark_M" + std::to_string(M) + "_ef" + std::to_string(ef_construct);
     } else {
         dimension = 960;
         query_path += "/benchmark/gist_1m/gist_query.fvecs";
         groundtruth_path += "/benchmark/gist_1m/gist_groundtruth.ivecs";
-        table_name = "gist_benchmark";
+        table_name = "gist_benchmark_M" + std::to_string(M) + "_ef" + std::to_string(ef_construct);
     }
     std::cout << "query from: " << query_path << std::endl;
     std::cout << "groundtruth is: " << groundtruth_path << std::endl;
+    std::cout << "table_name: " << table_name << std::endl;
 
     if (!fs.Exists(query_path)) {
         std::cerr << "File: " << query_path << " doesn't exist" << std::endl;
@@ -218,7 +213,7 @@ int main(int argc, char *argv[]) {
                     query_results[query_idx].emplace_back(data[i].ToUint64());
                 }
             }
-//            delete[] embedding_data_ptr;
+            // delete[] embedding_data_ptr;
         };
         BaseProfiler profiler;
         profiler.Begin();

--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -30,6 +30,7 @@ module;
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <shared_mutex>
@@ -211,6 +212,7 @@ export {
     using atomic_u32 = std::atomic_uint32_t;
     using atomic_u64 = std::atomic_uint64_t;
     using ai64 = std::atomic_int64_t;
+    using ai32 = std::atomic_int32_t;
     using aptr = std::atomic_uintptr_t;
     using atomic_bool = std::atomic_bool;
 
@@ -359,6 +361,8 @@ export {
     template <typename T>
     using LockGuard = std::lock_guard<T>;
 
+    using TryToLock = std::try_to_lock_t;
+
     constexpr std::memory_order MemoryOrderRelax = std::memory_order::relaxed;
     constexpr std::memory_order MemoryOrderConsume = std::memory_order::consume;
     constexpr std::memory_order MemoryOrderRelease = std::memory_order::release;
@@ -431,6 +435,12 @@ export template <typename T1, typename T2>
 struct CompareByFirst {
     using P = std::pair<T1, T2>;
     bool operator()(const P &lhs, const P &rhs) const { return lhs.first < rhs.first; }
+};
+
+export template <typename T1, typename T2>
+struct CompareByFirstReverse {
+    using P = std::pair<T1, T2>;
+    bool operator()(const P &lhs, const P &rhs) const { return lhs.first > rhs.first; }
 };
 
 } // namespace infinity

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -143,6 +143,51 @@ void FragmentBuilder::BuildFragments(PhysicalOperator *phys_op, PlanFragment *cu
             current_fragment_ptr->AddChild(Move(next_plan_fragment));
             return;
         }
+        case PhysicalOperatorType::kCreateIndexPrepare: {
+            if (phys_op->left() != nullptr || phys_op->right() != nullptr) {
+                Error<SchedulerException>(Format("Invalid input node of {}", phys_op->GetName()));
+            }
+            current_fragment_ptr->AddOperator(phys_op);
+            current_fragment_ptr->SetFragmentType(FragmentType::kSerialMaterialize);
+            current_fragment_ptr->SetSourceNode(query_context_ptr_, SourceType::kEmpty, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
+            return;
+        }
+        case PhysicalOperatorType::kCreateIndexDo: {
+            if (phys_op->left() == nullptr || phys_op->right() != nullptr) {
+                Error<SchedulerException>(Format("Invalid input node of {}", phys_op->GetName()));
+            }
+            current_fragment_ptr->AddOperator(phys_op);
+            current_fragment_ptr->SetFragmentType(FragmentType::kParallelMaterialize);
+            current_fragment_ptr->SetSourceNode(query_context_ptr_, SourceType::kLocalQueue, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
+
+            auto next_plan_fragment = MakeUnique<PlanFragment>(GetFragmentId());
+            next_plan_fragment->SetSinkNode(query_context_ptr_,
+                                            SinkType::kLocalQueue,
+                                            phys_op->left()->GetOutputNames(),
+                                            phys_op->left()->GetOutputTypes());
+            BuildFragments(phys_op->left(), next_plan_fragment.get());
+
+            current_fragment_ptr->AddChild(Move(next_plan_fragment));
+            return;
+        }
+        case PhysicalOperatorType::kCreateIndexFinish: {
+            if (phys_op->left() == nullptr || phys_op->right() != nullptr) {
+                Error<SchedulerException>(Format("Invalid input node of {}", phys_op->GetName()));
+            }
+            current_fragment_ptr->AddOperator(phys_op);
+            current_fragment_ptr->SetFragmentType(FragmentType::kSerialMaterialize);
+            current_fragment_ptr->SetSourceNode(query_context_ptr_, SourceType::kLocalQueue, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
+
+            auto next_plan_fragment = MakeUnique<PlanFragment>(GetFragmentId());
+            next_plan_fragment->SetSinkNode(query_context_ptr_,
+                                            SinkType::kLocalQueue,
+                                            phys_op->left()->GetOutputNames(),
+                                            phys_op->left()->GetOutputTypes());
+            BuildFragments(phys_op->left(), next_plan_fragment.get());
+
+            current_fragment_ptr->AddChild(Move(next_plan_fragment));
+            return;
+        }
         case PhysicalOperatorType::kParallelAggregate:
         case PhysicalOperatorType::kFilter:
         case PhysicalOperatorType::kHash:

--- a/src/executor/fragment_builder.cppm
+++ b/src/executor/fragment_builder.cppm
@@ -29,9 +29,9 @@ public:
 
     UniquePtr<PlanFragment> BuildFragment(PhysicalOperator *phys_op);
 
+private:
     void BuildFragments(PhysicalOperator *phys_op, PlanFragment *current_fragment_ptr);
 
-private:
     void BuildExplain(PhysicalOperator *phys_op, PlanFragment *current_fragment_ptr);
 
     idx_t GetFragmentId() { return fragment_id_++; }

--- a/src/executor/operator/physical_create_index_do.cpp
+++ b/src/executor/operator/physical_create_index_do.cpp
@@ -1,0 +1,48 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import parser;
+import physical_operator_type;
+import physical_operator;
+import query_context;
+import operator_state;
+import load_meta;
+
+import index_def;
+
+module physical_create_index_do;
+
+namespace infinity {
+PhysicalCreateIndexDo::PhysicalCreateIndexDo(u64 id,
+                                             UniquePtr<PhysicalOperator> left,
+                                             SharedPtr<String> schema_name,
+                                             SharedPtr<String> table_name,
+                                             SharedPtr<IndexDef> index_definition,
+                                             SharedPtr<Vector<String>> output_names,
+                                             SharedPtr<Vector<SharedPtr<DataType>>> output_types,
+                                             SharedPtr<Vector<LoadMeta>> load_metas)
+    : PhysicalOperator(PhysicalOperatorType::kCreateIndexDo, Move(left), nullptr, id, load_metas), schema_name_(schema_name), table_name_(table_name),
+      index_def_ptr_(index_definition), output_names_(output_names), output_types_(output_types) {}
+
+void PhysicalCreateIndexDo::Init() {}
+
+bool PhysicalCreateIndexDo::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    auto create_index_do_state = static_cast<CreateIndexDoOperatorState *>(operator_state);
+    //
+}
+
+}; // namespace infinity

--- a/src/executor/operator/physical_create_index_do.cpp
+++ b/src/executor/operator/physical_create_index_do.cpp
@@ -23,26 +23,162 @@ import operator_state;
 import load_meta;
 
 import index_def;
+import create_index_data;
+import base_table_ref;
+import table_collection_entry;
+import table_index_entry;
+import segment_column_index_entry;
+import status;
+import infinity_exception;
+import buffer_handle;
+import index_hnsw;
+import index_base;
+import hnsw_common;
+import dist_func_l2;
+import dist_func_ip;
+import hnsw_alg;
+import lvq_store;
+import plain_store;
+import buffer_manager;
+import txn_store;
 
 module physical_create_index_do;
 
 namespace infinity {
 PhysicalCreateIndexDo::PhysicalCreateIndexDo(u64 id,
                                              UniquePtr<PhysicalOperator> left,
-                                             SharedPtr<String> schema_name,
-                                             SharedPtr<String> table_name,
-                                             SharedPtr<IndexDef> index_definition,
+                                             SharedPtr<BaseTableRef> base_table_ref,
+                                             SharedPtr<String> index_name,
                                              SharedPtr<Vector<String>> output_names,
                                              SharedPtr<Vector<SharedPtr<DataType>>> output_types,
                                              SharedPtr<Vector<LoadMeta>> load_metas)
-    : PhysicalOperator(PhysicalOperatorType::kCreateIndexDo, Move(left), nullptr, id, load_metas), schema_name_(schema_name), table_name_(table_name),
-      index_def_ptr_(index_definition), output_names_(output_names), output_types_(output_types) {}
+    : PhysicalOperator(PhysicalOperatorType::kCreateIndexDo, Move(left), nullptr, id, load_metas), base_table_ref_(base_table_ref),
+      index_name_(index_name), output_names_(output_names), output_types_(output_types) {}
 
 void PhysicalCreateIndexDo::Init() {}
 
+// FIXME: fetch and add a block one time
+template <typename Hnsw>
+void InsertHnsw(HashMap<u32, atomic_u64> &create_index_idxes,
+                const HashMap<u32, SharedPtr<SegmentColumnIndexEntry>> &segment_column_index_entries,
+                BufferManager *buffer_mgr) {
+    for (auto &[segment_id, create_index_idx] : create_index_idxes) {
+        auto iter = segment_column_index_entries.find(segment_id);
+        if (iter == segment_column_index_entries.end()) {
+            Error<ExecutorException>("Segment id not found in column index entry.");
+        }
+        auto *segment_column_index_entry = iter->second.get();
+
+        auto buffer_handle = SegmentColumnIndexEntry::GetIndex(segment_column_index_entry, buffer_mgr);
+        auto *hnsw_index = static_cast<Hnsw *>(buffer_handle.GetDataMut());
+
+        SizeT vertex_n = hnsw_index->GetVertexNum();
+        while (true) {
+            SizeT idx = create_index_idx.fetch_add(1);
+            if (idx >= vertex_n) {
+                break;
+            }
+            hnsw_index->Build(idx);
+        }
+    }
+}
+
 bool PhysicalCreateIndexDo::Execute(QueryContext *query_context, OperatorState *operator_state) {
-    auto create_index_do_state = static_cast<CreateIndexDoOperatorState *>(operator_state);
-    //
+    auto *txn = query_context->GetTxn();
+    auto *create_index_do_state = static_cast<CreateIndexDoOperatorState *>(operator_state);
+    auto &create_index_idxes = create_index_do_state->create_index_shared_data_->create_index_idxes_;
+
+    TableCollectionEntry *table_entry = nullptr;
+    Status get_table_entry_status = txn->GetTableEntry(*base_table_ref_->schema_name(), *base_table_ref_->table_name(), table_entry);
+    if (!get_table_entry_status.ok()) {
+        operator_state->error_message_ = Move(get_table_entry_status.msg_);
+        return false;
+    }
+
+    TxnTableStore *table_store = txn->GetTxnTableStore(table_entry);
+    auto iter = table_store->txn_indexes_store_.find(*index_name_);
+    if (iter == table_store->txn_indexes_store_.end()) {
+        Error<ExecutorException>("Index name not found in txn index store.");
+    }
+    TxnIndexStore &txn_index_store = iter->second;
+
+    auto *table_index_entry = txn_index_store.table_index_entry_;
+    if (table_index_entry->index_def_->index_array_.size() != 1) {
+        Error<NotImplementException>("Not implemented");
+    }
+    auto *index_base = table_index_entry->index_def_->index_array_[0].get();
+    auto *hnsw_def = static_cast<IndexHnsw *>(index_base);
+
+    if (txn_index_store.index_entry_map_.size() != 1) {
+        Error<NotImplementException>("Not implemented");
+    }
+    const auto &[column_id, segment_column_index_entries] = *txn_index_store.index_entry_map_.begin();
+
+    auto *column_def = table_entry->columns_[column_id].get();
+    if (column_def->type()->type() != LogicalType::kEmbedding) {
+        Error<ExecutorException>("Create index on non-embedding column is not supported yet.");
+    }
+    TypeInfo *type_info = column_def->type()->type_info().get();
+    auto embedding_info = static_cast<EmbeddingInfo *>(type_info);
+
+    switch (embedding_info->Type()) {
+        case kElemFloat: {
+            switch (hnsw_def->encode_type_) {
+                case HnswEncodeType::kPlain: {
+                    switch (hnsw_def->metric_type_) {
+                        case MetricType::kMerticInnerProduct: {
+                            InsertHnsw<KnnHnsw<float, u64, PlainStore<float>, PlainIPDist<float>>>(create_index_idxes,
+                                                                                                   segment_column_index_entries,
+                                                                                                   txn->GetBufferMgr());
+                            break;
+                        }
+                        case MetricType::kMerticL2: {
+                            InsertHnsw<KnnHnsw<float, u64, PlainStore<float>, PlainL2Dist<float>>>(create_index_idxes,
+                                                                                                   segment_column_index_entries,
+                                                                                                   txn->GetBufferMgr());
+                            break;
+                        }
+                        default: {
+                            Error<StorageException>("Not implemented");
+                        }
+                    }
+                    break;
+                }
+                case HnswEncodeType::kLVQ: {
+                    switch (hnsw_def->metric_type_) {
+                        case MetricType::kMerticInnerProduct: {
+                            InsertHnsw<KnnHnsw<float, u64, LVQStore<float, i8, LVQIPCache<float, i8>>, LVQIPDist<float, i8>>>(
+                                create_index_idxes,
+                                segment_column_index_entries,
+                                txn->GetBufferMgr());
+                            break;
+                        }
+                        case MetricType::kMerticL2: {
+                            InsertHnsw<KnnHnsw<float, u64, LVQStore<float, i8, LVQL2Cache<float, i8>>, LVQL2Dist<float, i8>>>(
+                                create_index_idxes,
+                                segment_column_index_entries,
+                                txn->GetBufferMgr());
+                            break;
+                        }
+                        default: {
+                            Error<StorageException>("Not implemented");
+                        }
+                    }
+                    break;
+                }
+                default: {
+                    Error<StorageException>("Not implemented");
+                }
+            }
+            break;
+        }
+        default: {
+            Error<NotImplementException>("Create index on non-float embedding column is not supported yet.");
+        }
+    }
+    operator_state->SetComplete();
+
+    return true;
 }
 
 }; // namespace infinity

--- a/src/executor/operator/physical_create_index_do.cppm
+++ b/src/executor/operator/physical_create_index_do.cppm
@@ -1,0 +1,60 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import parser;
+import physical_operator_type;
+import physical_operator;
+import query_context;
+import operator_state;
+import load_meta;
+
+import index_def;
+
+export module physical_create_index_do;
+
+namespace infinity {
+
+export class PhysicalCreateIndexDo : public PhysicalOperator {
+public:
+    PhysicalCreateIndexDo(u64 id,
+                          UniquePtr<PhysicalOperator> left,
+                          SharedPtr<String> schema_name,
+                          SharedPtr<String> table_name,
+                          SharedPtr<IndexDef> index_definition,
+                          SharedPtr<Vector<String>> output_names,
+                          SharedPtr<Vector<SharedPtr<DataType>>> output_types,
+                          SharedPtr<Vector<LoadMeta>> load_metas);
+
+public:
+    void Init() override;
+
+    bool Execute(QueryContext *query_context, OperatorState *operator_state) override;
+
+    SharedPtr<Vector<String>> GetOutputNames() const override { return output_names_; }
+
+    SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }
+
+public:
+    const SharedPtr<String> schema_name_{};
+    const SharedPtr<String> table_name_{};
+    const SharedPtr<IndexDef> index_def_ptr_{};
+
+    const SharedPtr<Vector<String>> output_names_{};
+    const SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};
+};
+
+} // namespace infinity

--- a/src/executor/operator/physical_create_index_do.cppm
+++ b/src/executor/operator/physical_create_index_do.cppm
@@ -23,6 +23,7 @@ import operator_state;
 import load_meta;
 
 import index_def;
+import base_table_ref;
 
 export module physical_create_index_do;
 
@@ -32,9 +33,8 @@ export class PhysicalCreateIndexDo : public PhysicalOperator {
 public:
     PhysicalCreateIndexDo(u64 id,
                           UniquePtr<PhysicalOperator> left,
-                          SharedPtr<String> schema_name,
-                          SharedPtr<String> table_name,
-                          SharedPtr<IndexDef> index_definition,
+                          SharedPtr<BaseTableRef> base_table_ref,
+                          SharedPtr<String> index_name,
                           SharedPtr<Vector<String>> output_names,
                           SharedPtr<Vector<SharedPtr<DataType>>> output_types,
                           SharedPtr<Vector<LoadMeta>> load_metas);
@@ -49,9 +49,9 @@ public:
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }
 
 public:
-    const SharedPtr<String> schema_name_{};
-    const SharedPtr<String> table_name_{};
-    const SharedPtr<IndexDef> index_def_ptr_{};
+    // for create fragemnt context
+    const SharedPtr<BaseTableRef> base_table_ref_{};
+    const SharedPtr<String> index_name_{};
 
     const SharedPtr<Vector<String>> output_names_{};
     const SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};

--- a/src/executor/operator/physical_create_index_do.cppm
+++ b/src/executor/operator/physical_create_index_do.cppm
@@ -44,6 +44,8 @@ public:
 
     bool Execute(QueryContext *query_context, OperatorState *operator_state) override;
 
+    SizeT TaskletCount() override { return 0; }
+
     SharedPtr<Vector<String>> GetOutputNames() const override { return output_names_; }
 
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }

--- a/src/executor/operator/physical_create_index_finish.cpp
+++ b/src/executor/operator/physical_create_index_finish.cpp
@@ -1,0 +1,42 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import parser;
+import physical_operator_type;
+import physical_operator;
+import query_context;
+import operator_state;
+import load_meta;
+
+module physical_create_index_finish;
+
+namespace infinity {
+PhysicalCreateIndexFinish::PhysicalCreateIndexFinish(u64 id,
+                                                     UniquePtr<PhysicalOperator> left,
+                                                     SharedPtr<Vector<String>> output_names,
+                                                     SharedPtr<Vector<SharedPtr<DataType>>> output_types,
+                                                     SharedPtr<Vector<LoadMeta>> load_metas)
+    : PhysicalOperator(PhysicalOperatorType::kCreateIndexFinish, Move(left), nullptr, id, load_metas), output_names_(output_names),
+      output_types_(output_types) {}
+
+void PhysicalCreateIndexFinish::Init() {}
+
+bool PhysicalCreateIndexFinish::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    //
+}
+
+} // namespace infinity

--- a/src/executor/operator/physical_create_index_finish.cppm
+++ b/src/executor/operator/physical_create_index_finish.cppm
@@ -42,6 +42,8 @@ public:
 
     bool Execute(QueryContext *query_context, OperatorState *operator_state) override;
 
+    SizeT TaskletCount() override { return 1; }
+
     SharedPtr<Vector<String>> GetOutputNames() const override { return output_names_; }
 
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }

--- a/src/executor/operator/physical_create_index_finish.cppm
+++ b/src/executor/operator/physical_create_index_finish.cppm
@@ -21,6 +21,7 @@ import physical_operator;
 import query_context;
 import operator_state;
 import load_meta;
+import index_def;
 
 export module physical_create_index_finish;
 
@@ -29,6 +30,9 @@ export class PhysicalCreateIndexFinish : public PhysicalOperator {
 public:
     PhysicalCreateIndexFinish(u64 id,
                               UniquePtr<PhysicalOperator> left,
+                              SharedPtr<String> db_name,
+                              SharedPtr<String> table_name,
+                              SharedPtr<IndexDef> index_def,
                               SharedPtr<Vector<String>> output_names,
                               SharedPtr<Vector<SharedPtr<DataType>>> output_types,
                               SharedPtr<Vector<LoadMeta>> load_metas);
@@ -43,6 +47,10 @@ public:
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }
 
 public:
+    const SharedPtr<String> db_name_{};
+    const SharedPtr<String> table_name_{};
+    const SharedPtr<IndexDef> index_def_{};
+
     const SharedPtr<Vector<String>> output_names_{};
     const SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};
 };

--- a/src/executor/operator/physical_create_index_finish.cppm
+++ b/src/executor/operator/physical_create_index_finish.cppm
@@ -1,0 +1,50 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import parser;
+import physical_operator_type;
+import physical_operator;
+import query_context;
+import operator_state;
+import load_meta;
+
+export module physical_create_index_finish;
+
+namespace infinity {
+export class PhysicalCreateIndexFinish : public PhysicalOperator {
+public:
+    PhysicalCreateIndexFinish(u64 id,
+                              UniquePtr<PhysicalOperator> left,
+                              SharedPtr<Vector<String>> output_names,
+                              SharedPtr<Vector<SharedPtr<DataType>>> output_types,
+                              SharedPtr<Vector<LoadMeta>> load_metas);
+
+public:
+    void Init() override;
+
+    bool Execute(QueryContext *query_context, OperatorState *operator_state) override;
+
+    SharedPtr<Vector<String>> GetOutputNames() const override { return output_names_; }
+
+    SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }
+
+public:
+    const SharedPtr<Vector<String>> output_names_{};
+    const SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};
+};
+
+} // namespace infinity

--- a/src/executor/operator/physical_create_index_prepare.cpp
+++ b/src/executor/operator/physical_create_index_prepare.cpp
@@ -1,0 +1,73 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import parser;
+import physical_operator_type;
+import physical_operator;
+import query_context;
+import operator_state;
+import load_meta;
+
+import index_def;
+import table_collection_entry;
+import status;
+import infinity_exception;
+
+module physical_create_index_prepare;
+
+namespace infinity {
+PhysicalCreateIndexPrepare::PhysicalCreateIndexPrepare(u64 id,
+                                                       SharedPtr<String> schema_name,
+                                                       SharedPtr<String> table_name,
+                                                       SharedPtr<IndexDef> index_definition,
+                                                       ConflictType conflict_type,
+                                                       SharedPtr<Vector<String>> output_names,
+                                                       SharedPtr<Vector<SharedPtr<DataType>>> output_types,
+                                                       SharedPtr<Vector<LoadMeta>> load_metas)
+    : PhysicalOperator(PhysicalOperatorType::kCreateIndexPrepare, nullptr, nullptr, id, load_metas), schema_name_(schema_name),
+      table_name_(table_name), index_def_ptr_(index_definition), conflict_type_(conflict_type), output_names_(output_names),
+      output_types_(output_types) {}
+
+void PhysicalCreateIndexPrepare::Init() {}
+
+bool PhysicalCreateIndexPrepare::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    auto *txn = query_context->GetTxn();
+    TableCollectionEntry *table_entry = nullptr;
+    Status get_table_status = txn->GetTableEntry(*schema_name_, *table_name_, table_entry);
+    if (!get_table_status.ok()) {
+        operator_state->error_message_ = Move(get_table_status.msg_);
+        return false;
+    }
+    Status create_index_status = txn->CreateIndex(*table_name_, table_entry, index_def_ptr_, conflict_type_);
+    if (!create_index_status.ok()) {
+        operator_state->error_message_ = Move(create_index_status.msg_);
+        return false;
+    }
+    operator_state->SetComplete();
+    
+    if (index_def_ptr_->index_array_.size() != 1) {
+        Error<ExecutorException>("Index definition size is not 1");
+    }
+    const auto &index_def = index_def_ptr_->index_array_[0];
+    if (index_def->index_type_ != IndexType::kHnsw) {
+        Error<ExecutorException>("Index type is not hnsw");
+    }
+
+    
+    return true;
+}
+} // namespace infinity

--- a/src/executor/operator/physical_create_index_prepare.cpp
+++ b/src/executor/operator/physical_create_index_prepare.cpp
@@ -26,6 +26,26 @@ import index_def;
 import table_collection_entry;
 import status;
 import infinity_exception;
+import base_entry;
+import segment_entry;
+import table_index_entry;
+import column_index_entry;
+import segment_column_index_entry;
+import index_base;
+import index_file_worker;
+import segment_iter;
+import buffer_manager;
+import buffer_handle;
+import index_hnsw;
+import default_values;
+import txn_store;
+
+import hnsw_common;
+import dist_func_l2;
+import dist_func_ip;
+import hnsw_alg;
+import lvq_store;
+import plain_store;
 
 module physical_create_index_prepare;
 
@@ -44,30 +64,137 @@ PhysicalCreateIndexPrepare::PhysicalCreateIndexPrepare(u64 id,
 
 void PhysicalCreateIndexPrepare::Init() {}
 
+template <typename Hnsw>
+void InsertHnswPrepare(BufferHandle buffer_handle, const SegmentEntry *segment_entry, u32 column_id) {
+    auto hnsw_index = static_cast<Hnsw *>(buffer_handle.GetDataMut());
+
+    u32 segment_offset = 0;
+    Vector<u64> row_ids;
+    const auto &block_entries = segment_entry->block_entries_;
+    for (SizeT i = 0; i < block_entries.size(); ++i) {
+        const auto &block_entry = block_entries[i];
+        SizeT block_row_cnt = block_entry->row_count_;
+
+        for (SizeT block_offset = 0; block_offset < block_row_cnt; ++block_offset) {
+            RowID row_id(segment_entry->segment_id_, segment_offset + block_offset);
+            row_ids.push_back(row_id.ToUint64());
+        }
+        segment_offset += DEFAULT_BLOCK_CAPACITY;
+    }
+    OneColumnIterator<float> one_column_iter(segment_entry, column_id);
+
+    hnsw_index->StoreData(one_column_iter, row_ids.data(), row_ids.size());
+}
+
 bool PhysicalCreateIndexPrepare::Execute(QueryContext *query_context, OperatorState *operator_state) {
     auto *txn = query_context->GetTxn();
+    TxnTimeStamp begin_ts = txn->BeginTS();
+    BufferManager *buffer_mgr = txn->GetBufferMgr();
+
     TableCollectionEntry *table_entry = nullptr;
     Status get_table_status = txn->GetTableEntry(*schema_name_, *table_name_, table_entry);
     if (!get_table_status.ok()) {
         operator_state->error_message_ = Move(get_table_status.msg_);
         return false;
     }
-    Status create_index_status = txn->CreateIndex(*table_name_, table_entry, index_def_ptr_, conflict_type_);
+
+    TableIndexEntry *table_index_entry = nullptr;
+    Status create_index_status = txn->CreateIndex(table_entry, index_def_ptr_, conflict_type_, table_index_entry);
     if (!create_index_status.ok()) {
         operator_state->error_message_ = Move(create_index_status.msg_);
         return false;
     }
-    operator_state->SetComplete();
-    
-    if (index_def_ptr_->index_array_.size() != 1) {
-        Error<ExecutorException>("Index definition size is not 1");
+
+    if (table_index_entry->irs_index_entry_.get() != nullptr) {
+        Error<NotImplementException>("TableCollectionEntry::CreateIndexFilePrepare");
     }
-    const auto &index_def = index_def_ptr_->index_array_[0];
-    if (index_def->index_type_ != IndexType::kHnsw) {
-        Error<ExecutorException>("Index type is not hnsw");
+    if (table_index_entry->column_index_map_.size() != 1) {
+        Error<NotImplementException>("TableCollectionEntry::CreateIndexFilePrepare");
+    }
+    auto [column_id, base_entry] = *table_index_entry->column_index_map_.begin();
+    SharedPtr<ColumnDef> column_def = table_entry->columns_[column_id];
+    auto *column_index_entry = static_cast<ColumnIndexEntry *>(base_entry.get());
+
+    for (const auto &[segment_id, segment_entry] : table_entry->segment_map_) {
+        u64 column_id = column_def->id();
+        IndexBase *index_base = column_index_entry->index_base_.get();
+        UniquePtr<CreateIndexParam> create_index_param = SegmentEntry::GetCreateIndexParam(segment_entry.get(), index_base, column_def.get());
+        SharedPtr<SegmentColumnIndexEntry> segment_column_index_entry =
+            SegmentColumnIndexEntry::NewIndexEntry(column_index_entry, segment_entry->segment_id_, begin_ts, buffer_mgr, create_index_param.get());
+
+        if (index_base->index_type_ != IndexType::kHnsw) {
+            Error<StorageException>("Only HNSW index is supported.");
+        }
+        auto *index_hnsw = static_cast<IndexHnsw *>(index_base);
+        if (column_def->type()->type() != LogicalType::kEmbedding) {
+            Error<StorageException>("HNSW supports embedding type.");
+        }
+        TypeInfo *type_info = column_def->type()->type_info().get();
+        auto embedding_info = static_cast<EmbeddingInfo *>(type_info);
+
+        BufferHandle buffer_handle = SegmentColumnIndexEntry::GetIndex(segment_column_index_entry.get(), buffer_mgr);
+        switch (embedding_info->Type()) {
+            case kElemFloat: {
+                switch (index_hnsw->encode_type_) {
+                    case HnswEncodeType::kPlain: {
+                        switch (index_hnsw->metric_type_) {
+                            case MetricType::kMerticInnerProduct: {
+                                InsertHnswPrepare<KnnHnsw<float, u64, PlainStore<float>, PlainIPDist<float>>>(buffer_handle,
+                                                                                                              segment_entry.get(),
+                                                                                                              column_id);
+                                break;
+                            }
+                            case MetricType::kMerticL2: {
+                                InsertHnswPrepare<KnnHnsw<float, u64, PlainStore<float>, PlainL2Dist<float>>>(buffer_handle,
+                                                                                                              segment_entry.get(),
+                                                                                                              column_id);
+                                break;
+                            }
+                            default: {
+                                Error<StorageException>("Not implemented");
+                            }
+                        }
+                        break;
+                    }
+                    case HnswEncodeType::kLVQ: {
+                        switch (index_hnsw->metric_type_) {
+                            case MetricType::kMerticInnerProduct: {
+                                InsertHnswPrepare<KnnHnsw<float, u64, LVQStore<float, i8, LVQIPCache<float, i8>>, LVQIPDist<float, i8>>>(
+                                    buffer_handle,
+                                    segment_entry.get(),
+                                    column_id);
+                                break;
+                            }
+                            case MetricType::kMerticL2: {
+                                InsertHnswPrepare<KnnHnsw<float, u64, LVQStore<float, i8, LVQL2Cache<float, i8>>, LVQL2Dist<float, i8>>>(
+                                    buffer_handle,
+                                    segment_entry.get(),
+                                    column_id);
+                                break;
+                            }
+                            default: {
+                                Error<StorageException>("Not implemented");
+                            }
+                        }
+                        break;
+                    }
+                    default: {
+                        Error<StorageException>("Not implemented");
+                    }
+                }
+                break;
+            }
+            default: {
+                Error<StorageException>("Not implemented");
+            }
+        }
+        TxnTableStore *table_store = txn->GetTxnTableStore(table_entry);
+        table_store->CreateIndexFile(table_index_entry, column_id, segment_id, segment_column_index_entry);
+
+        column_index_entry->index_by_segment.emplace(segment_id, segment_column_index_entry);
     }
 
-    
+    operator_state->SetComplete();
     return true;
 }
 } // namespace infinity

--- a/src/executor/operator/physical_create_index_prepare.cppm
+++ b/src/executor/operator/physical_create_index_prepare.cppm
@@ -43,6 +43,8 @@ public:
 
     bool Execute(QueryContext *query_context, OperatorState *operator_state) override;
 
+    SizeT TaskletCount() override { return 1; }
+
     SharedPtr<Vector<String>> GetOutputNames() const override { return output_names_; }
 
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }

--- a/src/executor/operator/physical_create_index_prepare.cppm
+++ b/src/executor/operator/physical_create_index_prepare.cppm
@@ -1,0 +1,60 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import parser;
+import physical_operator_type;
+import physical_operator;
+import query_context;
+import operator_state;
+import load_meta;
+
+import index_def;
+
+export module physical_create_index_prepare;
+
+namespace infinity {
+export class PhysicalCreateIndexPrepare : public PhysicalOperator {
+public:
+    PhysicalCreateIndexPrepare(u64 id,
+                               SharedPtr<String> schema_name,
+                               SharedPtr<String> table_name,
+                               SharedPtr<IndexDef> index_definition,
+                               ConflictType conflict_type,
+                               SharedPtr<Vector<String>> output_names,
+                               SharedPtr<Vector<SharedPtr<DataType>>> output_types,
+                               SharedPtr<Vector<LoadMeta>> load_metas);
+
+public:
+    void Init() override;
+
+    bool Execute(QueryContext *query_context, OperatorState *operator_state) override;
+
+    SharedPtr<Vector<String>> GetOutputNames() const override { return output_names_; }
+
+    SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const override { return output_types_; }
+
+public:
+    const SharedPtr<String> schema_name_{};
+    const SharedPtr<String> table_name_{};
+    const SharedPtr<IndexDef> index_def_ptr_{};
+    const ConflictType conflict_type_{};
+
+    const SharedPtr<Vector<String>> output_names_{};
+    const SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};
+};
+
+} // namespace infinity

--- a/src/executor/operator/physical_knn_scan.cpp
+++ b/src/executor/operator/physical_knn_scan.cpp
@@ -147,8 +147,8 @@ void PhysicalKnnScan::Init() {}
 
 bool PhysicalKnnScan::Execute(QueryContext *query_context, OperatorState *operator_state) {
     auto *knn_scan_operator_state = static_cast<KnnScanOperatorState *>(operator_state);
-    auto elem_type = knn_scan_operator_state->knn_scan_function_data_->shared_data_->elem_type_;
-    auto dist_type = knn_scan_operator_state->knn_scan_function_data_->shared_data_->knn_distance_type_;
+    auto elem_type = knn_scan_operator_state->knn_scan_function_data_->knn_scan_shared_data_->elem_type_;
+    auto dist_type = knn_scan_operator_state->knn_scan_function_data_->knn_scan_shared_data_->knn_distance_type_;
     switch (elem_type) {
         case kElemFloat: {
             switch (dist_type) {
@@ -239,7 +239,7 @@ SizeT PhysicalKnnScan::BlockEntryCount() const { return base_table_ref_->block_i
 template <typename DataType, template <typename, typename> typename C>
 void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperatorState *operator_state) {
     auto knn_scan_function_data = operator_state->knn_scan_function_data_.get();
-    auto knn_scan_shared_data = knn_scan_function_data->shared_data_;
+    auto knn_scan_shared_data = knn_scan_function_data->knn_scan_shared_data_;
 
     auto dist_func = static_cast<KnnDistance1<DataType> *>(knn_scan_function_data->knn_distance_.get());
     auto merge_heap = static_cast<MergeKnn<DataType, C> *>(knn_scan_function_data->merge_knn_base_.get());

--- a/src/executor/operator/physical_knn_scan.cpp
+++ b/src/executor/operator/physical_knn_scan.cpp
@@ -373,7 +373,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
             case IndexType::kHnsw: {
                 BufferHandle index_handle = SegmentColumnIndexEntry::GetIndex(segment_column_index_entry, buffer_mgr);
                 auto index_hnsw = static_cast<IndexHnsw *>(segment_column_index_entry->column_index_entry_->index_base_.get());
-                auto KnnScanOld = [&](auto *index) {
+                auto KnnScan = [&](auto *index) {
                     Vector<DataType> dists(knn_scan_shared_data->topk_ * knn_scan_shared_data->query_count_);
                     Vector<RowID> row_ids(knn_scan_shared_data->topk_ * knn_scan_shared_data->query_count_);
 
@@ -388,15 +388,14 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                     for (u64 query_idx = 0; query_idx < knn_scan_shared_data->query_count_; ++query_idx) {
                         const DataType *query =
                             static_cast<const DataType *>(knn_scan_shared_data->query_embedding_) + query_idx * knn_scan_shared_data->dimension_;
-                        MaxHeap<Pair<DataType, u64>> heap = index->KnnSearch(query, knn_scan_shared_data->topk_, bitmask);
+                        Vector<Pair<DataType, u64>> result = index->KnnSearch(query, knn_scan_shared_data->topk_, bitmask);
                         if (result_n < 0) {
-                            result_n = heap.size();
-                        } else if (result_n != (i64)heap.size()) {
+                            result_n = result.size();
+                        } else if (result_n != (i64)result.size()) {
                             throw ExecutorException("Bug");
                         }
                         u64 id = 0;
-                        while (!heap.empty()) {
-                            const auto &[dist, row_id] = heap.top();
+                        for (const auto &[dist, row_id] : result) {
                             row_ids[query_idx * knn_scan_shared_data->topk_ + id] = RowID::FromUint64(row_id);
                             switch (knn_scan_shared_data->knn_distance_type_) {
                                 case KnnDistanceType::kInvalid: {
@@ -414,81 +413,22 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                                 }
                             }
                             ++id;
-                            heap.pop();
                         }
                     }
                     merge_heap->Search(dists.data(), row_ids.data(), result_n);
                 };
-                auto KnnScanUseHeap = [&]<typename LabelType>(auto *index) {
-                    if constexpr (!std::is_same_v<LabelType, u64>) {
-                        Error<ExecutorException>("Bug: Hnsw LabelType must be u64");
-                    }
-                    for (const auto &opt_param : knn_scan_shared_data->opt_params_) {
-                        if (opt_param.param_name_ == "ef") {
-                            u64 ef = std::stoull(opt_param.param_value_);
-                            index->SetEf(ef);
-                        }
-                    }
-                    i64 result_n = -1;
-                    for (u64 query_idx = 0; query_idx < knn_scan_shared_data->query_count_; ++query_idx) {
-                        const DataType *query =
-                            static_cast<const DataType *>(knn_scan_shared_data->query_embedding_) + query_idx * knn_scan_shared_data->dimension_;
-                        auto search_result = index->KnnSearchReturnPair(query, knn_scan_shared_data->topk_, bitmask);
-                        auto &[result_size, unique_ptr_pair] = search_result;
-                        auto &[d_ptr, l_ptr] = unique_ptr_pair;
-                        if (result_n < 0) {
-                            result_n = result_size;
-                        } else if (result_n != (i64)result_size) {
-                            throw ExecutorException("Bug");
-                        }
-                        if (result_size <= 0) {
-                            continue;
-                        }
-                        UniquePtr<RowID[]> row_ids_ptr;
-                        RowID *row_ids = nullptr;
-                        if constexpr (sizeof(RowID) == sizeof(LabelType)) {
-                            row_ids = reinterpret_cast<RowID *>(l_ptr.get());
-                        } else {
-                            row_ids_ptr = MakeUniqueForOverwrite<RowID[]>(result_size);
-                            row_ids = row_ids_ptr.get();
-                        }
-                        for (SizeT i = 0; i < result_size; ++i) {
-                            row_ids[i] = RowID::FromUint64(l_ptr[i]);
-                        }
-                        switch (knn_scan_shared_data->knn_distance_type_) {
-                            case KnnDistanceType::kInvalid: {
-                                throw ExecutorException("Bug");
-                            }
-                            case KnnDistanceType::kL2:
-                            case KnnDistanceType::kHamming: {
-                                break;
-                            }
-                            case KnnDistanceType::kCosine:
-                            case KnnDistanceType::kInnerProduct: {
-                                for (SizeT i = 0; i < result_size; ++i) {
-                                    d_ptr[i] = -d_ptr[i];
-                                }
-                                break;
-                            }
-                        }
-                        merge_heap->Search(0, d_ptr.get(), row_ids, result_size);
-                    }
-                };
-                auto KnnScan = [&](auto *index) {
-                    using LabelType = typename std::remove_pointer_t<decltype(index)>::HnswLabelType;
-                    KnnScanUseHeap.template operator()<LabelType>(index);
-                };
+                using LabelType = u64;
                 switch (index_hnsw->encode_type_) {
                     case HnswEncodeType::kPlain: {
                         switch (index_hnsw->metric_type_) {
                             case MetricType::kMerticInnerProduct: {
-                                using Hnsw = KnnHnsw<f32, u64, PlainStore<f32>, PlainIPDist<f32>>;
+                                using Hnsw = KnnHnsw<f32, LabelType, PlainStore<f32>, PlainIPDist<f32>>;
                                 // Fixme: const_cast here. may have bug.
                                 KnnScan(const_cast<Hnsw *>(static_cast<const Hnsw *>(index_handle.GetData())));
                                 break;
                             }
                             case MetricType::kMerticL2: {
-                                using Hnsw = KnnHnsw<f32, u64, PlainStore<f32>, PlainL2Dist<f32>>;
+                                using Hnsw = KnnHnsw<f32, LabelType, PlainStore<f32>, PlainL2Dist<f32>>;
                                 KnnScan(const_cast<Hnsw *>(static_cast<const Hnsw *>(index_handle.GetData())));
                                 break;
                             }
@@ -501,12 +441,12 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                     case HnswEncodeType::kLVQ: {
                         switch (index_hnsw->metric_type_) {
                             case MetricType::kMerticInnerProduct: {
-                                using Hnsw = KnnHnsw<f32, u64, LVQStore<f32, i8, LVQIPCache<f32, i8>>, LVQIPDist<f32, i8>>;
+                                using Hnsw = KnnHnsw<f32, LabelType, LVQStore<f32, i8, LVQIPCache<f32, i8>>, LVQIPDist<f32, i8>>;
                                 KnnScan(const_cast<Hnsw *>(static_cast<const Hnsw *>(index_handle.GetData())));
                                 break;
                             }
                             case MetricType::kMerticL2: {
-                                using Hnsw = KnnHnsw<f32, u64, LVQStore<f32, i8, LVQL2Cache<f32, i8>>, LVQL2Dist<f32, i8>>;
+                                using Hnsw = KnnHnsw<f32, LabelType, LVQStore<f32, i8, LVQL2Cache<f32, i8>>, LVQL2Dist<f32, i8>>;
                                 KnnScan(const_cast<Hnsw *>(static_cast<const Hnsw *>(index_handle.GetData())));
                                 break;
                             }

--- a/src/executor/operator/physical_sink.cpp
+++ b/src/executor/operator/physical_sink.cpp
@@ -325,6 +325,17 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(ResultSinkState *result_si
             }
             break;
         }
+        case PhysicalOperatorType::kCreateIndexFinish: {
+            auto *output_state = static_cast<CreateIndexFinishOperatorState *>(task_operator_state);
+            if (output_state->error_message_.get() != nullptr) {
+                result_sink_state->error_message_ = Move(output_state->error_message_);
+                break;
+            }
+            result_sink_state->result_def_ = {
+                MakeShared<ColumnDef>(0, MakeShared<DataType>(LogicalType::kInteger), "OK", HashSet<ConstraintType>()),
+            };
+            break;
+        }
         default: {
             Error<NotImplementException>(Format("{} isn't supported here.", PhysicalOperatorToString(task_operator_state->operator_type_)));
         }
@@ -343,6 +354,11 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MessageSinkState *message_
             message_sink_state->message_ = Move(insert_output_state->result_msg_);
             break;
         }
+        case PhysicalOperatorType::kCreateIndexPrepare: {
+            auto *create_index_prepare_output_state = static_cast<CreateIndexPrepareOperatorState *>(task_operator_state);
+            message_sink_state->message_ = Move(create_index_prepare_output_state->result_msg_);
+            break;
+        }
         default: {
             Error<NotImplementException>(Format("{} isn't supported here.", PhysicalOperatorToString(task_operator_state->operator_type_)));
             break;
@@ -351,15 +367,13 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MessageSinkState *message_
 }
 
 void PhysicalSink::FillSinkStateFromLastOperatorState(QueueSinkState *queue_sink_state, OperatorState *task_operator_state) {
-    if(queue_sink_state->error_message_.get() != nullptr) {
+    if (queue_sink_state->error_message_.get() != nullptr) {
         LOG_TRACE(Format("Error: {} is sent to notify next fragment", *queue_sink_state->error_message_));
-        SharedPtr<FragmentData> fragment_data = MakeShared<FragmentData>();
-        fragment_data->error_message_ = MakeUnique<String>(*queue_sink_state->error_message_);
-        fragment_data->fragment_id_ = queue_sink_state->fragment_id_;
+        auto fragment_error = MakeShared<FragmentError>(queue_sink_state->fragment_id_, MakeUnique<String>(*queue_sink_state->error_message_));
         for (const auto &next_fragment_queue : queue_sink_state->fragment_data_queues_) {
-            next_fragment_queue->Enqueue(fragment_data);
+            next_fragment_queue->Enqueue(fragment_error);
         }
-        return ;
+        return;
     }
 
     if (!task_operator_state->Complete()) {
@@ -368,15 +382,18 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(QueueSinkState *queue_sink
     }
     SizeT output_data_block_count = task_operator_state->data_block_array_.size();
     if (output_data_block_count == 0) {
-        Error<ExecutorException>("No output from knn scan");
+        for (const auto &next_fragment_queue : queue_sink_state->fragment_data_queues_) {
+            next_fragment_queue->Enqueue(MakeShared<FragmentNone>(queue_sink_state->fragment_id_));
+        }
+        return;
+        // Error<ExecutorException>("No output from last operator.");
     }
     for (SizeT idx = 0; idx < output_data_block_count; ++idx) {
-        SharedPtr<FragmentData> fragment_data = MakeShared<FragmentData>();
-        fragment_data->fragment_id_ = queue_sink_state->fragment_id_;
-        fragment_data->task_id_ = queue_sink_state->task_id_;
-        fragment_data->data_block_ = Move(task_operator_state->data_block_array_[idx]);
-        fragment_data->data_count_ = output_data_block_count;
-        fragment_data->data_idx_ = idx;
+        auto fragment_data = MakeShared<FragmentData>(queue_sink_state->fragment_id_,
+                                                      Move(task_operator_state->data_block_array_[idx]),
+                                                      queue_sink_state->task_id_,
+                                                      idx,
+                                                      output_data_block_count);
         for (const auto &next_fragment_queue : queue_sink_state->fragment_data_queues_) {
             next_fragment_queue->Enqueue(fragment_data);
         }

--- a/src/executor/operator/physical_sink.cpp
+++ b/src/executor/operator/physical_sink.cpp
@@ -131,19 +131,6 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MaterializeSinkState *mate
             }
             break;
         }
-        case PhysicalOperatorType::kKnnScan: {
-            throw ExecutorException("KnnScan shouldn't be here");
-            KnnScanOperatorState *knn_output_state = static_cast<KnnScanOperatorState *>(task_op_state);
-            if (knn_output_state->data_block_array_.empty()) {
-                Error<ExecutorException>("Empty knn scan output");
-            }
-
-            for (auto &data_block : knn_output_state->data_block_array_) {
-                materialize_sink_state->data_block_array_.emplace_back(Move(data_block));
-            }
-            knn_output_state->data_block_array_.clear();
-            break;
-        }
         case PhysicalOperatorType::kAggregate: {
             AggregateOperatorState *agg_output_state = static_cast<AggregateOperatorState *>(task_op_state);
             if (agg_output_state->data_block_array_.empty()) {

--- a/src/executor/operator/physical_sink.cpp
+++ b/src/executor/operator/physical_sink.cpp
@@ -354,11 +354,6 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MessageSinkState *message_
             message_sink_state->message_ = Move(insert_output_state->result_msg_);
             break;
         }
-        case PhysicalOperatorType::kCreateIndexPrepare: {
-            auto *create_index_prepare_output_state = static_cast<CreateIndexPrepareOperatorState *>(task_operator_state);
-            message_sink_state->message_ = Move(create_index_prepare_output_state->result_msg_);
-            break;
-        }
         default: {
             Error<NotImplementException>(Format("{} isn't supported here.", PhysicalOperatorToString(task_operator_state->operator_type_)));
             break;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -89,6 +89,11 @@ bool QueueSourceState::GetData() {
             fusion_op_state->input_complete_ = completed;
             break;
         }
+        case PhysicalOperatorType::kCreateIndexDo: {
+            auto *create_index_do_op_state = static_cast<CreateIndexDoOperatorState *>(next_op_state);
+            create_index_do_op_state->input_complete_ = completed;
+            break;
+        }
         case PhysicalOperatorType::kCreateIndexFinish: {
             auto *create_index_finish_op_state = static_cast<CreateIndexFinishOperatorState *>(next_op_state);
             create_index_finish_op_state->input_complete_ = completed;

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -232,6 +232,18 @@ export struct CreateIndexOperatorState : public OperatorState {
     inline explicit CreateIndexOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndex) {}
 };
 
+export struct CreateIndexPrepareOperatorState : public OperatorState {
+    inline explicit CreateIndexPrepareOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexPrepare) {}
+};
+
+export struct CreateIndexDoOperatorState : public OperatorState {
+    inline explicit CreateIndexDoOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexDo) {}
+};
+
+export struct CreateIndexFinishOperatorState : public OperatorState {
+    inline explicit CreateIndexFinishOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexFinish) {}
+};
+
 // Create Collection
 export struct CreateCollectionOperatorState : public OperatorState {
     inline explicit CreateCollectionOperatorState() : OperatorState(PhysicalOperatorType::kCreateCollection) {}

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -242,7 +242,8 @@ export struct CreateIndexPrepareOperatorState : public OperatorState {
 export struct CreateIndexDoOperatorState : public OperatorState {
     inline explicit CreateIndexDoOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexDo) {}
 
-    CreateIndexSharedData *create_index_shared_data_{};
+    bool input_complete_ = false;
+    CreateIndexSharedData *create_index_shared_data_;
 };
 
 export struct CreateIndexFinishOperatorState : public OperatorState {

--- a/src/executor/physical_operator_type.cpp
+++ b/src/executor/physical_operator_type.cpp
@@ -132,6 +132,12 @@ String PhysicalOperatorToString(PhysicalOperatorType type) {
             return "Fusion";
         case PhysicalOperatorType::kMergeAggregate:
             return "MergeAggregate";
+        case PhysicalOperatorType::kCreateIndexPrepare:
+            return "CreateIndexPrepare";
+        case PhysicalOperatorType::kCreateIndexDo:
+            return "CreateIndexDo";
+        case PhysicalOperatorType::kCreateIndexFinish:
+            return "CreateIndexFinish";
     }
 
     Error<NotImplementException>("Unknown physical operator type");

--- a/src/executor/physical_operator_type.cppm
+++ b/src/executor/physical_operator_type.cppm
@@ -70,6 +70,7 @@ export enum class PhysicalOperatorType : i8 {
     kInsert,
     kImport,
     kExport,
+    kCreateIndexDo,
 
     // DDL
     kAlter,
@@ -83,6 +84,9 @@ export enum class PhysicalOperatorType : i8 {
     kDropCollection,
     kDropDatabase,
     kDropView,
+
+    kCreateIndexPrepare,
+    kCreateIndexFinish,
 
     // misc
     kExplain,

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -75,6 +75,9 @@ import physical_drop_index;
 import physical_command;
 import physical_match;
 import physical_fusion;
+import physical_create_index_prepare;
+import physical_create_index_do;
+import physical_create_index_finish;
 
 import logical_node;
 import logical_node_type;
@@ -307,14 +310,44 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildCreateTable(const SharedPtr<Lo
 
 UniquePtr<PhysicalOperator> PhysicalPlanner::BuildCreateIndex(const SharedPtr<LogicalNode> &logical_operator) const {
     auto logical_create_index = static_pointer_cast<LogicalCreateIndex>(logical_operator);
-    return PhysicalCreateIndex::Make(logical_create_index->schema_name(),
-                                     logical_create_index->table_name(),
-                                     logical_create_index->index_definition(),
-                                     logical_create_index->conflict_type(),
-                                     logical_create_index->GetOutputNames(),
-                                     logical_create_index->GetOutputTypes(),
-                                     logical_create_index->node_id(),
-                                     logical_operator->load_metas());
+    const auto &index_def_ptr = logical_create_index->index_definition();
+    if (index_def_ptr->index_array_.size() != 1 || index_def_ptr->index_array_[0]->index_type_ != IndexType::kHnsw) {
+        // TODO: invalidate multiple index in one statement.
+        // TODO: support other index types.
+        // use old `PhysicalCreateIndex`
+        return PhysicalCreateIndex::Make(logical_create_index->schema_name(),
+                                         logical_create_index->table_name(),
+                                         logical_create_index->index_definition(),
+                                         logical_create_index->conflict_type(),
+                                         logical_create_index->GetOutputNames(),
+                                         logical_create_index->GetOutputTypes(),
+                                         logical_create_index->node_id(),
+                                         logical_operator->load_metas());
+    }
+
+    // use new `PhysicalCreateIndexPrepare` `PhysicalCreateIndexDo` `PhysicalCreateIndexFinish`
+    auto create_index_prepare = MakeUnique<PhysicalCreateIndexPrepare>(logical_create_index->node_id(),
+                                                                       logical_create_index->schema_name(),
+                                                                       logical_create_index->table_name(),
+                                                                       logical_create_index->index_definition(),
+                                                                       logical_create_index->conflict_type(),
+                                                                       logical_create_index->GetOutputNames(),
+                                                                       logical_create_index->GetOutputTypes(),
+                                                                       logical_create_index->load_metas());
+    auto create_index_do = MakeUnique<PhysicalCreateIndexDo>(logical_create_index->node_id(),
+                                                             Move(create_index_prepare),
+                                                             logical_create_index->schema_name(),
+                                                             logical_create_index->table_name(),
+                                                             logical_create_index->index_definition(),
+                                                             logical_create_index->GetOutputNames(),
+                                                             logical_create_index->GetOutputTypes(),
+                                                             logical_create_index->load_metas());
+    auto create_index_finish = MakeUnique<PhysicalCreateIndexFinish>(logical_create_index->node_id(),
+                                                                     Move(create_index_do),
+                                                                     logical_create_index->GetOutputNames(),
+                                                                     logical_create_index->GetOutputTypes(),
+                                                                     logical_create_index->load_metas());
+    return create_index_finish;
 }
 
 UniquePtr<PhysicalOperator> PhysicalPlanner::BuildCreateCollection(const SharedPtr<LogicalNode> &logical_operator) const {

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -311,7 +311,7 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildCreateTable(const SharedPtr<Lo
 UniquePtr<PhysicalOperator> PhysicalPlanner::BuildCreateIndex(const SharedPtr<LogicalNode> &logical_operator) const {
     auto logical_create_index = static_pointer_cast<LogicalCreateIndex>(logical_operator);
     const auto &index_def_ptr = logical_create_index->index_definition();
-    if (index_def_ptr->index_array_.size() != 1 || index_def_ptr->index_array_[0]->index_type_ != IndexType::kHnsw) {
+    if (true || index_def_ptr->index_array_.size() != 1 || index_def_ptr->index_array_[0]->index_type_ != IndexType::kHnsw) {
         // TODO: invalidate multiple index in one statement.
         // TODO: support other index types.
         // use old `PhysicalCreateIndex`

--- a/src/function/table/create_index_data.cppm
+++ b/src/function/table/create_index_data.cppm
@@ -1,0 +1,36 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <algorithm>
+
+import stl;
+import segment_entry;
+
+export module create_index_data;
+
+namespace infinity {
+
+export struct CreateIndexSharedData {
+    CreateIndexSharedData(const Map<u32, SharedPtr<SegmentEntry>> &segment_map)  {
+        for (const auto &[segment_id, _] : segment_map) {
+            create_index_idxes_.emplace(segment_id, 0);
+        }
+    }
+
+    HashMap<u32, atomic_u64> create_index_idxes_{};
+};
+
+}; // namespace infinity

--- a/src/function/table/knn_scan_data.cppm
+++ b/src/function/table/knn_scan_data.cppm
@@ -123,7 +123,7 @@ private:
     void Init();
 
 public:
-    KnnScanSharedData* shared_data_;
+    KnnScanSharedData* knn_scan_shared_data_;
     const u32 task_id_;
 
     UniquePtr<MergeKnnBase> merge_knn_base_{};

--- a/src/main/resource_manager.cppm
+++ b/src/main/resource_manager.cppm
@@ -30,7 +30,7 @@ public:
         return cpu_count;
     }
 
-    inline u64 GetCpuResource() { return GetCpuResource(4); }
+    inline u64 GetCpuResource() { return GetCpuResource(Thread::hardware_concurrency()); }
 
     inline u64 GetMemoryResource(u64 memory_size) {
         total_memory_ -= memory_size;

--- a/src/planner/bound/base_table_ref.cppm
+++ b/src/planner/bound/base_table_ref.cppm
@@ -22,6 +22,7 @@ import table_collection_entry;
 import parser;
 import table_function;
 import block_index;
+import db_entry;
 
 import infinity_exception;
 
@@ -42,7 +43,7 @@ public:
           block_index_(Move(block_index)), column_names_(Move(column_names)), column_types_(Move(column_types)), table_index_(table_index) {}
 
     void RetainColumnByIndices(const Vector<SizeT> &&indices) {
-         // OPT1212: linear judge in assert
+         // FIXME: linear judge in assert
         if (!std::is_sorted(indices.cbegin(), indices.cend())) {
             Error<PlannerException>("Indices must be in order");
         }
@@ -51,6 +52,10 @@ public:
         replace_field<String>(*column_names_, indices);
         replace_field<SharedPtr<DataType>>(*column_types_, indices);
     };
+
+    SharedPtr<String> schema_name() const { return table_entry_ptr_->table_collection_meta_->db_entry_->db_name_; }
+
+    SharedPtr<String> table_name() const { return table_entry_ptr_->table_collection_name_; }
 
     TableCollectionEntry *table_entry_ptr_{};
     Vector<SizeT> column_ids_{};

--- a/src/planner/explain_logical_plan.cpp
+++ b/src/planner/explain_logical_plan.cpp
@@ -313,12 +313,12 @@ void ExplainLogicalPlan::Explain(const LogicalCreateIndex *create_node, SharedPt
     }
 
     {
-        String schema_name_str = String(intent_size, ' ') + " - schema name: " + *create_node->schema_name();
+        String schema_name_str = String(intent_size, ' ') + " - schema name: " + *create_node->base_table_ref()->schema_name();
         result->emplace_back(MakeShared<String>(schema_name_str));
     }
 
     {
-        String table_name_str = String(intent_size, ' ') + " - table name: " + *create_node->table_name();
+        String table_name_str = String(intent_size, ' ') + " - table name: " + *create_node->base_table_ref()->table_name();
         result->emplace_back(MakeShared<String>(table_name_str));
     }
 

--- a/src/planner/logical_planner.cpp
+++ b/src/planner/logical_planner.cpp
@@ -68,6 +68,7 @@ import index_base;
 import index_ivfflat;
 import index_hnsw;
 import index_full_text;
+import base_table_ref;
 
 module logical_planner;
 
@@ -490,8 +491,11 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, Shared
         index_def_ptr->index_array_.emplace_back(base_index_ptr);
     }
 
+    UniquePtr<QueryBinder> query_binder_ptr = MakeUnique<QueryBinder>(this->query_context_ptr_, bind_context_ptr);
+    auto base_table_ref = std::static_pointer_cast<BaseTableRef>(query_binder_ptr->GetTableRef(*schema_name, *table_name));
+
     auto logical_create_index_operator =
-        LogicalCreateIndex::Make(bind_context_ptr->GetNewLogicalNodeId(), schema_name, table_name, index_def_ptr, create_index_info->conflict_type_);
+        MakeShared<LogicalCreateIndex>(bind_context_ptr->GetNewLogicalNodeId(), base_table_ref, index_def_ptr, create_index_info->conflict_type_);
 
     this->logical_plan_ = logical_create_index_operator;
     this->names_ptr_->emplace_back("OK");

--- a/src/planner/node/logical_create_index.cpp
+++ b/src/planner/node/logical_create_index.cpp
@@ -47,7 +47,8 @@ String LogicalCreateIndex::ToString(i64 &space) const {
         space -= 4;
         arrow_str = "->  ";
     }
-    ss << String(space, ' ') << arrow_str << "Create Table: " << *schema_name_ << "." << index_definition_->ToString();
+    ss << String(space, ' ') << arrow_str << "Create Table: " << *base_table_ref_->table_name() << "."
+       << index_definition_->ToString();
     space += arrow_str.size();
 
     return ss.str();

--- a/src/planner/node/logical_create_index.cppm
+++ b/src/planner/node/logical_create_index.cppm
@@ -19,6 +19,7 @@ import logical_node_type;
 import column_binding;
 import logical_node;
 import parser;
+import base_table_ref;
 
 export module logical_create_index;
 
@@ -39,31 +40,19 @@ public:
     inline String name() override { return "LogicalCreateIndex"; }
 
 public:
-    static inline SharedPtr<LogicalCreateIndex>
-    Make(u64 node_id, SharedPtr<String> schema_name, SharedPtr<String> table_name, SharedPtr<IndexDef> index_def, ConflictType conflict_type) {
-        return MakeShared<LogicalCreateIndex>(node_id, schema_name, table_name, index_def, conflict_type);
-    }
-
-    inline LogicalCreateIndex(u64 node_id,
-                              SharedPtr<String> schema_name,
-                              SharedPtr<String> table_name,
-                              SharedPtr<IndexDef> index_def,
-                              ConflictType conflict_type)
-        : LogicalNode(node_id, LogicalNodeType::kCreateIndex), schema_name_(schema_name), table_name_(table_name), index_definition_(index_def),
+    inline LogicalCreateIndex(u64 node_id, SharedPtr<BaseTableRef> base_table_ref, SharedPtr<IndexDef> index_def, ConflictType conflict_type)
+        : LogicalNode(node_id, LogicalNodeType::kCreateIndex), base_table_ref_(base_table_ref), index_definition_(index_def),
           conflict_type_(conflict_type) {}
 
 public:
-    [[nodiscard]] inline SharedPtr<String> schema_name() const { return schema_name_; }
-
-    [[nodiscard]] inline SharedPtr<String> table_name() const { return table_name_; }
+    [[nodiscard]] inline SharedPtr<BaseTableRef> base_table_ref() const { return base_table_ref_; }
 
     [[nodiscard]] inline SharedPtr<IndexDef> index_definition() const { return index_definition_; }
 
     [[nodiscard]] inline ConflictType conflict_type() const { return conflict_type_; }
 
 private:
-    SharedPtr<String> schema_name_{};
-    SharedPtr<String> table_name_{};
+    SharedPtr<BaseTableRef> base_table_ref_{};
     SharedPtr<IndexDef> index_definition_{};
     ConflictType conflict_type_{ConflictType::kInvalid};
 };

--- a/src/planner/query_binder.cpp
+++ b/src/planner/query_binder.cpp
@@ -913,13 +913,18 @@ void QueryBinder::CheckKnnAndOrderBy(KnnDistanceType distance_type, OrderType or
     }
 }
 
+SharedPtr<TableRef> QueryBinder::GetTableRef(const String &db_name, const String &table_name) {
+    TableReference from_table;
+    from_table.db_name_ = db_name;
+    from_table.table_name_ = table_name;
+    return BuildBaseTable(this->query_context_ptr_, &from_table);
+}
+
 UniquePtr<BoundDeleteStatement> QueryBinder::BindDelete(const DeleteStatement &statement) {
     // refers to QueryBinder::BindSelect
     UniquePtr<BoundDeleteStatement> bound_delete_statement = BoundDeleteStatement::Make(bind_context_ptr_);
-    TableReference from_table;
-    from_table.db_name_ = statement.schema_name_;
-    from_table.table_name_ = statement.table_name_;
-    SharedPtr<TableRef> base_table_ref = QueryBinder::BuildBaseTable(this->query_context_ptr_, &from_table);
+    SharedPtr<TableRef> base_table_ref = GetTableRef(statement.schema_name_, statement.table_name_);
+
     bound_delete_statement->table_ref_ptr_ = base_table_ref;
     if (base_table_ref.get() == nullptr) {
         Error<PlannerException>(Format("Cannot bind {}.{} to a table", statement.schema_name_, statement.table_name_));
@@ -937,10 +942,8 @@ UniquePtr<BoundDeleteStatement> QueryBinder::BindDelete(const DeleteStatement &s
 UniquePtr<BoundUpdateStatement> QueryBinder::BindUpdate(const UpdateStatement &statement) {
     // refers to QueryBinder::BindSelect
     UniquePtr<BoundUpdateStatement> bound_update_statement = BoundUpdateStatement::Make(bind_context_ptr_);
-    TableReference from_table;
-    from_table.db_name_ = statement.schema_name_;
-    from_table.table_name_ = statement.table_name_;
-    SharedPtr<TableRef> base_table_ref = QueryBinder::BuildBaseTable(this->query_context_ptr_, &from_table);
+    SharedPtr<TableRef> base_table_ref = GetTableRef(statement.schema_name_, statement.table_name_);
+
     bound_update_statement->table_ref_ptr_ = base_table_ref;
     if (base_table_ref.get() == nullptr) {
         Error<PlannerException>(Format("Cannot bind {}.{} to a table", statement.schema_name_, statement.table_name_));

--- a/src/planner/query_binder.cppm
+++ b/src/planner/query_binder.cppm
@@ -42,6 +42,8 @@ public:
 
     UniquePtr<BoundUpdateStatement> BindUpdate(const UpdateStatement &statement);
 
+    SharedPtr<TableRef> GetTableRef(const String &db_name, const String &table_name);
+
     QueryContext *query_context_ptr_;
 
     SharedPtr<BindContext> bind_context_ptr_;

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -96,6 +96,11 @@ public:
 
     [[nodiscard]] inline FragmentType ContextType() const { return fragment_type_; }
 
+private:
+    void MakeSourceState(i64 parallel_count);
+
+    void MakeSinkState(i64 parallel_count);
+
 protected:
     virtual SharedPtr<DataTable> GetResultInternal() = 0;
 
@@ -128,7 +133,11 @@ public:
     SharedPtr<DataTable> GetResultInternal() final;
 
 public:
-    UniquePtr<KnnScanSharedData> shared_data_{};
+    UniquePtr<KnnScanSharedData> knn_scan_shared_data_{};
+};
+
+export struct CreateIndexSharedData {
+    Vector<atomic_u64> create_index_idxes_{};
 };
 
 export class ParallelMaterializedFragmentCtx final : public FragmentContext {
@@ -141,7 +150,9 @@ public:
     SharedPtr<DataTable> GetResultInternal() final;
 
 public:
-    UniquePtr<KnnScanSharedData> shared_data_{};
+    UniquePtr<KnnScanSharedData> knn_scan_shared_data_{};
+
+    UniquePtr<CreateIndexSharedData> create_index_shared_data_{};
 
 protected:
     HashMap<u64, Vector<SharedPtr<DataBlock>>> task_results_{};

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -24,6 +24,7 @@ import physical_sink;
 import data_table;
 import data_block;
 import knn_scan_data;
+import create_index_data;
 
 export module fragment_context;
 
@@ -134,10 +135,6 @@ public:
 
 public:
     UniquePtr<KnnScanSharedData> knn_scan_shared_data_{};
-};
-
-export struct CreateIndexSharedData {
-    Vector<atomic_u64> create_index_idxes_{};
 };
 
 export class ParallelMaterializedFragmentCtx final : public FragmentContext {

--- a/src/scheduler/fragment_data.cppm
+++ b/src/scheduler/fragment_data.cppm
@@ -21,13 +21,40 @@ export module fragment_data;
 
 namespace infinity {
 
-export struct FragmentData {
-    UniquePtr<DataBlock> data_block_{};
-    UniquePtr<String> error_message_{};
+export enum class FragmentDataType {
+    kData,
+    kNone,
+    kError,
+    kInvalid,
+};
+
+export struct FragmentDataBase {
+    FragmentDataType type_{FragmentDataType::kInvalid};
     u64 fragment_id_{u64_max};
+
+    FragmentDataBase(FragmentDataType type, u64 fragment_id) : type_(type), fragment_id_(fragment_id) {}
+};
+
+export struct FragmentError : public FragmentDataBase {
+    UniquePtr<String> error_message_{};
+
+    FragmentError(u64 fragment_id, UniquePtr<String> error_message)
+        : FragmentDataBase(FragmentDataType::kError, fragment_id), error_message_(Move(error_message)) {}
+};
+
+export struct FragmentData : public FragmentDataBase {
+    UniquePtr<DataBlock> data_block_{};
     i64 task_id_{-1};
     SizeT data_idx_{u64_max};
     SizeT data_count_{u64_max};
+
+    FragmentData(u64 fragment_id, UniquePtr<DataBlock> data_block, i64 task_id, SizeT data_idx, SizeT data_count)
+        : FragmentDataBase(FragmentDataType::kData, fragment_id), data_block_(Move(data_block)), task_id_(task_id), data_idx_(data_idx),
+          data_count_(data_count) {}
+};
+
+export struct FragmentNone : public FragmentDataBase {
+    FragmentNone(u64 fragment_id) : FragmentDataBase(FragmentDataType::kNone, fragment_id) {}
 };
 
 } // namespace infinity

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -93,7 +93,8 @@ void TaskScheduler::Schedule(QueryContext *query_context, const Vector<FragmentT
     //    if the first op isn't SCAN op, fragment task source type is kQueue and a task_result_queue need to be created.
     //    According to the fragment output type to set the correct fragment task sink type.
     //    Set the queue of parent fragment task.
-    ScheduleOneWorkerIfPossible(query_context, tasks, plan_fragment);
+    // ScheduleOneWorkerIfPossible(query_context, tasks, plan_fwosfasdfragment);
+    ScheduleRoundRobin(query_context, tasks, plan_fragment);
 }
 
 void TaskScheduler::ScheduleOneWorkerPerQuery(QueryContext *query_context, const Vector<FragmentTask *> &tasks, PlanFragment *plan_fragment) {
@@ -138,9 +139,11 @@ void TaskScheduler::ScheduleOneWorkerIfPossible(QueryContext *query_context, con
 
 void TaskScheduler::ScheduleRoundRobin(QueryContext *query_context, const Vector<FragmentTask *> &tasks, PlanFragment *plan_fragment) {
     LOG_TRACE(Format("Schedule {} tasks of query id: {} into scheduler with RR policy", tasks.size(), query_context->query_id()));
+    u64 worker_id = 0;
     for (const auto &fragment_task : tasks) {
-        u64 worker_id = ProposedWorkerID(worker_count_);
         ScheduleTask(fragment_task, worker_id);
+        worker_id++;
+        worker_id %= worker_count_;
     }
 }
 

--- a/src/storage/knnindex/knn_hnsw/dist_func_l2.cppm
+++ b/src/storage/knnindex/knn_hnsw/dist_func_l2.cppm
@@ -45,13 +45,13 @@ public:
             if (dim % 16 == 0) {
                 SIMDFunc = F32L2AVX512;
             } else {
-                SIMDFunc = F32L2BF;
+                SIMDFunc = F32L2AVX512Residual;
             }
 #elif defined(USE_AVX)
             if (dim % 16 == 0) {
                 SIMDFunc = F32L2AVX;
             } else {
-                SIMDFunc = F32L2BF;
+                SIMDFunc = F32L2AVXResidual;
             }
 #else
             SIMDFunc = F32L2BF;
@@ -101,13 +101,13 @@ public:
             if (dim % 64 == 0) {
                 SIMDFunc = I8IPAVX512;
             } else {
-                SIMDFunc = I8IPBF;
+                SIMDFunc = I8IPAVX512Residual;
             }
 #elif defined(USE_AVX)
             if (dim % 32 == 0) {
                 SIMDFunc = I8IPAVX;
             } else {
-                SIMDFunc = I8IPBF;
+                SIMDFunc = I8IPAVXResidual;
             }
 #else
             SIMDFunc = I8IPBF;

--- a/src/storage/knnindex/knn_hnsw/graph_store.cppm
+++ b/src/storage/knnindex/knn_hnsw/graph_store.cppm
@@ -103,6 +103,7 @@ private:
           graph_(static_cast<char *>(operator new[](max_vertex * level0_size_, std::align_val_t(8)))), //
           loaded_vertex_n_(loaded_vertex_n),                                                           //
           loaded_layers_(loaded_layers)                                                                //
+                                                                                                       //
     {}
 
     void Init() {
@@ -261,6 +262,9 @@ public:
                     VertexType neighbor_idx = neighbors[i];
                     assert(neighbor_idx < cur_vertex_n && neighbor_idx >= 0);
                     assert(neighbor_idx != vertex_i);
+
+                    int n_layer = GetLevel0(neighbor_idx).GetLayers().second;
+                    assert(n_layer >= layer_i);
                 }
             }
         }
@@ -283,7 +287,13 @@ public:
             os << "layer " << layer << std::endl;
             for (VertexType vertex_i : layer2vertex[layer]) {
                 os << vertex_i << ": ";
-                auto [neighbors, neighbor_n] = GetLevel0(vertex_i).GetNeighbors();
+                const int *neighbors = nullptr;
+                int neighbor_n = 0;
+                if (layer == 0) {
+                    std::tie(neighbors, neighbor_n) = GetLevel0(vertex_i).GetNeighbors();
+                } else {
+                    std::tie(neighbors, neighbor_n) = GetLevelX(GetLevel0(vertex_i), layer).GetNeighbors();
+                }
                 for (int i = 0; i < neighbor_n; ++i) {
                     os << neighbors[i] << ", ";
                 }

--- a/src/storage/knnindex/knn_hnsw/hnsw_alg.cppm
+++ b/src/storage/knnindex/knn_hnsw/hnsw_alg.cppm
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 module;
+#include <algorithm>
 #include <iostream>
 #include <random>
 
@@ -49,8 +50,8 @@ public:
 
     using PDV = Pair<DataType, VertexType>;
     using CMP = CompareByFirst<DataType, VertexType>;
+    using CMPReverse = CompareByFirstReverse<DataType, VertexType>;
     using DistHeap = Heap<PDV, CMP>;
-    using HnswLabelType = LabelType;
 
     constexpr static int prefetch_offset_ = 0;
     constexpr static int prefetch_step_ = 2;
@@ -71,6 +72,9 @@ private:
     Distance distance_;
     const UniquePtr<LabelType[]> labels_;
 
+    Mutex global_mutex_;
+    mutable Vector<RWMutex> vertex_mutex_;
+
 private:
     KnnHnsw(SizeT M,
             SizeT Mmax,
@@ -87,7 +91,8 @@ private:
           data_store_(Move(data_store)),                                                 //
           graph_store_(Move(graph_store)),                                               //
           distance_(Move(distance)),                                                     //
-          labels_(Move(labels)) {
+          labels_(Move(labels)),                                                         //
+          vertex_mutex_(data_store_.max_vec_num()) {
         if (ef == 0) {
             ef = ef_construction_;
         }
@@ -126,83 +131,19 @@ private:
         return static_cast<i32>(r);
     }
 
-    template <typename Iterator>
-        requires DataIteratorConcept<Iterator, const DataType *>
-    VertexType StoreData(Iterator iter, const LabelType *labels, SizeT insert_n) {
-        auto ret = data_store_.AddVec(iter, insert_n);
-        if (ret == DataStore::ERR_IDX) {
-            Error<StorageException>("Data index is not enough.");
-        }
-        std::copy(labels, labels + insert_n, labels_.get() + ret);
-        return ret;
-    }
-
-public:
     // return the nearest `ef_construction_` neighbors of `query` in layer `layer_idx`
-    // return value is a max heap of distance
-    DistHeap SearchLayer(VertexType enter_point, const StoreType &query, i32 layer_idx, SizeT candidate_n) const {
-        DistHeap result;
+    template <bool WithLock = false>
+    Vector<PDV> SearchLayer(VertexType enter_point, const StoreType &query, i32 layer_idx, SizeT result_n, const Bitmask &bitmask = Bitmask()) const {
+        Vector<PDV> result;
         DistHeap candidate;
 
         data_store_.Prefetch(enter_point);
-        DataType dist = distance_(query, data_store_.GetVec(enter_point), data_store_);
-
+        // enter_point will not be added to result_handler, the distance is not used
+        auto dist = bitmask.IsTrue(enter_point) ? distance_(query, data_store_.GetVec(enter_point), data_store_) : 0;
         candidate.emplace(-dist, enter_point);
-        result.emplace(dist, enter_point);
-
-        Vector<bool> visited(data_store_.cur_vec_num(), false);
-        visited[enter_point] = true;
-
-        while (!candidate.empty()) {
-            const auto [minus_c_dist, c_idx] = candidate.top();
-            candidate.pop();
-            if (-minus_c_dist > result.top().first && result.size() == candidate_n) {
-                break;
-            }
-            const auto [neighbors_p, neighbor_size] = graph_store_.GetNeighbors(c_idx, layer_idx);
-            int prefetch_start = neighbor_size - 1 - prefetch_offset_;
-            for (int i = neighbor_size - 1; i >= 0; --i) {
-                VertexType n_idx = neighbors_p[i];
-                if (visited[n_idx]) {
-                    continue;
-                }
-                visited[n_idx] = true;
-                if (prefetch_start >= 0) {
-                    int lower = Max(0, prefetch_start - prefetch_step_);
-                    for (int i = prefetch_start; i >= lower; --i) {
-                        data_store_.Prefetch(neighbors_p[i]);
-                    }
-                    prefetch_start -= prefetch_step_;
-                }
-                dist = distance_(query, data_store_.GetVec(n_idx), data_store_);
-                if (dist < result.top().first || result.size() < candidate_n) {
-                    candidate.emplace(-dist, n_idx);
-                    result.emplace(dist, n_idx);
-                    if (result.size() > candidate_n) {
-                        result.pop();
-                    }
-                }
-            }
-        }
-        return result;
-    }
-
-    DistHeap SearchLayer(VertexType enter_point, const StoreType &query, i32 layer_idx, SizeT candidate_n, const Bitmask &bitmask) const {
-        if (bitmask.IsAllTrue()) {
-            return SearchLayer(enter_point, query, layer_idx, candidate_n);
-        }
-        DistHeap result;
-        DistHeap candidate;
-
-        DataType dist{};
         if (bitmask.IsTrue(enter_point)) {
-            data_store_.Prefetch(enter_point);
-            dist = distance_(query, data_store_.GetVec(enter_point), data_store_);
-
-            candidate.emplace(-dist, enter_point);
-            result.emplace(dist, enter_point);
-        } else {
-            candidate.emplace(LimitMax<DataType>(), enter_point);
+            result.emplace_back(dist, enter_point);
+            std::push_heap(result.begin(), result.end(), CMP());
         }
 
         Vector<bool> visited(data_store_.cur_vec_num(), false);
@@ -211,9 +152,15 @@ public:
         while (!candidate.empty()) {
             const auto [minus_c_dist, c_idx] = candidate.top();
             candidate.pop();
-            if (result.size() == candidate_n && -minus_c_dist > result.top().first) {
+            if (result.size() == result_n && -minus_c_dist > result[0].first) {
                 break;
             }
+
+            SharedLock<RWMutex> lock;
+            if constexpr (WithLock) {
+                lock = SharedLock<RWMutex>(vertex_mutex_[c_idx]);
+            }
+
             const auto [neighbors_p, neighbor_size] = graph_store_.GetNeighbors(c_idx, layer_idx);
             int prefetch_start = neighbor_size - 1 - prefetch_offset_;
             for (int i = neighbor_size - 1; i >= 0; --i) {
@@ -229,134 +176,37 @@ public:
                     }
                     prefetch_start -= prefetch_step_;
                 }
-                dist = distance_(query, data_store_.GetVec(n_idx), data_store_);
-                if (result.size() < candidate_n || dist < result.top().first) {
+                auto dist = distance_(query, data_store_.GetVec(n_idx), data_store_);
+                if (result.size() < result_n || dist < result[0].first) {
                     candidate.emplace(-dist, n_idx);
                     if (bitmask.IsTrue(n_idx)) {
-                        result.emplace(dist, n_idx);
-                        if (result.size() > candidate_n) {
-                            result.pop();
+                        if (result.size() == result_n) {
+                            std::pop_heap(result.begin(), result.end(), CMP());
+                            result.pop_back();
                         }
+                        result.emplace_back(dist, n_idx);
+                        std::push_heap(result.begin(), result.end(), CMP());
                     }
                 }
             }
         }
+
         return result;
     }
 
-    Pair<u32, Pair<UniquePtr<DataType[]>, UniquePtr<VertexType[]>>>
-    SearchLayerReturnPair(VertexType enter_point, const StoreType &query, i32 layer_idx, SizeT candidate_n) const {
-        auto d_ptr = MakeUniqueForOverwrite<DataType[]>(candidate_n);
-        auto i_ptr = MakeUniqueForOverwrite<VertexType[]>(candidate_n);
-        HeapResultHandler<CompareMax<DataType, VertexType>> result_handler(1, candidate_n, d_ptr.get(), i_ptr.get());
-        result_handler.Begin();
-        DistHeap candidate;
-
-        data_store_.Prefetch(enter_point);
-        auto dist = distance_(query, data_store_.GetVec(enter_point), data_store_);
-
-        candidate.emplace(-dist, enter_point);
-        result_handler.AddResult(0, dist, enter_point);
-
-        Vector<bool> visited(data_store_.cur_vec_num(), false);
-        visited[enter_point] = true;
-
-        while (!candidate.empty()) {
-            const auto [minus_c_dist, c_idx] = candidate.top();
-            candidate.pop();
-            if (result_handler.GetSize(0) == candidate_n && -minus_c_dist > result_handler.GetDistance0(0)) {
-                break;
-            }
-            const auto [neighbors_p, neighbor_size] = graph_store_.GetNeighbors(c_idx, layer_idx);
-            int prefetch_start = neighbor_size - 1 - prefetch_offset_;
-            for (int i = neighbor_size - 1; i >= 0; --i) {
-                VertexType n_idx = neighbors_p[i];
-                if (visited[n_idx]) {
-                    continue;
-                }
-                visited[n_idx] = true;
-                if (prefetch_start >= 0) {
-                    int lower = Max(0, prefetch_start - prefetch_step_);
-                    for (int i = prefetch_start; i >= lower; --i) {
-                        data_store_.Prefetch(neighbors_p[i]);
-                    }
-                    prefetch_start -= prefetch_step_;
-                }
-                auto dist = distance_(query, data_store_.GetVec(n_idx), data_store_);
-                if (result_handler.GetSize(0) < candidate_n || dist < result_handler.GetDistance0(0)) {
-                    candidate.emplace(-dist, n_idx);
-                    result_handler.AddResult(0, dist, n_idx);
-                }
-            }
-        }
-        result_handler.EndWithoutSort();
-        return {result_handler.GetSize(0), MakePair(Move(d_ptr), Move(i_ptr))};
-    }
-
-    Pair<u32, Pair<UniquePtr<DataType[]>, UniquePtr<VertexType[]>>>
-    SearchLayerReturnPair(VertexType enter_point, const StoreType &query, i32 layer_idx, SizeT candidate_n, const Bitmask &bitmask) const {
-        if (bitmask.IsAllTrue()) {
-            return SearchLayerReturnPair(enter_point, query, layer_idx, candidate_n);
-        }
-        auto d_ptr = MakeUniqueForOverwrite<DataType[]>(candidate_n);
-        auto v_ptr = MakeUniqueForOverwrite<VertexType[]>(candidate_n);
-        HeapResultHandler<CompareMax<DataType, VertexType>> result_handler(1, candidate_n, d_ptr.get(), v_ptr.get());
-        result_handler.Begin();
-        DistHeap candidate;
-
-        if (bitmask.IsTrue(enter_point)) {
-            data_store_.Prefetch(enter_point);
-            auto dist = distance_(query, data_store_.GetVec(enter_point), data_store_);
-
-            candidate.emplace(-dist, enter_point);
-            result_handler.AddResult(0, dist, enter_point);
-        } else {
-            candidate.emplace(LimitMax<DataType>(), enter_point);
-        }
-
-        Vector<bool> visited(data_store_.cur_vec_num(), false);
-        visited[enter_point] = true;
-
-        while (!candidate.empty()) {
-            const auto [minus_c_dist, c_idx] = candidate.top();
-            candidate.pop();
-            if (result_handler.GetSize(0) == candidate_n && -minus_c_dist > result_handler.GetDistance0(0)) {
-                break;
-            }
-            const auto [neighbors_p, neighbor_size] = graph_store_.GetNeighbors(c_idx, layer_idx);
-            int prefetch_start = neighbor_size - 1 - prefetch_offset_;
-            for (int i = neighbor_size - 1; i >= 0; --i) {
-                VertexType n_idx = neighbors_p[i];
-                if (visited[n_idx]) {
-                    continue;
-                }
-                visited[n_idx] = true;
-                if (prefetch_start >= 0) {
-                    int lower = Max(0, prefetch_start - prefetch_step_);
-                    for (int i = prefetch_start; i >= lower; --i) {
-                        data_store_.Prefetch(neighbors_p[i]);
-                    }
-                    prefetch_start -= prefetch_step_;
-                }
-                auto dist = distance_(query, data_store_.GetVec(n_idx), data_store_);
-                if (result_handler.GetSize(0) < candidate_n || dist < result_handler.GetDistance0(0)) {
-                    candidate.emplace(-dist, n_idx);
-                    if (bitmask.IsTrue(n_idx)) {
-                        result_handler.AddResult(0, dist, n_idx);
-                    }
-                }
-            }
-        }
-        result_handler.EndWithoutSort();
-        return {result_handler.GetSize(0), MakePair(Move(d_ptr), Move(v_ptr))};
-    }
-
+    template <bool WithLock = false>
     VertexType SearchLayerNearest(VertexType enter_point, const StoreType &query, i32 layer_idx) const {
         VertexType cur_p = enter_point;
         DataType cur_dist = distance_(query, data_store_.GetVec(cur_p), data_store_);
         bool check = true;
         while (check) {
             check = false;
+
+            SharedLock<RWMutex> lock;
+            if constexpr (WithLock) {
+                lock = SharedLock<RWMutex>(vertex_mutex_[cur_p]);
+            }
+
             const auto [neighbors_p, neighbor_size] = graph_store_.GetNeighbors(cur_p, layer_idx);
             for (int i = neighbor_size - 1; i >= 0; --i) {
                 VertexType n_idx = neighbors_p[i];
@@ -371,24 +221,25 @@ public:
         return cur_p;
     }
 
-    // DistHeap is the min heap whose key is the minus distance to query
-    // result distance is increasing
-    void SelectNeighborsHeuristic(DistHeap &candidates, SizeT M, VertexType *result_p, VertexListSize *result_size_p) const {
+    // the function does not need mutex because the lock of `result_p` is already acquired
+    void SelectNeighborsHeuristic(Vector<PDV> candidates, SizeT M, VertexType *result_p, VertexListSize *result_size_p) const {
         VertexListSize result_size = 0;
-        if (SizeT c_size = candidates.size(); c_size < M) {
-            while (!candidates.empty()) {
-                result_p[result_size++] = candidates.top().second;
-                candidates.pop();
+        if (candidates.size() < M) {
+            // std::sort(candidates.begin(), candidates.end(), CMPReverse());
+            for (const auto &[_, idx] : candidates) {
+                result_p[result_size++] = idx;
             }
         } else {
+            std::make_heap(candidates.begin(), candidates.end(), CMPReverse());
             while (!candidates.empty() && SizeT(result_size) < M) {
-                const auto &[minus_c_dist, c_idx] = candidates.top();
+                std::pop_heap(candidates.begin(), candidates.end(), CMPReverse());
+                const auto &[c_dist, c_idx] = candidates.back();
                 StoreType c_data = data_store_.GetVec(c_idx);
                 bool check = true;
                 for (SizeT i = 0; i < SizeT(result_size); ++i) {
                     VertexType r_idx = result_p[i];
                     DataType cr_dist = distance_(c_data, data_store_.GetVec(r_idx), data_store_);
-                    if (cr_dist < -minus_c_dist) {
+                    if (cr_dist < c_dist) {
                         check = false;
                         break;
                     }
@@ -396,15 +247,23 @@ public:
                 if (check) {
                     result_p[result_size++] = c_idx;
                 }
-                candidates.pop();
+                candidates.pop_back();
             }
+            // std::reverse(result_p, result_p + result_size);
         }
         *result_size_p = result_size;
     }
 
+    template <bool WithLock = true>
     void ConnectNeighbors(VertexType vertex_i, const VertexType *q_neighbors_p, VertexListSize q_neighbor_size, i32 layer_idx) {
         for (int i = 0; i < q_neighbor_size; ++i) {
             VertexType n_idx = q_neighbors_p[i];
+
+            UniqueLock<RWMutex> lock;
+            if constexpr (WithLock) {
+                lock = UniqueLock<RWMutex>(vertex_mutex_[n_idx]);
+            }
+
             auto [n_neighbors_p, n_neighbor_size_p] = graph_store_.GetNeighborsMut(n_idx, layer_idx);
             VertexListSize n_neighbor_size = *n_neighbor_size_p;
             SizeT Mmax = layer_idx == 0 ? Mmax0_ : Mmax_;
@@ -416,122 +275,107 @@ public:
             StoreType n_data = data_store_.GetVec(n_idx);
             DataType n_dist = distance_(n_data, data_store_.GetVec(vertex_i), data_store_);
 
-            Vector<PDV> tmp;
-            tmp.reserve(n_neighbor_size + 1);
-            tmp.emplace_back(-n_dist, vertex_i);
+            Vector<PDV> candidates;
+            candidates.reserve(n_neighbor_size + 1);
+            candidates.emplace_back(n_dist, vertex_i);
             for (int i = 0; i < n_neighbor_size; ++i) {
-                tmp.emplace_back(-distance_(n_data, data_store_.GetVec(n_neighbors_p[i]), data_store_), n_neighbors_p[i]);
+                candidates.emplace_back(distance_(n_data, data_store_.GetVec(n_neighbors_p[i]), data_store_), n_neighbors_p[i]);
             }
 
-            DistHeap candidates(tmp.begin(), tmp.end());
-            SelectNeighborsHeuristic(candidates, Mmax, n_neighbors_p, n_neighbor_size_p); // write in memory
+            SelectNeighborsHeuristic(Move(candidates), Mmax, n_neighbors_p, n_neighbor_size_p); // write in memory
+        }
+    }
+
+public:
+    // This function will be removed
+    template <typename Iterator>
+        requires DataIteratorConcept<Iterator, const DataType *>
+    void InsertVecs(Iterator iter, const LabelType *labels, SizeT insert_n) {
+        VertexType start_i = StoreData(iter, labels, insert_n);
+        for (VertexType vertex_i = start_i; vertex_i < VertexType(start_i + insert_n); ++vertex_i) {
+            Build(vertex_i);
+        }
+    }
+
+    // This function for test
+    void InsertVecs(const DataType *query, const LabelType *labels, SizeT insert_n) {
+        VertexType start_i = StoreDataRaw(query, labels, insert_n);
+        for (VertexType vertex_i = start_i; vertex_i < VertexType(start_i + insert_n); ++vertex_i) {
+            Build(vertex_i);
         }
     }
 
     template <typename Iterator>
         requires DataIteratorConcept<Iterator, const DataType *>
-    void InsertVecs(Iterator query_iter, const LabelType *labels, SizeT insert_n) {
-        const VertexType vertex_i1 = StoreData(Move(query_iter), labels, insert_n);
-        for (SizeT i = 0; i < insert_n; ++i) {
-            StoreType query = data_store_.GetVec(vertex_i1 + i);
-            i32 q_layer = GenerateRandomLayer();
-            i32 max_layer = graph_store_.max_layer();
-            VertexType ep = graph_store_.enterpoint();
-            VertexType vertex_i = vertex_i1 + i;
-            graph_store_.AddVertex(vertex_i, q_layer);
+    VertexType StoreData(Iterator iter, const LabelType *labels, SizeT insert_n) {
+        auto ret = data_store_.AddVec(iter, insert_n);
+        if (ret == DataStore::ERR_IDX) {
+            Error<StorageException>("Data index is not enough.");
+        }
+        std::copy(labels, labels + insert_n, labels_.get() + ret);
+        return ret;
+    }
 
-            for (i32 cur_layer = max_layer; cur_layer > q_layer; --cur_layer) {
-                ep = SearchLayerNearest(ep, query, cur_layer);
+    VertexType StoreDataRaw(const DataType *query, const LabelType *labels, SizeT insert_n) {
+        return StoreData(DenseVectorIter(query, data_store_.dim(), insert_n), labels, insert_n);
+    }
+
+    VertexType StoreDataRaw(const DataType *query, LabelType label) { return StoreDataRaw(query, &label, 1); }
+
+    template <bool WithLock = true>
+    void Build(VertexType vertex_i) {
+        UniqueLock<Mutex> global_lock;
+        if constexpr (WithLock) {
+            global_lock = UniqueLock<Mutex>(global_mutex_);
+        }
+
+        i32 q_layer = GenerateRandomLayer();
+        i32 max_layer = graph_store_.max_layer();
+        if constexpr (WithLock) {
+            if (q_layer <= max_layer) {
+                global_lock.unlock();
             }
-            for (i32 cur_layer = Min(q_layer, max_layer); cur_layer >= 0; --cur_layer) {
-                DistHeap search_result = SearchLayer(ep, query, cur_layer, ef_construction_); // TODO:: use pool
-                DistHeap candidates;
-                while (!search_result.empty()) {
-                    const auto &[dist, idx] = search_result.top();
-                    candidates.emplace(-dist, idx);
-                    search_result.pop();
-                }
-                const auto [q_neighbors_p, q_neighbor_size_p] = graph_store_.GetNeighborsMut(vertex_i, cur_layer);
-                SelectNeighborsHeuristic(candidates, M_, q_neighbors_p, q_neighbor_size_p);
-                ep = q_neighbors_p[0];
-                ConnectNeighbors(vertex_i, q_neighbors_p, *q_neighbor_size_p, cur_layer);
-            }
-            if (i && i % 10000 == 0) {
-                std::cout << "Inserted " << i << " / " << insert_n << std::endl;
-            }
+        }
+
+        UniqueLock<RWMutex> lock;
+        if constexpr (WithLock) {
+            lock = UniqueLock<RWMutex>(vertex_mutex_[vertex_i]);
+        }
+        StoreType query = data_store_.GetVec(vertex_i);
+
+        VertexType ep = graph_store_.enterpoint();
+        graph_store_.AddVertex(vertex_i, q_layer);
+
+        for (i32 cur_layer = max_layer; cur_layer > q_layer; --cur_layer) {
+            ep = SearchLayerNearest<WithLock>(ep, query, cur_layer);
+        }
+        for (i32 cur_layer = Min(q_layer, max_layer); cur_layer >= 0; --cur_layer) {
+            Vector<PDV> search_result = SearchLayer<WithLock>(ep, query, cur_layer, ef_construction_);
+
+            const auto [q_neighbors_p, q_neighbor_size_p] = graph_store_.GetNeighborsMut(vertex_i, cur_layer);
+            SelectNeighborsHeuristic(Move(search_result), M_, q_neighbors_p, q_neighbor_size_p);
+            ep = q_neighbors_p[0];
+            ConnectNeighbors<WithLock>(vertex_i, q_neighbors_p, *q_neighbor_size_p, cur_layer);
         }
     }
 
-    // this two interface is for test and benchmark
-    void Insert(const DataType *queries, const LabelType *labels, SizeT insert_n) {
-        InsertVecs(DenseVectorIter(queries, data_store_.dim(), insert_n), labels, insert_n);
-    }
-    void Insert(const DataType *query, LabelType label) { Insert(query, &label, 1); }
-
-    MaxHeap<Pair<DataType, LabelType>> KnnSearch(const DataType *q, SizeT k) const {
+    template <bool WithLock = false>
+    Vector<Pair<DataType, LabelType>> KnnSearch(const DataType *q, SizeT k, const Bitmask &bitmask = Bitmask()) const {
         auto query = data_store_.MakeQuery(q);
         VertexType ep = graph_store_.enterpoint();
         for (i32 cur_layer = graph_store_.max_layer(); cur_layer > 0; --cur_layer) {
-            ep = SearchLayerNearest(ep, query, cur_layer);
+            ep = SearchLayerNearest<WithLock>(ep, query, cur_layer);
         }
-        DistHeap search_result = SearchLayer(ep, query, 0, Max(k, ef_));
-        while (search_result.size() > k) {
-            search_result.pop();
-        }
-        MaxHeap<Pair<DataType, LabelType>> result; // TODO:: reserve
-        while (!search_result.empty()) {
-            const auto &[dist, idx] = search_result.top();
-            result.emplace(dist, labels_[idx]);
-            search_result.pop();
+        Vector<PDV> search_result = SearchLayer<WithLock>(ep, query, 0, Max(k, ef_), bitmask);
+
+        std::sort_heap(search_result.begin(), search_result.end(), CMP());
+        Vector<Pair<DataType, LabelType>> result;
+        for (SizeT i = 0; i < Min(k, search_result.size()); ++i) {
+            result.emplace_back(search_result[i].first, labels_[search_result[i].second]);
         }
         return result;
     }
 
-    MaxHeap<Pair<DataType, LabelType>> KnnSearch(const DataType *q, SizeT k, const Bitmask &bitmask) const {
-        auto query = data_store_.MakeQuery(q);
-        VertexType ep = graph_store_.enterpoint();
-        for (i32 cur_layer = graph_store_.max_layer(); cur_layer > 0; --cur_layer) {
-            ep = SearchLayerNearest(ep, query, cur_layer);
-        }
-        DistHeap search_result = SearchLayer(ep, query, 0, Max(k, ef_), bitmask);
-        while (search_result.size() > k) {
-            search_result.pop();
-        }
-        MaxHeap<Pair<DataType, LabelType>> result; // TODO:: reserve
-        while (!search_result.empty()) {
-            const auto &[dist, idx] = search_result.top();
-            result.emplace(dist, labels_[idx]);
-            search_result.pop();
-        }
-        return result;
-    }
-
-    Pair<u32, Pair<UniquePtr<DataType[]>, UniquePtr<LabelType[]>>> KnnSearchReturnPair(const DataType *q, SizeT k, const Bitmask &bitmask) const {
-        auto query = data_store_.MakeQuery(q);
-        VertexType ep = graph_store_.enterpoint();
-        for (i32 cur_layer = graph_store_.max_layer(); cur_layer > 0; --cur_layer) {
-            ep = SearchLayerNearest(ep, query, cur_layer);
-        }
-        auto search_result = SearchLayerReturnPair(ep, query, 0, Max(k, ef_), bitmask);
-        auto &[result_size, unique_ptr_pair] = search_result;
-        auto &[d_ptr, v_ptr] = unique_ptr_pair;
-        UniquePtr<LabelType[]> l_ptr;
-        if constexpr (sizeof(LabelType) == sizeof(VertexType)) {
-            auto label_ptr = reinterpret_cast<LabelType *>(v_ptr.get());
-            for (SizeT i = 0; i < result_size; ++i) {
-                label_ptr[i] = labels_[v_ptr[i]];
-            }
-            l_ptr.reset(reinterpret_cast<LabelType *>(v_ptr.release()));
-        } else {
-            l_ptr = MakeUniqueForOverwrite<LabelType[]>(result_size);
-            for (SizeT i = 0; i < result_size; ++i) {
-                l_ptr[i] = labels_[v_ptr[i]];
-            }
-        }
-        return {result_size, MakePair(Move(d_ptr), Move(l_ptr))};
-    }
-
-public:
     void SetEf(SizeT ef) { ef_ = ef; }
 
     void Save(FileHandler &file_handler) {

--- a/src/storage/knnindex/knn_hnsw/hnsw_alg.cppm
+++ b/src/storage/knnindex/knn_hnsw/hnsw_alg.cppm
@@ -378,6 +378,8 @@ public:
 
     void SetEf(SizeT ef) { ef_ = ef; }
 
+    SizeT GetVertexNum() const { return data_store_.cur_vec_num(); }
+
     void Save(FileHandler &file_handler) {
         file_handler.Write(&M_, sizeof(M_));
         file_handler.Write(&ef_construction_, sizeof(ef_construction_));

--- a/src/storage/knnindex/knn_hnsw/hnsw_common.cppm
+++ b/src/storage/knnindex/knn_hnsw/hnsw_common.cppm
@@ -124,6 +124,7 @@ public:
 };
 
 export using VertexType = i32;
+export using AtomicVtxType = ai32;
 export using VertexListSize = i32;
 export using LayerSize = i32;
 

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -164,22 +164,6 @@ void SegmentEntry::DeleteData(SegmentEntry *segment_entry, Txn *txn_ptr, const H
     }
 }
 
-template <typename DataType>
-class OneColumnIterator {
-public:
-    OneColumnIterator(const SegmentEntry *entry, SizeT column_id) : segment_iter_(entry, MakeShared<Vector<SizeT>>(Vector<SizeT>{column_id})) {}
-
-    Optional<const DataType *> Next() {
-        if (auto ret = segment_iter_.Next(); ret) {
-            return reinterpret_cast<const DataType *>((*ret)[0]);
-        }
-        return None;
-    }
-
-private:
-    SegmentIter segment_iter_;
-};
-
 SharedPtr<SegmentColumnIndexEntry> SegmentEntry::CreateIndexFile(SegmentEntry *segment_entry,
                                                                  ColumnIndexEntry *column_index_entry,
                                                                  SharedPtr<ColumnDef> column_def,
@@ -324,45 +308,6 @@ SharedPtr<SegmentColumnIndexEntry> SegmentEntry::CreateIndexFile(SegmentEntry *s
     }
     txn_store->CreateIndexFile(column_index_entry->table_index_entry_, column_id, segment_entry->segment_id_, segment_column_index_entry);
     return segment_column_index_entry;
-}
-
-SharedPtr<SegmentColumnIndexEntry> SegmentEntry::CreateIndexFilePrepare(SegmentEntry *segment_entry,
-                                                                        ColumnIndexEntry *column_index_entry,
-                                                                        SharedPtr<ColumnDef> column_def,
-                                                                        TxnTimeStamp create_ts,
-                                                                        BufferManager *buffer_mgr) {
-    u64 column_id = column_def->id();
-    IndexBase *index_base = column_index_entry->index_base_.get();
-    UniquePtr<CreateIndexParam> create_index_param = SegmentEntry::GetCreateIndexParam(segment_entry, index_base, column_def.get());
-    SharedPtr<SegmentColumnIndexEntry> segment_column_index_entry =
-        SegmentColumnIndexEntry::NewIndexEntry(column_index_entry, segment_entry->segment_id_, create_ts, buffer_mgr, create_index_param.get());
-
-    if (index_base->index_type_ != IndexType::kHnsw) {
-        Error<StorageException>("Only HNSW index is supported.");
-    }
-    auto *index_hnsw = static_cast<IndexHnsw *>(index_base);
-    if (column_def->type()->type() != LogicalType::kEmbedding) {
-        Error<StorageException>("HNSW supports embedding type.");
-    }
-    TypeInfo *type_info = column_def->type()->type_info().get();
-    auto embedding_info = static_cast<EmbeddingInfo *>(type_info);
-
-    BufferHandle buffer_handle = SegmentColumnIndexEntry::GetIndex(segment_column_index_entry.get(), buffer_mgr);
-    auto InsertHnswPrepare = [&](auto &hnsw_index) {
-        u32 segment_offset = 0;
-        Vector<u64> row_ids;
-        for (const auto &block_entry : segment_entry->block_entries_) {
-            SizeT block_row_cnt = block_entry->row_count_;
-
-            for (SizeT block_offset = 0; block_offset < block_row_cnt; ++block_offset) {
-                RowID row_id(segment_entry->segment_id_, segment_offset + block_offset);
-                row_ids.push_back(row_id.ToUint64());
-            }
-            segment_offset += DEFAULT_BLOCK_CAPACITY;
-        }
-        OneColumnIterator<float> one_column_iter(segment_entry, column_id);
-        // hnsw_index->
-    };
 }
 
 void SegmentEntry::CommitAppend(SegmentEntry *segment_entry, Txn *txn_ptr, u16 block_id, u16, u16) {

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -75,6 +75,12 @@ public:
                                                               BufferManager *buffer_mgr,
                                                               TxnTableStore *txn_store);
 
+    static SharedPtr<SegmentColumnIndexEntry> CreateIndexFilePrepare(SegmentEntry *segment_entry,
+                                                                     ColumnIndexEntry *column_index_entry,
+                                                                     SharedPtr<ColumnDef> column_def,
+                                                                     TxnTimeStamp create_ts,
+                                                                     BufferManager *buffer_mgr);
+
     static void CommitAppend(SegmentEntry *segment_entry, Txn *txn_ptr, u16 block_id, u16 start_pos, u16 row_count);
 
     static void CommitDelete(SegmentEntry *segment_entry, Txn *txn_ptr, const HashMap<u16, Vector<RowID>> &block_row_hashmap);

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -75,12 +75,6 @@ public:
                                                               BufferManager *buffer_mgr,
                                                               TxnTableStore *txn_store);
 
-    static SharedPtr<SegmentColumnIndexEntry> CreateIndexFilePrepare(SegmentEntry *segment_entry,
-                                                                     ColumnIndexEntry *column_index_entry,
-                                                                     SharedPtr<ColumnDef> column_def,
-                                                                     TxnTimeStamp create_ts,
-                                                                     BufferManager *buffer_mgr);
-
     static void CommitAppend(SegmentEntry *segment_entry, Txn *txn_ptr, u16 block_id, u16 start_pos, u16 row_count);
 
     static void CommitDelete(SegmentEntry *segment_entry, Txn *txn_ptr, const HashMap<u16, Vector<RowID>> &block_row_hashmap);

--- a/src/storage/meta/entry/table_collection_entry.cpp
+++ b/src/storage/meta/entry/table_collection_entry.cpp
@@ -262,26 +262,6 @@ void TableCollectionEntry::CreateIndexFile(TableCollectionEntry *table_entry,
     }
 }
 
-void TableCollectionEntry::CreateIndexFilePrepare(TableCollectionEntry *table_entry,
-                                                  TableIndexEntry *table_index_entry,
-                                                  TxnTimeStamp begin_ts,
-                                                  BufferManager *buffer_mgr) {
-    if (table_index_entry->irs_index_entry_.get() != nullptr) {
-        Error<NotImplementException>("TableCollectionEntry::CreateIndexFilePrepare");
-    }
-    if (table_index_entry->column_index_map_.size() != 1) {
-        Error<NotImplementException>("TableCollectionEntry::CreateIndexFilePrepare");
-    }
-
-    auto [column_id, base_entry] = *table_index_entry->column_index_map_.begin();
-    SharedPtr<ColumnDef> column_def = table_entry->columns_[column_id];
-    auto column_index_entry = static_cast<ColumnIndexEntry *>(base_entry.get());
-
-    for (const auto &[segment_id, segment_entry] : table_entry->segment_map_) {
-        SegmentEntry::CreateIndexFilePrepare(segment_entry.get(), column_index_entry, column_def, begin_ts, buffer_mgr);
-    }
-}
-
 UniquePtr<String> TableCollectionEntry::Delete(TableCollectionEntry *table_entry, Txn *txn_ptr, DeleteState &delete_state) {
     for (const auto &to_delete_seg_rows : delete_state.rows_) {
         u32 segment_id = to_delete_seg_rows.first;

--- a/src/storage/meta/entry/table_collection_entry.cpp
+++ b/src/storage/meta/entry/table_collection_entry.cpp
@@ -262,6 +262,26 @@ void TableCollectionEntry::CreateIndexFile(TableCollectionEntry *table_entry,
     }
 }
 
+void TableCollectionEntry::CreateIndexFilePrepare(TableCollectionEntry *table_entry,
+                                                  TableIndexEntry *table_index_entry,
+                                                  TxnTimeStamp begin_ts,
+                                                  BufferManager *buffer_mgr) {
+    if (table_index_entry->irs_index_entry_.get() != nullptr) {
+        Error<NotImplementException>("TableCollectionEntry::CreateIndexFilePrepare");
+    }
+    if (table_index_entry->column_index_map_.size() != 1) {
+        Error<NotImplementException>("TableCollectionEntry::CreateIndexFilePrepare");
+    }
+
+    auto [column_id, base_entry] = *table_index_entry->column_index_map_.begin();
+    SharedPtr<ColumnDef> column_def = table_entry->columns_[column_id];
+    auto column_index_entry = static_cast<ColumnIndexEntry *>(base_entry.get());
+
+    for (const auto &[segment_id, segment_entry] : table_entry->segment_map_) {
+        SegmentEntry::CreateIndexFilePrepare(segment_entry.get(), column_index_entry, column_def, begin_ts, buffer_mgr);
+    }
+}
+
 UniquePtr<String> TableCollectionEntry::Delete(TableCollectionEntry *table_entry, Txn *txn_ptr, DeleteState &delete_state) {
     for (const auto &to_delete_seg_rows : delete_state.rows_) {
         u32 segment_id = to_delete_seg_rows.first;

--- a/src/storage/meta/entry/table_collection_entry.cppm
+++ b/src/storage/meta/entry/table_collection_entry.cppm
@@ -85,6 +85,9 @@ public:
                                 TxnTimeStamp begin_ts,
                                 BufferManager *buffer_mgr);
 
+    static void
+    CreateIndexFilePrepare(TableCollectionEntry *table_entry, TableIndexEntry *table_index_entry, TxnTimeStamp begin_ts, BufferManager *buffer_mgr);
+
     static UniquePtr<String> Delete(TableCollectionEntry *table_entry, Txn *txn_ptr, DeleteState &delete_state);
 
     static void CommitAppend(TableCollectionEntry *table_entry, Txn *txn_ptr, const AppendState *append_state_ptr);

--- a/src/storage/meta/entry/table_collection_entry.cppm
+++ b/src/storage/meta/entry/table_collection_entry.cppm
@@ -85,9 +85,6 @@ public:
                                 TxnTimeStamp begin_ts,
                                 BufferManager *buffer_mgr);
 
-    static void
-    CreateIndexFilePrepare(TableCollectionEntry *table_entry, TableIndexEntry *table_index_entry, TxnTimeStamp begin_ts, BufferManager *buffer_mgr);
-
     static UniquePtr<String> Delete(TableCollectionEntry *table_entry, Txn *txn_ptr, DeleteState &delete_state);
 
     static void CommitAppend(TableCollectionEntry *table_entry, Txn *txn_ptr, const AppendState *append_state_ptr);

--- a/src/storage/meta/iter/segment_iter.cppm
+++ b/src/storage/meta/iter/segment_iter.cppm
@@ -56,4 +56,20 @@ private:
     SharedPtr<Vector<SizeT>> column_ids_;
 };
 
+export template <typename DataType>
+class OneColumnIterator {
+public:
+    OneColumnIterator(const SegmentEntry *entry, SizeT column_id) : segment_iter_(entry, MakeShared<Vector<SizeT>>(Vector<SizeT>{column_id})) {}
+
+    Optional<const DataType *> Next() {
+        if (auto ret = segment_iter_.Next(); ret) {
+            return reinterpret_cast<const DataType *>((*ret)[0]);
+        }
+        return None;
+    }
+
+private:
+    SegmentIter segment_iter_;
+};
+
 } // namespace infinity

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -83,6 +83,21 @@ Status Txn::GetTableEntry(const String &db_name, const String &table_name, Table
     return Status::OK();
 }
 
+Status Txn::GetTableIndexEntry(const String &db_name, const String &table_name, const String &index_name, TableIndexEntry *&table_index_entry) {
+    TableCollectionEntry *table_entry = nullptr;
+    Status table_status = GetTableEntry(db_name, table_name, table_entry);
+    if (!table_status.ok()) {
+        return table_status;
+    }
+
+    BaseEntry *base_entry = nullptr;
+    TableCollectionEntry::GetIndex(table_entry, index_name, txn_id_, txn_context_.GetBeginTS(), base_entry);
+    table_index_entry = static_cast<TableIndexEntry *>(base_entry);
+
+    return Status::OK();
+}
+
+
 Status Txn::Append(const String &db_name, const String &table_name, const SharedPtr<DataBlock> &input_block) {
     TableCollectionEntry *table_entry{nullptr};
     Status status = GetTableEntry(db_name, table_name, table_entry);
@@ -422,7 +437,7 @@ Status Txn::CreateIndex(const String &db_name, const String &table_name, const S
 }
 
 Status
-Txn::CreateIndex(const String &table_name, TableCollectionEntry *table_entry, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type) {
+Txn::CreateIndex(TableCollectionEntry *table_entry, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type, TableIndexEntry *&table_index_entry) {
     TxnTimeStamp begin_ts = txn_context_.GetBeginTS();
 
     BaseEntry *base_entry{nullptr};
@@ -431,8 +446,8 @@ Txn::CreateIndex(const String &table_name, TableCollectionEntry *table_entry, co
         return index_status;
     }
 
-    auto *table_index_entry = static_cast<TableIndexEntry *>(base_entry);
-    TableCollectionEntry::CreateIndexFilePrepare(table_entry, table_index_entry, begin_ts, GetBufferMgr());
+    table_index_entry = static_cast<TableIndexEntry *>(base_entry);
+    txn_indexes_.emplace(*index_def->index_name_, table_index_entry);
     return index_status;
 }
 

--- a/src/storage/txn/txn.cppm
+++ b/src/storage/txn/txn.cppm
@@ -95,6 +95,8 @@ public:
     // Index OPs
     Status CreateIndex(const String &db_name, const String &table_name, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type);
 
+    Status CreateIndex(const String &table_name, TableCollectionEntry *table_entry, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type);
+
     Status DropIndexByName(const String &db_name, const String &table_name, const String &index_name, ConflictType conflict_type);
 
     // View Ops

--- a/src/storage/txn/txn.cppm
+++ b/src/storage/txn/txn.cppm
@@ -92,10 +92,12 @@ public:
 
     Status GetTableEntry(const String &db_name, const String &table_name, TableCollectionEntry *&table_entry);
 
+    Status GetTableIndexEntry(const String &db_name, const String &table_name, const String &index_name, TableIndexEntry *&table_index_entry);
+
     // Index OPs
     Status CreateIndex(const String &db_name, const String &table_name, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type);
 
-    Status CreateIndex(const String &table_name, TableCollectionEntry *table_entry, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type);
+    Status CreateIndex(TableCollectionEntry *table_entry, const SharedPtr<IndexDef> &index_def, ConflictType conflict_type, TableIndexEntry *&table_index_entry);
 
     Status DropIndexByName(const String &db_name, const String &table_name, const String &index_name, ConflictType conflict_type);
 

--- a/src/unit_test/storage/knnindex/knn_hnsw/test_dist_func.cpp
+++ b/src/unit_test/storage/knnindex/knn_hnsw/test_dist_func.cpp
@@ -43,13 +43,11 @@ float F32L2Test(const float *v1, const float *v2, size_t dim) {
 }
 
 TEST_F(DistFuncTest, test1) {
-    size_t dim = 32;
+    size_t dim = 200;
     size_t vec_n = 10000;
 
     auto vecs1 = std::make_unique<int8_t[]>(dim * vec_n);
     auto vecs2 = std::make_unique<int8_t[]>(dim * vec_n);
-
-    assert(dim % 32 == 0);
 
     // generate a random vector of int8_t
     std::default_random_engine rng;
@@ -64,7 +62,7 @@ TEST_F(DistFuncTest, test1) {
     for (size_t i = 0; i < vec_n; ++i) {
         auto v1 = vecs1.get() + i * dim;
         auto v2 = vecs2.get() + i * dim;
-        int32_t res = I8IPAVX(v1, v2, dim);
+        int32_t res = I8IPAVXResidual(v1, v2, dim);
         int32_t res2 = I8IPTest(v1, v2, dim);
         EXPECT_EQ(res, res2);
     }
@@ -75,7 +73,7 @@ TEST_F(DistFuncTest, test2) {
     using Distance = LVQL2Dist<float, int8_t>;
     using LVQ8Data = LVQ8Store::StoreType;
 
-    size_t dim = 128;
+    size_t dim = 200;
     size_t vec_n = 10000;
 
     auto vecs1 = std::make_unique<float[]>(dim * vec_n);
@@ -83,11 +81,11 @@ TEST_F(DistFuncTest, test2) {
 
     // generate a random vector of float
     std::default_random_engine rng;
-    std::uniform_real_distribution<float> dist(0, 1);
+    std::uniform_real_distribution<float> rdist(0, 1);
     for (size_t i = 0; i < vec_n; ++i) {
         for (size_t j = 0; j < dim; ++j) {
-            vecs1[i * dim + j] = dist(rng);
-            vecs2[i * dim + j] = dist(rng);
+            vecs1[i * dim + j] = rdist(rng);
+            vecs2[i * dim + j] = rdist(rng);
         }
     }
 

--- a/src/unit_test/test_hnsw.cpp
+++ b/src/unit_test/test_hnsw.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <queue>
@@ -33,21 +34,23 @@ using namespace infinity;
 
 int main() {
     using LabelT = uint64_t;
-    using RetHeap = std::priority_queue<std::pair<float, LabelT>>;
 
     std::string save_dir = tmp_data_path();
 
-    int dim = 128;
+    int dim = 16;
     int element_size = 1000;
+    int M = 16;
+    int ef_construction = 200;
 
-    // using Hnsw = KnnHnsw<float, LabelT, PlainStore<float>, PlainL2Dist<float>>;
-    using Hnsw = KnnHnsw<float, LabelT, LVQStore<float, int8_t, LVQL2Cache<float, int8_t>>, LVQL2Dist<float, int8_t>>;
+    using Hnsw = KnnHnsw<float, LabelT, PlainStore<float>, PlainL2Dist<float>>;
+    // using Hnsw = KnnHnsw<float, LabelT, LVQStore<float, int8_t, LVQL2Cache<float, int8_t>>, LVQL2Dist<float, int8_t>>;
 
     // NOTE: inner product correct rate is not 1. (the vector and itself's distance is not the smallest)
     // using Hnsw = KnnHnsw<float, LabelT, PlainStore<float>, PlainIPDist<float>>;
     // using Hnsw = KnnHnsw<float, LabelT, LVQStore<float, int8_t, LVQIPCache<float, int8_t>>, LVQIPDist<float, int8_t>>;
 
-    std::default_random_engine rng;
+    std::mt19937 rng;
+    rng.seed(0);
     std::uniform_real_distribution<float> distrib_real;
 
     auto data = std::make_unique<float[]>(dim * element_size);
@@ -57,27 +60,23 @@ int main() {
 
     LocalFileSystem fs;
 
-    int M = 16;
-    int ef_construction = 200;
-
     {
         auto hnsw_index = Hnsw::Make(element_size, dim, M, ef_construction, {});
 
         auto labels = std::make_unique<LabelT[]>(element_size);
         std::iota(labels.get(), labels.get() + element_size, 0);
-        hnsw_index->Insert(data.get(), labels.get(), element_size);
-        // hnsw_index->Dump(std::cout);
+        hnsw_index->InsertVecs(data.get(), labels.get(), element_size);
+        std::ofstream os("tmp/dump.txt");
+        hnsw_index->Dump(os);
         hnsw_index->Check();
-
-        // hnsw_index->Dump(std::cout);
-        hnsw_index->Check();
+        return 0;
 
         hnsw_index->SetEf(10);
         int correct = 0;
         for (int i = 0; i < element_size; ++i) {
             const float *query = data.get() + i * dim;
-            RetHeap result = hnsw_index->KnnSearch(query, 1);
-            if (result.top().second == (LabelT)i) {
+            auto result = hnsw_index->KnnSearch(query, 1);
+            if (result[0].second == (LabelT)i) {
                 ++correct;
             }
         }
@@ -97,12 +96,12 @@ int main() {
         hnsw_index->SetEf(10);
 
         // hnsw_index->Dump(std::cout);
-        // hnsw_index->Check();
+        hnsw_index->Check();
         int correct = 0;
         for (int i = 0; i < element_size; ++i) {
             const float *query = data.get() + i * dim;
-            std::priority_queue<std::pair<float, LabelT>> result = hnsw_index->KnnSearch(query, 1);
-            if (result.top().second == (LabelT)i) {
+            auto result = hnsw_index->KnnSearch(query, 1);
+            if (result[0].second == (LabelT)i) {
                 ++correct;
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Create hnsw index in parallel.

Issue link:
https://github.com/infiniflow/infinity/issues/341

### What is changed and how it works?

Note: Use round robin schedule strategy in "task_scheduler.cpp" can apply this pr.

0. Add mutex in hnsw algorithm to support access in multiple thread.
1. Add physical_node: CreateIndexPrepare, CreateIndexDo, CreateIndexFinish.
2. The 3 physical_node has different parallel number, so in 3 different fragment.
3. Use QueueSink and QueueSource to ensure the task execute in topic topological order.
4. Change QueueSource/Sink queue's content into an base class. So queue can transfer different information.

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer