### PR TITLE
Add scheduler

### DIFF
--- a/src/common/blocking_queue.cppm
+++ b/src/common/blocking_queue.cppm
@@ -102,6 +102,16 @@ public:
         full_cv_.notify_one();
     }
 
+    bool TryDequeueBulk(Vector<T> &output_array) {
+        UniqueLock<Mutex> lock(queue_mutex_);
+        if (queue_.empty()) {
+            return false;
+        }
+        output_array.insert(output_array.end(), queue_.begin(), queue_.end());
+        queue_.clear();
+        full_cv_.notify_one();
+    }
+
     [[nodiscard]] SizeT Size() const {
         LockGuard<Mutex> lock(queue_mutex_);
         return queue_.size();

--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -94,6 +94,9 @@ export {
     template <typename S, typename T, typename H = std::hash<S>>
     using HashMap = std::unordered_map<S, T, H>;
 
+    template <typename S, typename T, typename H = std::hash<S>>
+    using MultiHashMap = std::unordered_multimap<S, T, H>;
+
     template <typename S>
     using HashSet = std::unordered_set<S>;
 

--- a/src/executor/fragment/plan_fragment.cppm
+++ b/src/executor/fragment/plan_fragment.cppm
@@ -57,6 +57,8 @@ public:
 
     [[nodiscard]] inline PhysicalSink *GetSinkNode() const { return sink_.get(); }
 
+    [[nodiscard]] inline PlanFragment *GetParent() const { return parent_; }
+
     inline void AddChild(UniquePtr<PlanFragment> child_fragment) {
         child_fragment->parent_ = this;
         children_.emplace_back(Move(child_fragment));

--- a/src/executor/operator/physical_create_index_finish.cpp
+++ b/src/executor/operator/physical_create_index_finish.cpp
@@ -45,13 +45,10 @@ bool PhysicalCreateIndexFinish::Execute(QueryContext *query_context, OperatorSta
     auto *txn = query_context->GetTxn();
     auto *create_index_finish_op_state = static_cast<CreateIndexFinishOperatorState *>(operator_state);
 
-    if (create_index_finish_op_state->input_complete_) {
-        txn->AddWalCmd(MakeShared<WalCmdCreateIndex>(*db_name_, *table_name_, index_def_));
+    txn->AddWalCmd(MakeShared<WalCmdCreateIndex>(*db_name_, *table_name_, index_def_));
 
-        operator_state->SetComplete();
-        return true;
-    }
-    return false;
+    operator_state->SetComplete();
+    return true;
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_sink.cpp
+++ b/src/executor/operator/physical_sink.cpp
@@ -338,6 +338,16 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MessageSinkState *message_
             message_sink_state->message_ = Move(insert_output_state->result_msg_);
             break;
         }
+        case PhysicalOperatorType::kCreateIndexPrepare: {
+            auto *create_index_prepare_output_state = static_cast<CreateIndexPrepareOperatorState *>(task_operator_state);
+            message_sink_state->message_ = Move(create_index_prepare_output_state->result_msg_);
+            break;
+        }
+        case PhysicalOperatorType::kCreateIndexDo: {
+            auto *create_index_do_output_state = static_cast<CreateIndexDoOperatorState *>(task_operator_state);
+            message_sink_state->message_ = Move(create_index_do_output_state->result_msg_);
+            break;
+        }
         default: {
             Error<NotImplementException>(Format("{} isn't supported here.", PhysicalOperatorToString(task_operator_state->operator_type_)));
             break;

--- a/src/executor/operator/physical_source.cpp
+++ b/src/executor/operator/physical_source.cpp
@@ -57,13 +57,4 @@ bool PhysicalSource::Execute(QueryContext *, SourceState *source_state) {
     return true;
 }
 
-bool PhysicalSource::ReadyToExec(SourceState *source_state) {
-    bool result = true;
-    if (source_state->state_type_ == SourceStateType::kQueue) {
-        QueueSourceState *queue_source_state = static_cast<QueueSourceState *>(source_state);
-        result = queue_source_state->source_queue_.Size() > 0;
-    }
-    return result;
-}
-
 } // namespace infinity

--- a/src/executor/operator/physical_source.cppm
+++ b/src/executor/operator/physical_source.cppm
@@ -53,8 +53,6 @@ public:
 
     bool Execute(QueryContext *query_context, SourceState *source_state);
 
-    bool ReadyToExec(SourceState *source_state);
-
     inline SharedPtr<Vector<String>> GetOutputNames() const final { return output_names_; }
 
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return output_types_; }

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -42,6 +42,11 @@ bool QueueSourceState::GetData() {
     SharedPtr<FragmentDataBase> fragment_data_base = nullptr;
     source_queue_.Dequeue(fragment_data_base);
 
+    OperatorState *next_op_state1 = this->next_op_state_;
+    if (next_op_state1->operator_type_ == PhysicalOperatorType::kFusion) {
+        int a = 1;
+    }
+
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -97,16 +97,6 @@ bool QueueSourceState::GetData() {
             fusion_op_state->input_complete_ = completed;
             break;
         }
-        case PhysicalOperatorType::kCreateIndexDo: {
-            auto *create_index_do_op_state = static_cast<CreateIndexDoOperatorState *>(next_op_state);
-            create_index_do_op_state->input_complete_ = completed;
-            break;
-        }
-        case PhysicalOperatorType::kCreateIndexFinish: {
-            auto *create_index_finish_op_state = static_cast<CreateIndexFinishOperatorState *>(next_op_state);
-            create_index_finish_op_state->input_complete_ = completed;
-            break;
-        }
         case PhysicalOperatorType::kMergeLimit: {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
             MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)next_op_state;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -42,11 +42,6 @@ bool QueueSourceState::GetData() {
     SharedPtr<FragmentDataBase> fragment_data_base = nullptr;
     source_queue_.Dequeue(fragment_data_base);
 
-    OperatorState *next_op_state1 = this->next_op_state_;
-    if (next_op_state1->operator_type_ == PhysicalOperatorType::kFusion) {
-        int a = 1;
-    }
-
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -245,14 +245,13 @@ export struct CreateIndexPrepareOperatorState : public OperatorState {
 export struct CreateIndexDoOperatorState : public OperatorState {
     inline explicit CreateIndexDoOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexDo) {}
 
-    bool input_complete_ = false;
+    UniquePtr<String> result_msg_{};
     CreateIndexSharedData *create_index_shared_data_;
 };
 
 export struct CreateIndexFinishOperatorState : public OperatorState {
     inline explicit CreateIndexFinishOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexFinish) {}
 
-    bool input_complete_ = false;
     UniquePtr<String> error_message_{};
 };
 

--- a/src/executor/physical_operator_type.cppm
+++ b/src/executor/physical_operator_type.cppm
@@ -70,7 +70,6 @@ export enum class PhysicalOperatorType : i8 {
     kInsert,
     kImport,
     kExport,
-    kCreateIndexDo,
 
     // DDL
     kAlter,
@@ -86,6 +85,7 @@ export enum class PhysicalOperatorType : i8 {
     kDropView,
 
     kCreateIndexPrepare,
+    kCreateIndexDo,
     kCreateIndexFinish,
 
     // misc

--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -145,7 +145,7 @@ QueryResult QueryContext::QueryStatement(const BaseStatement *statement) {
         StopProfile(QueryPhase::kTaskBuild);
 
         StartProfile(QueryPhase::kExecution);
-        scheduler_->Schedule(this, plan_fragment.get());
+        scheduler_->Schedule(plan_fragment.get());
         query_result.result_table_ = plan_fragment->GetResult();
         query_result.root_operator_type_ = logical_plan->operator_type();
         StopProfile(QueryPhase::kExecution);

--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -141,12 +141,11 @@ QueryResult QueryContext::QueryStatement(const BaseStatement *statement) {
         StopProfile(QueryPhase::kPipelineBuild);
 
         StartProfile(QueryPhase::kTaskBuild);
-        Vector<FragmentTask *> tasks;
-        FragmentContext::BuildTask(this, nullptr, plan_fragment.get(), tasks);
+        FragmentContext::BuildTask(this, nullptr, plan_fragment.get());
         StopProfile(QueryPhase::kTaskBuild);
 
         StartProfile(QueryPhase::kExecution);
-        scheduler_->Schedule(this, tasks, plan_fragment.get());
+        scheduler_->Schedule(this, plan_fragment.get());
         query_result.result_table_ = plan_fragment->GetResult();
         query_result.root_operator_type_ = logical_plan->operator_type();
         StopProfile(QueryPhase::kExecution);

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -52,7 +52,7 @@ class PlanFragment;
 export class FragmentContext {
 public:
     static void
-    BuildTask(QueryContext *query_context, FragmentContext *parent_context, PlanFragment *fragment_ptr, Vector<FragmentTask *> &tasks);
+    BuildTask(QueryContext *query_context, FragmentContext *parent_context, PlanFragment *fragment_ptr);
 
 public:
     explicit FragmentContext(PlanFragment *fragment_ptr, QueryContext *query_context);

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -101,8 +101,6 @@ public:
 
     [[nodiscard]] inline FragmentType ContextType() const { return fragment_type_; }
 
-    Vector<PlanFragment *> GetSchedulableFragments();
-
 private:
     bool TryStartFragment() {
         if (fragment_status_ != FragmentStatus::kNotStart) {

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -32,14 +32,13 @@ namespace infinity {
 
 class PlanFragment;
 
-//class KnnScanSharedData;
+enum class FragmentStatus {
+    kNotStart,
+    kStart,
+    kFinish,
+    kInvalid,
+};
 
-// enum class FragmentStatus {
-//     kNotStart,
-//     k
-//     kStart,
-//     kFinish,
-// };
 export enum class FragmentType {
     kInvalid,
     kSerialMaterialize,
@@ -59,7 +58,7 @@ public:
 
     virtual ~FragmentContext() = default;
 
-    inline void IncreaseTask() { task_n_.fetch_add(1); }
+    inline void IncreaseTask() { unfinished_task_n_.fetch_add(1); }
 
     inline void FlushProfiler(TaskProfiler &profiler) {
         if(!query_context_->is_enable_profiling()) {
@@ -68,7 +67,7 @@ public:
         query_context_->FlushProfiler(Move(profiler));
     }
 
-    void FinishTask();
+    void TryFinishFragment();
 
     Vector<PhysicalOperator *> &GetOperators();
 
@@ -85,14 +84,14 @@ public:
 
     inline SharedPtr<DataTable> GetResult() {
         UniqueLock<Mutex> lk(locker_);
-        cv_.wait(lk, [&] { return completed_; });
+        cv_.wait(lk, [&] { return fragment_status_ == FragmentStatus::kFinish; });
 
         return GetResultInternal();
     }
 
     inline void Complete() {
         UniqueLock<Mutex> lk(locker_);
-        completed_ = true;
+        fragment_status_ = FragmentStatus::kFinish;
         cv_.notify_one();
     }
 
@@ -102,7 +101,22 @@ public:
 
     [[nodiscard]] inline FragmentType ContextType() const { return fragment_type_; }
 
+    Vector<PlanFragment *> GetSchedulableFragments();
+
 private:
+    bool TryStartFragment() {
+        if (fragment_status_ != FragmentStatus::kNotStart) {
+            return false;
+        }
+        u64 unfinished_child = unfinished_child_n_.fetch_sub(1);
+        return unfinished_child == 1;
+    }
+
+    bool TryFinishFragmentInner() {
+        u64 unfinished_task = unfinished_task_n_.fetch_sub(1);
+        return unfinished_task == 1;
+    }
+
     void MakeSourceState(i64 parallel_count);
 
     void MakeSinkState(i64 parallel_count);
@@ -111,22 +125,22 @@ protected:
     virtual SharedPtr<DataTable> GetResultInternal() = 0;
 
 protected:
-    atomic_u64 task_n_{0};
-
     Mutex locker_{};
     CondVar cv_{};
 
     PlanFragment *fragment_ptr_{};
-    //    HashMap<u64, UniquePtr<FragmentTask>> tasks_;
+
+    QueryContext *query_context_{};
+
     Vector<UniquePtr<FragmentTask>> tasks_{};
 
-    bool finish_building_{false};
-    bool completed_{false};
-    i64 finished_task_count_{};
     Vector<SharedPtr<DataBlock>> data_array_{};
 
     FragmentType fragment_type_{FragmentType::kInvalid};
-    QueryContext *query_context_{};
+    FragmentStatus fragment_status_{FragmentStatus::kInvalid};
+
+    atomic_u64 unfinished_task_n_{0};
+    atomic_u64 unfinished_child_n_{0};
 };
 
 export class SerialMaterializedFragmentCtx final : public FragmentContext {

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -126,10 +126,10 @@ TaskBinding FragmentTask::TaskBinding() const {
     return binding;
 }
 
-void FragmentTask::TryCompleteFragment() {
+void FragmentTask::CompleteTask() {
     FragmentContext *fragment_context = (FragmentContext *)fragment_context_;
     LOG_TRACE(Format("Task: {} of Fragment: {} is completed", task_id_, FragmentId()));
-    fragment_context->FinishTask();
+    fragment_context->TryFinishFragment();
 }
 
 String FragmentTask::PhysOpsToString() {

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -120,7 +120,8 @@ bool FragmentTask::QuitFromWorkerLoop() {
         return false;
     }
     if (source_state_->state_type_ != SourceStateType::kQueue) {
-        Error<SchedulerException>("SourceStateType is not kQueue");
+        return false;
+        // Error<SchedulerException>("SourceStateType is not kQueue");
     }
     auto *queue_state = static_cast<QueueSourceState *>(source_state_.get());
 

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -111,9 +111,7 @@ u64 FragmentTask::FragmentId() const {
 }
 
 // Finished **OR** Error
-bool FragmentTask::IsComplete() const {
-    return status_ == FragmentTaskStatus::kError || status_ == FragmentTaskStatus::kFinished;
-}
+bool FragmentTask::IsComplete() const { return sink_state_->prev_op_state_->Complete() || status_ == FragmentTaskStatus::kError; }
 
 // Stream fragment source has no data
 bool FragmentTask::QuitFromWorkerLoop() {

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -60,7 +60,7 @@ void FragmentTask::OnExecute(i64) {
 
     bool execute_success{false};
     bool source_complete = source_op->Execute(fragment_context->query_context(), source_state_.get());
-    if (source_state_->error_message_.get() == nullptr) {
+    if(source_state_->error_message_.get() == nullptr) {
         // No source error
         Vector<PhysicalOperator *> &operator_refs = fragment_context->GetOperators();
 
@@ -120,8 +120,8 @@ bool FragmentTask::QuitFromWorkerLoop() {
         return false;
     }
     if (source_state_->state_type_ != SourceStateType::kQueue) {
+        // fragment's source is not from queue
         return false;
-        // Error<SchedulerException>("SourceStateType is not kQueue");
     }
     auto *queue_state = static_cast<QueueSourceState *>(source_state_.get());
 

--- a/src/scheduler/fragment_task.cppm
+++ b/src/scheduler/fragment_task.cppm
@@ -22,6 +22,8 @@ export module fragment_task;
 
 namespace infinity {
 
+class FragmentContext;
+
 // Task type:
 // DDL task
 // DML task
@@ -78,6 +80,8 @@ public:
 
     [[nodiscard]] inline i64 LastWorkerID() const { return last_worker_id_; }
 
+    u64 FragmentId() const;
+
     [[nodiscard]] inline i64 TaskID() const { return task_id_; }
 
     [[nodiscard]] bool Ready() const;
@@ -90,13 +94,11 @@ public:
 
     String PhysOpsToString();
 
-    inline void set_status(FragmentTaskStatus new_status) {
-        status_ = new_status;
-    }
+    inline void set_status(FragmentTaskStatus new_status) { status_ = new_status; }
 
-    [[nodiscard]] inline FragmentTaskStatus status() const {
-        return status_;
-    }
+    [[nodiscard]] inline FragmentTaskStatus status() const { return status_; }
+
+    FragmentContext *fragment_context() const;
 
 public:
     FragmentTaskStatus status_{FragmentTaskStatus::kReady};

--- a/src/scheduler/fragment_task.cppm
+++ b/src/scheduler/fragment_task.cppm
@@ -64,21 +64,13 @@ public:
 
     [[nodiscard]] inline bool IsTerminator() const { return is_terminator_; }
 
-    // Set source
-    // Scan source
-    //    void
-    //    AddSourceSegment(const SegmentEntry* segment_entry_ptr);
-    //
-    //    // Input queue
-    //    void
-    //    AddQueue(const BatchBlockingQueue);
     void Init();
 
     void OnExecute(i64 worker_id);
 
     inline void SetLastWorkID(i64 worker_id) { last_worker_id_ = worker_id; }
 
-    [[nodiscard]] inline i64 LastWorkerID() const { return last_worker_id_; }
+    // [[nodiscard]] inline i64 LastWorkerID() const { return last_worker_id_; }
 
     u64 FragmentId() const;
 
@@ -90,7 +82,7 @@ public:
 
     [[nodiscard]] TaskBinding TaskBinding() const;
 
-    void TryCompleteFragment();
+    void CompleteTask();
 
     String PhysOpsToString();
 
@@ -112,7 +104,7 @@ public:
 private:
     void *fragment_context_{};
     bool is_terminator_{false};
-    i64 last_worker_id_{-1};
+    [[maybe_unused]] i64 last_worker_id_{-1};
     i64 task_id_{-1};
     i64 operator_count_{0};
 };

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -115,12 +115,16 @@ void TaskScheduler::ScheduleFragment(PlanFragment *plan_fragment) {
             task_ptrs.emplace_back(task.get());
         }
     }
-
+    last_cpu_id_ = 0; // FIXME
     u64 &worker_id = last_cpu_id_;
     for (auto *task_ptr : task_ptrs) {
-        ScheduleTask(task_ptr, worker_id);
-        ++worker_id;
-        worker_id %= worker_count_;
+        if (task_ptr->LastWorkerID() == -1) {
+            ScheduleTask(task_ptr, worker_id);
+            ++worker_id;
+            worker_id %= worker_count_;
+        } else {
+            ScheduleTask(task_ptr, task_ptr->LastWorkerID());
+        }
     }
 }
 

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -46,9 +46,11 @@ public:
 
     void UnInit();
 
-    void Schedule(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
+    void Schedule(QueryContext* query_context, PlanFragment* plan_fragment);
 
 private:
+    Vector<Vector<FragmentTask *>> TraversePlanFragment(PlanFragment* plan_fragment);
+
     void ScheduleOneWorkerPerQuery(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
     void ScheduleOneWorkerIfPossible(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
     void ScheduleRoundRobin(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -26,7 +26,7 @@ namespace infinity {
 class QueryContext;
 class PlanFragment;
 
-using FragmentTaskBlockQueue = BlockingQueue<FragmentTask *>;
+using FragmentTaskBlockQueue = BlockingQueue<FragmentTask*>;
 
 struct Worker {
     Worker(u64 cpu_id, UniquePtr<FragmentTaskBlockQueue> queue, UniquePtr<Thread> thread)

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -46,11 +46,11 @@ public:
 
     void UnInit();
 
-    void Schedule(PlanFragment * plan_fragment);
+    // Schedule start fragments
+    void Schedule(PlanFragment * plan_fragment_root);
 
-    void ScheduleFragment(PlanFragment * plan_fragment);
-
-    void ScheduleTasks(Vector<FragmentTask *> fragment_tasks);
+    // `plan_fragment` can be scheduled because all of its dependencies are met.
+    void ScheduleFragment(PlanFragment *plan_fragment);
 
 private:
     Vector<PlanFragment *> GetStartFragments(PlanFragment* plan_fragment);

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -46,9 +46,11 @@ public:
 
     void UnInit();
 
-    void Schedule(QueryContext* query_context, PlanFragment* plan_fragment);
+    void Schedule(PlanFragment * plan_fragment);
 
-    void ScheduleFragments(Vector<PlanFragment *> plan_fragment);
+    void ScheduleFragment(PlanFragment * plan_fragment);
+
+    void ScheduleTasks(Vector<FragmentTask *> fragment_tasks);
 
 private:
     Vector<PlanFragment *> GetStartFragments(PlanFragment* plan_fragment);
@@ -57,9 +59,10 @@ private:
     // void ScheduleOneWorkerIfPossible(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
     // void ScheduleRoundRobin(const Vector<FragmentTask *> &tasks);
 
-    // inline void ScheduleTask(FragmentTask *task, u64 worker_id) {
-    //     worker_array_[worker_id].queue_->Enqueue(task);
-    // }
+    inline void ScheduleTask(FragmentTask *task, u64 worker_id) {
+        task->set_status(FragmentTaskStatus::kRunning);
+        worker_array_[worker_id].queue_->Enqueue(task);
+    }
 
     inline u64 ProposedWorkerID(u64 object_id) const {
         return (object_id) % worker_count_;

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -59,14 +59,11 @@ private:
     // void ScheduleOneWorkerIfPossible(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
     // void ScheduleRoundRobin(const Vector<FragmentTask *> &tasks);
 
-    inline void ScheduleTask(FragmentTask *task, u64 worker_id) {
-        task->set_status(FragmentTaskStatus::kRunning);
-        worker_array_[worker_id].queue_->Enqueue(task);
-    }
+    void ScheduleTask(FragmentTask *task, u64 worker_id);
 
-    inline u64 ProposedWorkerID(u64 object_id) const {
-        return (object_id) % worker_count_;
-    }
+    // inline u64 ProposedWorkerID(u64 object_id) const {
+    //     return (object_id) % worker_count_;
+    // }
 
     void WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id);
 

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -26,7 +26,7 @@ namespace infinity {
 class QueryContext;
 class PlanFragment;
 
-using FragmentTaskBlockQueue = BlockingQueue<FragmentTask*>;
+using FragmentTaskBlockQueue = BlockingQueue<FragmentTask *>;
 
 struct Worker {
     Worker(u64 cpu_id, UniquePtr<FragmentTaskBlockQueue> queue, UniquePtr<Thread> thread)
@@ -48,35 +48,32 @@ public:
 
     void Schedule(QueryContext* query_context, PlanFragment* plan_fragment);
 
+    void ScheduleFragments(Vector<PlanFragment *> plan_fragment);
+
 private:
-    Vector<Vector<FragmentTask *>> TraversePlanFragment(PlanFragment* plan_fragment);
+    Vector<PlanFragment *> GetStartFragments(PlanFragment* plan_fragment);
 
-    void ScheduleOneWorkerPerQuery(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
-    void ScheduleOneWorkerIfPossible(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
-    void ScheduleRoundRobin(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
+    // void ScheduleOneWorkerPerQuery(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
+    // void ScheduleOneWorkerIfPossible(QueryContext* query_context, const Vector<FragmentTask *> &tasks, PlanFragment* plan_fragment);
+    // void ScheduleRoundRobin(const Vector<FragmentTask *> &tasks);
 
-    inline void ScheduleTask(FragmentTask *task, u64 worker_id) {
-        worker_array_[worker_id].queue_->Enqueue(task);
-    }
+    // inline void ScheduleTask(FragmentTask *task, u64 worker_id) {
+    //     worker_array_[worker_id].queue_->Enqueue(task);
+    // }
 
     inline u64 ProposedWorkerID(u64 object_id) const {
         return (object_id) % worker_count_;
     }
 
-    void ToReadyQueue(FragmentTask *task);
-
-    void CoordinatorLoop(FragmentTaskBlockQueue *ready_queue, i64 cpu_id);
-
     void WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id);
 
 private:
+    u64 last_cpu_id_{0};
+
     bool initialized_{false};
 
     Vector<Worker> worker_array_{};
     Deque<Atomic<u64>> worker_workloads_{};
-
-    UniquePtr<FragmentTaskBlockQueue> ready_queue_{};
-    UniquePtr<Thread> coordinator_{};
 
     u64 worker_count_{0};
 };

--- a/src/unit_test/test_helper/sql_runner.cpp
+++ b/src/unit_test/test_helper/sql_runner.cpp
@@ -102,7 +102,7 @@ SharedPtr<DataTable> SQLRunner::Run(const String &sql_text, bool print) {
     FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get());
 
     // Schedule the query tasks
-    query_context_ptr->scheduler()->Schedule(query_context_ptr.get(), plan_fragment.get());
+    query_context_ptr->scheduler()->Schedule(plan_fragment.get());
 
     // Initialize query result
     QueryResult query_result;

--- a/src/unit_test/test_helper/sql_runner.cpp
+++ b/src/unit_test/test_helper/sql_runner.cpp
@@ -99,11 +99,10 @@ SharedPtr<DataTable> SQLRunner::Run(const String &sql_text, bool print) {
     // Fragment Builder, only for test now. plan fragment is same as pipeline.
     auto plan_fragment = query_context_ptr->fragment_builder()->BuildFragment(physical_plan.get());
 
-    Vector<FragmentTask *> tasks;
-    FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get(), tasks);
+    FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get());
 
     // Schedule the query tasks
-    query_context_ptr->scheduler()->Schedule(query_context_ptr.get(), tasks, plan_fragment.get());
+    query_context_ptr->scheduler()->Schedule(query_context_ptr.get(), plan_fragment.get());
 
     // Initialize query result
     QueryResult query_result;


### PR DESCRIPTION
### What problem does this PR solve?

Refactor the scheduler.

Issue link:
https://github.com/infiniflow/infinity/issues/387
### What is changed and how it works?
0. Remove coordinate thread.
1. Determine init fragments in `TaskScheduler::Schedule`. Init fragments are leaf fragments.
2. In `TaskScheduler::WorkerLoop`, when a fragment task finished, if `FragmentTask::IsComplete` return true, `FragmentTask::CompleteTask` is called, which calls `FragmentContext::TryFinishFragment`. The latter reduce the `unfinished_task_n_` in `FragmentContext` and when it is 0, it reduce its parent `FragmentContext`'s `unfinished_child_n_` by `FragmentContext::TryStartFragment`. If it returns true, then schedule that parent fragment by `TaskScheduler::ScheduleFragment`.
3. For `FragmentType::kParallelStream`,  the return value of `FragmentContext::TryStartFragment` will be ignored, and all its parent tasks that not in work loop can be scheduled in.
4. And for `FragmentType::kParallelStream`, if `FragmentContext::TryFinishFragment` return false, the task souce will be checked if there is more data. If not, this task will be scheduled out.

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer