### PR TITLE
implement physical_limit.cpp for support limit

### DIFF
--- a/src/common/blocking_queue.cppm
+++ b/src/common/blocking_queue.cppm
@@ -26,18 +26,32 @@ class BlockingQueue {
 public:
     explicit BlockingQueue(SizeT capacity = DEFAULT_BLOCKING_QUEUE_SIZE) : capacity_(capacity) {}
 
-    void Enqueue(T& task) {
+    void NotAllowEnqueue() {
+        allow_enqueue_ = false;
+    }
+
+    bool Enqueue(T& task) {
         UniqueLock<Mutex> lock(queue_mutex_);
+
+        if (!allow_enqueue_) {
+            return false;
+        }
         full_cv_.wait(lock, [this] { return queue_.size() < capacity_; });
         queue_.push_back(task);
         empty_cv_.notify_one();
+        return true;
     }
 
-    void Enqueue(T&& task) {
+    bool Enqueue(T&& task) {
         UniqueLock<Mutex> lock(queue_mutex_);
+
+        if (!allow_enqueue_) {
+            return false;
+        }
         full_cv_.wait(lock, [this] { return queue_.size() < capacity_; });
         queue_.push_back(Forward<T>(task));
         empty_cv_.notify_one();
+        return true;
     }
 
     void EnqueueBulk(List<T> &input_queue) {
@@ -99,6 +113,7 @@ public:
     }
 
 protected:
+    atomic_bool allow_enqueue_{true};
     mutable Mutex queue_mutex_{};
     CondVar full_cv_{};
     CondVar empty_cv_{};

--- a/src/common/blocking_queue.cppm
+++ b/src/common/blocking_queue.cppm
@@ -31,11 +31,11 @@ public:
     }
 
     bool Enqueue(T& task) {
-        UniqueLock<Mutex> lock(queue_mutex_);
-
         if (!allow_enqueue_) {
             return false;
         }
+
+        UniqueLock<Mutex> lock(queue_mutex_);
         full_cv_.wait(lock, [this] { return queue_.size() < capacity_; });
         queue_.push_back(task);
         empty_cv_.notify_one();
@@ -43,11 +43,11 @@ public:
     }
 
     bool Enqueue(T&& task) {
-        UniqueLock<Mutex> lock(queue_mutex_);
-
         if (!allow_enqueue_) {
             return false;
         }
+
+        UniqueLock<Mutex> lock(queue_mutex_);
         full_cv_.wait(lock, [this] { return queue_.size() < capacity_; });
         queue_.push_back(Forward<T>(task));
         empty_cv_.notify_one();

--- a/src/executor/fragment/plan_fragment.cppm
+++ b/src/executor/fragment/plan_fragment.cppm
@@ -18,6 +18,7 @@ import stl;
 import parser;
 import data_table;
 import fragment_context;
+import operator_state;
 import physical_operator;
 import physical_source;
 import physical_sink;

--- a/src/executor/fragment/plan_fragment.cppm
+++ b/src/executor/fragment/plan_fragment.cppm
@@ -18,7 +18,6 @@ import stl;
 import parser;
 import data_table;
 import fragment_context;
-import operator_state;
 import physical_operator;
 import physical_source;
 import physical_sink;

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -22,6 +22,7 @@ import physical_sink;
 import physical_source;
 import physical_explain;
 import physical_knn_scan;
+import operator_state;
 
 import infinity_exception;
 import parser;

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -22,7 +22,6 @@ import physical_sink;
 import physical_source;
 import physical_explain;
 import physical_knn_scan;
-import operator_state;
 
 import infinity_exception;
 import parser;

--- a/src/executor/operator/physical_filter.cppm
+++ b/src/executor/operator/physical_filter.cppm
@@ -47,8 +47,7 @@ public:
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     inline const SharedPtr<BaseExpression> &condition() const { return condition_; }

--- a/src/executor/operator/physical_limit.cpp
+++ b/src/executor/operator/physical_limit.cpp
@@ -92,7 +92,7 @@ bool AtomicCounter::IsLimitOver() {
 }
 
 SizeT UnSyncCounter::Offset(SizeT row_count) {
-    SizeT result;
+    SizeT result = 0;
 
     if (offset_ <= 0) {
         return 0;
@@ -111,7 +111,7 @@ SizeT UnSyncCounter::Offset(SizeT row_count) {
 }
 
 SizeT UnSyncCounter::Limit(SizeT row_count) {
-    SizeT result;
+    SizeT result = 0;
 
     if (limit_ <= 0) {
         return 0;

--- a/src/executor/operator/physical_limit.cpp
+++ b/src/executor/operator/physical_limit.cpp
@@ -18,9 +18,13 @@ module;
 
 import stl;
 import txn;
+import base_expression;
+import default_values;
+import load_meta;
 import query_context;
 import table_def;
 import data_table;
+import default_values;
 import parser;
 import physical_operator_type;
 import operator_state;
@@ -34,130 +38,201 @@ module physical_limit;
 
 namespace infinity {
 
-void PhysicalLimit::Init() {}
+SizeT AtomicCounter::Offset(SizeT row_count) {
+    auto success = false;
+    SizeT result;
 
-bool PhysicalLimit::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    while (!success) {
+        i64 current_offset = offset_;
+        if (current_offset <= 0) {
+            return 0;
+        }
+        i64 last_offset = current_offset - row_count;
 
-#if 0
-    // output table definition is same as input
-    input_table_ = left_->output();
-    Assert<ExecutorException>(input_table_.get() != nullptr, "No input");
-
-    Assert<ExecutorException>(limit_expr_->type() == ExpressionType::kValue, "Currently, only support constant limit expression");
-
-    i64 limit = (static_pointer_cast<ValueExpression>(limit_expr_))->GetValue().value_.big_int;
-    Assert<ExecutorException>(limit > 0, "Limit should be larger than 0");
-    i64 offset = 0;
-    if (offset_expr_ != nullptr) {
-        Assert<ExecutorException>(offset_expr_->type() == ExpressionType::kValue, "Currently, only support constant limit expression");
-        offset = (static_pointer_cast<ValueExpression>(offset_expr_))->GetValue().value_.big_int;
-        Assert<ExecutorException>(offset >= 0 && offset < input_table_->row_count(),
-                                  "Offset should be larger or equal than 0 and less than row number");
+        if (last_offset > 0) {
+            success = offset_.compare_exchange_strong(current_offset, last_offset);
+            result = row_count;
+        } else {
+            success = offset_.compare_exchange_strong(current_offset, 0);
+            result = current_offset;
+        }
     }
 
-    output_ = GetLimitOutput(input_table_, limit, offset);
-#endif
+    return result;
+}
+
+SizeT AtomicCounter::Limit(SizeT row_count) {
+    auto success = false;
+    SizeT result;
+
+    while (!success) {
+        i64 current_limit = limit_;
+        if (current_limit <= 0) {
+            return 0;
+        }
+        i64 last_limit = current_limit - row_count;
+
+        if (last_limit > 0) {
+            success = limit_.compare_exchange_strong(current_limit, last_limit);
+            result = row_count;
+        } else {
+            success = limit_.compare_exchange_strong(current_limit, 0);
+            result = current_limit;
+        }
+    }
+
+    return result;
+}
+
+bool AtomicCounter::IsLimitOver() {
+    if (limit_ < 0) {
+        Error<ExecutorException>("limit is not allowed to be smaller than 0");
+    }
+    return limit_ == 0;
+}
+
+SizeT UnSyncCounter::Offset(SizeT row_count) {
+    SizeT result;
+
+    if (offset_ <= 0) {
+        return 0;
+    }
+    i64 last_offset = offset_ - row_count;
+
+    if (last_offset > 0) {
+        result = row_count;
+        offset_ = last_offset;
+    } else {
+        result = offset_;
+        offset_ = 0;
+    }
+
+    return result;
+}
+
+SizeT UnSyncCounter::Limit(SizeT row_count) {
+    SizeT result;
+
+    if (limit_ <= 0) {
+        return 0;
+    }
+    i64 last_limit = limit_ - row_count;
+
+    if (last_limit > 0) {
+        result = row_count;
+        limit_ = last_limit;
+    } else {
+        result = limit_;
+        limit_ = 0;
+    }
+
+    return result;
+}
+
+bool UnSyncCounter::IsLimitOver() {
+    if (limit_ < 0) {
+        Error<ExecutorException>("limit is not allowed to be smaller than 0");
+    }
+    return limit_ == 0;
+}
+
+PhysicalLimit::PhysicalLimit(u64 id,
+                             UniquePtr<PhysicalOperator> left,
+                             SharedPtr<BaseExpression> limit_expr,
+                             SharedPtr<BaseExpression> offset_expr,
+                             SharedPtr<Vector<LoadMeta>> load_metas)
+    : PhysicalOperator(PhysicalOperatorType::kLimit, Move(left), nullptr, id, load_metas), limit_expr_(Move(limit_expr)),
+      offset_expr_(Move(offset_expr)) {
+    i64 offset = 0;
+    i64 limit = (static_pointer_cast<ValueExpression>(limit_expr_))->GetValue().value_.big_int;
+
+    if (offset_expr_ != nullptr) {
+        offset = (static_pointer_cast<ValueExpression>(offset_expr_))->GetValue().value_.big_int;
+    }
+
+    counter_ = MakeShared<UnSyncCounter>(offset, limit);
+}
+
+void PhysicalLimit::Init() {}
+
+SizeT PhysicalLimit::TaskletCount() {
+    i64 limit = (static_pointer_cast<ValueExpression>(limit_expr_))->GetValue().value_.big_int;
+
+    return limit / DEFAULT_BLOCK_CAPACITY;
+}
+
+//    offset     limit + offset
+//    left       right
+// | a | b | c | d | e | f
+bool PhysicalLimit::Execute(QueryContext *query_context,
+                            const Vector<UniquePtr<DataBlock>> &input_blocks,
+                            Vector<UniquePtr<DataBlock>> &output_blocks,
+                            SharedPtr<LimitCounter> counter) {
+    SizeT input_row_count = 0;
+
+    for (SizeT block_id = 0; block_id < input_blocks.size(); block_id++) {
+        input_row_count += input_blocks[block_id]->row_count();
+    }
+
+    SizeT offset = counter->Offset(input_row_count);
+    if (offset == input_row_count) {
+        return true;
+    }
+
+    SizeT limit = counter->Limit(input_row_count - offset);
+    SizeT block_start_idx = 0;
+
+    for (SizeT block_id = 0; block_id < input_blocks.size(); block_id++) {
+        if (input_blocks[block_id]->row_count() == 0) {
+            continue;
+        }
+        SizeT max_offset = input_blocks[block_id]->row_count() - 1;
+
+        if (offset > max_offset) {
+            offset -= max_offset;
+            continue;
+        } else {
+            block_start_idx = block_id;
+            break;
+        }
+    }
+
+    for (SizeT block_id = block_start_idx; block_id < input_blocks.size(); block_id++) {
+        auto &input_block = input_blocks[block_id];
+        auto row_count = input_block->row_count();
+        if (row_count == 0) {
+            continue;
+        }
+        auto block = DataBlock::MakeUniquePtr();
+
+        block->Init(input_block->types());
+        if (limit >= row_count) {
+            block->AppendWith(input_block.get(), offset, row_count);
+            limit -= row_count;
+        } else {
+            block->AppendWith(input_block.get(), offset, limit);
+            limit = 0;
+        }
+        block->Finalize();
+        output_blocks.push_back(Move(block));
+        offset = 0;
+
+        if (limit == 0) {
+            break;
+        }
+    }
+
     return true;
 }
 
-SharedPtr<DataTable> PhysicalLimit::GetLimitOutput(const SharedPtr<DataTable> &input_table, i64 limit, i64 offset) {
-    SizeT start_block = 0;
-    SizeT start_row_id = 0;
-    SizeT end_block = 0;
-    SizeT end_row_id = 0;
+bool PhysicalLimit::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    auto result = Execute(query_context, operator_state->prev_op_state_->data_block_array_, operator_state->data_block_array_, counter_);
 
-    if (offset == 0) {
-        if (limit >= (i64)input_table->row_count()) {
-            return input_table;
-        } else {
-            start_block = 0;
-            start_row_id = 0;
-            SizeT block_count = input_table->DataBlockCount();
-            i64 total_row_count = limit;
-            for (SizeT block_id = 0; block_id < block_count; ++block_id) {
-                SizeT block_row_count = input_table->GetDataBlockById(block_id)->row_count();
-                if (total_row_count > (i64)block_row_count) {
-                    total_row_count -= block_row_count;
-                } else {
-                    end_block = block_id;
-                    end_row_id = total_row_count;
-                    break;
-                }
-            }
-        }
-    } else {
-        i64 total_row_count = offset;
-        SizeT block_count = input_table->DataBlockCount();
-        SizeT rest_row_count = 0;
-        for (SizeT block_id = 0; block_id < block_count; ++block_id) {
-            SizeT block_row_count = input_table->GetDataBlockById(block_id)->row_count();
-            if (total_row_count >= (i64)block_row_count) {
-                total_row_count -= block_row_count;
-            } else {
-                start_block = block_id;
-                start_row_id = total_row_count;
-                rest_row_count = block_row_count - total_row_count;
-                break;
-            }
-        }
-
-        total_row_count = limit;
-        if (total_row_count <= (i64)rest_row_count) {
-            end_block = start_block;
-            end_row_id = total_row_count;
-        } else {
-            total_row_count -= rest_row_count;
-            for (SizeT block_id = start_block + 1; block_id < block_count; ++block_id) {
-                SizeT block_row_count = input_table->GetDataBlockById(block_id)->row_count();
-                if (total_row_count > (i64)block_row_count) {
-                    total_row_count -= block_row_count;
-                } else {
-                    end_block = block_id;
-                    end_row_id = total_row_count;
-                    break;
-                }
-            }
-        }
+    operator_state->prev_op_state_->data_block_array_.clear();
+    if (counter_->IsLimitOver() || operator_state->prev_op_state_->Complete()) {
+        operator_state->SetComplete();
     }
-
-    // Copy from input table to output table
-    SizeT column_count = input_table->ColumnCount();
-    Vector<SharedPtr<DataType>> types;
-    types.reserve(column_count);
-    Vector<SharedPtr<ColumnDef>> columns;
-    columns.reserve(column_count);
-    for (SizeT idx = 0; idx < column_count; ++idx) {
-        SharedPtr<DataType> col_type = input_table->GetColumnTypeById(idx);
-        types.emplace_back(col_type);
-
-        String col_name = input_table->GetColumnNameById(idx);
-
-        SharedPtr<ColumnDef> col_def = MakeShared<ColumnDef>(idx, col_type, col_name, HashSet<ConstraintType>());
-        columns.emplace_back(col_def);
-    }
-
-    SharedPtr<TableDef> table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("limit"), columns);
-    SharedPtr<DataTable> output_table = DataTable::Make(table_def, TableType::kIntermediate);
-
-    const Vector<SharedPtr<DataBlock>> &input_datablocks = input_table->data_blocks_;
-
-    for (SizeT block_id = start_block; block_id <= end_block; ++block_id) {
-        SizeT input_start_offset = start_row_id;
-        SizeT input_end_offset;
-        if (end_block == block_id) {
-            input_end_offset = end_row_id;
-        } else {
-            // current input block isn't the last one.
-            input_end_offset = input_datablocks[block_id]->row_count();
-        }
-
-        SharedPtr<DataBlock> output_datablock = DataBlock::Make();
-        output_datablock->Init(input_datablocks[block_id], input_start_offset, input_end_offset);
-        output_table->Append(output_datablock);
-
-        start_row_id = 0;
-    }
-    return output_table;
+    return result;
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_limit.cppm
+++ b/src/executor/operator/physical_limit.cppm
@@ -54,8 +54,8 @@ public:
     bool IsLimitOver();
 
 private:
-    ai64 offset_;
-    ai64 limit_;
+    ai64 offset_{};
+    ai64 limit_{};
 };
 
 export class UnSyncCounter : public LimitCounter {
@@ -69,8 +69,8 @@ public:
     bool IsLimitOver();
 
 private:
-    i64 offset_;
-    i64 limit_;
+    i64 offset_{};
+    i64 limit_{};
 };
 
 export class PhysicalLimit : public PhysicalOperator {
@@ -108,7 +108,7 @@ private:
     SharedPtr<BaseExpression> limit_expr_{};
     SharedPtr<BaseExpression> offset_expr_{};
 
-    UniquePtr<LimitCounter> counter_;
+    UniquePtr<LimitCounter> counter_{};
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_limit.cppm
+++ b/src/executor/operator/physical_limit.cppm
@@ -45,7 +45,7 @@ public:
 
 export class AtomicCounter : public LimitCounter {
 public:
-    AtomicCounter(const i64 &offset, const i64 &limit) : offset_(offset), limit_(limit) {}
+    AtomicCounter(i64 offset, i64 limit) : offset_(offset), limit_(limit) {}
 
     SizeT Offset(SizeT row_count);
 
@@ -60,7 +60,7 @@ private:
 
 export class UnSyncCounter : public LimitCounter {
 public:
-    UnSyncCounter(const i64 &offset, const i64 &limit) : offset_(offset), limit_(limit) {}
+    UnSyncCounter(i64 offset, i64 limit) : offset_(offset), limit_(limit) {}
 
     SizeT Offset(SizeT row_count);
 
@@ -88,7 +88,7 @@ public:
     static bool Execute(QueryContext *query_context,
                         const Vector<UniquePtr<DataBlock>> &input_blocks,
                         Vector<UniquePtr<DataBlock>> &output_blocks,
-                        SharedPtr<LimitCounter> counter);
+                        LimitCounter *counter);
 
     bool Execute(QueryContext *query_context, OperatorState *operator_state) final;
 
@@ -96,7 +96,9 @@ public:
 
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
-    SizeT TaskletCount() override;
+    SizeT TaskletCount() override {
+        return left_->TaskletCount();
+    }
 
     inline const SharedPtr<BaseExpression> &limit_expr() const { return limit_expr_; }
 
@@ -106,7 +108,7 @@ private:
     SharedPtr<BaseExpression> limit_expr_{};
     SharedPtr<BaseExpression> offset_expr_{};
 
-    SharedPtr<LimitCounter> counter_;
+    UniquePtr<LimitCounter> counter_;
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_limit.cpp
+++ b/src/executor/operator/physical_merge_limit.cpp
@@ -14,15 +14,49 @@
 
 module;
 
+#include <memory>
+
+import stl;
 import query_context;
+import base_expression;
+import load_meta;
+import physical_operator_type;
+import value_expression;
+import physical_limit;
 import operator_state;
 
 module physical_merge_limit;
 
 namespace infinity {
 
+PhysicalMergeLimit::PhysicalMergeLimit(u64 id,
+                                       UniquePtr<PhysicalOperator> left,
+                                       SharedPtr<BaseExpression> limit_expr,
+                                       SharedPtr<BaseExpression> offset_expr,
+                                       SharedPtr<Vector<LoadMeta>> load_metas)
+    : PhysicalOperator(PhysicalOperatorType::kMergeLimit, Move(left), nullptr, id, load_metas), limit_expr_(Move(limit_expr)),
+      offset_expr_(Move(offset_expr)) {
+    i64 offset = 0;
+    i64 limit = (static_pointer_cast<ValueExpression>(limit_expr_))->GetValue().value_.big_int;
+
+    if (offset_expr_ != nullptr) {
+        offset = (static_pointer_cast<ValueExpression>(offset_expr_))->GetValue().value_.big_int;
+    }
+    counter_ = MakeShared<UnSyncCounter>(offset, limit);
+}
+
 void PhysicalMergeLimit::Init() {}
 
-bool PhysicalMergeLimit::Execute(QueryContext *, OperatorState *) { return true; }
+bool PhysicalMergeLimit::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)operator_state;
+    auto result = PhysicalLimit::Execute(query_context, limit_op_state->input_data_blocks_, limit_op_state->data_block_array_, counter_);
+
+    if (counter_->IsLimitOver() || limit_op_state->input_complete_) {
+        limit_op_state->input_complete_ = true;
+        limit_op_state->SetComplete();
+    }
+    limit_op_state->input_data_blocks_.clear();
+    return result;
+}
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_limit.cppm
+++ b/src/executor/operator/physical_merge_limit.cppm
@@ -56,7 +56,7 @@ private:
     SharedPtr<BaseExpression> limit_expr_{};
     SharedPtr<BaseExpression> offset_expr_{};
 
-    SharedPtr<LimitCounter> counter_;
+    UniquePtr<LimitCounter> counter_;
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_limit.cppm
+++ b/src/executor/operator/physical_merge_limit.cppm
@@ -16,9 +16,11 @@ module;
 
 import stl;
 import parser;
+import base_expression;
 import query_context;
 import operator_state;
 import physical_operator;
+import physical_limit;
 import physical_operator_type;
 import load_meta;
 import infinity_exception;
@@ -29,12 +31,11 @@ namespace infinity {
 
 export class PhysicalMergeLimit final : public PhysicalOperator {
 public:
-    explicit PhysicalMergeLimit(SharedPtr<Vector<String>> output_names,
-                                SharedPtr<Vector<SharedPtr<DataType>>> output_types,
-                                u64 id,
-                                SharedPtr<Vector<LoadMeta>> load_metas)
-        : PhysicalOperator(PhysicalOperatorType::kMergeLimit, nullptr, nullptr, id, load_metas), output_names_(Move(output_names)),
-          output_types_(Move(output_types)) {}
+    explicit PhysicalMergeLimit(u64 id,
+                                UniquePtr<PhysicalOperator> left,
+                                SharedPtr<BaseExpression> limit_expr,
+                                SharedPtr<BaseExpression> offset_expr,
+                                SharedPtr<Vector<LoadMeta>> load_metas);
 
     ~PhysicalMergeLimit() override = default;
 
@@ -42,9 +43,9 @@ public:
 
     bool Execute(QueryContext *query_context, OperatorState *operator_state) final;
 
-    inline SharedPtr<Vector<String>> GetOutputNames() const final { return output_names_; }
+    inline SharedPtr<Vector<String>> GetOutputNames() const final { return left_->GetOutputNames(); }
 
-    inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return output_types_; }
+    inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
     SizeT TaskletCount() override {
         Error<NotImplementException>("TaskletCount not Implement");
@@ -52,8 +53,10 @@ public:
     }
 
 private:
-    SharedPtr<Vector<String>> output_names_{};
-    SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};
+    SharedPtr<BaseExpression> limit_expr_{};
+    SharedPtr<BaseExpression> offset_expr_{};
+
+    SharedPtr<LimitCounter> counter_;
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_limit.cppm
+++ b/src/executor/operator/physical_merge_limit.cppm
@@ -56,7 +56,7 @@ private:
     SharedPtr<BaseExpression> limit_expr_{};
     SharedPtr<BaseExpression> offset_expr_{};
 
-    UniquePtr<LimitCounter> counter_;
+    UniquePtr<LimitCounter> counter_{};
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_project.cppm
+++ b/src/executor/operator/physical_project.cppm
@@ -49,8 +49,7 @@ public:
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final;
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     Vector<SharedPtr<BaseExpression>> expressions_{};

--- a/src/executor/operator/physical_sink.cppm
+++ b/src/executor/operator/physical_sink.cppm
@@ -27,6 +27,8 @@ export module physical_sink;
 
 namespace infinity {
 
+class FragmentContext;
+
 export enum class SinkType {
     kInvalid,
     kLocalQueue,
@@ -46,7 +48,7 @@ public:
 
     bool Execute(QueryContext *query_context, OperatorState *output_state) final;
 
-    bool Execute(QueryContext *query_context, SinkState *sink_state);
+    bool Execute(QueryContext *query_context, FragmentContext *fragment_context, SinkState *sink_state);
 
     inline SharedPtr<Vector<String>> GetOutputNames() const final { return output_names_; }
 
@@ -68,7 +70,7 @@ private:
 
     void FillSinkStateFromLastOperatorState(SummarySinkState *message_sink_state, OperatorState *task_operator_state);
 
-    void FillSinkStateFromLastOperatorState(QueueSinkState *queue_sink_state, OperatorState *task_operator_state);
+    void FillSinkStateFromLastOperatorState(FragmentContext *fragment_context, QueueSinkState *queue_sink_state, OperatorState *task_operator_state);
 
 private:
     SharedPtr<Vector<String>> output_names_{};

--- a/src/executor/operator/physical_sort.cppm
+++ b/src/executor/operator/physical_sort.cppm
@@ -57,8 +57,7 @@ public:
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     Vector<SharedPtr<BaseExpression>> expressions_;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -45,7 +45,10 @@ bool QueueSourceState::GetData() {
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
-            if (fragment_data->data_idx_ + 1 == fragment_data->data_count_) {
+            if (!fragment_data->data_idx_.has_value()) {
+                // fragment completed
+                MarkCompletedTask(fragment_data->fragment_id_);
+            } else if (fragment_data->data_idx_.value() + 1 == fragment_data->data_count_) {
                 // Get an all data from this
                 MarkCompletedTask(fragment_data->fragment_id_);
             }
@@ -97,6 +100,12 @@ bool QueueSourceState::GetData() {
         case PhysicalOperatorType::kCreateIndexFinish: {
             auto *create_index_finish_op_state = static_cast<CreateIndexFinishOperatorState *>(next_op_state);
             create_index_finish_op_state->input_complete_ = completed;
+            break;
+        }
+        case PhysicalOperatorType::kMergeLimit: {
+            MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)next_op_state;
+            limit_op_state->input_data_blocks_.push_back(Move(fragment_data->data_block_));
+            limit_op_state->input_complete_ = completed;
             break;
         }
         default: {

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -103,6 +103,7 @@ bool QueueSourceState::GetData() {
             break;
         }
         case PhysicalOperatorType::kMergeLimit: {
+            auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
             MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)next_op_state;
             limit_op_state->input_data_blocks_.push_back(Move(fragment_data->data_block_));
             limit_op_state->input_complete_ = completed;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -106,7 +106,12 @@ bool QueueSourceState::GetData() {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
             MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)next_op_state;
             limit_op_state->input_data_blocks_.push_back(Move(fragment_data->data_block_));
-            limit_op_state->input_complete_ = completed;
+            if (!limit_op_state->input_complete_) {
+                limit_op_state->input_complete_ = completed;
+            }
+            if (limit_op_state->input_complete_) {
+                source_queue_.NotAllowEnqueue();
+            }
             break;
         }
         default: {

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -31,13 +31,6 @@ export module operator_state;
 
 namespace infinity {
 
-export enum class FragmentType {
-    kInvalid,
-    kSerialMaterialize,
-    kParallelMaterialize,
-    kParallelStream,
-};
-
 export struct OperatorState {
     inline explicit OperatorState(PhysicalOperatorType operator_type) : operator_type_(operator_type) {}
     virtual ~OperatorState() = default;
@@ -417,34 +410,31 @@ export enum class SinkStateType {
 
 export struct SinkState {
     virtual ~SinkState() {}
-    inline explicit SinkState(SinkStateType state_type, u64 fragment_id, FragmentType fragment_type, u64 task_id)
-        : fragment_id_(fragment_id), task_id_(task_id), fragment_type_(fragment_type), state_type_(state_type) {}
+    inline explicit SinkState(SinkStateType state_type, u64 fragment_id, u64 task_id)
+        : fragment_id_(fragment_id), task_id_(task_id), state_type_(state_type) {}
 
     inline void SetPrevOpState(OperatorState *prev_op_state) { prev_op_state_ = prev_op_state; }
 
     [[nodiscard]] inline SinkStateType state_type() const { return state_type_; }
 
-    [[nodiscard]] inline bool IsMaterialize() const { return fragment_type_ == FragmentType::kSerialMaterialize || fragment_type_ == FragmentType::kParallelMaterialize; }
-
     inline bool Error() const { return error_message_.get() != nullptr; }
 
     u64 fragment_id_{};
     u64 task_id_{};
-    FragmentType fragment_type_{};
     OperatorState *prev_op_state_{};
     SinkStateType state_type_{SinkStateType::kInvalid};
     UniquePtr<String> error_message_{};
 };
 
 export struct QueueSinkState : public SinkState {
-    inline explicit QueueSinkState(u64 fragment_id, FragmentType fragment_type, u64 task_id) : SinkState(SinkStateType::kQueue, fragment_id, fragment_type, task_id) {}
+    inline explicit QueueSinkState(u64 fragment_id, u64 task_id) : SinkState(SinkStateType::kQueue, fragment_id, task_id) {}
 
     Vector<UniquePtr<DataBlock>> data_block_array_{};
     Vector<BlockingQueue<SharedPtr<FragmentDataBase>> *> fragment_data_queues_;
 };
 
 export struct MaterializeSinkState : public SinkState {
-    inline explicit MaterializeSinkState(u64 fragment_id, FragmentType fragment_type, u64 task_id) : SinkState(SinkStateType::kMaterialize, fragment_id, fragment_type, task_id) {}
+    inline explicit MaterializeSinkState(u64 fragment_id, u64 task_id) : SinkState(SinkStateType::kMaterialize, fragment_id, task_id) {}
 
     SharedPtr<Vector<SharedPtr<DataType>>> column_types_{};
     SharedPtr<Vector<String>> column_names_{};
@@ -454,19 +444,19 @@ export struct MaterializeSinkState : public SinkState {
 };
 
 export struct ResultSinkState : public SinkState {
-    inline explicit ResultSinkState() : SinkState(SinkStateType::kResult, 0, FragmentType::kInvalid, 0) {}
+    inline explicit ResultSinkState() : SinkState(SinkStateType::kResult, 0, 0) {}
 
     SharedPtr<ColumnDef> result_def_{};
 };
 
 export struct MessageSinkState : public SinkState {
-    inline explicit MessageSinkState() : SinkState(SinkStateType::kMessage, 0, FragmentType::kInvalid, 0) {}
+    inline explicit MessageSinkState() : SinkState(SinkStateType::kMessage, 0, 0) {}
 
     UniquePtr<String> message_{};
 };
 
 export struct SummarySinkState : public SinkState {
-    inline explicit SummarySinkState() : SinkState(SinkStateType::kSummary, 0, FragmentType::kInvalid, 0), count_(0), sum_(0) {}
+    inline explicit SummarySinkState() : SinkState(SinkStateType::kSummary, 0, 0), count_(0), sum_(0) {}
 
     u64 count_;
     u64 sum_;

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -115,6 +115,8 @@ import logical_match;
 import logical_fusion;
 
 import parser;
+import value;
+import value_expression;
 import explain_physical_plan;
 
 import infinity_exception;
@@ -543,11 +545,11 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildAggregate(const SharedPtr<Logi
         return physical_agg_op;
     } else {
         return MakeUnique<PhysicalMergeAggregate>(query_context_ptr_->GetNextNodeID(),
-                                            logical_aggregate->base_table_ref_,
-                                            Move(physical_agg_op),
-                                            logical_aggregate->GetOutputNames(),
-                                            logical_aggregate->GetOutputTypes(),
-                                            logical_operator->load_metas());
+                                                  logical_aggregate->base_table_ref_,
+                                                  Move(physical_agg_op),
+                                                  logical_aggregate->GetOutputNames(),
+                                                  logical_aggregate->GetOutputTypes(),
+                                                  logical_operator->load_metas());
     }
 }
 
@@ -638,16 +640,25 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildLimit(const SharedPtr<LogicalN
 
     SharedPtr<LogicalLimit> logical_limit = static_pointer_cast<LogicalLimit>(logical_operator);
     UniquePtr<PhysicalOperator> input_physical_operator = BuildPhysicalOperator(input_logical_node);
-    auto limit_op = MakeUnique<PhysicalLimit>(logical_operator->node_id(),
-                                     Move(input_physical_operator),
-                                     logical_limit->limit_expression_,
-                                     logical_limit->offset_expression_,
-                                     logical_operator->load_metas());
-    if (limit_op->TaskletCount() <= 1) {
-        return limit_op;
+    if (input_physical_operator->TaskletCount() <= 1) {
+        return MakeUnique<PhysicalLimit>(logical_operator->node_id(),
+                                         Move(input_physical_operator),
+                                         logical_limit->limit_expression_,
+                                         logical_limit->offset_expression_,
+                                         logical_operator->load_metas());
     } else {
+        i64 child_limit = (static_pointer_cast<ValueExpression>(logical_limit->limit_expression_))->GetValue().value_.big_int;
+
+        if (logical_limit->offset_expression_ != nullptr) {
+            child_limit += (static_pointer_cast<ValueExpression>(logical_limit->offset_expression_))->GetValue().value_.big_int;
+        }
+        auto child_limit_op = MakeUnique<PhysicalLimit>(logical_operator->node_id(),
+                                                        Move(input_physical_operator),
+                                                        MakeShared<ValueExpression>(Value::MakeBigInt(child_limit)),
+                                                        nullptr,
+                                                        logical_operator->load_metas());
         return MakeUnique<PhysicalMergeLimit>(query_context_ptr_->GetNextNodeID(),
-                                              Move(limit_op),
+                                              Move(child_limit_op),
                                               logical_limit->limit_expression_,
                                               logical_limit->offset_expression_,
                                               logical_operator->load_metas());

--- a/src/planner/bound_select_statement.cpp
+++ b/src/planner/bound_select_statement.cpp
@@ -110,6 +110,12 @@ SharedPtr<LogicalNode> BoundSelectStatement::BuildPlan(QueryContext *query_conte
             root = sort;
         }
 
+        if (limit_expression_ != nullptr) {
+            auto limit = MakeShared<LogicalLimit>(bind_context->GetNewLogicalNodeId(), limit_expression_, offset_expression_);
+            limit->set_left_node(root);
+            root = limit;
+        }
+
         auto project = MakeShared<LogicalProject>(bind_context->GetNewLogicalNodeId(), projection_expressions_, projection_index_);
         project->set_left_node(root);
         root = project;

--- a/src/planner/optimizer/lazy_load.cpp
+++ b/src/planner/optimizer/lazy_load.cpp
@@ -135,6 +135,7 @@ void CleanScan::VisitNode(LogicalNode &op) {
             match.base_table_ref_->RetainColumnByIndices(Move(project_indices));
             break;
         }
+        case LogicalNodeType::kLimit:
         case LogicalNodeType::kFusion: {
             // Skip
             VisitNodeChildren(op);

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -687,7 +687,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
             }
 
             for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                auto sink_state = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), task_id);
+                auto sink_state = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), task_id);
                 sink_state->column_types_ = last_operator->GetOutputTypes();
                 sink_state->column_names_ = last_operator->GetOutputNames();
 
@@ -705,7 +705,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
             }
 
             for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                auto sink_state = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), task_id);
+                auto sink_state = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
 
                 tasks_[task_id]->sink_state_ = Move(sink_state);
             }
@@ -726,7 +726,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
                 Error<SchedulerException>(Format("{} task count isn't correct.", PhysicalOperatorToString(last_operator->operator_type())));
             }
 
-            tasks_[0]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), 0);
+            tasks_[0]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), 0);
             break;
         }
 
@@ -741,7 +741,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
                 Error<SchedulerException>(Format("{} task count isn't correct.", PhysicalOperatorToString(last_operator->operator_type())));
             }
 
-            tasks_[0]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), 0);
+            tasks_[0]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), 0);
             MaterializeSinkState *sink_state_ptr = static_cast<MaterializeSinkState *>(tasks_[0]->sink_state_.get());
             sink_state_ptr->column_types_ = last_operator->GetOutputTypes();
             sink_state_ptr->column_names_ = last_operator->GetOutputNames();
@@ -749,7 +749,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
         }
         case PhysicalOperatorType::kMatch: {
             for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                tasks_[task_id]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), task_id);
+                tasks_[task_id]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
             }
             break;
         }
@@ -767,7 +767,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
             }
 
             for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                tasks_[task_id]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), task_id);
+                tasks_[task_id]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
             }
             break;
         }
@@ -784,7 +784,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
             }
 
             for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                tasks_[task_id]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), task_id);
+                tasks_[task_id]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), task_id);
                 MaterializeSinkState *sink_state_ptr = static_cast<MaterializeSinkState *>(tasks_[task_id]->sink_state_.get());
                 sink_state_ptr->column_types_ = last_operator->GetOutputTypes();
                 sink_state_ptr->column_names_ = last_operator->GetOutputNames();
@@ -797,7 +797,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
                     Error<SchedulerException>("SerialMaterialize type fragment should only have 1 task.");
                 }
 
-                tasks_[0]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), 0);
+                tasks_[0]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), 0);
                 MaterializeSinkState *sink_state_ptr = static_cast<MaterializeSinkState *>(tasks_[0]->sink_state_.get());
                 sink_state_ptr->column_types_ = last_operator->GetOutputTypes();
                 sink_state_ptr->column_names_ = last_operator->GetOutputNames();
@@ -807,7 +807,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
                 }
 
                 for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                    tasks_[task_id]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), fragment_ptr_->GetFragmentType(), task_id);
+                    tasks_[task_id]->sink_state_ = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), task_id);
                     MaterializeSinkState *sink_state_ptr = static_cast<MaterializeSinkState *>(tasks_[task_id]->sink_state_.get());
                     sink_state_ptr->column_types_ = last_operator->GetOutputTypes();
                     sink_state_ptr->column_names_ = last_operator->GetOutputNames();

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -18,7 +18,6 @@ import stl;
 import fragment_task;
 import query_context;
 import profiler;
-import operator_state;
 import physical_operator;
 import physical_source;
 import physical_sink;
@@ -30,6 +29,23 @@ import create_index_data;
 export module fragment_context;
 
 namespace infinity {
+
+class PlanFragment;
+
+//class KnnScanSharedData;
+
+// enum class FragmentStatus {
+//     kNotStart,
+//     k
+//     kStart,
+//     kFinish,
+// };
+export enum class FragmentType {
+    kInvalid,
+    kSerialMaterialize,
+    kParallelMaterialize,
+    kParallelStream,
+};
 
 class PlanFragment;
 
@@ -63,6 +79,9 @@ public:
     void CreateTasks(i64 parallel_count, i64 operator_count);
 
     inline Vector<UniquePtr<FragmentTask>> &Tasks() { return tasks_; }
+
+    [[nodiscard]] inline bool IsMaterialize() const { return fragment_type_ == FragmentType::kSerialMaterialize || fragment_type_ == FragmentType::kParallelMaterialize; }
+
 
     inline SharedPtr<DataTable> GetResult() {
         UniqueLock<Mutex> lk(locker_);

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -18,6 +18,7 @@ import stl;
 import fragment_task;
 import query_context;
 import profiler;
+import operator_state;
 import physical_operator;
 import physical_source;
 import physical_sink;
@@ -31,21 +32,6 @@ export module fragment_context;
 namespace infinity {
 
 class PlanFragment;
-
-//class KnnScanSharedData;
-
-// enum class FragmentStatus {
-//     kNotStart,
-//     k
-//     kStart,
-//     kFinish,
-// };
-export enum class FragmentType {
-    kInvalid,
-    kSerialMaterialize,
-    kParallelMaterialize,
-    kParallelStream,
-};
 
 export class FragmentContext {
 public:

--- a/src/scheduler/fragment_data.cppm
+++ b/src/scheduler/fragment_data.cppm
@@ -45,7 +45,7 @@ export struct FragmentError : public FragmentDataBase {
 export struct FragmentData : public FragmentDataBase {
     UniquePtr<DataBlock> data_block_{};
     i64 task_id_{-1};
-    SizeT data_idx_{u64_max};
+    Optional<SizeT> data_idx_{};
     SizeT data_count_{u64_max};
 
     FragmentData(u64 fragment_id, UniquePtr<DataBlock> data_block, i64 task_id, SizeT data_idx, SizeT data_count)

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -100,7 +100,7 @@ void FragmentTask::OnExecute(i64) {
 
     if (execute_success or sink_state_->error_message_.get() != nullptr) {
         PhysicalSink *sink_op = fragment_context->GetSinkOperator();
-        sink_op->Execute(query_context, sink_state_.get());
+        sink_op->Execute(query_context, fragment_context, sink_state_.get());
     }
 }
 

--- a/src/storage/data_block.cpp
+++ b/src/storage/data_block.cpp
@@ -271,7 +271,7 @@ void DataBlock::AppendWith(const DataBlock *other) {
     }
 }
 
-void DataBlock::AppendWith(const SharedPtr<DataBlock> &other, SizeT from, SizeT count) {
+void DataBlock::AppendWith(const DataBlock *other, SizeT from, SizeT count) {
     if (other->column_count() != this->column_count()) {
         Error<StorageException>(
             Format("Attempt merge block with column count {} into block with column count {}", other->column_count(), this->column_count()));

--- a/src/storage/data_block.cppm
+++ b/src/storage/data_block.cppm
@@ -80,7 +80,7 @@ public:
 
     void AppendWith(const DataBlock *other);
 
-    void AppendWith(const SharedPtr<DataBlock> &other, SizeT from, SizeT count);
+    void AppendWith(const DataBlock *other, SizeT from, SizeT count);
 
     void InsertVector(const SharedPtr<ColumnVector> &vector, SizeT index);
 

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -64,17 +64,17 @@ UniquePtr<String> TxnTableStore::Append(const SharedPtr<DataBlock> &input_block)
 
     if (current_block->row_count() + input_block->row_count() > current_block->capacity()) {
         SizeT to_append = current_block->capacity() - current_block->row_count();
-        current_block->AppendWith(input_block, 0, to_append);
+        current_block->AppendWith(input_block.get(), 0, to_append);
         current_block->Finalize();
 
         blocks_.emplace_back(DataBlock::Make());
         blocks_.back()->Init(column_types);
         ++current_block_id_;
         current_block = blocks_[current_block_id_].get();
-        current_block->AppendWith(input_block, to_append, input_block->row_count() - to_append);
+        current_block->AppendWith(input_block.get(), to_append, input_block->row_count() - to_append);
     } else {
         SizeT to_append = input_block->row_count();
-        current_block->AppendWith(input_block, 0, to_append);
+        current_block->AppendWith(input_block.get(), 0, to_append);
     }
     current_block->Finalize();
 

--- a/test/sql/dql/limit.slt
+++ b/test/sql/dql/limit.slt
@@ -1,0 +1,42 @@
+statement ok
+DROP TABLE IF EXISTS test_limit;
+
+statement ok
+CREATE TABLE test_limit (c1 INTEGER, c2 INTEGER);
+
+statement ok
+INSERT INTO test_limit VALUES(0,1),(2,3),(4,5),(6,7);
+
+query II
+SELECT * FROM test_limit limit 0;
+----
+
+query II
+SELECT * FROM test_limit limit 10;
+----
+0 1
+2 3
+4 5
+6 7
+
+query II
+SELECT * FROM test_limit limit 2;
+----
+0 1
+2 3
+
+query II
+SELECT * FROM test_limit limit 2 offset 0;
+----
+0 1
+2 3
+
+query II
+SELECT * FROM test_limit limit 2 offset 2;
+----
+4 5
+6 7
+
+query II
+SELECT * FROM test_limit limit 2 offset 4;
+----

--- a/test/sql/dql/limit.slt
+++ b/test/sql/dql/limit.slt
@@ -32,10 +32,23 @@ SELECT * FROM test_limit limit 2 offset 0;
 2 3
 
 query II
+SELECT * FROM test_limit where c1 > 0 limit 2 offset 1;
+----
+4 5
+6 7
+
+
+query II
 SELECT * FROM test_limit limit 2 offset 2;
 ----
 4 5
 6 7
+
+query II
+SELECT * FROM test_limit order by c1 desc limit 2 offset 2;
+----
+2 3
+0 1
 
 query II
 SELECT * FROM test_limit limit 2 offset 4;

--- a/tools/generate_limit.py
+++ b/tools/generate_limit.py
@@ -8,14 +8,13 @@ def generate(generate_if_exists: bool, copy_dir: str):
     row_n = 9000
     limit = 8500
     offset = 20
-    dim = 128
     limit_dir = "./test/data/csv"
     slt_dir = "./test/sql/dql"
 
-    table_name = "test_limit"
-    limit_path = limit_dir + "/test_limit.csv"
-    slt_path = slt_dir + "/limit.slt"
-    copy_path = copy_dir + "/test_limit.csv"
+    table_name = "test_big_limit"
+    limit_path = limit_dir + "/test_big_limit.csv"
+    slt_path = slt_dir + "/big_limit.slt"
+    copy_path = copy_dir + "/test_big_limit.csv"
 
     os.makedirs(limit_dir, exist_ok=True)
     os.makedirs(slt_dir, exist_ok=True)
@@ -32,7 +31,7 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write("\n")
         slt_file.write("statement ok\n")
         slt_file.write(
-            "CREATE TABLE {} (c1 int, c2 int);\n".format(table_name, dim)
+            "CREATE TABLE {} (c1 int, c2 int);\n".format(table_name)
         )
         slt_file.write("\n")
         slt_file.write("query I\n")
@@ -52,7 +51,7 @@ def generate(generate_if_exists: bool, copy_dir: str):
             limit_file.write("\n")
 
         for _ in range(limit):
-            slt_file.write("0,0")
+            slt_file.write("0 0")
             slt_file.write("\n")
 
         slt_file.write("\n")

--- a/tools/generate_limit.py
+++ b/tools/generate_limit.py
@@ -1,0 +1,82 @@
+import numpy as np
+import random
+import os
+import argparse
+
+
+def generate(generate_if_exists: bool, copy_dir: str):
+    row_n = 9000
+    limit = 8500
+    offset = 20
+    dim = 128
+    limit_dir = "./test/data/csv"
+    slt_dir = "./test/sql/dql"
+
+    table_name = "test_limit"
+    limit_path = limit_dir + "/test_limit.csv"
+    slt_path = slt_dir + "/limit.slt"
+    copy_path = copy_dir + "/test_limit.csv"
+
+    os.makedirs(limit_dir, exist_ok=True)
+    os.makedirs(slt_dir, exist_ok=True)
+    if os.path.exists(limit_path) and os.path.exists(slt_path) and generate_if_exists:
+        print(
+            "File {} and {} already existed exists. Skip Generating.".format(
+                slt_path, limit_path
+            )
+        )
+        return
+    with open(limit_path, "w") as limit_file, open(slt_path, "w") as slt_file:
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write(
+            "CREATE TABLE {} (c1 int, c2 int);\n".format(table_name, dim)
+        )
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write(
+            "COPY {} FROM '{}' WITH ( DELIMITER ',' );\n".format(
+                table_name, copy_path
+            )
+        )
+        slt_file.write("----\n")
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT * FROM {} limit {} offset {};\n".format(table_name, limit, offset))
+        slt_file.write("----\n")
+
+        for _ in range(row_n):
+            limit_file.write("0,0")
+            limit_file.write("\n")
+
+        for _ in range(limit):
+            slt_file.write("0,0")
+            slt_file.write("\n")
+
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE {};\n".format(table_name))
+    random.random()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate limit data for test")
+
+    parser.add_argument(
+        "-g",
+        "--generate",
+        type=bool,
+        default=False,
+        dest="generate_if_exists",
+    )
+    parser.add_argument(
+        "-c",
+        "--copy",
+        type=str,
+        default="/tmp/infinity/test_data",
+        dest="copy_dir",
+    )
+    args = parser.parse_args()
+    generate(args.generate_if_exists, args.copy_dir)

--- a/tools/generate_sort.py
+++ b/tools/generate_sort.py
@@ -6,7 +6,6 @@ import argparse
 
 def generate(generate_if_exists: bool, copy_dir: str):
     row_n = 9000
-    dim = 128
     sort_dir = "./test/data/csv"
     slt_dir = "./test/sql/dql"
 
@@ -30,7 +29,7 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write("\n")
         slt_file.write("statement ok\n")
         slt_file.write(
-            "CREATE TABLE {} (c1 int, c2 int);\n".format(table_name, dim)
+            "CREATE TABLE {} (c1 int, c2 int);\n".format(table_name)
         )
         slt_file.write("\n")
         slt_file.write("query I\n")

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -5,6 +5,7 @@ from shutil import copyfile
 from generate_big import generate as generate1
 from generate_fvecs import generate as generate2
 from generate_sort import generate as generate3
+from generate_limit import generate as generate4
 
 
 def python_skd_test(python_test_dir: str):
@@ -106,6 +107,7 @@ if __name__ == "__main__":
     generate1(args.generate_if_exists, args.copy)
     generate2(args.generate_if_exists, args.copy)
     generate3(args.generate_if_exists, args.copy)
+    generate4(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
     python_skd_test(python_test_dir)
     test_process(args.path, args.test, args.data, args.copy)


### PR DESCRIPTION
### What problem does this PR solve?

- implement physical_limit.cpp & physical_merge_limit.cpp
- fixed build logical_plan for limit
- add python test script for limit
- support stream sink for physical_sink.cpp

Issue link: https://github.com/infiniflow/infinity/issues/362

### What is changed and how it works?

```
kould=> SELECT * FROM test_limit limit 10;
 c1 | c2 
----+----
  0 |  1
  2 |  3
  4 |  5
  6 |  7
(4 rows)

kould=> SELECT * FROM test_limit limit 2 offset 2;
 c1 | c2 
----+----
  4 |  5
  6 |  7
(2 rows)
```

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer