### PR TITLE
Refactor sqllogictest.py to use subprocess module

### DIFF
--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from shutil import copyfile
+import subprocess
 
 from generate_big import generate as generate1
 from generate_fvecs import generate as generate2
@@ -13,7 +14,14 @@ def python_skd_test(python_test_dir: str):
     print("python test path is {}".format(python_test_dir))
     # os.system(f"cd {python_test_dir}/test")
     os.system(f"pip install infinity_sdk")
-    os.system(f"python -m pytest {python_test_dir}/test")
+    print("start pysdk test...")
+    process = subprocess.run(["python", "-m", "pytest", f"{python_test_dir}/test"], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+    output, error = process.stdout, process.stderr
+    if process.returncode != 0:
+        raise Exception(f"An error occurred: {error.decode()}")  # Raises an exception with the error message.
+    else:
+        print(f"Output: {output.decode()}")  # Prints the output.
 
 
 def test_process(sqllogictest_bin: str, slt_dir: str, data_dir: str, copy_dir: str):
@@ -25,7 +33,12 @@ def test_process(sqllogictest_bin: str, slt_dir: str, data_dir: str, copy_dir: s
     for dirpath, dirnames, filenames in os.walk(slt_dir):
         for filename in filenames:
             file = os.path.join(dirpath, filename)
-            os.system(sqllogictest_bin + " " + file)
+            process = subprocess.run([sqllogictest_bin, file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            output, error = process.stdout, process.stderr
+            if process.returncode != 0:
+                raise Exception(f"An error occurred: {error.decode()}")  # Prints the error message.
+            else:
+                print(f"Output: {output.decode()}")  # Prints the output.
             print("Finished running test file: " + file)
             print("-" * 100)
             test_cnt += 1


### PR DESCRIPTION
Refactored the sqllogictest.py script to use the subprocess module instead of os.system for executing commands. This aids in better error handling by capturing and displaying stdout and stderr. As a result, it improves debugging and traceability by raising exceptions with error messages when commands fail and printing the output when they succeed.

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer