### PR TITLE
For avg functions replacing it with (sum / count); count(*)

### DIFF
--- a/src/executor/expression/expression_evaluator.cpp
+++ b/src/executor/expression/expression_evaluator.cpp
@@ -79,10 +79,10 @@ void ExpressionEvaluator::Execute(const SharedPtr<AggregateExpression> &expr,
     // Create output chunk.
     // TODO: Now output chunk is pre-allocate memory in expression state
     // TODO: In the future, it can be implemented as on-demand allocation.
-    SharedPtr<ColumnVector> &child_output = child_state->OutputColumnVector();
-    Execute(child_expr, child_state, child_output);
+    SharedPtr<ColumnVector> &child_output_col = child_state->OutputColumnVector();
+    this->Execute(child_expr, child_state, child_output_col);
 
-    if (expr->aggregate_function_.argument_type_ != *child_output->data_type()) {
+    if (expr->aggregate_function_.argument_type_ != *child_output_col->data_type()) {
         Error<ExecutorException>("Argument type isn't matched with the child expression output");
     }
     if (expr->aggregate_function_.return_type_ != *output_column_vector->data_type()) {
@@ -93,7 +93,7 @@ void ExpressionEvaluator::Execute(const SharedPtr<AggregateExpression> &expr,
     expr->aggregate_function_.init_func_(expr->aggregate_function_.GetState());
 
     // 2. Loop to fill the aggregate state
-    expr->aggregate_function_.update_func_(expr->aggregate_function_.GetState(), child_output);
+    expr->aggregate_function_.update_func_(expr->aggregate_function_.GetState(), child_output_col);
 
     // 3. Get the aggregate result and append to output column vector.
 
@@ -157,7 +157,8 @@ void ExpressionEvaluator::Execute(const SharedPtr<ValueExpression> &expr,
                                   SharedPtr<ExpressionState> &,
                                   SharedPtr<ColumnVector> &output_column_vector) {
     // memory copy here.
-    output_column_vector->SetValue(0, expr->GetValue());
+    auto value = expr->GetValue();
+    output_column_vector->SetValue(0, value);
     output_column_vector->Finalize(1);
 }
 

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -38,7 +38,7 @@ UniquePtr<PlanFragment> FragmentBuilder::BuildFragment(PhysicalOperator *phys_op
     auto plan_fragment = MakeUnique<PlanFragment>(GetFragmentId());
     plan_fragment->SetSinkNode(query_context_ptr_, SinkType::kResult, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
     BuildFragments(phys_op, plan_fragment.get());
-    if (plan_fragment->GetSourceNode() != nullptr) {
+    if (plan_fragment->GetSourceNode() == nullptr) {
         plan_fragment->SetSourceNode(query_context_ptr_, SourceType::kEmpty, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
     }
     return plan_fragment;
@@ -188,6 +188,7 @@ void FragmentBuilder::BuildFragments(PhysicalOperator *phys_op, PlanFragment *cu
                                             phys_op->left()->GetOutputTypes());
             BuildFragments(phys_op->left(), next_plan_fragment.get());
             current_fragment_ptr->AddChild(Move(next_plan_fragment));
+
             if (phys_op->right() != nullptr) {
                 auto next_plan_fragment = MakeUnique<PlanFragment>(GetFragmentId());
                 next_plan_fragment->SetSinkNode(query_context_ptr_,

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -188,7 +188,6 @@ void FragmentBuilder::BuildFragments(PhysicalOperator *phys_op, PlanFragment *cu
                                             phys_op->left()->GetOutputTypes());
             BuildFragments(phys_op->left(), next_plan_fragment.get());
             current_fragment_ptr->AddChild(Move(next_plan_fragment));
-
             if (phys_op->right() != nullptr) {
                 auto next_plan_fragment = MakeUnique<PlanFragment>(GetFragmentId());
                 next_plan_fragment->SetSinkNode(query_context_ptr_,

--- a/src/executor/operator/physical_aggregate.cpp
+++ b/src/executor/operator/physical_aggregate.cpp
@@ -619,12 +619,11 @@ bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>
         SizeT expression_count = aggregates_count;
         // calculate every columns value
         for (SizeT expr_idx = 0; expr_idx < expression_count; ++expr_idx) {
+            LOG_TRACE("Physical aggregate Execute");
             evaluator.Execute(aggregates_[expr_idx], expr_states[expr_idx], output_data_block->column_vectors[expr_idx]);
         }
         output_data_block->Finalize();
     }
-
-    LOG_TRACE("Physical aggregate");
     return true;
 }
 

--- a/src/executor/operator/physical_aggregate.cpp
+++ b/src/executor/operator/physical_aggregate.cpp
@@ -63,7 +63,7 @@ bool PhysicalAggregate::Execute(QueryContext *query_context, OperatorState *oper
 #if 0
     groupby_columns.reserve(group_count);
 
-    Vector<DataType> types;s
+    Vector<DataType> types;
     types.reserve(group_count);
 
     for(i64 idx = 0; auto& expr: groups_) {

--- a/src/executor/operator/physical_aggregate.cpp
+++ b/src/executor/operator/physical_aggregate.cpp
@@ -605,25 +605,6 @@ bool PhysicalAggregate::SimpleAggregate(SharedPtr<DataTable> &output_table,
         LOG_TRACE("No input, no aggregate result");
         return true;
     }
-    // Loop blocks
-
-    //    ExpressionEvaluator evaluator;
-    //    //evaluator.Init(input_table_->data_blocks_);
-    //    for (SizeT expr_idx = 0; expr_idx < aggregates_count; ++expr_idx) {
-    //
-    //        ExpressionEvaluator evaluator;
-    //        evaluator.Init(aggregates_[])
-    //        Vector<SharedPtr<ColumnVector>> blocks_column;
-    //        blocks_column.emplace_back(output_data_block->column_vectors[expr_idx]);
-    //        evaluator.Execute(aggregates_[expr_idx], expr_states[expr_idx], blocks_column[expr_idx]);
-    //        if(blocks_column[0].get() != output_data_block->column_vectors[expr_idx].get()) {
-    //            // column vector in blocks column might be changed to the column vector from column reference.
-    //            // This check and assignment is to make sure the right column vector are assign to output_data_block
-    //            output_data_block->column_vectors[expr_idx] = blocks_column[0];
-    //        }
-    //    }
-    //
-    //    output_data_block->Finalize();
 
     for (SizeT block_idx = 0; block_idx < input_block_count; ++block_idx) {
         DataBlock *input_data_block = pre_operator_state->data_block_array_[block_idx].get();
@@ -650,6 +631,8 @@ bool PhysicalAggregate::SimpleAggregate(SharedPtr<DataTable> &output_table,
     if (pre_operator_state->Complete()) {
         aggregate_operator_state->SetComplete();
     }
+
+    LOG_TRACE("Physical aggregate");
     return true;
 }
 

--- a/src/executor/operator/physical_aggregate.cppm
+++ b/src/executor/operator/physical_aggregate.cppm
@@ -25,6 +25,7 @@ import hash_table;
 import base_expression;
 import load_meta;
 import infinity_exception;
+import data_block;
 
 export module physical_aggregate;
 
@@ -44,8 +45,8 @@ public:
                                Vector<SharedPtr<BaseExpression>> aggregates,
                                u64 aggregate_index,
                                SharedPtr<Vector<LoadMeta>> load_metas)
-        : PhysicalOperator(PhysicalOperatorType::kAggregate, Move(left), nullptr, id, load_metas), groups_(Move(groups)), aggregates_(Move(aggregates)),
-          groupby_index_(groupby_index), aggregate_index_(aggregate_index) {}
+        : PhysicalOperator(PhysicalOperatorType::kAggregate, Move(left), nullptr, id, load_metas), groups_(Move(groups)),
+          aggregates_(Move(aggregates)), groupby_index_(groupby_index), aggregate_index_(aggregate_index) {}
 
     ~PhysicalAggregate() override = default;
 
@@ -66,9 +67,7 @@ public:
     Vector<SharedPtr<BaseExpression>> aggregates_{};
     HashTable hash_table_;
 
-    bool SimpleAggregate(SharedPtr<DataTable> &output_table,
-                                            OperatorState *pre_operator_state,
-                                            AggregateOperatorState *aggregate_operator_state);
+    bool SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>> &input_blocks, Vector<UniquePtr<DataBlock>> &output_blocks);
 
     inline u64 GroupTableIndex() const { return groupby_index_; }
 

--- a/src/executor/operator/physical_merge_aggregate.cpp
+++ b/src/executor/operator/physical_merge_aggregate.cpp
@@ -31,6 +31,9 @@ module physical_merge_aggregate;
 
 namespace infinity {
 
+template <typename T>
+using MathOperation = StdFunction<T(T, T)>;
+
 void PhysicalMergeAggregate::Init() {}
 
 bool PhysicalMergeAggregate::Execute(QueryContext *query_context, OperatorState *operator_state) {
@@ -53,80 +56,122 @@ bool PhysicalMergeAggregate::Execute(QueryContext *query_context, OperatorState 
     return false;
 }
 
-void PhysicalMergeAggregate::SimpleMergeAggregateExecute(MergeAggregateOperatorState *merge_aggregate_op_state) {
-    if (merge_aggregate_op_state->data_block_array_.size() == 0) {
-        merge_aggregate_op_state->data_block_array_.emplace_back(Move(merge_aggregate_op_state->input_data_block_));
+void PhysicalMergeAggregate::SimpleMergeAggregateExecute(MergeAggregateOperatorState *op_state) {
+    if (op_state->data_block_array_.empty()) {
+        op_state->data_block_array_.emplace_back(Move(op_state->input_data_block_));
     } else {
         auto agg_op = dynamic_cast<PhysicalAggregate *>(this->left());
-
-        for (SizeT col_idx = 0; auto expr : agg_op->aggregates_) {
-            auto agg_expression = static_cast<AggregateExpression *>(expr.get());
+        auto aggs_size = agg_op->aggregates_.size();
+        for (SizeT col_idx = 0; col_idx < aggs_size; ++col_idx) {
+            auto agg_expression = static_cast<AggregateExpression *>(agg_op->aggregates_[col_idx].get());
 
             auto function_name = agg_expression->aggregate_function_.GetFuncName();
 
-            auto function_return_type = agg_expression->aggregate_function_.return_type_;
+            auto func_return_type = agg_expression->aggregate_function_.return_type_;
 
-            if (String(function_name) == String("COUNT")) {
-                LOG_TRACE("PhysicalAggregate::Execute:: COUNT");
-                UpdateBlockData(merge_aggregate_op_state, col_idx);
-            } else if (String(function_name) == String("MIN")) {
-                LOG_TRACE("PhysicalAggregate::Execute:: MIN");
-                IntegerT input_int = GetDataFromValueAtInputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, col_idx, 0);
-                IntegerT out_int = GetDataFromValueAtOutputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, col_idx, 0);
-                IntegerT new_int = MinValue(input_int, out_int);
-                WriteIntegerAtPosition(merge_aggregate_op_state, 0, col_idx, 0, new_int);
-            } else if (String(function_name) == String("MAX")) {
-                LOG_TRACE("PhysicalAggregate::Execute:: MAX");
-
-                IntegerT input_int = GetDataFromValueAtInputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, col_idx, 0);
-                IntegerT out_int = GetDataFromValueAtOutputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, col_idx, 0);
-                IntegerT new_int = MaxValue(input_int, out_int);
-                WriteIntegerAtPosition(merge_aggregate_op_state, 0, col_idx, 0, new_int);
-            } else if (String(function_name) == String("SUM")) {
-                LOG_TRACE("PhysicalAggregate::Execute:: COUNT");
-                UpdateBlockData(merge_aggregate_op_state, col_idx);
+            switch (func_return_type.type()) {
+                case kInteger: {
+                    HandleAggregateFunction<IntegerT>(function_name, op_state, col_idx);
+                    break;
+                }
+                case kBigInt: {
+                    HandleAggregateFunction<BigIntT>(function_name, op_state, col_idx);
+                    break;
+                }
+                case kFloat: {
+                    HandleAggregateFunction<FloatT>(function_name, op_state, col_idx);
+                    break;
+                }
+                case kDouble: {
+                    HandleAggregateFunction<DoubleT>(function_name, op_state, col_idx);
+                    break;
+                }
+                default:
+                    Error<NotImplementException>("input_value_type not Implement");
             }
-
-            ++col_idx;
         }
-    }
-}
-
-void PhysicalMergeAggregate::UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state, SizeT col_idx) {
-    Value input_value = merge_aggregate_op_state->input_data_block_->GetValue(col_idx, 0);
-    DataType input_value_type = input_value.type();
-    if (!input_value_type.IsNumeric()) {
-        Error<NotImplementException>("input_value_type not Implement");
-    }
-
-    switch (input_value_type.type()) {
-        case kBigInt: {
-            auto new_big_int = AddData<BigIntT>(input_value, merge_aggregate_op_state);
-            merge_aggregate_op_state->data_block_array_[0]->SetValue(col_idx, 0, Value::MakeBigInt(new_big_int));
-            return;
-        }
-        case kInteger: {
-            auto new_int = AddData<BigIntT>(input_value, merge_aggregate_op_state);
-            merge_aggregate_op_state->data_block_array_[0]->SetValue(col_idx, 0, Value::MakeInt(new_int));
-            return;
-        }
-        case kDouble: {
-            auto new_double = AddData<DoubleT>(input_value, merge_aggregate_op_state);
-            merge_aggregate_op_state->data_block_array_[0]->SetValue(col_idx, 0, Value::MakeDouble(new_double));
-            return;
-        }
-        default:
-            Error<NotImplementException>("input_value_type not Implement");
     }
 }
 
 template <typename T>
-T PhysicalMergeAggregate::AddData(Value input_value, MergeAggregateOperatorState *merge_aggregate_op_state) {
-    T input = input_value.GetValue<T>();
-    Value out_value = merge_aggregate_op_state->data_block_array_[0]->GetValue(0, 0);
-    T out_put = out_value.GetValue<T>();
-    T new_input = input + out_put;
-    return new_input;
+void PhysicalMergeAggregate::HandleAggregateFunction(const String &function_name, MergeAggregateOperatorState *op_state, SizeT col_idx) {
+    if (String(function_name) == String("COUNT")) {
+        LOG_TRACE("COUNT");
+        HandleCount<T>(op_state, col_idx);
+    } else if (String(function_name) == String("MIN")) {
+        LOG_TRACE("MIN");
+        HandleMin<T>(op_state, col_idx);
+    } else if (String(function_name) == String("MAX")) {
+        LOG_TRACE("MAX");
+        HandleMax<T>(op_state, col_idx);
+    } else if (String(function_name) == String("SUM")) {
+        LOG_TRACE("SUM");
+        HandleSum<T>(op_state, col_idx);
+    }
+}
+
+template <typename T>
+void PhysicalMergeAggregate::HandleMin(MergeAggregateOperatorState *op_state, SizeT col_idx) {
+    MathOperation<T> minOperation = [](T a, T b) -> T { return (a < b) ? a : b; };
+    UpdateData<T>(op_state, minOperation, col_idx);
+}
+
+template <typename T>
+void PhysicalMergeAggregate::HandleMax(MergeAggregateOperatorState *op_state, SizeT col_idx) {
+    MathOperation<T> maxOperation = [](T a, T b) -> T { return (a > b) ? a : b; };
+    UpdateData<T>(op_state, maxOperation, col_idx);
+}
+
+template <typename T>
+void PhysicalMergeAggregate::HandleCount(MergeAggregateOperatorState *op_state, SizeT col_idx) {
+    MathOperation<T> countOperation = [](T a, T b) -> T { return a + b; };
+    UpdateData<T>(op_state, countOperation, col_idx);
+}
+
+template <typename T>
+void PhysicalMergeAggregate::HandleSum(MergeAggregateOperatorState *op_state, SizeT col_idx) {
+    MathOperation<T> sumOperation = [](T a, T b) -> T { return a + b; };
+    UpdateData<T>(op_state, sumOperation, col_idx);
+}
+
+template <typename T>
+T PhysicalMergeAggregate::GetInputData(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx) {
+    Value value = op_state->input_data_block_->GetValue(col_idx, row_idx);
+    return value.GetValue<T>();
+}
+
+template <typename T>
+T PhysicalMergeAggregate::GetOutputData(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx) {
+    Value value = op_state->data_block_array_[block_index]->GetValue(col_idx, row_idx);
+    return value.GetValue<T>();
+}
+
+template <typename T>
+void PhysicalMergeAggregate::WriteValueAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, T value) {
+    op_state->data_block_array_[block_index]->SetValue(col_idx, row_idx, CreateValue(value));
+}
+
+template <typename T>
+void PhysicalMergeAggregate::UpdateData(MergeAggregateOperatorState *op_state, MathOperation<T> operation, SizeT col_idx) {
+    T input = GetInputData<T>(op_state, 0, col_idx, 0);
+    T output = GetOutputData<T>(op_state, 0, col_idx, 0);
+    T new_value = operation(input, output);
+    WriteValueAtPosition<T>(op_state, 0, col_idx, 0, new_value);
+}
+
+template <typename T>
+T PhysicalMergeAggregate::AddData(T a, T b) {
+    return a + b;
+}
+
+template <typename T>
+T PhysicalMergeAggregate::MinValue(T a, T b) {
+    return (a < b) ? a : b;
+}
+
+template <typename T>
+T PhysicalMergeAggregate::MaxValue(T a, T b) {
+    return (a > b) ? a : b;
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_aggregate.cpp
+++ b/src/executor/operator/physical_merge_aggregate.cpp
@@ -88,47 +88,6 @@ bool PhysicalMergeAggregate::Execute(QueryContext *query_context, OperatorState 
     }
 }
 
-bool PhysicalMergeAggregate::SimpleMergeAggregateExecute(Vector<UniquePtr<DataBlock>> &input_blocks, Vector<UniquePtr<DataBlock>> &output_blocks) {
-
-    // for (SizeT block_idx = 0; block_idx < input_blocks.size(); ++block_idx) {
-    //     DataBlock *input_data_block = input_blocks[block_idx].get();
-    //     if (output_blocks.size() == 0) {
-    //         output_blocks.emplace_back(Move(input_blocks[block_idx]));
-    //     } else {
-    //         auto agg_op = dynamic_cast<PhysicalAggregate *>(this->left());
-    //
-    //         for (SizeT col_idx = 0; const auto &expr : agg_op->aggregates_) {
-    //             auto agg_expression = static_cast<AggregateExpression *>(expr.get());
-    //
-    //             auto function_name = agg_expression->aggregate_function_.GetFuncName();
-    //
-    //             auto function_return_type = agg_expression->aggregate_function_.return_type_;
-    //
-    //             if (String(function_name) == String("COUNT")) {
-    //                 LOG_TRACE("PhysicalAggregate::Execute:: COUNT");
-    //                 // UpdateBlockData(merge_aggregate_op_state);
-    //             } else if (String(function_name) == String("MIN")) {
-    //                 LOG_TRACE("PhysicalAggregate::Execute:: MIN");
-    //                 IntegerT input_int = GetDataFromValueAtInputBlockPosition2<IntegerT>(input_blocks, block_idx, 0, col_idx);
-    //                 IntegerT out_int = GetDataFromValueAtOutputBlockPosition2<IntegerT>(output_blocks, block_idx, 0, col_idx);
-    //                 IntegerT new_int = MinValue(input_int, out_int);
-    //                 WriteIntegerAtPosition2(output_blocks, block_idx, 0, col_idx, new_int);
-    //             } else if (String(function_name) == String("MAX")) {
-    //                 LOG_TRACE("PhysicalAggregate::Execute:: MAX");
-    //
-    //                 IntegerT input_int = GetDataFromValueAtInputBlockPosition2<IntegerT>(input_blocks, block_idx, 0, col_idx);
-    //                 IntegerT out_int = GetDataFromValueAtOutputBlockPosition2<IntegerT>(output_blocks, block_idx, 0, col_idx);
-    //                 IntegerT new_int = MaxValue(input_int, out_int);
-    //                 WriteIntegerAtPosition2(output_blocks, block_idx, 0, col_idx, new_int);
-    //             } else if (String(function_name) == String("SUM")) {
-    //                 // UpdateBlockData(merge_aggregate_op_state);
-    //             }
-    //         }
-    //     }
-    // }
-    return false;
-}
-
 void PhysicalMergeAggregate::UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state, SizeT col_idx) {
     Value input_value = merge_aggregate_op_state->input_data_block_->GetValue(col_idx, 0);
     DataType input_value_type = input_value.type();

--- a/src/executor/operator/physical_merge_aggregate.cpp
+++ b/src/executor/operator/physical_merge_aggregate.cpp
@@ -42,9 +42,9 @@ bool PhysicalMergeAggregate::Execute(QueryContext *query_context, OperatorState 
     if (merge_aggregate_op_state->input_complete_) {
 
         LOG_TRACE("PhysicalMergeAggregate::Input is complete");
-        // for (auto &output_block : merge_aggregate_op_state->data_block_array_) {
-        //     output_block->Finalize();
-        // }
+        for (auto &output_block : merge_aggregate_op_state->data_block_array_) {
+            output_block->Finalize();
+        }
 
         merge_aggregate_op_state->SetComplete();
         return true;
@@ -83,6 +83,7 @@ void PhysicalMergeAggregate::SimpleMergeAggregateExecute(MergeAggregateOperatorS
                 IntegerT new_int = MaxValue(input_int, out_int);
                 WriteIntegerAtPosition(merge_aggregate_op_state, 0, col_idx, 0, new_int);
             } else if (String(function_name) == String("SUM")) {
+                LOG_TRACE("PhysicalAggregate::Execute:: COUNT");
                 UpdateBlockData(merge_aggregate_op_state, col_idx);
             }
 

--- a/src/executor/operator/physical_merge_aggregate.cpp
+++ b/src/executor/operator/physical_merge_aggregate.cpp
@@ -14,9 +14,18 @@
 
 module;
 
+#include <string>
+#include <vector>
+import stl;
 import query_context;
 import operator_state;
 import infinity_exception;
+import logger;
+import value;
+import data_block;
+import parser;
+import physical_aggregate;
+import aggregate_expression;
 
 module physical_merge_aggregate;
 
@@ -25,8 +34,88 @@ namespace infinity {
 void PhysicalMergeAggregate::Init() {}
 
 bool PhysicalMergeAggregate::Execute(QueryContext *query_context, OperatorState *operator_state) {
-    Error<NotImplementException>("Not Implement");
-    return false;
+    LOG_TRACE("PhysicalMergeAggregate::Execute:: mark");
+    auto merge_aggregate_op_state = static_cast<MergeAggregateOperatorState *>(operator_state);
+
+    if (!merge_aggregate_op_state->input_complete_) {
+        if (merge_aggregate_op_state->data_block_array_.size() == 0) {
+            merge_aggregate_op_state->data_block_array_.emplace_back(Move(merge_aggregate_op_state->input_data_block_));
+        } else {
+
+            auto agg_op = dynamic_cast<PhysicalAggregate *>(this->left());
+
+            for (auto expr : agg_op->aggregates_) {
+                auto agg_expression = static_cast<AggregateExpression *>(expr.get());
+
+                auto function_name = agg_expression->aggregate_function_.GetFuncName();
+
+                auto function_return_type = agg_expression->aggregate_function_.return_type_;
+
+                if (String(function_name) == String("COUNT")) {
+                    LOG_TRACE("PhysicalAggregate::Execute:: COUNT");
+                    UpdateBlockData(merge_aggregate_op_state);
+                } else if (String(function_name) == String("MIN")) {
+                    LOG_TRACE("PhysicalAggregate::Execute:: MIN");
+                    IntegerT input_int = GetDataFromValueAtInputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, 0);
+                    IntegerT out_int = GetDataFromValueAtOutputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, 0, 0);
+                    IntegerT new_int = MinValue(input_int, out_int);
+                    WriteIntegerAtPosition(merge_aggregate_op_state, 0, 0, 0, new_int);
+                } else if (String(function_name) == String("MAX")) {
+                    LOG_TRACE("PhysicalAggregate::Execute:: MAX");
+
+                    IntegerT input_int = GetDataFromValueAtInputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, 0);
+                    IntegerT out_int = GetDataFromValueAtOutputBlockPosition<IntegerT>(merge_aggregate_op_state, 0, 0, 0);
+                    IntegerT new_int = MaxValue(input_int, out_int);
+                    WriteIntegerAtPosition(merge_aggregate_op_state, 0, 0, 0, new_int);
+                } else if (String(function_name) == String("SUM")) {
+                    UpdateBlockData(merge_aggregate_op_state);
+                }
+            }
+        }
+        return false;
+    } else {
+        LOG_TRACE("PhysicalAggregate::Input is complete");
+        merge_aggregate_op_state->data_block_array_.back()->Finalize();
+        merge_aggregate_op_state->SetComplete();
+        return true;
+    }
+}
+
+void PhysicalMergeAggregate::UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state) {
+    Value input_value = merge_aggregate_op_state->input_data_block_->GetValue(0, 0);
+    DataType input_value_type = input_value.type();
+    if (!input_value_type.IsNumeric()) {
+        Error<NotImplementException>("input_value_type not Implement");
+    }
+
+    switch (input_value_type.type()) {
+        case kBigInt: {
+            auto new_big_int = AddData<BigIntT>(input_value, merge_aggregate_op_state);
+            merge_aggregate_op_state->data_block_array_[0]->SetValue(0, 0, Value::MakeBigInt(new_big_int));
+            return;
+        }
+        case kInteger: {
+            auto new_int = AddData<BigIntT>(input_value, merge_aggregate_op_state);
+            merge_aggregate_op_state->data_block_array_[0]->SetValue(0, 0, Value::MakeInt(new_int));
+            return;
+        }
+        case kDouble: {
+            auto new_double = AddData<DoubleT>(input_value, merge_aggregate_op_state);
+            merge_aggregate_op_state->data_block_array_[0]->SetValue(0, 0, Value::MakeDouble(new_double));
+            return;
+        }
+        default:
+            Error<NotImplementException>("input_value_type not Implement");
+    }
+}
+
+template <typename T>
+T PhysicalMergeAggregate::AddData(Value input_value, MergeAggregateOperatorState *merge_aggregate_op_state) {
+    T input = input_value.GetValue<T>();
+    Value out_value = merge_aggregate_op_state->data_block_array_[0]->GetValue(0, 0);
+    T out_put = out_value.GetValue<T>();
+    T new_input = input + out_put;
+    return new_input;
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_merge_aggregate.cppm
+++ b/src/executor/operator/physical_merge_aggregate.cppm
@@ -56,32 +56,81 @@ public:
         return 0;
     }
 
+    template <typename T>
+    T GetDataFromValueAtInputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
+
+    template <typename T>
+    T GetDataFromValueAtOutputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
+
+    void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, IntegerT integer);
+
+    template <typename T>
+    T GetInputData(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
+
+    template <typename T>
+    T GetOutputData(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
+
+    template <typename T>
+    T MinValue(T a, T b);
+
+    template <typename T>
+    T MaxValue(T a, T b);
+
+    template <typename T>
+    T AddData(T a, T b);
+
+    template <typename T>
+    using MathOperation = StdFunction<T(T, T)>;
+
+    void SimpleMergeAggregateExecute(MergeAggregateOperatorState *merge_aggregate_op_state);
+
     void UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state, SizeT col_idx);
 
     template <typename T>
-    T AddData(Value input_value, MergeAggregateOperatorState *merge_aggregate_op_state);
+    void UpdateData(MergeAggregateOperatorState *op_state, MathOperation<T> operation, SizeT col_idx);
 
     template <typename T>
-    T GetDataFromValueAtInputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx) {
-        Value value = op_state->input_data_block_->GetValue(col_idx, row_idx);
-        return value.GetValue<T>();
-    }
+    void WriteValueAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, T value);
 
     template <typename T>
-    T GetDataFromValueAtOutputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx) {
-        Value value = op_state->data_block_array_[block_index]->GetValue(col_idx, row_idx);
-        return value.GetValue<T>();
+    void HandleSum(MergeAggregateOperatorState *op_state, SizeT col_idx);
+
+    template <typename T>
+    void HandleCount(MergeAggregateOperatorState *op_state, SizeT col_idx);
+
+    template <typename T>
+    void HandleMin(MergeAggregateOperatorState *op_state, SizeT col_idx);
+
+    template <typename T>
+    void HandleMax(MergeAggregateOperatorState *op_state, SizeT col_idx);
+
+    template <typename T>
+    void HandleAggregateFunction(const String &function_name, MergeAggregateOperatorState *op_state, SizeT col_idx);
+
+    template <typename T>
+    Value CreateValue(T value) {
+        Error<NotImplementException>("Unhandled type for makeValue");
     }
 
-    void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, IntegerT integer) {
-        op_state->data_block_array_[block_index]->SetValue(col_idx, row_idx, Value::MakeInt(integer));
+    template <>
+    Value CreateValue<IntegerT>(IntegerT value) {
+        return Value::MakeInt(value);
     }
 
-    IntegerT MinValue(IntegerT a, IntegerT b) { return (a < b) ? a : b; }
+    template <>
+    Value CreateValue<BigIntT>(BigIntT value) {
+        return Value::MakeBigInt(value);
+    }
 
-    IntegerT MaxValue(IntegerT a, IntegerT b) { return (a > b) ? a : b; }
+    template <>
+    Value CreateValue<DoubleT>(DoubleT value) {
+        return Value::MakeDouble(value);
+    }
 
-    void SimpleMergeAggregateExecute(MergeAggregateOperatorState *merge_aggregate_op_state) ;
+    template <>
+    Value CreateValue<FloatT>(FloatT value) {
+        return Value::MakeFloat(value);
+    }
 
 private:
     SharedPtr<Vector<String>> output_names_{};

--- a/src/executor/operator/physical_merge_aggregate.cppm
+++ b/src/executor/operator/physical_merge_aggregate.cppm
@@ -24,9 +24,9 @@ import load_meta;
 import base_table_ref;
 import infinity_exception;
 import value;
+import data_block;
 
 export module physical_merge_aggregate;
-#include "../../../../../../../usr/x86_64-linux-gnu/include/complex.h"
 
 namespace infinity {
 
@@ -56,30 +56,48 @@ public:
         return 0;
     }
 
-    void UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state);
+    void UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state, SizeT col_idx);
 
     template <typename T>
     T AddData(Value input_value, MergeAggregateOperatorState *merge_aggregate_op_state);
 
     template <typename T>
-    T GetDataFromValueAtInputBlockPosition(MergeAggregateOperatorState *op_state, SizeT row, SizeT col) {
-        Value value = op_state->input_data_block_->GetValue(row, col);
+    T GetDataFromValueAtInputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx) {
+        Value value = op_state->input_data_block_->GetValue(col_idx, row_idx);
         return value.GetValue<T>();
     }
 
     template <typename T>
-    T GetDataFromValueAtOutputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT row, SizeT col) {
-        Value value = op_state->data_block_array_[block_index]->GetValue(row, col);
+    T GetDataFromValueAtOutputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx) {
+        Value value = op_state->data_block_array_[block_index]->GetValue(col_idx, row_idx);
         return value.GetValue<T>();
     }
 
-    void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT row, SizeT col, IntegerT integer) {
-        op_state->data_block_array_[block_index]->SetValue(row, col, Value::MakeInt(integer));
+    // template <typename T>
+    // T GetDataFromValueAtInputBlockPosition2(const Vector<UniquePtr<DataBlock>> &input_blocks, SizeT block_index, SizeT row, SizeT col) {
+    //     Value value = input_blocks[block_index]->GetValue(col, row);
+    //     return value.GetValue<T>();
+    // }
+    //
+    // template <typename T>
+    // T GetDataFromValueAtOutputBlockPosition2(const Vector<UniquePtr<DataBlock>> &output_blocks, SizeT block_index, SizeT row, SizeT col) {
+    //     Value value = output_blocks[block_index]->GetValue(col, row);
+    //     return value.GetValue<T>();
+    // }
+
+    void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, IntegerT integer) {
+        op_state->data_block_array_[block_index]->SetValue(col_idx, row_idx, Value::MakeInt(integer));
     }
+
+    // void WriteIntegerAtPosition2(Vector<UniquePtr<DataBlock>> &output_blocks, SizeT block_index, SizeT row, SizeT col, IntegerT integer) {
+    //     output_blocks[block_index]->SetValue(col, row, Value::MakeInt(integer));
+    // }
 
     IntegerT MinValue(IntegerT a, IntegerT b) { return (a < b) ? a : b; }
 
     IntegerT MaxValue(IntegerT a, IntegerT b) { return (a > b) ? a : b; }
+
+    bool SimpleMergeAggregateExecute(Vector<UniquePtr<DataBlock>> &input_blocks, Vector<UniquePtr<DataBlock>> &output_blocks);
 
 private:
     SharedPtr<Vector<String>> output_names_{};

--- a/src/executor/operator/physical_merge_aggregate.cppm
+++ b/src/executor/operator/physical_merge_aggregate.cppm
@@ -23,8 +23,10 @@ import physical_operator_type;
 import load_meta;
 import base_table_ref;
 import infinity_exception;
+import value;
 
 export module physical_merge_aggregate;
+#include "../../../../../../../usr/x86_64-linux-gnu/include/complex.h"
 
 namespace infinity {
 
@@ -53,6 +55,32 @@ public:
         Error<NotImplementException>("TaskletCount not Implement");
         return 0;
     }
+
+    void UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state);
+
+    template <typename T>
+    T AddData(Value input_value, MergeAggregateOperatorState *merge_aggregate_op_state);
+
+    template <typename T>
+    T GetDataFromValueAtInputBlockPosition(MergeAggregateOperatorState *op_state, SizeT row, SizeT col) {
+        Value value = op_state->input_data_block_->GetValue(row, col);
+        return value.GetValue<T>();
+    }
+
+    template <typename T>
+    T GetDataFromValueAtOutputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT row, SizeT col) {
+        Value value = op_state->data_block_array_[block_index]->GetValue(row, col);
+        return value.GetValue<T>();
+    }
+
+    void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT row, SizeT col, IntegerT integer) {
+        op_state->data_block_array_[block_index]->SetValue(row, col, Value::MakeInt(integer));
+    }
+
+    IntegerT MinValue(IntegerT a, IntegerT b) { return (a < b) ? a : b; }
+
+    IntegerT MaxValue(IntegerT a, IntegerT b) { return (a > b) ? a : b; }
+
 private:
     SharedPtr<Vector<String>> output_names_{};
     SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};

--- a/src/executor/operator/physical_merge_aggregate.cppm
+++ b/src/executor/operator/physical_merge_aggregate.cppm
@@ -57,34 +57,15 @@ public:
     }
 
     template <typename T>
-    T GetDataFromValueAtInputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
-
-    template <typename T>
-    T GetDataFromValueAtOutputBlockPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
-
-    void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, IntegerT integer);
-
-    template <typename T>
     T GetInputData(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
 
     template <typename T>
     T GetOutputData(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx);
 
     template <typename T>
-    T MinValue(T a, T b);
-
-    template <typename T>
-    T MaxValue(T a, T b);
-
-    template <typename T>
-    T AddData(T a, T b);
-
-    template <typename T>
     using MathOperation = StdFunction<T(T, T)>;
 
     void SimpleMergeAggregateExecute(MergeAggregateOperatorState *merge_aggregate_op_state);
-
-    void UpdateBlockData(MergeAggregateOperatorState *merge_aggregate_op_state, SizeT col_idx);
 
     template <typename T>
     void UpdateData(MergeAggregateOperatorState *op_state, MathOperation<T> operation, SizeT col_idx);
@@ -130,6 +111,16 @@ public:
     template <>
     Value CreateValue<FloatT>(FloatT value) {
         return Value::MakeFloat(value);
+    }
+
+    template <>
+    Value CreateValue<TinyIntT>(TinyIntT value) {
+        return Value::MakeTinyInt(value);
+    }
+
+    template <>
+    Value CreateValue<SmallIntT>(SmallIntT value) {
+        return Value::MakeSmallInt(value);
     }
 
 private:

--- a/src/executor/operator/physical_merge_aggregate.cppm
+++ b/src/executor/operator/physical_merge_aggregate.cppm
@@ -73,31 +73,13 @@ public:
         return value.GetValue<T>();
     }
 
-    // template <typename T>
-    // T GetDataFromValueAtInputBlockPosition2(const Vector<UniquePtr<DataBlock>> &input_blocks, SizeT block_index, SizeT row, SizeT col) {
-    //     Value value = input_blocks[block_index]->GetValue(col, row);
-    //     return value.GetValue<T>();
-    // }
-    //
-    // template <typename T>
-    // T GetDataFromValueAtOutputBlockPosition2(const Vector<UniquePtr<DataBlock>> &output_blocks, SizeT block_index, SizeT row, SizeT col) {
-    //     Value value = output_blocks[block_index]->GetValue(col, row);
-    //     return value.GetValue<T>();
-    // }
-
     void WriteIntegerAtPosition(MergeAggregateOperatorState *op_state, SizeT block_index, SizeT col_idx, SizeT row_idx, IntegerT integer) {
         op_state->data_block_array_[block_index]->SetValue(col_idx, row_idx, Value::MakeInt(integer));
     }
 
-    // void WriteIntegerAtPosition2(Vector<UniquePtr<DataBlock>> &output_blocks, SizeT block_index, SizeT row, SizeT col, IntegerT integer) {
-    //     output_blocks[block_index]->SetValue(col, row, Value::MakeInt(integer));
-    // }
-
     IntegerT MinValue(IntegerT a, IntegerT b) { return (a < b) ? a : b; }
 
     IntegerT MaxValue(IntegerT a, IntegerT b) { return (a > b) ? a : b; }
-
-    bool SimpleMergeAggregateExecute(Vector<UniquePtr<DataBlock>> &input_blocks, Vector<UniquePtr<DataBlock>> &output_blocks);
 
 private:
     SharedPtr<Vector<String>> output_names_{};

--- a/src/executor/operator/physical_merge_aggregate.cppm
+++ b/src/executor/operator/physical_merge_aggregate.cppm
@@ -81,6 +81,8 @@ public:
 
     IntegerT MaxValue(IntegerT a, IntegerT b) { return (a > b) ? a : b; }
 
+    void SimpleMergeAggregateExecute(MergeAggregateOperatorState *merge_aggregate_op_state) ;
+
 private:
     SharedPtr<Vector<String>> output_names_{};
     SharedPtr<Vector<SharedPtr<DataType>>> output_types_{};

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -104,6 +104,13 @@ bool QueueSourceState::GetData() {
             }
             break;
         }
+        case PhysicalOperatorType::kMergeAggregate: {
+            auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
+            MergeAggregateOperatorState *merge_aggregate_op_state = (MergeAggregateOperatorState *)next_op_state;
+            merge_aggregate_op_state->input_data_block_ = Move(fragment_data->data_block_);
+            merge_aggregate_op_state->input_complete_ = completed;
+            break;
+        }
         default: {
             Error<ExecutorException>("Not support operator type");
             break;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -107,6 +107,7 @@ bool QueueSourceState::GetData() {
         case PhysicalOperatorType::kMergeAggregate: {
             auto *fragment_data = static_cast<FragmentData *>(fragment_data_base.get());
             MergeAggregateOperatorState *merge_aggregate_op_state = (MergeAggregateOperatorState *)next_op_state;
+            //merge_aggregate_op_state->input_data_blocks_.push_back(Move(fragment_data->data_block_));
             merge_aggregate_op_state->input_data_block_ = Move(fragment_data->data_block_);
             merge_aggregate_op_state->input_complete_ = completed;
             break;

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -61,6 +61,7 @@ export struct MergeAggregateOperatorState : public OperatorState {
     inline explicit MergeAggregateOperatorState() : OperatorState(PhysicalOperatorType::kMergeAggregate) {}
 
     /// Since merge agg is the first op, no previous operator state. This ptr is to get input data.
+    //Vector<UniquePtr<DataBlock>> input_data_blocks_{nullptr};
     UniquePtr<DataBlock> input_data_block_{nullptr};
     bool input_complete_{false};
 };

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -59,6 +59,10 @@ export struct AggregateOperatorState : public OperatorState {
 // Merge Aggregate
 export struct MergeAggregateOperatorState : public OperatorState {
     inline explicit MergeAggregateOperatorState() : OperatorState(PhysicalOperatorType::kMergeAggregate) {}
+
+    /// Since merge agg is the first op, no previous operator state. This ptr is to get input data.
+    UniquePtr<DataBlock> input_data_block_{nullptr};
+    bool input_complete_{false};
 };
 
 // Merge Parallel Aggregate

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -494,6 +494,8 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildAggregate(const SharedPtr<Logi
         input_physical_operator = BuildPhysicalOperator(input_logical_node);
     }
 
+    SizeT tasklet_count = input_physical_operator->TaskletCount();
+
     auto physical_agg_op = MakeUnique<PhysicalAggregate>(logical_aggregate->node_id(),
                                                          Move(input_physical_operator),
                                                          logical_aggregate->groups_,
@@ -502,7 +504,7 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildAggregate(const SharedPtr<Logi
                                                          logical_aggregate->aggregate_index_,
                                                          logical_operator->load_metas());
 
-    SizeT tasklet_count = input_physical_operator->TaskletCount();
+
 
     if (tasklet_count == 1) {
         return physical_agg_op;

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -494,8 +494,6 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildAggregate(const SharedPtr<Logi
         input_physical_operator = BuildPhysicalOperator(input_logical_node);
     }
 
-    SizeT tasklet_count = input_physical_operator->TaskletCount();
-
     auto physical_agg_op = MakeUnique<PhysicalAggregate>(logical_aggregate->node_id(),
                                                          Move(input_physical_operator),
                                                          logical_aggregate->groups_,
@@ -503,6 +501,8 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildAggregate(const SharedPtr<Logi
                                                          logical_aggregate->aggregates_,
                                                          logical_aggregate->aggregate_index_,
                                                          logical_operator->load_metas());
+
+    SizeT tasklet_count = input_physical_operator->TaskletCount();
 
     if (tasklet_count == 1) {
         return physical_agg_op;

--- a/src/function/aggregate/count.cpp
+++ b/src/function/aggregate/count.cpp
@@ -159,15 +159,16 @@ void RegisterCountFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
         function_set_ptr->AddFunction(count_function);
     }
     {
-//        AggregateFunction count_function =
-//            UnaryAggregate<CountState<PathT, BigIntT>, PathT, BigIntT>(func_name, DataType(LogicalType::kPath), DataType(LogicalType::kBigInt));
-//        function_set_ptr->AddFunction(count_function);
+        //        AggregateFunction count_function =
+        //            UnaryAggregate<CountState<PathT, BigIntT>, PathT, BigIntT>(func_name, DataType(LogicalType::kPath),
+        //            DataType(LogicalType::kBigInt));
+        //        function_set_ptr->AddFunction(count_function);
     }
     {
-//        AggregateFunction count_function = UnaryAggregate<CountState<PolygonT, BigIntT>, PolygonT, BigIntT>(func_name,
-//                                                                                                            DataType(LogicalType::kPolygon),
-//                                                                                                            DataType(LogicalType::kBigInt));
-//        function_set_ptr->AddFunction(count_function);
+        //        AggregateFunction count_function = UnaryAggregate<CountState<PolygonT, BigIntT>, PolygonT, BigIntT>(func_name,
+        //                                                                                                            DataType(LogicalType::kPolygon),
+        //                                                                                                            DataType(LogicalType::kBigInt));
+        //        function_set_ptr->AddFunction(count_function);
     }
     {
         AggregateFunction count_function =
@@ -175,9 +176,10 @@ void RegisterCountFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
         function_set_ptr->AddFunction(count_function);
     }
     {
-//        AggregateFunction count_function =
-//            UnaryAggregate<CountState<BitmapT, BigIntT>, BitmapT, BigIntT>(func_name, DataType(LogicalType::kBitmap), DataType(LogicalType::kBigInt));
-//        function_set_ptr->AddFunction(count_function);
+        //        AggregateFunction count_function =
+        //            UnaryAggregate<CountState<BitmapT, BigIntT>, BitmapT, BigIntT>(func_name, DataType(LogicalType::kBitmap),
+        //            DataType(LogicalType::kBigInt));
+        //        function_set_ptr->AddFunction(count_function);
     }
     {
         AggregateFunction count_function =
@@ -185,9 +187,10 @@ void RegisterCountFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
         function_set_ptr->AddFunction(count_function);
     }
     {
-//        AggregateFunction count_function =
-//            UnaryAggregate<CountState<BlobT, BigIntT>, BlobT, BigIntT>(func_name, DataType(LogicalType::kBlob), DataType(LogicalType::kBigInt));
-//        function_set_ptr->AddFunction(count_function);
+        //        AggregateFunction count_function =
+        //            UnaryAggregate<CountState<BlobT, BigIntT>, BlobT, BigIntT>(func_name, DataType(LogicalType::kBlob),
+        //            DataType(LogicalType::kBigInt));
+        //        function_set_ptr->AddFunction(count_function);
     }
     {
         AggregateFunction count_function = UnaryAggregate<CountState<EmbeddingT, BigIntT>, EmbeddingT, BigIntT>(func_name,

--- a/src/function/aggregate/count_star.cpp
+++ b/src/function/aggregate/count_star.cpp
@@ -1,0 +1,59 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+import new_catalog;
+
+import infinity_exception;
+import aggregate_function;
+import aggregate_function_set;
+import parser;
+import third_party;
+
+module count_star;
+
+namespace infinity {
+
+template <typename ResultType>
+struct CountStarState {
+    i64 value_{};
+
+    void Initialize() { this->value_ = 0; }
+
+    void Update(i64 *__restrict input, SizeT idx) { value_ = input[idx]; }
+
+    inline void ConstantUpdate(i64 *__restrict input, SizeT idx, SizeT) { value_ = input[idx]; }
+
+    inline ptr_t Finalize() { return (ptr_t)&value_; }
+
+    inline static SizeT Size(const DataType &) { return sizeof(i64); }
+};
+
+void RegisterCountStarFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
+    String func_name = "COUNT_STAR";
+
+    SharedPtr<AggregateFunctionSet> function_set_ptr = MakeShared<AggregateFunctionSet>(func_name);
+
+    {
+        AggregateFunction count_function =
+            CountStarAggregate<CountStarState<BigIntT>, BigIntT>(func_name, DataType(LogicalType::kBigInt), DataType(LogicalType::kBigInt));
+        function_set_ptr->AddFunction(count_function);
+    }
+
+    NewCatalog::AddFunctionSet(catalog_ptr.get(), function_set_ptr);
+}
+
+} // namespace infinity

--- a/src/function/aggregate/count_star.cppm
+++ b/src/function/aggregate/count_star.cppm
@@ -1,0 +1,27 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+import stl;
+
+export module count_star;
+
+namespace infinity {
+
+class NewCatalog;
+
+export void RegisterCountStarFunction(const UniquePtr<NewCatalog> &catalog_ptr);
+
+}

--- a/src/function/aggregate_function.cppm
+++ b/src/function/aggregate_function.cppm
@@ -119,9 +119,7 @@ public:
 
     [[nodiscard]] ptr_t GetState() const { return state_data_.get(); }
 
-    [[nodiscard]] String GetFuncName() const {
-        return name_;
-    }
+    [[nodiscard]] String GetFuncName() const { return name_; }
 
 public:
     AggregateInitializeFuncType init_func_;
@@ -144,5 +142,50 @@ inline AggregateFunction UnaryAggregate(const String &name, const DataType &inpu
                              AggregateOperation::StateInitialize<AggregateState>,
                              AggregateOperation::StateUpdate<AggregateState, InputType>,
                              AggregateOperation::StateFinalize<AggregateState, ResultType>);
+}
+
+
+class CountStarAggregateOperation {
+public:
+    template <typename AggregateState>
+    static inline void StateInitialize(const ptr_t state) {
+        ((AggregateState *)state)->Initialize();
+    }
+
+    template <typename AggregateState>
+    static inline void StateUpdate(const ptr_t state, const SharedPtr<ColumnVector> &input_column_vector) {
+        // Loop execute state update according to the input column vector
+
+        switch (input_column_vector->vector_type()) {
+            case ColumnVectorType::kConstant: {
+                auto *input_ptr = (i64 *)(input_column_vector->data());
+                ((AggregateState *)state)->Update(input_ptr, 0);
+                break;
+            }
+            default: {
+                Error<NotImplementException>("Other type of column vector isn't implemented");
+            }
+        }
+    }
+
+    template <typename AggregateState, typename ResultType>
+    static inline ptr_t StateFinalize(const ptr_t state) {
+        // Loop execute state update according to the input column vector
+        ptr_t result = ((AggregateState *)state)->Finalize();
+        return result;
+    }
+};
+
+
+export template <typename AggregateState,typename ResultType>
+inline auto CountStarAggregate(String &name, const DataType &input_type, const DataType &return_type) -> AggregateFunction {
+    auto agg_function = AggregateFunction(name,
+                                          input_type,
+                                          return_type,
+                                          AggregateState::Size(input_type),
+                                          CountStarAggregateOperation::StateInitialize<AggregateState>,
+                                          CountStarAggregateOperation::StateUpdate<AggregateState>,
+                                          CountStarAggregateOperation::StateFinalize<AggregateState, ResultType>);
+    return agg_function;
 }
 } // namespace infinity

--- a/src/function/aggregate_function.cppm
+++ b/src/function/aggregate_function.cppm
@@ -119,6 +119,10 @@ public:
 
     [[nodiscard]] ptr_t GetState() const { return state_data_.get(); }
 
+    [[nodiscard]] String GetFuncName() const {
+        return name_;
+    }
+
 public:
     AggregateInitializeFuncType init_func_;
     AggregateUpdateFuncType update_func_;

--- a/src/function/builtin_functions.cpp
+++ b/src/function/builtin_functions.cpp
@@ -22,6 +22,7 @@ import first;
 import max;
 import min;
 import sum;
+import count_star;
 
 import add;
 import abs;
@@ -52,6 +53,7 @@ import special_function;
 
 import parser;
 
+
 module builtin_functions;
 
 namespace infinity {
@@ -68,6 +70,7 @@ void BuiltinFunctions::Init() {
 void BuiltinFunctions::RegisterAggregateFunction() {
     RegisterAvgFunction(catalog_ptr_);
     RegisterCountFunction(catalog_ptr_);
+    RegisterCountStarFunction(catalog_ptr_);
     RegisterFirstFunction(catalog_ptr_);
     RegisterMaxFunction(catalog_ptr_);
     RegisterMinFunction(catalog_ptr_);

--- a/src/function/scalar/divide.cpp
+++ b/src/function/scalar/divide.cpp
@@ -38,14 +38,14 @@ struct DivFunction {
         if (left == std::numeric_limits<TA>::min() && right == -1) {
             return false;
         }
-        result = left / right;
+        result = DoubleT(left) / DoubleT(right);
         return true;
     }
 };
 
 template <>
 inline bool DivFunction::Run(FloatT left, FloatT right, FloatT &result) {
-    result = left / right;
+    result = left / DoubleT(right);
     if (std::isnan(result) || std::isinf(result))
         return false;
     return true;
@@ -65,6 +65,12 @@ inline bool DivFunction::Run(HugeIntT, HugeIntT, HugeIntT &) {
     return false;
 }
 
+template <>
+inline bool DivFunction::Run(HugeIntT, HugeIntT, DoubleT &) {
+    Error<NotImplementException>("Not implement huge int divide operator.");
+    return false;
+}
+
 void RegisterDivFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
     String func_name = "/";
 
@@ -72,38 +78,38 @@ void RegisterDivFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
 
     ScalarFunction div_function_int8(func_name,
                                      {DataType(LogicalType::kTinyInt), DataType(LogicalType::kTinyInt)},
-                                     {DataType(LogicalType::kTinyInt)},
-                                     &ScalarFunction::BinaryFunctionWithFailure<TinyIntT, TinyIntT, TinyIntT, DivFunction>);
+                                     {DataType(LogicalType::kDouble)},
+                                     &ScalarFunction::BinaryFunctionWithFailure<TinyIntT, TinyIntT, DoubleT, DivFunction>);
     function_set_ptr->AddFunction(div_function_int8);
 
     ScalarFunction div_function_int16(func_name,
                                       {DataType(LogicalType::kSmallInt), DataType(LogicalType::kSmallInt)},
-                                      {DataType(LogicalType::kSmallInt)},
-                                      &ScalarFunction::BinaryFunctionWithFailure<SmallIntT, SmallIntT, SmallIntT, DivFunction>);
+                                      {DataType(LogicalType::kDouble)},
+                                      &ScalarFunction::BinaryFunctionWithFailure<SmallIntT, SmallIntT, DoubleT, DivFunction>);
     function_set_ptr->AddFunction(div_function_int16);
 
     ScalarFunction div_function_int32(func_name,
                                       {DataType(LogicalType::kInteger), DataType(LogicalType::kInteger)},
-                                      {DataType(LogicalType::kInteger)},
-                                      &ScalarFunction::BinaryFunctionWithFailure<IntegerT, IntegerT, IntegerT, DivFunction>);
+                                      {DataType(LogicalType::kDouble)},
+                                      &ScalarFunction::BinaryFunctionWithFailure<IntegerT, IntegerT, DoubleT, DivFunction>);
     function_set_ptr->AddFunction(div_function_int32);
 
     ScalarFunction div_function_int64(func_name,
                                       {DataType(LogicalType::kBigInt), DataType(LogicalType::kBigInt)},
-                                      {DataType(LogicalType::kBigInt)},
-                                      &ScalarFunction::BinaryFunctionWithFailure<BigIntT, BigIntT, BigIntT, DivFunction>);
+                                      {DataType(LogicalType::kDouble)},
+                                      &ScalarFunction::BinaryFunctionWithFailure<BigIntT, BigIntT, DoubleT, DivFunction>);
     function_set_ptr->AddFunction(div_function_int64);
 
     ScalarFunction div_function_int128(func_name,
                                        {DataType(LogicalType::kHugeInt), DataType(LogicalType::kHugeInt)},
-                                       {DataType(LogicalType::kHugeInt)},
-                                       &ScalarFunction::BinaryFunctionWithFailure<HugeIntT, HugeIntT, HugeIntT, DivFunction>);
+                                       {DataType(LogicalType::kDouble)},
+                                       &ScalarFunction::BinaryFunctionWithFailure<HugeIntT, HugeIntT, DoubleT, DivFunction>);
     function_set_ptr->AddFunction(div_function_int128);
 
     ScalarFunction div_function_float(func_name,
                                       {DataType(LogicalType::kFloat), DataType(LogicalType::kFloat)},
-                                      {DataType(LogicalType::kFloat)},
-                                      &ScalarFunction::BinaryFunctionWithFailure<FloatT, FloatT, FloatT, DivFunction>);
+                                      {DataType(LogicalType::kDouble)},
+                                      &ScalarFunction::BinaryFunctionWithFailure<FloatT, FloatT, DoubleT, DivFunction>);
     function_set_ptr->AddFunction(div_function_float);
 
     ScalarFunction div_function_double(func_name,

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -101,7 +101,7 @@ SharedPtr<String> Config::Init(const SharedPtr<String> &config_path) {
     u64 default_log_file_rotate_count = 10;
 
     // Set the log level before performance test of DB
-    LogLevel default_log_level = LogLevel::kTrace;
+    LogLevel default_log_level = LogLevel::kInfo;
 
     // Default storage config
     SharedPtr<String> default_data_dir = MakeShared<String>("/tmp/infinity/data");

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -101,7 +101,7 @@ SharedPtr<String> Config::Init(const SharedPtr<String> &config_path) {
     u64 default_log_file_rotate_count = 10;
 
     // Set the log level before performance test of DB
-    LogLevel default_log_level = LogLevel::kInfo;
+    LogLevel default_log_level = LogLevel::kTrace;
 
     // Default storage config
     SharedPtr<String> default_data_dir = MakeShared<String>("/tmp/infinity/data");

--- a/src/planner/binder/project_binder.cpp
+++ b/src/planner/binder/project_binder.cpp
@@ -136,11 +136,6 @@ SharedPtr<BaseExpression> ProjectBinder::BuildFuncExpr(const FunctionExpr &expr,
         if (this->binding_agg_func_) {
             Error<PlannerException>(Format("Aggregate function {} is called in another aggregate function.", function_set_ptr->name()));
         } else {
-            // if (IsEqual(function_set_ptr->name(),String("AVG"))) {
-            //     this->binding_agg_func_ = false;
-            // }else {
-            //     this->binding_agg_func_ = true;
-            // }
             this->binding_agg_func_ = true;
         }
     }

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -64,6 +64,7 @@ namespace infinity {
 
 SharedPtr<BaseExpression> ExpressionBinder::Bind(const ParsedExpr &expr, BindContext *bind_context_ptr, i64 depth, bool root) {
     // Call implemented BuildExpression
+
     SharedPtr<BaseExpression> result = BuildExpression(expr, bind_context_ptr, depth, root);
     if (result.get() == nullptr) {
         if (result.get() == nullptr) {
@@ -286,23 +287,40 @@ SharedPtr<BaseExpression> ExpressionBinder::BuildFuncExpr(const FunctionExpr &ex
         Vector<String> col_names{};
         ColumnExpr *col_expr = nullptr;
         FunctionExpr *div_function_expr = new FunctionExpr();
-        FunctionExpr *sum_function_expr = new FunctionExpr();
-        FunctionExpr *count_function_expr = new FunctionExpr();
-        Vector<ParsedExpr *> *arguments = new Vector<ParsedExpr *>();
+        div_function_expr->func_name_ = String("div");
+        div_function_expr->arguments_ = new Vector<ParsedExpr*>();
+
         if (expr.arguments_->size() == 1) {
             if ((*expr.arguments_)[0]->type_ == ParsedExprType::kColumn) {
                 col_expr = (ColumnExpr *)(*expr.arguments_)[0];
                 col_names = col_expr->names_;
             }
+            FunctionExpr *sum_function_expr = new FunctionExpr();
             sum_function_expr->func_name_ = String("sum");
-            sum_function_expr->arguments_->reserve(1);
+            sum_function_expr->arguments_ = new Vector<ParsedExpr*>();
+            ColumnExpr* column_expr_for_sum = new ColumnExpr();
+            column_expr_for_sum->names_.emplace_back(col_names[0]);
+            sum_function_expr->arguments_->emplace_back(column_expr_for_sum);
+
+            FunctionExpr *count_function_expr = new FunctionExpr();
             count_function_expr->func_name_= String("count");
-            sum_function_expr->arguments_->reserve(1);
-            *count_function_expr->arguments_->emplace_back(col_expr);
-            arguments->emplace_back(sum_function_expr);
-            arguments->emplace_back(count_function_expr);
-            div_function_expr->arguments_=arguments;
+            count_function_expr->arguments_ = new Vector<ParsedExpr*>();
+            ColumnExpr* column_expr_for_count = new ColumnExpr();
+            column_expr_for_sum->names_.emplace_back(col_names[0]);
+            count_function_expr->arguments_->emplace_back(column_expr_for_count);
+
+            div_function_expr->arguments_->emplace_back(sum_function_expr);
+            div_function_expr->arguments_->emplace_back(count_function_expr);
         }
+
+        // Vector<SharedPtr<BaseExpression>> arguments;
+        // arguments.reserve(div_function_expr->arguments_->size());
+        // for (const auto *arg_expr : *div_function_expr->arguments_) {
+        //     // The argument expression isn't root expression.
+        //     // SharedPtr<BaseExpression> expr_ptr
+        //     auto expr_ptr = BuildExpression(*arg_expr, bind_context_ptr, depth, false);
+        //     arguments.emplace_back(expr_ptr);
+        // }
     }
 
     Vector<SharedPtr<BaseExpression>> arguments;

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -281,48 +281,6 @@ SharedPtr<BaseExpression> ExpressionBinder::BuildFuncExpr(const FunctionExpr &ex
         }
     }
 
-    // covert avg function expr to (sum / count) function expr
-
-    if (function_set_ptr->name() == "AVG") {
-        Vector<String> col_names{};
-        ColumnExpr *col_expr = nullptr;
-        FunctionExpr *div_function_expr = new FunctionExpr();
-        div_function_expr->func_name_ = String("div");
-        div_function_expr->arguments_ = new Vector<ParsedExpr*>();
-
-        if (expr.arguments_->size() == 1) {
-            if ((*expr.arguments_)[0]->type_ == ParsedExprType::kColumn) {
-                col_expr = (ColumnExpr *)(*expr.arguments_)[0];
-                col_names = col_expr->names_;
-            }
-            FunctionExpr *sum_function_expr = new FunctionExpr();
-            sum_function_expr->func_name_ = String("sum");
-            sum_function_expr->arguments_ = new Vector<ParsedExpr*>();
-            ColumnExpr* column_expr_for_sum = new ColumnExpr();
-            column_expr_for_sum->names_.emplace_back(col_names[0]);
-            sum_function_expr->arguments_->emplace_back(column_expr_for_sum);
-
-            FunctionExpr *count_function_expr = new FunctionExpr();
-            count_function_expr->func_name_= String("count");
-            count_function_expr->arguments_ = new Vector<ParsedExpr*>();
-            ColumnExpr* column_expr_for_count = new ColumnExpr();
-            column_expr_for_sum->names_.emplace_back(col_names[0]);
-            count_function_expr->arguments_->emplace_back(column_expr_for_count);
-
-            div_function_expr->arguments_->emplace_back(sum_function_expr);
-            div_function_expr->arguments_->emplace_back(count_function_expr);
-        }
-
-        // Vector<SharedPtr<BaseExpression>> arguments;
-        // arguments.reserve(div_function_expr->arguments_->size());
-        // for (const auto *arg_expr : *div_function_expr->arguments_) {
-        //     // The argument expression isn't root expression.
-        //     // SharedPtr<BaseExpression> expr_ptr
-        //     auto expr_ptr = BuildExpression(*arg_expr, bind_context_ptr, depth, false);
-        //     arguments.emplace_back(expr_ptr);
-        // }
-    }
-
     Vector<SharedPtr<BaseExpression>> arguments;
     arguments.reserve(expr.arguments_->size());
     for (const auto *arg_expr : *expr.arguments_) {

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -275,7 +275,15 @@ SharedPtr<BaseExpression> ExpressionBinder::BuildFuncExpr(const FunctionExpr &ex
                 ColumnExpr *col_expr = (ColumnExpr *)(*expr.arguments_)[0];
                 if (col_expr->star_) {
                     delete (*expr.arguments_)[0];
-                    (*expr.arguments_)[0] = new ConstantExpr(LiteralType::kBoolean);
+                    auto constant_exp = new ConstantExpr(LiteralType::kInteger);
+                    // catulate row count
+                    String &table_name = bind_context_ptr->table_names_[0];
+                    TableCollectionEntry *table_entry = bind_context_ptr->binding_by_name_[table_name]->table_collection_entry_ptr_;
+                    constant_exp->integer_value_ = table_entry->row_count_;
+                    (*expr.arguments_)[0] = constant_exp;
+                    auto &expr_rewrite = (FunctionExpr &)expr;
+                    expr_rewrite.func_name_ = "COUNT_STAR";
+                    return ExpressionBinder::BuildFuncExpr(expr_rewrite, bind_context_ptr, depth, true);
                 }
             }
         }

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -688,7 +688,20 @@ void FragmentContext::CreateTasks(i64 cpu_count, i64 operator_count) {
         case PhysicalOperatorType::kInvalid: {
             Error<SchedulerException>("Unexpected operator type");
         }
-        case PhysicalOperatorType::kAggregate:
+        case PhysicalOperatorType::kAggregate: {
+            if (fragment_type_ != FragmentType::kParallelStream) {
+                Error<SchedulerException>(Format("{} should in parallel stream fragment", PhysicalOperatorToString(last_operator->operator_type())));
+            }
+
+            if ((i64)tasks_.size() != parallel_count) {
+                Error<SchedulerException>(Format("{} task count isn't correct.", PhysicalOperatorToString(last_operator->operator_type())));
+            }
+
+            for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
+                tasks_[task_id]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
+            }
+            break;
+        }
         case PhysicalOperatorType::kParallelAggregate:
         case PhysicalOperatorType::kHash:
         case PhysicalOperatorType::kTop: {
@@ -726,6 +739,7 @@ void FragmentContext::CreateTasks(i64 cpu_count, i64 operator_count) {
             break;
         }
         case PhysicalOperatorType::kMergeParallelAggregate:
+        case PhysicalOperatorType::kMergeAggregate:
         case PhysicalOperatorType::kMergeHash:
         case PhysicalOperatorType::kMergeLimit:
         case PhysicalOperatorType::kMergeTop:

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -698,7 +698,9 @@ void FragmentContext::CreateTasks(i64 cpu_count, i64 operator_count) {
             }
 
             for (u64 task_id = 0; (i64)task_id < parallel_count; ++task_id) {
-                tasks_[task_id]->sink_state_ = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
+                auto sink_state = MakeUnique<QueueSinkState>(fragment_ptr_->FragmentID(), task_id);
+
+                tasks_[task_id]->sink_state_ = Move(sink_state);
             }
             break;
         }

--- a/src/storage/meta/entry/table_collection_entry.cpp
+++ b/src/storage/meta/entry/table_collection_entry.cpp
@@ -322,7 +322,7 @@ void TableCollectionEntry::CommitDelete(TableCollectionEntry *table_entry, Txn *
         SegmentEntry::CommitDelete(segment, txn_ptr, block_row_hashmap);
         row_count += block_row_hashmap.size();
     }
-    table_entry->row_count_ += row_count;
+    table_entry->row_count_ -= row_count;
 }
 
 UniquePtr<String> TableCollectionEntry::RollbackDelete(TableCollectionEntry *, Txn *, DeleteState &, BufferManager *) {
@@ -348,7 +348,7 @@ UniquePtr<String> TableCollectionEntry::ImportSegment(TableCollectionEntry *tabl
     }
 
     UniqueLock<RWMutex> rw_locker(table_entry->rw_locker_);
-    table_entry->row_count_ += row_count;
+    table_entry->row_count_ = row_count;
     table_entry->segment_map_.emplace(segment->segment_id_, Move(segment));
     return nullptr;
 }

--- a/src/unit_test/function/scalar/div_functions.cpp
+++ b/src/unit_test/function/scalar/div_functions.cpp
@@ -53,7 +53,7 @@ TEST_F(DivFunctionsTest, div_func) {
         Vector<SharedPtr<BaseExpression>> inputs;
 
         SharedPtr<DataType> data_type = MakeShared<DataType>(LogicalType::kTinyInt);
-        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kTinyInt);
+        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kDouble);
         SharedPtr<ColumnExpression> col1_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c1", 0, 0);
         SharedPtr<ColumnExpression> col2_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c2", 1, 0);
 
@@ -61,7 +61,7 @@ TEST_F(DivFunctionsTest, div_func) {
         inputs.emplace_back(col2_expr_ptr);
 
         ScalarFunction func = scalar_function_set->GetMostMatchFunction(inputs);
-        EXPECT_STREQ("/(TinyInt, TinyInt)->TinyInt", func.ToString().c_str());
+        EXPECT_STREQ("/(TinyInt, TinyInt)->Double", func.ToString().c_str());
 
         Vector<SharedPtr<DataType>> column_types;
         column_types.emplace_back(data_type);
@@ -98,8 +98,8 @@ TEST_F(DivFunctionsTest, div_func) {
             } else {
                 Value v = result->GetValue(i);
                 EXPECT_TRUE(result->nulls_ptr_->IsTrue(i));
-                EXPECT_EQ(v.type_.type(), LogicalType::kTinyInt);
-                EXPECT_EQ(v.value_.tiny_int, 1);
+                EXPECT_EQ(v.type_.type(), LogicalType::kDouble);
+                EXPECT_EQ(v.value_.float64, 1);
             }
         }
     }
@@ -108,7 +108,7 @@ TEST_F(DivFunctionsTest, div_func) {
         Vector<SharedPtr<BaseExpression>> inputs;
 
         SharedPtr<DataType> data_type = MakeShared<DataType>(LogicalType::kSmallInt);
-        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kSmallInt);
+        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kDouble);
         SharedPtr<ColumnExpression> col1_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c1", 0, 0);
         SharedPtr<ColumnExpression> col2_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c2", 1, 0);
 
@@ -116,7 +116,7 @@ TEST_F(DivFunctionsTest, div_func) {
         inputs.emplace_back(col2_expr_ptr);
 
         ScalarFunction func = scalar_function_set->GetMostMatchFunction(inputs);
-        EXPECT_STREQ("/(SmallInt, SmallInt)->SmallInt", func.ToString().c_str());
+        EXPECT_STREQ("/(SmallInt, SmallInt)->Double", func.ToString().c_str());
 
         Vector<SharedPtr<DataType>> column_types;
         column_types.emplace_back(data_type);
@@ -152,8 +152,8 @@ TEST_F(DivFunctionsTest, div_func) {
             } else {
                 Value v = result->GetValue(i);
                 EXPECT_TRUE(result->nulls_ptr_->IsTrue(i));
-                EXPECT_EQ(v.type_.type(), LogicalType::kSmallInt);
-                EXPECT_EQ(v.value_.small_int, 2);
+                EXPECT_EQ(v.type_.type(), LogicalType::kDouble);
+                EXPECT_EQ(v.value_.float64, 2);
             }
         }
     }
@@ -162,7 +162,7 @@ TEST_F(DivFunctionsTest, div_func) {
         Vector<SharedPtr<BaseExpression>> inputs;
 
         SharedPtr<DataType> data_type = MakeShared<DataType>(LogicalType::kInteger);
-        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kInteger);
+        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kDouble);
         SharedPtr<ColumnExpression> col1_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c1", 0, 0);
         SharedPtr<ColumnExpression> col2_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c2", 1, 0);
 
@@ -170,7 +170,7 @@ TEST_F(DivFunctionsTest, div_func) {
         inputs.emplace_back(col2_expr_ptr);
 
         ScalarFunction func = scalar_function_set->GetMostMatchFunction(inputs);
-        EXPECT_STREQ("/(Integer, Integer)->Integer", func.ToString().c_str());
+        EXPECT_STREQ("/(Integer, Integer)->Double", func.ToString().c_str());
 
         Vector<SharedPtr<DataType>> column_types;
         column_types.emplace_back(data_type);
@@ -206,8 +206,8 @@ TEST_F(DivFunctionsTest, div_func) {
             } else {
                 Value v = result->GetValue(i);
                 EXPECT_TRUE(result->nulls_ptr_->IsTrue(i));
-                EXPECT_EQ(v.type_.type(), LogicalType::kInteger);
-                EXPECT_EQ(v.value_.integer, 3);
+                EXPECT_EQ(v.type_.type(), LogicalType::kDouble);
+                EXPECT_EQ(v.value_.float64, 3);
             }
         }
     }
@@ -216,7 +216,7 @@ TEST_F(DivFunctionsTest, div_func) {
         Vector<SharedPtr<BaseExpression>> inputs;
 
         SharedPtr<DataType> data_type = MakeShared<DataType>(LogicalType::kBigInt);
-        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kBigInt);
+        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kDouble);
         SharedPtr<ColumnExpression> col1_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c1", 0, 0);
         SharedPtr<ColumnExpression> col2_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c2", 1, 0);
 
@@ -224,7 +224,7 @@ TEST_F(DivFunctionsTest, div_func) {
         inputs.emplace_back(col2_expr_ptr);
 
         ScalarFunction func = scalar_function_set->GetMostMatchFunction(inputs);
-        EXPECT_STREQ("/(BigInt, BigInt)->BigInt", func.ToString().c_str());
+        EXPECT_STREQ("/(BigInt, BigInt)->Double", func.ToString().c_str());
 
         Vector<SharedPtr<DataType>> column_types;
         column_types.emplace_back(data_type);
@@ -260,8 +260,8 @@ TEST_F(DivFunctionsTest, div_func) {
             } else {
                 Value v = result->GetValue(i);
                 EXPECT_TRUE(result->nulls_ptr_->IsTrue(i));
-                EXPECT_EQ(v.type_.type(), LogicalType::kBigInt);
-                EXPECT_EQ(v.value_.big_int, 4);
+                EXPECT_EQ(v.type_.type(), LogicalType::kDouble);
+                EXPECT_EQ(v.value_.float64, 4);
             }
         }
     }
@@ -270,7 +270,7 @@ TEST_F(DivFunctionsTest, div_func) {
         Vector<SharedPtr<BaseExpression>> inputs;
 
         DataType data_type(LogicalType::kHugeInt);
-        DataType result_type(LogicalType::kHugeInt);
+        DataType result_type(LogicalType::kDouble);
         SharedPtr<ColumnExpression> col1_expr_ptr = MakeShared<ColumnExpression>(data_type, "t1", 1, "c1", 0, 0);
         SharedPtr<ColumnExpression> col2_expr_ptr = MakeShared<ColumnExpression>(data_type, "t1", 1, "c2", 1, 0);
 
@@ -278,7 +278,7 @@ TEST_F(DivFunctionsTest, div_func) {
         inputs.emplace_back(col2_expr_ptr);
 
         ScalarFunction func = scalar_function_set->GetMostMatchFunction(inputs);
-        EXPECT_STREQ("/(HugeInt, HugeInt)->HugeInt", func.ToString().c_str());
+        EXPECT_STREQ("/(HugeInt, HugeInt)->Double", func.ToString().c_str());
 
         // TODO: need to complete it.
     }
@@ -287,7 +287,7 @@ TEST_F(DivFunctionsTest, div_func) {
         Vector<SharedPtr<BaseExpression>> inputs;
 
         SharedPtr<DataType> data_type = MakeShared<DataType>(LogicalType::kFloat);
-        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kFloat);
+        SharedPtr<DataType> result_type = MakeShared<DataType>(LogicalType::kDouble);
         SharedPtr<ColumnExpression> col1_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c1", 0, 0);
         SharedPtr<ColumnExpression> col2_expr_ptr = MakeShared<ColumnExpression>(*data_type, "t1", 1, "c2", 1, 0);
 
@@ -295,7 +295,7 @@ TEST_F(DivFunctionsTest, div_func) {
         inputs.emplace_back(col2_expr_ptr);
 
         ScalarFunction func = scalar_function_set->GetMostMatchFunction(inputs);
-        EXPECT_STREQ("/(Float, Float)->Float", func.ToString().c_str());
+        EXPECT_STREQ("/(Float, Float)->Double", func.ToString().c_str());
 
         Vector<SharedPtr<DataType>> column_types;
         column_types.emplace_back(data_type);
@@ -331,8 +331,8 @@ TEST_F(DivFunctionsTest, div_func) {
             } else {
                 Value v = result->GetValue(i);
                 EXPECT_TRUE(result->nulls_ptr_->IsTrue(i));
-                EXPECT_EQ(v.type_.type(), LogicalType::kFloat);
-                EXPECT_FLOAT_EQ(v.value_.float32, 5);
+                EXPECT_EQ(v.type_.type(), LogicalType::kDouble);
+                EXPECT_FLOAT_EQ(v.value_.float64, 5);
             }
         }
     }

--- a/test/sql/basic.slt
+++ b/test/sql/basic.slt
@@ -2,6 +2,9 @@
 # description: Test basic sql statement for sample
 # group: [basic]
 
+statement ok
+DROP TABLE IF EXISTS NATION;
+
 # Expecting IDENTIFIER or PRIMARY or UNIQUE
 statement error
 CREATE TABLE NATION (

--- a/test/sql/dml/delete.slt
+++ b/test/sql/dml/delete.slt
@@ -23,6 +23,11 @@ SELECT * FROM products;
 5 6
 7 8
 
+query II
+SELECT count(*) FROM products;
+----
+4
+
 statement ok
 DELETE FROM products WHERE product_no = 3;
 
@@ -32,6 +37,11 @@ SELECT * FROM products;
 1 2
 5 6
 7 8
+
+query II
+SELECT count(*) FROM products;
+----
+3
 
 statement ok
 DELETE FROM products;

--- a/test/sql/dml/import/test_embedding.slt
+++ b/test/sql/dml/import/test_embedding.slt
@@ -22,6 +22,11 @@ SELECT c1, c2 FROM test_embedding_type;
 5 6,7,8
 9 10,11,12
 
+query II
+SELECT count(*) FROM test_embedding_type;
+----
+3
+
 
 # Clean up
 statement ok

--- a/test/sql/dml/import/test_jsonl.slt
+++ b/test/sql/dml/import/test_jsonl.slt
@@ -25,3 +25,11 @@ Ben 33 1,2,3,4,5
 William 28 1,2,3,4,5
 Chuck 29 1,2,3,4,5
 Viola 35 1,2,3,4,5
+
+query III
+SELECT count(*) FROM test_jsonl;
+----
+14
+
+statement ok
+DROP TABLE IF EXISTS test_jsonl;

--- a/test/sql/dml/import/test_varchar.slt
+++ b/test/sql/dml/import/test_varchar.slt
@@ -23,6 +23,12 @@ SELECT c1, c2 FROM test_varchar_type;
 3 hello world
 4 hello hello hello hello hello
 
+
+query III
+SELECT count(*) FROM test_varchar_type;
+----
+4
+
 # Clean up
 statement ok
 DROP TABLE test_varchar_type;

--- a/test/sql/dml/insert.slt
+++ b/test/sql/dml/insert.slt
@@ -19,6 +19,11 @@ SELECT * FROM products;
 ----
 1 2 a
 
+query II
+SELECT count(*) FROM products;
+----
+1
+
 query I
 INSERT INTO products VALUES (3, 4, 'abcdef'), (5, 6, 'abcdefghijklmnopqrstuvwxyz');
 ----
@@ -29,6 +34,11 @@ SELECT * FROM products;
 1 2 a
 3 4 abcdef
 5 6 abcdefghijklmnopqrstuvwxyz
+
+query II
+SELECT count(*) FROM products;
+----
+3
 
 # Clean up
 statement ok

--- a/test/sql/dml/update.slt
+++ b/test/sql/dml/update.slt
@@ -23,6 +23,11 @@ SELECT * FROM products;
 5 6
 7 8
 
+query II
+SELECT count(*) FROM products;
+----
+4
+
 statement ok
 UPDATE products SET price=100 WHERE product_no = 3;
 
@@ -33,6 +38,12 @@ SELECT * FROM products;
 3 100
 5 6
 7 8
+
+query II
+SELECT count(*) FROM products;
+----
+4
+
 
 statement ok
 UPDATE products SET price=price+3 WHERE product_no = 1 OR product_no = 5;

--- a/test/sql/dql/aggregate/test_simple_agg.slt
+++ b/test/sql/dql/aggregate/test_simple_agg.slt
@@ -22,7 +22,7 @@ SELECT SUM(c2) FROM simple_agg
 query I
 SELECT AVG(c1) FROM simple_agg
 ----
-2
+2.000000
 
 query II
 SELECT AVG(c2) FROM simple_agg

--- a/test/sql/dql/aggregate/test_simple_agg.slt
+++ b/test/sql/dql/aggregate/test_simple_agg.slt
@@ -99,6 +99,11 @@ SELECT MAX(c1)*AVG(c2) FROM simple_agg;
 ----
 6.000000
 
+query IIII
+SELECT COUNT(*) FROM simple_agg;
+----
+3
+
 
 statement ok
 DROP TABLE simple_agg;

--- a/test/sql/dql/aggregate/test_simple_agg.slt
+++ b/test/sql/dql/aggregate/test_simple_agg.slt
@@ -22,7 +22,7 @@ SELECT SUM(c2) FROM simple_agg
 query I
 SELECT AVG(c1) FROM simple_agg
 ----
-2.000000
+2
 
 query II
 SELECT AVG(c2) FROM simple_agg
@@ -53,6 +53,51 @@ query I
 SELECT COUNT(c1) FROM simple_agg
 ----
 3
+
+query III
+SELECT SUM(c1)+SUM(c1) FROM simple_agg;
+----
+12
+
+query III
+SELECT MAX(c1)+SUM(c1) FROM simple_agg;
+----
+9
+
+query III
+SELECT MAX(c1)+SUM(c2) FROM simple_agg;
+----
+9.000000
+
+query III
+SELECT MAX(c1)*SUM(c2) FROM simple_agg;
+----
+18.000000
+
+query III
+SELECT MAX(c1)*SUM(c2) FROM simple_agg;
+----
+18.000000
+
+query III
+SELECT MAX(c1)-SUM(c2) FROM simple_agg;
+----
+-3.000000
+
+query III
+SELECT MAX(c1)/SUM(c2) FROM simple_agg;
+----
+0.500000
+
+query III
+SELECT MAX(c1)/AVG(c2) FROM simple_agg;
+----
+1.500000
+
+query III
+SELECT MAX(c1)*AVG(c2) FROM simple_agg;
+----
+6.000000
 
 
 statement ok

--- a/test/sql/dql/aggregate/test_simple_agg.slt
+++ b/test/sql/dql/aggregate/test_simple_agg.slt
@@ -107,3 +107,112 @@ SELECT COUNT(*) FROM simple_agg;
 
 statement ok
 DROP TABLE simple_agg;
+
+
+statement ok
+CREATE TABLE simple_agg (c1 SMALLINT , c2 TINYINT);
+
+# insert data
+query I
+INSERT INTO simple_agg VALUES (1, 1),(2,2),(3,3);
+----
+
+query I
+SELECT SUM(c1) FROM simple_agg
+----
+6
+
+query II
+SELECT SUM(c2) FROM simple_agg
+----
+6
+
+query I
+SELECT AVG(c1) FROM simple_agg
+----
+2.000000
+
+query II
+SELECT AVG(c2) FROM simple_agg
+----
+2.000000
+
+query I
+SELECT MIN(c1) FROM simple_agg
+----
+1
+
+query II
+SELECT MIN(c2) FROM simple_agg
+----
+1
+
+query I
+SELECT MAX(c1) FROM simple_agg
+----
+3
+
+query II
+SELECT MAX(c2) FROM simple_agg
+----
+3
+
+query I
+SELECT COUNT(c1) FROM simple_agg
+----
+3
+
+query III
+SELECT SUM(c1)+SUM(c1) FROM simple_agg;
+----
+12
+
+query III
+SELECT MAX(c1)+SUM(c1) FROM simple_agg;
+----
+9
+
+query III
+SELECT MAX(c1)+SUM(c2) FROM simple_agg;
+----
+9
+
+query III
+SELECT MAX(c1)*SUM(c2) FROM simple_agg;
+----
+18
+
+query III
+SELECT MAX(c1)*SUM(c2) FROM simple_agg;
+----
+18
+
+query III
+SELECT MAX(c1)-SUM(c2) FROM simple_agg;
+----
+-3
+
+query III
+SELECT MAX(c1)/SUM(c2) FROM simple_agg;
+----
+0.500000
+
+
+query III
+SELECT MAX(c1)/AVG(c2) FROM simple_agg;
+----
+1.500000
+
+query III
+SELECT MAX(c1)*AVG(c2) FROM simple_agg;
+----
+6.000000
+
+query IIII
+SELECT COUNT(*) FROM simple_agg;
+----
+3
+
+statement ok
+DROP TABLE simple_agg;
+

--- a/test/sql/dql/rbo_rule/column_pruner.slt
+++ b/test/sql/dql/rbo_rule/column_pruner.slt
@@ -112,30 +112,32 @@ EXPLAIN LOGICAL SELECT MIN(c1 + 1), AVG(c2) FROM t1;
 ----
  PROJECT (4)
   - table index: #4
-  - expressions: [min((c1 + 1)) (#0), avg(c2) (#1)]
+  - expressions: [min((c1 + 1)) (#0), sum(c2) (#1) / count(c2) (#2)]
  -> AGGREGATE (3)
     - aggregate table index: #3
-    - aggregate: [MIN(CAST(c1 (#0) AS BigInt) + 1), AVG(c2 (#1))]
+    - aggregate: [MIN(CAST(c1 (#0) AS BigInt) + 1), SUM(c2 (#1)), COUNT(c2 (#1))]
    -> TABLE SCAN (2)
       - table name: t1(default.t1)
       - table index: #1
       - output columns: [c1, c2, __rowid]
+
 
 query I
 EXPLAIN LOGICAL SELECT Min(c1 + 1), AVG(c2) FROM t1 GROUP BY c1;
 ----
  PROJECT (4)
   - table index: #4
-  - expressions: [min((c1 + 1)) (#1), avg(c2) (#2)]
+  - expressions: [min((c1 + 1)) (#1), sum(c2) (#2) / count(c2) (#3)]
  -> AGGREGATE (3)
     - aggregate table index: #3
-    - aggregate: [MIN(CAST(c1 (#0) AS BigInt) + 1), AVG(c2 (#1))]
+    - aggregate: [MIN(CAST(c1 (#0) AS BigInt) + 1), SUM(c2 (#1)), COUNT(c2 (#1))]
     - group by table index: #2
     - group by: [c1 (#0)]
    -> TABLE SCAN (2)
       - table name: t1(default.t1)
       - table index: #1
       - output columns: [c1, c2, __rowid]
+
 
 query I
 EXPLAIN LOGICAL DELETE FROM t1 WHERE c1=1;

--- a/test/sql/dql/select.slt
+++ b/test/sql/dql/select.slt
@@ -2,6 +2,12 @@ statement ok
 DROP TABLE IF EXISTS select1;
 
 statement ok
+DROP TABLE IF EXISTS select2;
+
+statement ok
+DROP TABLE IF EXISTS select3;
+
+statement ok
 CREATE TABLE select1 (id INTEGER PRIMARY KEY, name VARCHAR, age INTEGER);
 
 statement ok

--- a/tools/generate_aggregate.py
+++ b/tools/generate_aggregate.py
@@ -7,7 +7,7 @@ import argparse
 def generate(generate_if_exists: bool, copy_dir: str):
     row_n = 9000
     sort_dir = "./test/data/csv"
-    slt_dir = "./test/sql/dql"
+    slt_dir = "./test/sql/dql/aggregate"
 
     table_name = "test_simple_agg_big_cpp"
     agg_path = sort_dir + "/test_simple_agg_big.csv"
@@ -31,6 +31,16 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write(
             "CREATE TABLE {} (c1 int, c2 float);\n".format(table_name)
         )
+
+        # select count(*) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT count(*) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(0))
+        slt_file.write("\n")
+
+
         slt_file.write("\n")
         slt_file.write("query I\n")
         slt_file.write(
@@ -98,6 +108,13 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write("\n")
 
 
+        # select count(*) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT count(*) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(row_n))
+        slt_file.write("\n")
 
 
         slt_file.write("\n")

--- a/tools/generate_aggregate.py
+++ b/tools/generate_aggregate.py
@@ -1,0 +1,123 @@
+import numpy as np
+import random
+import os
+import argparse
+
+
+def generate(generate_if_exists: bool, copy_dir: str):
+    row_n = 8000
+    sort_dir = "./test/data/csv"
+    slt_dir = "./test/sql/dql"
+
+    table_name = "test_simple_agg_big_cpp"
+    agg_path = sort_dir + "/test_simple_agg_big.csv"
+    slt_path = slt_dir + "/test_simple_agg_big.slt"
+    copy_path = copy_dir + "/test_simple_agg_big.csv"
+
+    os.makedirs(sort_dir, exist_ok=True)
+    os.makedirs(slt_dir, exist_ok=True)
+    if os.path.exists(agg_path) and os.path.exists(slt_path) and generate_if_exists:
+        print(
+            "File {} and {} already existed exists. Skip Generating.".format(
+                slt_path, agg_path
+            )
+        )
+        return
+    with open(agg_path, "w") as agg_file, open(slt_path, "w") as slt_file:
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write(
+            "CREATE TABLE {} (c1 int, c2 float);\n".format(table_name)
+        )
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write(
+            "COPY {} FROM '{}' WITH ( DELIMITER ',' );\n".format(
+                table_name, copy_path
+            )
+        )
+
+
+        sequence = np.arange(1, 8001)
+
+        for i in sequence:
+            agg_file.write(str(i) + "," + str(i))
+            agg_file.write("\n")
+
+
+        # select max(c1) from test_simple_agg_big
+
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT max(c1) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(8000))
+        slt_file.write("\n")
+
+        # select min(c2) from test_simple_agg_big
+
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT min(c1) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(1))
+        slt_file.write("\n")
+
+
+        # select sum(c1) from test_simple_agg_big
+
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT sum(c1) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(np.sum(sequence)))
+        slt_file.write("\n")
+
+
+        # select avg(c1) from test_simple_agg_big
+
+        # slt_file.write("\n")
+        # slt_file.write("query I\n")
+        # slt_file.write("SELECT AVG(c1) FROM {};\n".format(table_name))
+        # slt_file.write("----\n")
+        # slt_file.write(str(np.mean(sequence)))
+        # slt_file.write("\n")
+
+        # select count(c1) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT count(c1) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(8000))
+        slt_file.write("\n")
+
+
+
+
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE {};\n".format(table_name))
+    random.random()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate limit data for test")
+
+    parser.add_argument(
+        "-g",
+        "--generate",
+        type=bool,
+        default=False,
+        dest="generate_if_exists",
+    )
+    parser.add_argument(
+        "-c",
+        "--copy",
+        type=str,
+        default="/tmp/infinity/test_data",
+        dest="copy_dir",
+    )
+    args = parser.parse_args()
+    generate(args.generate_if_exists, args.copy_dir)

--- a/tools/generate_aggregate.py
+++ b/tools/generate_aggregate.py
@@ -23,10 +23,19 @@ def generate(generate_if_exists: bool, copy_dir: str):
             )
         )
         return
+
+    sequence = np.arange(1, row_n + 1)
     with open(agg_path, "w") as agg_file, open(slt_path, "w") as slt_file:
+        # write to csv
+        for i in sequence:
+            agg_file.write(str(i) + "," + str(i))
+            agg_file.write("\n")
+
+        # write to slt
         slt_file.write("statement ok\n")
         slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
         slt_file.write("\n")
+
         slt_file.write("statement ok\n")
         slt_file.write(
             "CREATE TABLE {} (c1 int, c2 float);\n".format(table_name)
@@ -40,7 +49,6 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write(str(0))
         slt_file.write("\n")
 
-
         slt_file.write("\n")
         slt_file.write("query I\n")
         slt_file.write(
@@ -49,16 +57,15 @@ def generate(generate_if_exists: bool, copy_dir: str):
             )
         )
 
-        sequence = np.arange(1, row_n+1)
-
-        for i in sequence:
-            agg_file.write(str(i) + "," + str(i))
-            agg_file.write("\n")
 
 
         slt_file.write("\n")
-        slt_file.write("statement ok\n")
-        slt_file.write("SELECT c1 FROM {};\n".format(table_name))
+        slt_file.write("query I\n")
+        slt_file.write("SELECT * FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        for i in sequence:
+            slt_file.write(str(i) + " " + str(i)+".000000")
+            slt_file.write("\n")
         slt_file.write("\n")
 
 
@@ -80,7 +87,6 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write(str(1))
         slt_file.write("\n")
 
-
         # select sum(c1) from test_simple_agg_big
 
         slt_file.write("\n")
@@ -90,13 +96,12 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write(str(np.sum(sequence)))
         slt_file.write("\n")
 
-
         # select avg(c1) from test_simple_agg_big
         slt_file.write("\n")
         slt_file.write("query I\n")
         slt_file.write("SELECT AVG(c1) FROM {};\n".format(table_name))
         slt_file.write("----\n")
-        slt_file.write(str(np.mean(sequence))+"00000")
+        slt_file.write(str(np.mean(sequence)) + "00000")
         slt_file.write("\n")
 
         # select count(c1) from test_simple_agg_big
@@ -107,6 +112,85 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write(str(row_n))
         slt_file.write("\n")
 
+        # select count(*) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT count(*) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(row_n))
+        slt_file.write("\n")
+
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE {};\n".format(table_name))
+
+        # -------------------------------------
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write(
+            "CREATE TABLE {} (c1 SMALLINT, c2 TINYINT);\n".format(table_name)
+        )
+
+        # select count(*) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT count(*) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(0))
+        slt_file.write("\n")
+
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write(
+            "COPY {} FROM '{}' WITH ( DELIMITER ',' );\n".format(
+                table_name, copy_path
+            )
+        )
+
+        sequence = np.arange(1, row_n + 1)
+
+        # select max(c1) from test_simple_agg_big
+        # c2 is tinyint
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT max(c2) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(pow(2, 7) - 1))
+        slt_file.write("\n")
+
+        # select min(c2) from test_simple_agg_big
+
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT min(c1) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(1))
+        slt_file.write("\n")
+
+        # select sum(c1) from test_simple_agg_big
+
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT sum(c2) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(np.sum(np.arange(1, 128))))
+        slt_file.write("\n")
+
+        # select avg(c1) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT AVG(c2) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(np.around(np.sum(np.arange(1, 128)) / 9000, 6)))
+        slt_file.write("\n")
+
+        # select count(c1) from test_simple_agg_big
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT count(c2) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(row_n))
+        slt_file.write("\n")
 
         # select count(*) from test_simple_agg_big
         slt_file.write("\n")
@@ -116,11 +200,9 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write(str(row_n))
         slt_file.write("\n")
 
-
         slt_file.write("\n")
         slt_file.write("statement ok\n")
         slt_file.write("DROP TABLE {};\n".format(table_name))
-    random.random()
 
 
 if __name__ == "__main__":

--- a/tools/generate_aggregate.py
+++ b/tools/generate_aggregate.py
@@ -5,7 +5,7 @@ import argparse
 
 
 def generate(generate_if_exists: bool, copy_dir: str):
-    row_n = 8000
+    row_n = 9000
     sort_dir = "./test/data/csv"
     slt_dir = "./test/sql/dql"
 
@@ -39,12 +39,17 @@ def generate(generate_if_exists: bool, copy_dir: str):
             )
         )
 
-
-        sequence = np.arange(1, 8001)
+        sequence = np.arange(1, row_n+1)
 
         for i in sequence:
             agg_file.write(str(i) + "," + str(i))
             agg_file.write("\n")
+
+
+        slt_file.write("\n")
+        slt_file.write("statement ok\n")
+        slt_file.write("SELECT c1 FROM {};\n".format(table_name))
+        slt_file.write("\n")
 
 
         # select max(c1) from test_simple_agg_big
@@ -53,7 +58,7 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write("query I\n")
         slt_file.write("SELECT max(c1) FROM {};\n".format(table_name))
         slt_file.write("----\n")
-        slt_file.write(str(8000))
+        slt_file.write(str(row_n))
         slt_file.write("\n")
 
         # select min(c2) from test_simple_agg_big
@@ -77,20 +82,19 @@ def generate(generate_if_exists: bool, copy_dir: str):
 
 
         # select avg(c1) from test_simple_agg_big
-
-        # slt_file.write("\n")
-        # slt_file.write("query I\n")
-        # slt_file.write("SELECT AVG(c1) FROM {};\n".format(table_name))
-        # slt_file.write("----\n")
-        # slt_file.write(str(np.mean(sequence)))
-        # slt_file.write("\n")
+        slt_file.write("\n")
+        slt_file.write("query I\n")
+        slt_file.write("SELECT AVG(c1) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write(str(np.mean(sequence))+"00000")
+        slt_file.write("\n")
 
         # select count(c1) from test_simple_agg_big
         slt_file.write("\n")
         slt_file.write("query I\n")
         slt_file.write("SELECT count(c1) FROM {};\n".format(table_name))
         slt_file.write("----\n")
-        slt_file.write(str(8000))
+        slt_file.write(str(row_n))
         slt_file.write("\n")
 
 

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -6,6 +6,7 @@ from generate_big import generate as generate1
 from generate_fvecs import generate as generate2
 from generate_sort import generate as generate3
 from generate_limit import generate as generate4
+from generate_aggregate import generate as generate5
 
 
 def python_skd_test(python_test_dir: str):
@@ -108,6 +109,7 @@ if __name__ == "__main__":
     generate2(args.generate_if_exists, args.copy)
     generate3(args.generate_if_exists, args.copy)
     generate4(args.generate_if_exists, args.copy)
+    generate5(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
     python_skd_test(python_test_dir)
     test_process(args.path, args.test, args.data, args.copy)


### PR DESCRIPTION
### What problem does this PR solve?

For avg functions replacing it with (sum / count)

The commit involves converting avg function expressions to (sum / count) function expressions in the SQL planner and test updates accordingly. Tests cover both the regular and exceptional cases. Corresponding changes are reflected in other parts of the code like ProjectBinder and Aggregate operators.

`support` `count(*)`

Issue link: #357 

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer