### PR TITLE
implement physical_limit.cpp for support limit

### DIFF
--- a/src/executor/operator/physical_filter.cppm
+++ b/src/executor/operator/physical_filter.cppm
@@ -47,8 +47,7 @@ public:
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     inline const SharedPtr<BaseExpression> &condition() const { return condition_; }

--- a/src/executor/operator/physical_limit.cpp
+++ b/src/executor/operator/physical_limit.cpp
@@ -100,7 +100,7 @@ SizeT UnSyncCounter::Offset(SizeT row_count) {
     i64 last_offset = offset_ - row_count;
 
     if (last_offset > 0) {
-        result = row_count;
+        result = row_count - 1;
         offset_ = last_offset;
     } else {
         result = offset_;
@@ -180,10 +180,10 @@ bool PhysicalLimit::Execute(QueryContext *query_context,
         if (input_blocks[block_id]->row_count() == 0) {
             continue;
         }
-        SizeT max_offset = input_blocks[block_id]->row_count() - 1;
+        SizeT row_count = input_blocks[block_id]->row_count();
 
-        if (offset > max_offset) {
-            offset -= max_offset;
+        if (offset > row_count) {
+            offset -= row_count;
         } else {
             block_start_idx = block_id;
             break;

--- a/src/executor/operator/physical_limit.cppm
+++ b/src/executor/operator/physical_limit.cppm
@@ -21,6 +21,7 @@ import operator_state;
 import physical_operator;
 import physical_operator_type;
 import base_expression;
+import value_expression;
 import data_table;
 import load_meta;
 import infinity_exception;
@@ -29,19 +30,65 @@ export module physical_limit;
 
 namespace infinity {
 
+class DataBlock;
+
+export class LimitCounter {
+public:
+    // Returns the left index after offset
+    virtual SizeT Offset(SizeT row_count) = 0;
+
+    // Returns the right index after limit
+    virtual SizeT Limit(SizeT row_count) = 0;
+
+    virtual bool IsLimitOver() = 0;
+};
+
+export class AtomicCounter : public LimitCounter {
+public:
+    AtomicCounter(i64 offset, i64 limit) : offset_(offset), limit_(limit) {}
+
+    SizeT Offset(SizeT row_count);
+
+    SizeT Limit(SizeT row_count);
+
+    bool IsLimitOver();
+
+private:
+    ai64 offset_{};
+    ai64 limit_{};
+};
+
+export class UnSyncCounter : public LimitCounter {
+public:
+    UnSyncCounter(i64 offset, i64 limit) : offset_(offset), limit_(limit) {}
+
+    SizeT Offset(SizeT row_count);
+
+    SizeT Limit(SizeT row_count);
+
+    bool IsLimitOver();
+
+private:
+    i64 offset_{};
+    i64 limit_{};
+};
+
 export class PhysicalLimit : public PhysicalOperator {
 public:
     explicit PhysicalLimit(u64 id,
                            UniquePtr<PhysicalOperator> left,
                            SharedPtr<BaseExpression> limit_expr,
                            SharedPtr<BaseExpression> offset_expr,
-                           SharedPtr<Vector<LoadMeta>> load_metas)
-        : PhysicalOperator(PhysicalOperatorType::kLimit, Move(left), nullptr, id, load_metas), limit_expr_(Move(limit_expr)),
-          offset_expr_(Move(offset_expr)) {}
+                           SharedPtr<Vector<LoadMeta>> load_metas);
 
     ~PhysicalLimit() override = default;
 
     void Init() override;
+
+    static bool Execute(QueryContext *query_context,
+                        const Vector<UniquePtr<DataBlock>> &input_blocks,
+                        Vector<UniquePtr<DataBlock>> &output_blocks,
+                        LimitCounter *counter);
 
     bool Execute(QueryContext *query_context, OperatorState *operator_state) final;
 
@@ -50,22 +97,18 @@ public:
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     inline const SharedPtr<BaseExpression> &limit_expr() const { return limit_expr_; }
 
     inline const SharedPtr<BaseExpression> &offset_expr() const { return offset_expr_; }
 
-    static SharedPtr<DataTable> GetLimitOutput(const SharedPtr<DataTable> &input_table, i64 limit, i64 offset);
-
 private:
     SharedPtr<BaseExpression> limit_expr_{};
     SharedPtr<BaseExpression> offset_expr_{};
 
-    SharedPtr<DataTable> input_table_{};
-    u64 input_table_index_{};
+    UniquePtr<LimitCounter> counter_{};
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_limit.cpp
+++ b/src/executor/operator/physical_merge_limit.cpp
@@ -14,15 +14,53 @@
 
 module;
 
+#include <memory>
+
+import stl;
 import query_context;
+import base_expression;
+import load_meta;
+import physical_operator_type;
+import value_expression;
+import physical_limit;
 import operator_state;
 
 module physical_merge_limit;
 
 namespace infinity {
 
+PhysicalMergeLimit::PhysicalMergeLimit(u64 id,
+                                       UniquePtr<PhysicalOperator> left,
+                                       SharedPtr<BaseExpression> limit_expr,
+                                       SharedPtr<BaseExpression> offset_expr,
+                                       SharedPtr<Vector<LoadMeta>> load_metas)
+    : PhysicalOperator(PhysicalOperatorType::kMergeLimit, Move(left), nullptr, id, load_metas), limit_expr_(Move(limit_expr)),
+      offset_expr_(Move(offset_expr)) {
+    i64 offset = 0;
+    i64 limit = (static_pointer_cast<ValueExpression>(limit_expr_))->GetValue().value_.big_int;
+
+    if (offset_expr_ != nullptr) {
+        offset = (static_pointer_cast<ValueExpression>(offset_expr_))->GetValue().value_.big_int;
+    }
+    counter_ = MakeUnique<UnSyncCounter>(offset, limit);
+}
+
 void PhysicalMergeLimit::Init() {}
 
-bool PhysicalMergeLimit::Execute(QueryContext *, OperatorState *) { return true; }
+bool PhysicalMergeLimit::Execute(QueryContext *query_context, OperatorState *operator_state) {
+    MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)operator_state;
+
+    if (limit_op_state->input_data_blocks_.empty()) {
+        return false;
+    }
+    auto result = PhysicalLimit::Execute(query_context, limit_op_state->input_data_blocks_, limit_op_state->data_block_array_, counter_.get());
+
+    if (counter_->IsLimitOver() || limit_op_state->input_complete_) {
+        limit_op_state->input_complete_ = true;
+        limit_op_state->SetComplete();
+    }
+    limit_op_state->input_data_blocks_.clear();
+    return result;
+}
 
 } // namespace infinity

--- a/src/executor/operator/physical_project.cppm
+++ b/src/executor/operator/physical_project.cppm
@@ -49,8 +49,7 @@ public:
     SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final;
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     Vector<SharedPtr<BaseExpression>> expressions_{};

--- a/src/executor/operator/physical_sink.cppm
+++ b/src/executor/operator/physical_sink.cppm
@@ -27,6 +27,8 @@ export module physical_sink;
 
 namespace infinity {
 
+class FragmentContext;
+
 export enum class SinkType {
     kInvalid,
     kLocalQueue,
@@ -46,7 +48,7 @@ public:
 
     bool Execute(QueryContext *query_context, OperatorState *output_state) final;
 
-    bool Execute(QueryContext *query_context, SinkState *sink_state);
+    bool Execute(QueryContext *query_context, FragmentContext *fragment_context, SinkState *sink_state);
 
     inline SharedPtr<Vector<String>> GetOutputNames() const final { return output_names_; }
 
@@ -68,7 +70,7 @@ private:
 
     void FillSinkStateFromLastOperatorState(SummarySinkState *message_sink_state, OperatorState *task_operator_state);
 
-    void FillSinkStateFromLastOperatorState(QueueSinkState *queue_sink_state, OperatorState *task_operator_state);
+    void FillSinkStateFromLastOperatorState(FragmentContext *fragment_context, QueueSinkState *queue_sink_state, OperatorState *task_operator_state);
 
 private:
     SharedPtr<Vector<String>> output_names_{};

--- a/src/executor/operator/physical_sort.cppm
+++ b/src/executor/operator/physical_sort.cppm
@@ -57,8 +57,7 @@ public:
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return left_->GetOutputTypes(); }
 
     SizeT TaskletCount() override {
-        Error<NotImplementException>("TaskletCount not Implement");
-        return 0;
+        return left_->TaskletCount();
     }
 
     Vector<SharedPtr<BaseExpression>> expressions_;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -45,7 +45,10 @@ bool QueueSourceState::GetData() {
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
-            if (fragment_data->data_idx_ + 1 == fragment_data->data_count_) {
+            if (!fragment_data->data_idx_.has_value()) {
+                // fragment completed
+                MarkCompletedTask(fragment_data->fragment_id_);
+            } else if (fragment_data->data_idx_.value() + 1 == fragment_data->data_count_) {
                 // Get an all data from this
                 MarkCompletedTask(fragment_data->fragment_id_);
             }
@@ -87,6 +90,18 @@ bool QueueSourceState::GetData() {
             FusionOperatorState *fusion_op_state = (FusionOperatorState *)next_op_state;
             fusion_op_state->input_data_blocks_[fragment_data->fragment_id_].push_back(Move(fragment_data->data_block_));
             fusion_op_state->input_complete_ = completed;
+            break;
+        }
+        case PhysicalOperatorType::kMergeLimit: {
+            auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
+            MergeLimitOperatorState *limit_op_state = (MergeLimitOperatorState *)next_op_state;
+            limit_op_state->input_data_blocks_.push_back(Move(fragment_data->data_block_));
+            if (!limit_op_state->input_complete_) {
+                limit_op_state->input_complete_ = completed;
+            }
+            if (limit_op_state->input_complete_) {
+                source_queue_.NotAllowEnqueue();
+            }
             break;
         }
         default: {

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -152,6 +152,9 @@ export struct LimitOperatorState : public OperatorState {
 // Merge Limit
 export struct MergeLimitOperatorState : public OperatorState {
     inline explicit MergeLimitOperatorState() : OperatorState(PhysicalOperatorType::kMergeLimit) {}
+
+    Vector<UniquePtr<DataBlock>> input_data_blocks_{}; // Since merge knn is the first op, no previous operator state. This ptr is to get input data.
+    bool input_complete_{false};
 };
 
 // Merge Top

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -112,6 +112,8 @@ import logical_match;
 import logical_fusion;
 
 import parser;
+import value;
+import value_expression;
 import explain_physical_plan;
 
 import infinity_exception;
@@ -506,11 +508,11 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildAggregate(const SharedPtr<Logi
         return physical_agg_op;
     } else {
         return MakeUnique<PhysicalMergeAggregate>(query_context_ptr_->GetNextNodeID(),
-                                            logical_aggregate->base_table_ref_,
-                                            Move(physical_agg_op),
-                                            logical_aggregate->GetOutputNames(),
-                                            logical_aggregate->GetOutputTypes(),
-                                            logical_operator->load_metas());
+                                                  logical_aggregate->base_table_ref_,
+                                                  Move(physical_agg_op),
+                                                  logical_aggregate->GetOutputNames(),
+                                                  logical_aggregate->GetOutputTypes(),
+                                                  logical_operator->load_metas());
     }
 }
 
@@ -601,11 +603,29 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildLimit(const SharedPtr<LogicalN
 
     SharedPtr<LogicalLimit> logical_limit = static_pointer_cast<LogicalLimit>(logical_operator);
     UniquePtr<PhysicalOperator> input_physical_operator = BuildPhysicalOperator(input_logical_node);
-    return MakeUnique<PhysicalLimit>(logical_operator->node_id(),
-                                     Move(input_physical_operator),
-                                     logical_limit->limit_expression_,
-                                     logical_limit->offset_expression_,
-                                     logical_operator->load_metas());
+    if (input_physical_operator->TaskletCount() <= 1) {
+        return MakeUnique<PhysicalLimit>(logical_operator->node_id(),
+                                         Move(input_physical_operator),
+                                         logical_limit->limit_expression_,
+                                         logical_limit->offset_expression_,
+                                         logical_operator->load_metas());
+    } else {
+        i64 child_limit = (static_pointer_cast<ValueExpression>(logical_limit->limit_expression_))->GetValue().value_.big_int;
+
+        if (logical_limit->offset_expression_ != nullptr) {
+            child_limit += (static_pointer_cast<ValueExpression>(logical_limit->offset_expression_))->GetValue().value_.big_int;
+        }
+        auto child_limit_op = MakeUnique<PhysicalLimit>(logical_operator->node_id(),
+                                                        Move(input_physical_operator),
+                                                        MakeShared<ValueExpression>(Value::MakeBigInt(child_limit)),
+                                                        nullptr,
+                                                        logical_operator->load_metas());
+        return MakeUnique<PhysicalMergeLimit>(query_context_ptr_->GetNextNodeID(),
+                                              Move(child_limit_op),
+                                              logical_limit->limit_expression_,
+                                              logical_limit->offset_expression_,
+                                              logical_operator->load_metas());
+    }
 }
 
 UniquePtr<PhysicalOperator> PhysicalPlanner::BuildProjection(const SharedPtr<LogicalNode> &logical_operator) const {

--- a/src/planner/binder/order_binder.cpp
+++ b/src/planner/binder/order_binder.cpp
@@ -51,11 +51,18 @@ void OrderBinder::PushExtraExprToSelectList(ParsedExpr *expr, const SharedPtr<Bi
         return;
     }
 
+    if (expr->type_ == ParsedExprType::kFunction) {
+        return;
+    }
+
     bind_context_ptr->select_expr_name2index_[expr_name] = bind_context_ptr->select_expression_.size();
     bind_context_ptr->select_expression_.emplace_back(expr);
 }
 
 SharedPtr<BaseExpression> OrderBinder::BuildExpression(const ParsedExpr &expr, BindContext *bind_context_ptr, i64 depth, bool root) {
+    if (expr.type_ == ParsedExprType::kFunction) {
+        return ExpressionBinder::BuildFuncExpr((FunctionExpr &)expr, bind_context_ptr, depth, root);
+    }
     if (expr.type_ == ParsedExprType::kKnn) {
         return ExpressionBinder::BuildKnnExpr((KnnExpr &)expr, bind_context_ptr, depth, root);
     }

--- a/src/planner/binder/order_binder.cpp
+++ b/src/planner/binder/order_binder.cpp
@@ -51,10 +51,6 @@ void OrderBinder::PushExtraExprToSelectList(ParsedExpr *expr, const SharedPtr<Bi
         return;
     }
 
-    if (expr->type_ == ParsedExprType::kFunction) {
-        return;
-    }
-
     bind_context_ptr->select_expr_name2index_[expr_name] = bind_context_ptr->select_expression_.size();
     bind_context_ptr->select_expression_.emplace_back(expr);
 }

--- a/src/planner/bound/base_table_ref.cppm
+++ b/src/planner/bound/base_table_ref.cppm
@@ -52,6 +52,23 @@ public:
         replace_field<SharedPtr<DataType>>(*column_types_, indices);
     };
 
+    void RetainColumnByIds(Vector<SizeT> &&ids) {
+        if (ids.empty()) {
+            return;
+        }
+        Vector<SizeT> indices;
+        indices.reserve(ids.size());
+
+        std::sort(ids.begin(), ids.end());
+        for (SizeT i = 0, ids_i = 0; i < column_ids_.size() && ids_i < ids.size(); ++i) {
+            if (column_ids_[i] == ids[ids_i]) {
+                indices.push_back(i);
+                ids_i ++;
+            }
+        }
+        RetainColumnByIndices(Move(indices));
+    }
+
     TableCollectionEntry *table_entry_ptr_{};
     Vector<SizeT> column_ids_{};
     SharedPtr<BlockIndex> block_index_{};

--- a/src/planner/bound/base_table_ref.cppm
+++ b/src/planner/bound/base_table_ref.cppm
@@ -42,32 +42,10 @@ public:
           block_index_(Move(block_index)), column_names_(Move(column_names)), column_types_(Move(column_types)), table_index_(table_index) {}
 
     void RetainColumnByIndices(const Vector<SizeT> &&indices) {
-         // OPT1212: linear judge in assert
-        if (!std::is_sorted(indices.cbegin(), indices.cend())) {
-            Error<PlannerException>("Indices must be in order");
-        }
-
         replace_field<SizeT>(column_ids_, indices);
         replace_field<String>(*column_names_, indices);
         replace_field<SharedPtr<DataType>>(*column_types_, indices);
     };
-
-    void RetainColumnByIds(Vector<SizeT> &&ids) {
-        if (ids.empty()) {
-            return;
-        }
-        Vector<SizeT> indices;
-        indices.reserve(ids.size());
-
-        std::sort(ids.begin(), ids.end());
-        for (SizeT i = 0, ids_i = 0; i < column_ids_.size() && ids_i < ids.size(); ++i) {
-            if (column_ids_[i] == ids[ids_i]) {
-                indices.push_back(i);
-                ids_i ++;
-            }
-        }
-        RetainColumnByIndices(Move(indices));
-    }
 
     TableCollectionEntry *table_entry_ptr_{};
     Vector<SizeT> column_ids_{};

--- a/src/planner/bound_select_statement.cpp
+++ b/src/planner/bound_select_statement.cpp
@@ -110,6 +110,12 @@ SharedPtr<LogicalNode> BoundSelectStatement::BuildPlan(QueryContext *query_conte
             root = sort;
         }
 
+        if (limit_expression_ != nullptr) {
+            auto limit = MakeShared<LogicalLimit>(bind_context->GetNewLogicalNodeId(), limit_expression_, offset_expression_);
+            limit->set_left_node(root);
+            root = limit;
+        }
+
         auto project = MakeShared<LogicalProject>(bind_context->GetNewLogicalNodeId(), projection_expressions_, projection_index_);
         project->set_left_node(root);
         root = project;

--- a/src/planner/optimizer/lazy_load.cpp
+++ b/src/planner/optimizer/lazy_load.cpp
@@ -112,27 +112,27 @@ void CleanScan::VisitNode(LogicalNode &op) {
     switch (op.operator_type()) {
         case LogicalNodeType::kTableScan: {
             auto table_scan = dynamic_cast<LogicalTableScan &>(op);
-            Vector<SizeT> project_indices = LoadedColumn(last_op_load_metas_.get(), table_scan.base_table_ref_.get());
+            Vector<SizeT> project_ids = LoadedColumn(last_op_load_metas_.get(), table_scan.base_table_ref_.get());
 
             scan_table_indexes_.push_back(table_scan.base_table_ref_->table_index_);
-            table_scan.base_table_ref_->RetainColumnByIndices(Move(project_indices));
+            table_scan.base_table_ref_->RetainColumnByIds(Move(project_ids));
             table_scan.add_row_id_ = true;
             break;
         }
         case LogicalNodeType::kKnnScan: {
             auto knn_scan = dynamic_cast<LogicalKnnScan &>(op);
-            Vector<SizeT> project_indices = LoadedColumn(last_op_load_metas_.get(), knn_scan.base_table_ref_.get());
+            Vector<SizeT> project_ids = LoadedColumn(last_op_load_metas_.get(), knn_scan.base_table_ref_.get());
 
             scan_table_indexes_.push_back(knn_scan.base_table_ref_->table_index_);
-            knn_scan.base_table_ref_->RetainColumnByIndices(Move(project_indices));
+            knn_scan.base_table_ref_->RetainColumnByIds(Move(project_ids));
             break;
         }
         case LogicalNodeType::kMatch: {
             auto match = dynamic_cast<LogicalMatch &>(op);
-            Vector<SizeT> project_indices = LoadedColumn(last_op_load_metas_.get(), match.base_table_ref_.get());
+            Vector<SizeT> project_ids = LoadedColumn(last_op_load_metas_.get(), match.base_table_ref_.get());
 
             scan_table_indexes_.push_back(match.base_table_ref_->table_index_);
-            match.base_table_ref_->RetainColumnByIndices(Move(project_indices));
+            match.base_table_ref_->RetainColumnByIds(Move(project_ids));
             break;
         }
         case LogicalNodeType::kLimit:

--- a/src/planner/optimizer/lazy_load.cpp
+++ b/src/planner/optimizer/lazy_load.cpp
@@ -135,6 +135,7 @@ void CleanScan::VisitNode(LogicalNode &op) {
             match.base_table_ref_->RetainColumnByIndices(Move(project_indices));
             break;
         }
+        case LogicalNodeType::kLimit:
         case LogicalNodeType::kFusion: {
             // Skip
             VisitNodeChildren(op);

--- a/src/planner/optimizer/lazy_load.cppm
+++ b/src/planner/optimizer/lazy_load.cppm
@@ -37,7 +37,7 @@ public:
 private:
     SharedPtr<BaseExpression> VisitReplace(const SharedPtr<ColumnExpression> &expression) final;
 
-    Vector<ColumnBinding> scan_bindings_;
+    HashMap<SizeT, Vector<ColumnBinding>> scan_bindings_{};
     HashMap<SizeT, SharedPtr<Vector<SharedPtr<DataType>>>> column_types_{};
 
     HashSet<ColumnBinding> unloaded_bindings_;

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -691,7 +691,6 @@ void FragmentContext::CreateTasks(i64 cpu_count, i64 operator_count) {
         case PhysicalOperatorType::kAggregate:
         case PhysicalOperatorType::kParallelAggregate:
         case PhysicalOperatorType::kHash:
-        case PhysicalOperatorType::kLimit:
         case PhysicalOperatorType::kTop: {
             if (fragment_type_ != FragmentType::kParallelStream) {
                 Error<SchedulerException>(Format("{} should in parallel stream fragment", PhysicalOperatorToString(last_operator->operator_type())));
@@ -705,6 +704,22 @@ void FragmentContext::CreateTasks(i64 cpu_count, i64 operator_count) {
                 auto sink_state = MakeUnique<MaterializeSinkState>(fragment_ptr_->FragmentID(), task_id);
                 sink_state->column_types_ = last_operator->GetOutputTypes();
                 sink_state->column_names_ = last_operator->GetOutputNames();
+
+                tasks_[task_id]->sink_state_ = Move(sink_state);
+            }
+            break;
+        }
+        case PhysicalOperatorType::kLimit: {
+            if (fragment_type_ != FragmentType::kParallelStream) {
+                Error<SchedulerException>(Format("{} should in parallel stream fragment", PhysicalOperatorToString(last_operator->operator_type())));
+            }
+
+            if ((i64)tasks_.size() != parallel_count) {
+                Error<SchedulerException>(Format("{} task count isn't correct.", PhysicalOperatorToString(last_operator->operator_type())));
+            }
+
+            for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
+                auto sink_state = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
 
                 tasks_[task_id]->sink_state_ = Move(sink_state);
             }

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -46,6 +46,8 @@ export enum class FragmentType {
     kParallelStream,
 };
 
+class PlanFragment;
+
 export class FragmentContext {
 public:
     static void
@@ -76,6 +78,9 @@ public:
     void CreateTasks(i64 parallel_count, i64 operator_count);
 
     inline Vector<UniquePtr<FragmentTask>> &Tasks() { return tasks_; }
+
+    [[nodiscard]] inline bool IsMaterialize() const { return fragment_type_ == FragmentType::kSerialMaterialize || fragment_type_ == FragmentType::kParallelMaterialize; }
+
 
     inline SharedPtr<DataTable> GetResult() {
         UniqueLock<Mutex> lk(locker_);

--- a/src/scheduler/fragment_data.cppm
+++ b/src/scheduler/fragment_data.cppm
@@ -45,7 +45,7 @@ export struct FragmentError : public FragmentDataBase {
 export struct FragmentData : public FragmentDataBase {
     UniquePtr<DataBlock> data_block_{};
     i64 task_id_{-1};
-    SizeT data_idx_{u64_max};
+    Optional<SizeT> data_idx_{};
     SizeT data_count_{u64_max};
 
     FragmentData(u64 fragment_id, UniquePtr<DataBlock> data_block, i64 task_id, SizeT data_idx, SizeT data_count)

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -100,7 +100,7 @@ void FragmentTask::OnExecute(i64) {
 
     if (execute_success or sink_state_->error_message_.get() != nullptr) {
         PhysicalSink *sink_op = fragment_context->GetSinkOperator();
-        sink_op->Execute(query_context, sink_state_.get());
+        sink_op->Execute(query_context, fragment_context, sink_state_.get());
     }
 }
 

--- a/src/storage/data_block.cpp
+++ b/src/storage/data_block.cpp
@@ -274,7 +274,7 @@ void DataBlock::AppendWith(const DataBlock *other) {
     }
 }
 
-void DataBlock::AppendWith(const SharedPtr<DataBlock> &other, SizeT from, SizeT count) {
+void DataBlock::AppendWith(const DataBlock *other, SizeT from, SizeT count) {
     if (other->column_count() != this->column_count()) {
         Error<StorageException>(
             Format("Attempt merge block with column count {} into block with column count {}", other->column_count(), this->column_count()));

--- a/src/storage/data_block.cppm
+++ b/src/storage/data_block.cppm
@@ -80,7 +80,7 @@ public:
 
     void AppendWith(const DataBlock *other);
 
-    void AppendWith(const SharedPtr<DataBlock> &other, SizeT from, SizeT count);
+    void AppendWith(const DataBlock *other, SizeT from, SizeT count);
 
     void InsertVector(const SharedPtr<ColumnVector> &vector, SizeT index);
 

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -64,17 +64,17 @@ UniquePtr<String> TxnTableStore::Append(const SharedPtr<DataBlock> &input_block)
 
     if (current_block->row_count() + input_block->row_count() > current_block->capacity()) {
         SizeT to_append = current_block->capacity() - current_block->row_count();
-        current_block->AppendWith(input_block, 0, to_append);
+        current_block->AppendWith(input_block.get(), 0, to_append);
         current_block->Finalize();
 
         blocks_.emplace_back(DataBlock::Make());
         blocks_.back()->Init(column_types);
         ++current_block_id_;
         current_block = blocks_[current_block_id_].get();
-        current_block->AppendWith(input_block, to_append, input_block->row_count() - to_append);
+        current_block->AppendWith(input_block.get(), to_append, input_block->row_count() - to_append);
     } else {
         SizeT to_append = input_block->row_count();
-        current_block->AppendWith(input_block, 0, to_append);
+        current_block->AppendWith(input_block.get(), 0, to_append);
     }
     current_block->Finalize();
 

--- a/test/sql/dql/limit.slt
+++ b/test/sql/dql/limit.slt
@@ -1,0 +1,55 @@
+statement ok
+DROP TABLE IF EXISTS test_limit;
+
+statement ok
+CREATE TABLE test_limit (c1 INTEGER, c2 INTEGER);
+
+statement ok
+INSERT INTO test_limit VALUES(0,1),(2,3),(4,5),(6,7);
+
+query II
+SELECT * FROM test_limit limit 0;
+----
+
+query II
+SELECT * FROM test_limit limit 10;
+----
+0 1
+2 3
+4 5
+6 7
+
+query II
+SELECT * FROM test_limit limit 2;
+----
+0 1
+2 3
+
+query II
+SELECT * FROM test_limit limit 2 offset 0;
+----
+0 1
+2 3
+
+query II
+SELECT * FROM test_limit where c1 > 0 limit 2 offset 1;
+----
+4 5
+6 7
+
+
+query II
+SELECT * FROM test_limit limit 2 offset 2;
+----
+4 5
+6 7
+
+query II
+SELECT * FROM test_limit order by c1 desc limit 2 offset 2;
+----
+2 3
+0 1
+
+query II
+SELECT * FROM test_limit limit 2 offset 4;
+----

--- a/test/sql/dql/rbo_rule/column_pruner.slt
+++ b/test/sql/dql/rbo_rule/column_pruner.slt
@@ -73,9 +73,9 @@ EXPLAIN LOGICAL SELECT t1.c1, t2.c2 FROM t1 INNER JOIN t2 ON t1.c1 = t2.c2;
 ----
 PROJECT (5)
  - table index: #5
- - expressions: [c1 (#1), c2 (#0)]
+ - expressions: [c1 (#0), c2 (#1)]
 -> INNER JOIN(4)
-   - filters: [c1 (#1) = c2 (#0)
+   - filters: [c1 (#0) = c2 (#1)
    - output columns: [c1, __rowid, c2, __rowid]
   -> TABLE SCAN (2)
      - table name: t1(default.t1)
@@ -93,10 +93,10 @@ PROJECT (6)
  - table index: #5
  - expressions: [c1 (#0), c2 (#1)]
 -> FILTER (5)
-   - filter: CAST(c4 (#2) AS BigInt) > 1
+   - filter: CAST(c4 (#1) AS BigInt) > 1
    - output columns: [c1, __rowid, c2, __rowid]
   -> LEFT JOIN(4)
-     - filters: [c1 (#1) = c2 (#0)
+     - filters: [c1 (#0) = c2 (#1)
      - output columns: [c1, __rowid, c2, __rowid]
     -> TABLE SCAN (2)
        - table name: t1(default.t1)

--- a/test/sql/dql/select.slt
+++ b/test/sql/dql/select.slt
@@ -7,16 +7,64 @@ CREATE TABLE select1 (id INTEGER PRIMARY KEY, name VARCHAR, age INTEGER);
 statement ok
 CREATE TABLE select2 (id INTEGER , age INTEGER);
 
+statement ok
+CREATE TABLE select3 (c1 INTEGER, c2 INTEGER, c3 INTEGER);
+
 # copy data from csv file
 query I
 COPY select2 FROM '/tmp/infinity/test_data/nation.csv' WITH ( DELIMITER ',' );
 ----
+
+statement ok
+INSERT INTO select3 VALUES(0,1,2),(3,4,5),(6,7,8);
 
 #query ITI
 #SELECT * FROM select1 ORDER by age ASC;
 #----
 #2 Jane 25
 #1 John 30
+
+query III
+SELECT * from select3;
+----
+0 1 2
+3 4 5
+6 7 8
+
+query III
+SELECT c1, c2, c3 from select3;
+----
+0 1 2
+3 4 5
+6 7 8
+
+query III
+SELECT c2, c3 from select3;
+----
+1 2
+4 5
+7 8
+
+query III
+SELECT c2 from select3;
+----
+1
+4
+7
+
+query III
+SELECT c3, c2, c1 from select3;
+----
+2 1 0
+5 4 3
+8 7 6
+
+query III
+SELECT c2, c1 from select3;
+----
+1 0
+4 3
+7 6
 
 statement ok
 DROP TABLE select1;

--- a/test/sql/dql/sort_by_function.slt
+++ b/test/sql/dql/sort_by_function.slt
@@ -1,0 +1,13 @@
+statement ok
+CREATE TABLE t1 (c1 int, c2 int);
+
+statement ok
+INSERT INTO t1 VALUES(0, 1), (1, 4), (1, 5), (2, 3);
+
+query II
+select c1, c2 from t1 order by c1 + c2, c1;
+----
+0 1
+1 4
+2 3
+1 5

--- a/test/sql/dql/sort_by_function.slt
+++ b/test/sql/dql/sort_by_function.slt
@@ -11,3 +11,11 @@ select c1, c2 from t1 order by c1 + c2, c1;
 1 4
 2 3
 1 5
+
+query II
+select c1, c2, c1 + c2 from t1 order by c1 + c2, c1;
+----
+0 1 1
+1 4 5
+2 3 5
+1 5 6

--- a/tools/generate_limit.py
+++ b/tools/generate_limit.py
@@ -6,24 +6,26 @@ import argparse
 
 def generate(generate_if_exists: bool, copy_dir: str):
     row_n = 9000
-    sort_dir = "./test/data/csv"
+    limit = 8500
+    offset = 20
+    limit_dir = "./test/data/csv"
     slt_dir = "./test/sql/dql"
 
-    table_name = "test_sort"
-    sort_path = sort_dir + "/test_sort.csv"
-    slt_path = slt_dir + "/sort.slt"
-    copy_path = copy_dir + "/test_sort.csv"
+    table_name = "test_big_limit"
+    limit_path = limit_dir + "/test_big_limit.csv"
+    slt_path = slt_dir + "/big_limit.slt"
+    copy_path = copy_dir + "/test_big_limit.csv"
 
-    os.makedirs(sort_dir, exist_ok=True)
+    os.makedirs(limit_dir, exist_ok=True)
     os.makedirs(slt_dir, exist_ok=True)
-    if os.path.exists(sort_path) and os.path.exists(slt_path) and generate_if_exists:
+    if os.path.exists(limit_path) and os.path.exists(slt_path) and generate_if_exists:
         print(
             "File {} and {} already existed exists. Skip Generating.".format(
-                slt_path, sort_path
+                slt_path, limit_path
             )
         )
         return
-    with open(sort_path, "w") as sort_file, open(slt_path, "w") as slt_file:
+    with open(limit_path, "w") as limit_file, open(slt_path, "w") as slt_file:
         slt_file.write("statement ok\n")
         slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
         slt_file.write("\n")
@@ -41,16 +43,15 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write("----\n")
         slt_file.write("\n")
         slt_file.write("query I\n")
-        slt_file.write("SELECT * FROM {} order by c1, c2;\n".format(table_name))
+        slt_file.write("SELECT * FROM {} limit {} offset {};\n".format(table_name, limit, offset))
         slt_file.write("----\n")
 
-        random_integers = np.random.randint(low=1, high=row_n, size=row_n)
+        for _ in range(row_n):
+            limit_file.write("0,0")
+            limit_file.write("\n")
 
-        for i in random_integers:
-            sort_file.write("0," + str(i))
-            sort_file.write("\n")
-        for i in sorted(random_integers):
-            slt_file.write("0 " + str(i))
+        for _ in range(limit):
+            slt_file.write("0 0")
             slt_file.write("\n")
 
         slt_file.write("\n")
@@ -60,7 +61,7 @@ def generate(generate_if_exists: bool, copy_dir: str):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate sort data for test")
+    parser = argparse.ArgumentParser(description="Generate limit data for test")
 
     parser.add_argument(
         "-g",

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -5,6 +5,7 @@ from shutil import copyfile
 from generate_big import generate as generate1
 from generate_fvecs import generate as generate2
 from generate_sort import generate as generate3
+from generate_limit import generate as generate4
 
 
 def python_skd_test(python_test_dir: str):
@@ -106,6 +107,7 @@ if __name__ == "__main__":
     generate1(args.generate_if_exists, args.copy)
     generate2(args.generate_if_exists, args.copy)
     generate3(args.generate_if_exists, args.copy)
+    generate4(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
     python_skd_test(python_test_dir)
     test_process(args.path, args.test, args.data, args.copy)


### PR DESCRIPTION
### What problem does this PR solve?

- implement physical_limit.cpp & physical_merge_limit.cpp
- fixed build logical_plan for limit
- add python test script for limit
- support stream sink for physical_sink.cpp
- fix column binding miss on order by functions
  - `select c1, c2 from t1 order by c1 + c2, c1;`
- fix physical_limit offset
- fix lazy load output_names wrong on join
- remove `RetainColumnByIds`
- fix remapper error when Project has no first column or column order is reverse order 
  - `select c3, c2, c1 from select3;`
  - `select c2, c3 from select3;`

Issue link: https://github.com/infiniflow/infinity/issues/362

### What is changed and how it works?

```
kould=> SELECT * FROM test_limit limit 10;
 c1 | c2 
----+----
  0 |  1
  2 |  3
  4 |  5
  6 |  7
(4 rows)

kould=> SELECT * FROM test_limit limit 2 offset 2;
 c1 | c2 
----+----
  4 |  5
  6 |  7
(2 rows)
```

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer