### PR TITLE
New scheduler and fix bug.

### DIFF
--- a/src/common/blocking_queue.cppm
+++ b/src/common/blocking_queue.cppm
@@ -102,6 +102,17 @@ public:
         full_cv_.notify_one();
     }
 
+    bool TryDequeue(T& task) {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (queue_.empty()) {
+            return false;
+        }
+        task = queue_.front();
+        queue_.pop_front();
+        full_cv_.notify_one();
+        return true;
+    }
+
     bool TryDequeueBulk(Vector<T> &output_array) {
         std::unique_lock<std::mutex> lock(queue_mutex_);
         if (queue_.empty()) {

--- a/src/common/blocking_queue.cppm
+++ b/src/common/blocking_queue.cppm
@@ -102,6 +102,17 @@ public:
         full_cv_.notify_one();
     }
 
+    bool TryDequeueBulk(Vector<T> &output_array) {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (queue_.empty()) {
+            return false;
+        }
+        output_array.insert(output_array.end(), queue_.begin(), queue_.end());
+        queue_.clear();
+        full_cv_.notify_one();
+        return true;
+    }
+
     [[nodiscard]] SizeT Size() const {
         std::lock_guard<std::mutex> lock(queue_mutex_);
         return queue_.size();

--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -130,6 +130,9 @@ export {
     template <typename S, typename T, typename H = std::hash<S>>
     using HashMap = std::unordered_map<S, T, H>;
 
+    template <typename S, typename T, typename H = std::hash<S>>
+    using MultiHashMap = std::unordered_multimap<S, T, H>;
+
     template <typename S>
     using HashSet = std::unordered_set<S>;
 

--- a/src/executor/expression/expression_evaluator.cpp
+++ b/src/executor/expression/expression_evaluator.cpp
@@ -88,15 +88,17 @@ void ExpressionEvaluator::Execute(const SharedPtr<AggregateExpression> &expr,
         Error<ExecutorException>("Return type isn't matched with the output column vector");
     }
 
+    auto data_state = state->agg_state_;
+
     // 1. Initialize the aggregate state.
-    expr->aggregate_function_.init_func_(expr->aggregate_function_.GetState());
+    expr->aggregate_function_.init_func_(data_state);
 
     // 2. Loop to fill the aggregate state
-    expr->aggregate_function_.update_func_(expr->aggregate_function_.GetState(), child_output_col);
+    expr->aggregate_function_.update_func_(data_state, child_output_col);
 
     // 3. Get the aggregate result and append to output column vector.
 
-    const_ptr_t result_ptr = expr->aggregate_function_.finalize_func_(expr->aggregate_function_.GetState());
+    const_ptr_t result_ptr = expr->aggregate_function_.finalize_func_(data_state);
     output_column_vector->AppendByPtr(result_ptr);
 
     in_aggregate_ = false;
@@ -118,15 +120,11 @@ void ExpressionEvaluator::Execute(const SharedPtr<CastExpression> &expr,
     expr->func_.function(child_output, output_column_vector, child_output->Size(), cast_parameters);
 }
 
-void ExpressionEvaluator::Execute(const SharedPtr<CaseExpression> &,
-                                  SharedPtr<ExpressionState> &,
-                                  SharedPtr<ColumnVector> &) {
+void ExpressionEvaluator::Execute(const SharedPtr<CaseExpression> &, SharedPtr<ExpressionState> &, SharedPtr<ColumnVector> &) {
     Error<ExecutorException>("Case execution");
 }
 
-void ExpressionEvaluator::Execute(const SharedPtr<ColumnExpression> &,
-                                  SharedPtr<ExpressionState> &,
-                                  SharedPtr<ColumnVector> &) {
+void ExpressionEvaluator::Execute(const SharedPtr<ColumnExpression> &, SharedPtr<ExpressionState> &, SharedPtr<ColumnVector> &) {
     Error<ExecutorException>("Column expression");
 }
 
@@ -176,9 +174,7 @@ void ExpressionEvaluator::Execute(const SharedPtr<ReferenceExpression> &expr,
     output_column_vector = input_data_block_->column_vectors[column_index];
 }
 
-void ExpressionEvaluator::Execute(const SharedPtr<InExpression> &,
-                                  SharedPtr<ExpressionState> &,
-                                  SharedPtr<ColumnVector> &) {
+void ExpressionEvaluator::Execute(const SharedPtr<InExpression> &, SharedPtr<ExpressionState> &, SharedPtr<ColumnVector> &) {
     Error<ExecutorException>("IN execution isn't implemented yet.");
 }
 

--- a/src/executor/expression/expression_state.cpp
+++ b/src/executor/expression/expression_state.cpp
@@ -42,11 +42,11 @@ module expression_state;
 
 namespace infinity {
 
-SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<BaseExpression> &expression) {
+SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<BaseExpression> &expression, char *agg_state) {
 
     switch (expression->type()) {
         case ExpressionType::kAggregate:
-            return CreateState(static_pointer_cast<AggregateExpression>(expression));
+            return CreateState(static_pointer_cast<AggregateExpression>(expression), agg_state);
         case ExpressionType::kCast:
             return CreateState(static_pointer_cast<CastExpression>(expression));
         case ExpressionType::kCase:
@@ -69,12 +69,13 @@ SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<BaseExpr
     return nullptr;
 }
 
-SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<AggregateExpression> &agg_expr) {
+SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<AggregateExpression> &agg_expr, char *agg_state) {
     if (agg_expr->arguments().size() != 1) {
         Error<ExecutorException>("Aggregate function arguments error.");
     }
 
     SharedPtr<ExpressionState> result = MakeShared<ExpressionState>();
+    result->agg_state_ = agg_state;
     result->AddChild(agg_expr->arguments()[0]);
 
     // Aggregate function will only have one output value.

--- a/src/executor/expression/expression_state.cppm
+++ b/src/executor/expression/expression_state.cppm
@@ -32,9 +32,9 @@ namespace infinity {
 export class ExpressionState {
 public:
     // Static functions
-    static SharedPtr<ExpressionState> CreateState(const SharedPtr<BaseExpression> &expression);
+    static SharedPtr<ExpressionState> CreateState(const SharedPtr<BaseExpression> &expression, char * = nullptr);
 
-    static SharedPtr<ExpressionState> CreateState(const SharedPtr<AggregateExpression> &agg_expr);
+    static SharedPtr<ExpressionState> CreateState(const SharedPtr<AggregateExpression> &agg_expr, char *agg_state);
 
     static SharedPtr<ExpressionState> CreateState(const SharedPtr<CaseExpression> &agg_expr);
 
@@ -54,6 +54,8 @@ public:
     Vector<SharedPtr<ExpressionState>> &Children() { return children_; }
 
     SharedPtr<ColumnVector> &OutputColumnVector() { return column_vector_; }
+
+    char *agg_state_{};
 
 private:
     Vector<SharedPtr<ExpressionState>> children_;

--- a/src/executor/fragment/plan_fragment.cppm
+++ b/src/executor/fragment/plan_fragment.cppm
@@ -57,6 +57,8 @@ public:
 
     [[nodiscard]] inline PhysicalSink *GetSinkNode() const { return sink_.get(); }
 
+    [[nodiscard]] inline PlanFragment *GetParent() const { return parent_; }
+
     inline void AddChild(UniquePtr<PlanFragment> child_fragment) {
         child_fragment->parent_ = this;
         children_.emplace_back(std::move(child_fragment));

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -34,14 +34,15 @@ module fragment_builder;
 
 namespace infinity {
 
-UniquePtr<PlanFragment> FragmentBuilder::BuildFragment(PhysicalOperator *phys_op) {
+Pair<SizeT, UniquePtr<PlanFragment>> FragmentBuilder::BuildFragment(PhysicalOperator *phys_op) {
+    SizeT fragment_n1 = fragment_id_;
     auto plan_fragment = MakeUnique<PlanFragment>(GetFragmentId());
     plan_fragment->SetSinkNode(query_context_ptr_, SinkType::kResult, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
     BuildFragments(phys_op, plan_fragment.get());
     if (plan_fragment->GetSourceNode() == nullptr) {
         plan_fragment->SetSourceNode(query_context_ptr_, SourceType::kEmpty, phys_op->GetOutputNames(), phys_op->GetOutputTypes());
     }
-    return plan_fragment;
+    return {SizeT(fragment_id_ - fragment_n1), std::move(plan_fragment)};
 }
 
 void FragmentBuilder::BuildExplain(PhysicalOperator *phys_op, PlanFragment *current_fragment_ptr) {
@@ -63,7 +64,7 @@ void FragmentBuilder::BuildExplain(PhysicalOperator *phys_op, PlanFragment *curr
         case ExplainType::kPipeline: {
             // Build explain pipeline fragment
             SharedPtr<Vector<SharedPtr<String>>> texts_ptr = MakeShared<Vector<SharedPtr<String>>>();
-            auto explain_child_fragment = this->BuildFragment(phys_op->left());
+            auto [_fragment_n, explain_child_fragment] = this->BuildFragment(phys_op->left());
 
             // Generate explain context of the child fragment
             ExplainFragment::Explain(explain_child_fragment.get(), texts_ptr);

--- a/src/executor/fragment_builder.cppm
+++ b/src/executor/fragment_builder.cppm
@@ -27,7 +27,7 @@ export class FragmentBuilder {
 public:
     explicit FragmentBuilder(QueryContext *query_context_ptr) : query_context_ptr_(query_context_ptr) {}
 
-    UniquePtr<PlanFragment> BuildFragment(PhysicalOperator *phys_op);
+    Pair<SizeT, UniquePtr<PlanFragment>> BuildFragment(PhysicalOperator *phys_op);
 
 private:
     void BuildFragments(PhysicalOperator *phys_op, PlanFragment *current_fragment_ptr);

--- a/src/executor/operator/physical_aggregate.cpp
+++ b/src/executor/operator/physical_aggregate.cpp
@@ -620,38 +620,41 @@ bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>
         ExpressionEvaluator evaluator;
         evaluator.Init(input_data_block);
 
+        SizeT expression_count = aggregates_count;
+        // calculate every columns value
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            for (SizeT expr_idx = 0; expr_idx < expression_count; ++expr_idx) {
+                LOG_TRACE("Physical aggregate Execute");
+                evaluator.Execute(aggregates_[expr_idx], expr_states[expr_idx], output_data_block->column_vectors[expr_idx]);
+            }
+        }
+        output_data_block->Finalize();
         // {
         //     auto row = input_data_block->row_count();
         //     if (row == 0) {
-        //         // LOG_WARN("EEE");
+        //         LOG_WARN("EEE");
         //     } else {
         //         auto v = input_data_block->GetValue(0, 0);
         //         auto ti = v.value_.tiny_int;
         //         auto si = v.value_.small_int;
         //         auto i = v.value_.integer;
-        //         // LOG_WARN(fmt::format("Agg Input: {}, {},{} {} {}", u64(input_data_block), row, ti, si, i));
+        //         LOG_WARN(fmt::format("Agg Input: {}, {},{} {} {}", u64(input_data_block), row, ti, si, i));
         //     }
         // }
-
-        SizeT expression_count = aggregates_count;
-        // calculate every columns value
-        for (SizeT expr_idx = 0; expr_idx < expression_count; ++expr_idx) {
-            LOG_TRACE("Physical aggregate Execute");
-            evaluator.Execute(aggregates_[expr_idx], expr_states[expr_idx], output_data_block->column_vectors[expr_idx]);
-        }
         // {
         //     auto row = output_data_block->row_count();
         //     if (row == 0) {
-        //         // LOG_WARN("EEE");
+        //         auto row1 = input_data_block->row_count();
+        //         LOG_WARN(fmt::format("FFF {}", row1));
         //     } else {
         //         auto v = output_data_block->GetValue(0, 0);
         //         auto ti = v.value_.tiny_int;
         //         auto si = v.value_.small_int;
         //         auto i = v.value_.integer;
-        //         // LOG_WARN(fmt::format("Agg Output: {}, {},{} {} {}", u64(output_data_block), row, ti, si, i));
+        //         LOG_WARN(fmt::format("Agg Output: {}, {},{} {} {}", u64(output_data_block), row, ti, si, i));
         //     }
         // }
-        output_data_block->Finalize();
     }
     return true;
 }

--- a/src/executor/operator/physical_aggregate.cpp
+++ b/src/executor/operator/physical_aggregate.cpp
@@ -27,7 +27,7 @@ import data_block;
 import utility;
 import logger;
 import column_vector;
-
+import third_party;
 import infinity_exception;
 import default_values;
 import parser;
@@ -324,7 +324,8 @@ void PhysicalAggregate::GroupByInputTable(const SharedPtr<DataTable> &input_tabl
         }
 
         if (output_row_idx != datablock_size) {
-            Error<ExecutorException>("Expected block size: " + std::to_string(datablock_size) + ", but only copied data size: " + std::to_string(output_row_idx));
+            Error<ExecutorException>("Expected block size: " + std::to_string(datablock_size) +
+                                     ", but only copied data size: " + std::to_string(output_row_idx));
         }
 
         for (SizeT column_id = 0; column_id < column_count; ++column_id) {
@@ -619,12 +620,37 @@ bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>
         ExpressionEvaluator evaluator;
         evaluator.Init(input_data_block);
 
+        // {
+        //     auto row = input_data_block->row_count();
+        //     if (row == 0) {
+        //         // LOG_WARN("EEE");
+        //     } else {
+        //         auto v = input_data_block->GetValue(0, 0);
+        //         auto ti = v.value_.tiny_int;
+        //         auto si = v.value_.small_int;
+        //         auto i = v.value_.integer;
+        //         // LOG_WARN(fmt::format("Agg Input: {}, {},{} {} {}", u64(input_data_block), row, ti, si, i));
+        //     }
+        // }
+
         SizeT expression_count = aggregates_count;
         // calculate every columns value
         for (SizeT expr_idx = 0; expr_idx < expression_count; ++expr_idx) {
             LOG_TRACE("Physical aggregate Execute");
             evaluator.Execute(aggregates_[expr_idx], expr_states[expr_idx], output_data_block->column_vectors[expr_idx]);
         }
+        // {
+        //     auto row = output_data_block->row_count();
+        //     if (row == 0) {
+        //         // LOG_WARN("EEE");
+        //     } else {
+        //         auto v = output_data_block->GetValue(0, 0);
+        //         auto ti = v.value_.tiny_int;
+        //         auto si = v.value_.small_int;
+        //         auto i = v.value_.integer;
+        //         // LOG_WARN(fmt::format("Agg Output: {}, {},{} {} {}", u64(output_data_block), row, ti, si, i));
+        //     }
+        // }
         output_data_block->Finalize();
     }
     return true;

--- a/src/executor/operator/physical_aggregate.cppm
+++ b/src/executor/operator/physical_aggregate.cppm
@@ -67,7 +67,9 @@ public:
     Vector<SharedPtr<BaseExpression>> aggregates_{};
     HashTable hash_table_;
 
-    bool SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>> &input_blocks, Vector<UniquePtr<DataBlock>> &output_blocks);
+    bool SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>> &input_blocks,
+                                Vector<UniquePtr<DataBlock>> &output_blocks,
+                                Vector<UniquePtr<char[]>> &states);
 
     inline u64 GroupTableIndex() const { return groupby_index_; }
 
@@ -82,8 +84,6 @@ public:
     Vector<HashRange> GetHashRanges(i64 parallel_count) const;
 
 private:
-    std::mutex mutex_;
-
     SharedPtr<DataTable> input_table_{};
     u64 groupby_index_{};
     u64 aggregate_index_{};

--- a/src/executor/operator/physical_aggregate.cppm
+++ b/src/executor/operator/physical_aggregate.cppm
@@ -82,6 +82,8 @@ public:
     Vector<HashRange> GetHashRanges(i64 parallel_count) const;
 
 private:
+    std::mutex mutex_;
+
     SharedPtr<DataTable> input_table_{};
     u64 groupby_index_{};
     u64 aggregate_index_{};

--- a/src/executor/operator/physical_create_index_finish.cpp
+++ b/src/executor/operator/physical_create_index_finish.cpp
@@ -44,13 +44,10 @@ bool PhysicalCreateIndexFinish::Execute(QueryContext *query_context, OperatorSta
     auto *txn = query_context->GetTxn();
     auto *create_index_finish_op_state = static_cast<CreateIndexFinishOperatorState *>(operator_state);
 
-    if (create_index_finish_op_state->input_complete_) {
-        txn->AddWalCmd(MakeShared<WalCmdCreateIndex>(*db_name_, *table_name_, index_def_));
+    txn->AddWalCmd(MakeShared<WalCmdCreateIndex>(*db_name_, *table_name_, index_def_));
 
-        operator_state->SetComplete();
-        return true;
-    }
-    return false;
+    operator_state->SetComplete();
+    return true;
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_knn_scan.cpp
+++ b/src/executor/operator/physical_knn_scan.cpp
@@ -385,12 +385,12 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                         if (result_n < 0) {
                             result_n = result_n1;
                         } else if (result_n != (i64)result_n1) {
-                            throw ExecutorException("Bug");
+                            throw ExecutorException("KnnScan: result_n mismatch");
                         }
 
                         switch (knn_scan_shared_data->knn_distance_type_) {
                             case KnnDistanceType::kInvalid: {
-                                throw ExecutorException("Bug");
+                                throw ExecutorException("Invalid distance type");
                             }
                             case KnnDistanceType::kL2:
                             case KnnDistanceType::kHamming: {

--- a/src/executor/operator/physical_sink.cpp
+++ b/src/executor/operator/physical_sink.cpp
@@ -137,7 +137,10 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MaterializeSinkState *mate
                     Error<ExecutorException>("Empty agg output");
                 }
             } else {
-                materialize_sink_state->data_block_array_ = std::move(agg_output_state->data_block_array_);
+                for (auto &data_block : agg_output_state->data_block_array_) {
+                    materialize_sink_state->data_block_array_.emplace_back(std::move(data_block));
+                }
+                agg_output_state->data_block_array_.clear();
             }
             break;
         }

--- a/src/executor/operator/physical_sink.cpp
+++ b/src/executor/operator/physical_sink.cpp
@@ -361,6 +361,9 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MessageSinkState *message_
 void PhysicalSink::FillSinkStateFromLastOperatorState(FragmentContext *fragment_context,
                                                       QueueSinkState *queue_sink_state,
                                                       OperatorState *task_operator_state) {
+    // if (task_operator_state->operator_type_ == PhysicalOperatorType::kAggregate) {
+    //     LOG_WARN(fmt::format("Sink Agg task id {}, fragment id {}", queue_sink_state->task_id_, queue_sink_state->fragment_id_));
+    // }
     if (queue_sink_state->error_message_.get() != nullptr) {
         LOG_TRACE(fmt::format("Error: {} is sent to notify next fragment", *queue_sink_state->error_message_));
         auto fragment_error = MakeShared<FragmentError>(queue_sink_state->fragment_id_, MakeUnique<String>(*queue_sink_state->error_message_));

--- a/src/executor/operator/physical_source.cpp
+++ b/src/executor/operator/physical_source.cpp
@@ -57,13 +57,4 @@ bool PhysicalSource::Execute(QueryContext *, SourceState *source_state) {
     return true;
 }
 
-bool PhysicalSource::ReadyToExec(SourceState *source_state) {
-    bool result = true;
-    if (source_state->state_type_ == SourceStateType::kQueue) {
-        QueueSourceState *queue_source_state = static_cast<QueueSourceState *>(source_state);
-        result = queue_source_state->source_queue_.Size() > 0;
-    }
-    return result;
-}
-
 } // namespace infinity

--- a/src/executor/operator/physical_source.cppm
+++ b/src/executor/operator/physical_source.cppm
@@ -53,8 +53,6 @@ public:
 
     bool Execute(QueryContext *query_context, SourceState *source_state);
 
-    bool ReadyToExec(SourceState *source_state);
-
     inline SharedPtr<Vector<String>> GetOutputNames() const final { return output_names_; }
 
     inline SharedPtr<Vector<SharedPtr<DataType>>> GetOutputTypes() const final { return output_types_; }

--- a/src/executor/operator/physical_table_scan.cpp
+++ b/src/executor/operator/physical_table_scan.cpp
@@ -140,7 +140,7 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
         for (auto &global_block_id : *block_ids) {
             out += fmt::format("({},{}) ", global_block_id.segment_id_, global_block_id.block_id_);
         }
-        LOG_INFO(fmt::format("TableScan: block_ids: {}", out));
+        LOG_TRACE(fmt::format("TableScan: block_ids: {}", out));
     }
 
     // Here we assume output is a fresh data block, we have never written anything into it.

--- a/src/executor/operator/physical_table_scan.cpp
+++ b/src/executor/operator/physical_table_scan.cpp
@@ -135,6 +135,14 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
     TxnTimeStamp begin_ts = query_context->GetTxn()->BeginTS();
     SizeT &read_offset = table_scan_function_data_ptr->current_read_offset_;
 
+    {
+        String out;
+        for (auto &global_block_id : *block_ids) {
+            out += fmt::format("({},{}) ", global_block_id.segment_id_, global_block_id.block_id_);
+        }
+        LOG_INFO(fmt::format("TableScan: block_ids: {}", out));
+    }
+
     // Here we assume output is a fresh data block, we have never written anything into it.
     auto write_capacity = output_ptr->available_capacity();
     while (block_ids_idx < block_ids->size()) {
@@ -173,7 +181,7 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
         read_offset += write_size;
     }
 
-    LOG_TRACE(Format("TableScan: block_ids_idx: {}, block_ids.size(): {}", block_ids_idx, block_ids->size()));
+    LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}", block_ids_idx, block_ids->size()));
 
     if (block_ids_idx >= block_ids->size()) {
         table_scan_operator_state->SetComplete();

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -34,7 +34,7 @@ void QueueSourceState::MarkCompletedTask(u64 fragment_id) {
             num_tasks_.erase(it);
         }
     } else {
-        Error<ExecutorException>("Bug");
+        Error<ExecutorException>("Get unexpected data from child fragment");
     }
 }
 
@@ -43,9 +43,8 @@ void QueueSourceState::MarkCompletedTask(u64 fragment_id) {
 // True or false doesn't mean the source data is error or not.
 bool QueueSourceState::GetData() {
     SharedPtr<FragmentDataBase> fragment_data_base = nullptr;
-    // source_queue_.Dequeue(fragment_data_base); // FIXME
     if (!source_queue_.TryDequeue(fragment_data_base)) {
-        Error<ExecutorException>("Bug");
+        Error<ExecutorException>("This task should not be scheduled if the source queue is empty");
     }
 
     switch (fragment_data_base->type_) {

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -19,7 +19,8 @@ import stl;
 import physical_operator_type;
 import fragment_data;
 import infinity_exception;
-
+import logger;
+import third_party;
 module operator_state;
 
 namespace infinity {
@@ -32,6 +33,8 @@ void QueueSourceState::MarkCompletedTask(u64 fragment_id) {
         if (pending_tasks == 0) {
             num_tasks_.erase(it);
         }
+    } else {
+        Error<ExecutorException>("Bug");
     }
 }
 

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -112,16 +112,6 @@ bool QueueSourceState::GetData() {
             merge_aggregate_op_state->input_complete_ = completed;
             break;
         }
-        case PhysicalOperatorType::kCreateIndexDo: {
-            auto *create_index_do_op_state = static_cast<CreateIndexDoOperatorState *>(next_op_state);
-            create_index_do_op_state->input_complete_ = completed;
-            break;
-        }
-        case PhysicalOperatorType::kCreateIndexFinish: {
-            auto *create_index_finish_op_state = static_cast<CreateIndexFinishOperatorState *>(next_op_state);
-            create_index_finish_op_state->input_complete_ = completed;
-            break;
-        }
         default: {
             Error<ExecutorException>("Not support operator type");
             break;

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -43,7 +43,9 @@ void QueueSourceState::MarkCompletedTask(u64 fragment_id) {
 // True or false doesn't mean the source data is error or not.
 bool QueueSourceState::GetData() {
     SharedPtr<FragmentDataBase> fragment_data_base = nullptr;
-    source_queue_.Dequeue(fragment_data_base);
+    if (!source_queue_.TryDequeue(fragment_data_base)) {
+        Error<ExecutorException>("Bug");
+    }
 
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -43,9 +43,10 @@ void QueueSourceState::MarkCompletedTask(u64 fragment_id) {
 // True or false doesn't mean the source data is error or not.
 bool QueueSourceState::GetData() {
     SharedPtr<FragmentDataBase> fragment_data_base = nullptr;
-    if (!source_queue_.TryDequeue(fragment_data_base)) {
-        Error<ExecutorException>("Bug");
-    }
+    source_queue_.Dequeue(fragment_data_base); // FIXME
+    // if (!source_queue_.TryDequeue(fragment_data_base)) {
+    //     Error<ExecutorException>("Bug");
+    // }
 
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {
@@ -114,6 +115,25 @@ bool QueueSourceState::GetData() {
             MergeAggregateOperatorState *merge_aggregate_op_state = (MergeAggregateOperatorState *)next_op_state;
             // merge_aggregate_op_state->input_data_blocks_.push_back(std::move(fragment_data->data_block_));
             merge_aggregate_op_state->input_data_block_ = std::move(fragment_data->data_block_);
+
+            // {
+            //     auto row = merge_aggregate_op_state->input_data_block_->row_count();
+            //     if (row == 0) {
+            //         // LOG_WARN("FFF");
+            //     } else {
+            //         auto v = merge_aggregate_op_state->input_data_block_->GetValue(0, 0);
+            //         auto ti = v.value_.tiny_int;
+            //         auto si = v.value_.small_int;
+            //         auto i = v.value_.integer;
+            //         LOG_WARN(fmt::format("Merge Agg: task id {}, fragment id {}, completed {}, {} {} {}",
+            //                              fragment_data->task_id_,
+            //                              fragment_data->fragment_id_,
+            //                              completed,
+            //                              ti,
+            //                              si,
+            //                              i));
+            //     }
+            // }
             merge_aggregate_op_state->input_complete_ = completed;
             break;
         }

--- a/src/executor/operator_state.cpp
+++ b/src/executor/operator_state.cpp
@@ -43,10 +43,10 @@ void QueueSourceState::MarkCompletedTask(u64 fragment_id) {
 // True or false doesn't mean the source data is error or not.
 bool QueueSourceState::GetData() {
     SharedPtr<FragmentDataBase> fragment_data_base = nullptr;
-    source_queue_.Dequeue(fragment_data_base); // FIXME
-    // if (!source_queue_.TryDequeue(fragment_data_base)) {
-    //     Error<ExecutorException>("Bug");
-    // }
+    // source_queue_.Dequeue(fragment_data_base); // FIXME
+    if (!source_queue_.TryDequeue(fragment_data_base)) {
+        Error<ExecutorException>("Bug");
+    }
 
     switch (fragment_data_base->type_) {
         case FragmentDataType::kData: {

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -54,7 +54,10 @@ export struct OperatorState {
 
 // Aggregate
 export struct AggregateOperatorState : public OperatorState {
-    inline explicit AggregateOperatorState() : OperatorState(PhysicalOperatorType::kAggregate) {}
+    inline explicit AggregateOperatorState(Vector<UniquePtr<char[]>> states)
+        : OperatorState(PhysicalOperatorType::kAggregate), states_(std::move(states)) {}
+
+    Vector<UniquePtr<char[]>> states_;
 };
 
 // Merge Aggregate
@@ -62,7 +65,7 @@ export struct MergeAggregateOperatorState : public OperatorState {
     inline explicit MergeAggregateOperatorState() : OperatorState(PhysicalOperatorType::kMergeAggregate) {}
 
     /// Since merge agg is the first op, no previous operator state. This ptr is to get input data.
-    //Vector<UniquePtr<DataBlock>> input_data_blocks_{nullptr};
+    // Vector<UniquePtr<DataBlock>> input_data_blocks_{nullptr};
     UniquePtr<DataBlock> input_data_block_{nullptr};
     bool input_complete_{false};
 };
@@ -93,7 +96,7 @@ export struct TableScanOperatorState : public OperatorState {
 export struct KnnScanOperatorState : public OperatorState {
     inline explicit KnnScanOperatorState() : OperatorState(PhysicalOperatorType::kKnnScan) {}
 
-//    Vector<SharedPtr<DataBlock>> output_data_blocks_{};
+    //    Vector<SharedPtr<DataBlock>> output_data_blocks_{};
     UniquePtr<KnnScanFunctionData> knn_scan_function_data_{};
 };
 
@@ -216,7 +219,7 @@ export struct InsertOperatorState : public OperatorState {
 export struct ImportOperatorState : public OperatorState {
     inline explicit ImportOperatorState() : OperatorState(PhysicalOperatorType::kImport) {}
 
-//    Vector<SharedPtr<DataBlock>> output_{};
+    //    Vector<SharedPtr<DataBlock>> output_{};
     SharedPtr<TableDef> table_def_{};
     // For insert, update, delete, update
     UniquePtr<String> result_msg_{};

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -250,14 +250,13 @@ export struct CreateIndexPrepareOperatorState : public OperatorState {
 export struct CreateIndexDoOperatorState : public OperatorState {
     inline explicit CreateIndexDoOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexDo) {}
 
-    bool input_complete_ = false;
+    UniquePtr<String> result_msg_{};
     CreateIndexSharedData *create_index_shared_data_;
 };
 
 export struct CreateIndexFinishOperatorState : public OperatorState {
     inline explicit CreateIndexFinishOperatorState() : OperatorState(PhysicalOperatorType::kCreateIndexFinish) {}
 
-    bool input_complete_ = false;
     UniquePtr<String> error_message_{};
 };
 

--- a/src/executor/physical_operator_type.cppm
+++ b/src/executor/physical_operator_type.cppm
@@ -70,7 +70,6 @@ export enum class PhysicalOperatorType : i8 {
     kInsert,
     kImport,
     kExport,
-    kCreateIndexDo,
 
     // DDL
     kAlter,
@@ -86,6 +85,7 @@ export enum class PhysicalOperatorType : i8 {
     kDropView,
 
     kCreateIndexPrepare,
+    kCreateIndexDo,
     kCreateIndexFinish,
 
     // misc

--- a/src/function/aggregate_function.cppm
+++ b/src/function/aggregate_function.cppm
@@ -107,9 +107,8 @@ public:
                                AggregateUpdateFuncType update_func,
                                AggregateFinalizeFuncType finalize_func)
         : Function(std::move(name), FunctionType::kAggregate), init_func_(std::move(init_func)), update_func_(std::move(update_func)),
-          finalize_func_(std::move(finalize_func)), argument_type_(std::move(argument_type)), return_type_(std::move(return_type)), state_size_(state_size) {
-        state_data_ = SharedPtr<char[]>(new char[state_size_]());
-    }
+          finalize_func_(std::move(finalize_func)), argument_type_(std::move(argument_type)), return_type_(std::move(return_type)),
+          state_size_(state_size) {}
 
     void CastArgumentTypes(BaseExpression &input_argument);
 
@@ -117,7 +116,7 @@ public:
 
     [[nodiscard]] String ToString() const override;
 
-    [[nodiscard]] ptr_t GetState() const { return state_data_.get(); }
+    UniquePtr<char[]> InitState() const { return MakeUnique<char[]>(state_size_); }
 
     [[nodiscard]] String GetFuncName() const { return name_; }
 
@@ -129,7 +128,6 @@ public:
     DataType argument_type_;
     DataType return_type_;
 
-    SharedPtr<char[]> state_data_{nullptr};
     SizeT state_size_{};
 };
 
@@ -143,7 +141,6 @@ inline AggregateFunction UnaryAggregate(const String &name, const DataType &inpu
                              AggregateOperation::StateUpdate<AggregateState, InputType>,
                              AggregateOperation::StateFinalize<AggregateState, ResultType>);
 }
-
 
 class CountStarAggregateOperation {
 public:
@@ -176,8 +173,7 @@ public:
     }
 };
 
-
-export template <typename AggregateState,typename ResultType>
+export template <typename AggregateState, typename ResultType>
 inline auto CountStarAggregate(String &name, const DataType &input_type, const DataType &return_type) -> AggregateFunction {
     auto agg_function = AggregateFunction(name,
                                           input_type,

--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -141,12 +141,11 @@ QueryResult QueryContext::QueryStatement(const BaseStatement *statement) {
         StopProfile(QueryPhase::kPipelineBuild);
 
         StartProfile(QueryPhase::kTaskBuild);
-        Vector<FragmentTask *> tasks;
-        FragmentContext::BuildTask(this, nullptr, plan_fragment.get(), tasks);
+        FragmentContext::BuildTask(this, nullptr, plan_fragment.get());
         StopProfile(QueryPhase::kTaskBuild);
 
         StartProfile(QueryPhase::kExecution);
-        scheduler_->Schedule(this, tasks, plan_fragment.get());
+        scheduler_->Schedule(plan_fragment.get());
         query_result.result_table_ = plan_fragment->GetResult();
         query_result.root_operator_type_ = logical_plan->operator_type();
         StopProfile(QueryPhase::kExecution);

--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -137,11 +137,13 @@ QueryResult QueryContext::QueryStatement(const BaseStatement *statement) {
         StartProfile(QueryPhase::kPipelineBuild);
         // Fragment Builder, only for test now.
         // SharedPtr<PlanFragment> plan_fragment = fragment_builder.Build(physical_plan);
-        auto plan_fragment = fragment_builder_->BuildFragment(physical_plan.get());
+        auto [fragment_n, plan_fragment] = fragment_builder_->BuildFragment(physical_plan.get());
         StopProfile(QueryPhase::kPipelineBuild);
 
+        auto notifier = MakeUnique<Notifier>(fragment_n);
+
         StartProfile(QueryPhase::kTaskBuild);
-        FragmentContext::BuildTask(this, nullptr, plan_fragment.get());
+        FragmentContext::BuildTask(this, nullptr, plan_fragment.get(), notifier.get());
         StopProfile(QueryPhase::kTaskBuild);
 
         StartProfile(QueryPhase::kExecution);

--- a/src/main/resource_manager.cppm
+++ b/src/main/resource_manager.cppm
@@ -30,8 +30,8 @@ public:
         return cpu_count;
     }
 
-    // inline u64 GetCpuResource() { return GetCpuResource(Thread::hardware_concurrency()); }
-    inline u64 GetCpuResource() { return GetCpuResource(4); }
+    inline u64 GetCpuResource() { return GetCpuResource(Thread::hardware_concurrency()); }
+    // inline u64 GetCpuResource() { return GetCpuResource(4); }
 
     inline u64 GetMemoryResource(u64 memory_size) {
         total_memory_ -= memory_size;

--- a/src/main/resource_manager.cppm
+++ b/src/main/resource_manager.cppm
@@ -30,8 +30,8 @@ public:
         return cpu_count;
     }
 
-    inline u64 GetCpuResource() { return GetCpuResource(Thread::hardware_concurrency()); }
-    // inline u64 GetCpuResource() { return GetCpuResource(4); }
+    // inline u64 GetCpuResource() { return GetCpuResource(Thread::hardware_concurrency()); }
+    inline u64 GetCpuResource() { return GetCpuResource(4); }
 
     inline u64 GetMemoryResource(u64 memory_size) {
         total_memory_ -= memory_size;

--- a/src/network/thrift_server.cpp
+++ b/src/network/thrift_server.cpp
@@ -286,7 +286,7 @@ public:
         }
 
         if (current_offset != (i32)all_size) {
-            Error<NetworkException>("Bug");
+            Error<NetworkException>("Varchar data size not match");
         }
 
         output_column_field.column_vectors.emplace_back(std::move(dst));

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -446,7 +446,7 @@ void FragmentContext::TryFinishFragment() {
 
     // after notify, the data structure may be destroyed
     if (!TryFinishFragmentInner()) {
-        LOG_INFO(fmt::format("{} tasks in fragment {} are not completed", unfinished_task_n_.load(), fragment_id));
+        LOG_TRACE(fmt::format("{} tasks in fragment {} are not completed", unfinished_task_n_.load(), fragment_id));
         if (fragment_type_ != FragmentType::kParallelStream) {
             return;
         }
@@ -456,11 +456,10 @@ void FragmentContext::TryFinishFragment() {
         }
 
         auto *scheduler = query_context_->scheduler();
-        LOG_INFO(
-            fmt::format("Schedule fragment: {} before fragment {} has finished.", parent_plan_fragment->FragmentID(), fragment_id));
+        LOG_TRACE(fmt::format("Schedule fragment: {} before fragment {} has finished.", parent_plan_fragment->FragmentID(), fragment_id));
         scheduler->ScheduleFragment(parent_plan_fragment);
     } else {
-        LOG_INFO(fmt::format("All tasks in fragment: {} are completed", fragment_id));
+        LOG_TRACE(fmt::format("All tasks in fragment: {} are completed", fragment_id));
 
         auto *parent_plan_fragment = fragment_ptr_->GetParent();
         if (parent_plan_fragment != nullptr) {
@@ -469,10 +468,9 @@ void FragmentContext::TryFinishFragment() {
                 // All child fragment are finished.
 
                 auto *scheduler = query_context_->scheduler();
-                LOG_INFO(
-            fmt::format("Schedule fragment: {} because fragment {} has finished.",
-                                parent_plan_fragment->FragmentID(),
-                                fragment_ptr_->FragmentID()));
+                LOG_TRACE(fmt::format("Schedule fragment: {} because fragment {} has finished.",
+                                      parent_plan_fragment->FragmentID(),
+                                      fragment_ptr_->FragmentID()));
                 scheduler->ScheduleFragment(parent_plan_fragment);
             }
         }

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -53,7 +53,7 @@ export String FragmentType2String(FragmentType type) {
 }
 
 export class Notifier {
-    Atomic<SizeT> unfinished_fragment_n_;
+    SizeT unfinished_fragment_n_;
 
     std::mutex locker_{};
     std::condition_variable cv_{};
@@ -63,12 +63,12 @@ public:
 
     void Wait() {
         std::unique_lock<std::mutex> lk(locker_);
-        cv_.wait(lk, [&] { return unfinished_fragment_n_.load() == 0; });
+        cv_.wait(lk, [&] { return unfinished_fragment_n_ == 0; });
     }
 
     void Notify() {
         std::unique_lock<std::mutex> lk(locker_);
-        if (unfinished_fragment_n_.fetch_sub(1) == 1) {
+        if (--unfinished_fragment_n_ == 0) {
             cv_.notify_one();
         }
     }

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -33,8 +33,6 @@ namespace infinity {
 class PlanFragment;
 
 enum class FragmentStatus {
-    kNotStart,
-    kStart,
     kFinish,
     kInvalid,
 };
@@ -114,9 +112,6 @@ public:
 
 private:
     bool TryStartFragment() {
-        if (fragment_status_ != FragmentStatus::kNotStart) {
-            return false;
-        }
         u64 unfinished_child = unfinished_child_n_.fetch_sub(1);
         return unfinished_child == 1;
     }

--- a/src/scheduler/fragment_context.cppm
+++ b/src/scheduler/fragment_context.cppm
@@ -25,6 +25,8 @@ import data_table;
 import data_block;
 import knn_scan_data;
 import create_index_data;
+import logger;
+import third_party;
 
 export module fragment_context;
 
@@ -83,7 +85,10 @@ public:
 
     virtual ~FragmentContext() = default;
 
-    inline void IncreaseTask() { unfinished_task_n_.fetch_add(1); }
+    inline void IncreaseTask() {
+        unfinished_task_n_.fetch_add(1);
+        undone_task_n_.fetch_add(1);
+    }
 
     inline void FlushProfiler(TaskProfiler &profiler) {
         if (!query_context_->is_enable_profiling()) {
@@ -120,6 +125,8 @@ public:
 
     [[nodiscard]] inline FragmentType ContextType() const { return fragment_type_; }
 
+    void DumpFragmentCtx();
+
 private:
     bool TryStartFragment() {
         u64 unfinished_child = unfinished_child_n_.fetch_sub(1);
@@ -152,6 +159,7 @@ protected:
     FragmentType fragment_type_{FragmentType::kInvalid};
 
     atomic_u64 unfinished_task_n_{0};
+    atomic_u64 undone_task_n_{0};
     atomic_u64 unfinished_child_n_{0};
 };
 

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -121,6 +121,7 @@ bool FragmentTask::TryIntoWorkerLoop() {
 
 // Stream fragment source has no data
 bool FragmentTask::QuitFromWorkerLoop() {
+    return false; // FIXME
     // If reach here, child fragment must be stream
     if (source_state_->state_type_ != SourceStateType::kQueue) {
         // fragment's source is not from queue
@@ -130,10 +131,10 @@ bool FragmentTask::QuitFromWorkerLoop() {
 
     auto expect_status = FragmentTaskStatus::kRunning;
     if (queue_state->source_queue_.Empty() && status_.compare_exchange_strong(expect_status, FragmentTaskStatus::kPending)) {
-        LOG_TRACE(fmt::format("Task: {} of Fragment: {} quits from worker loop", task_id_, FragmentId()));
+        LOG_WARN(fmt::format("Task: {} of Fragment: {} quits from worker loop", task_id_, FragmentId()));
         return true;
     }
-    LOG_TRACE(fmt::format("Task: {} of Fragment: {} is still running", task_id_, FragmentId()));
+    LOG_WARN(fmt::format("Task: {} of Fragment: {} is still running", task_id_, FragmentId()));
     return false;
 }
 

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -44,7 +44,7 @@ void FragmentTask::Init() {
 }
 
 void FragmentTask::OnExecute(i64) {
-    LOG_INFO(fmt::format("Task: {} of Fragment: {} is running", task_id_, FragmentId()));
+    LOG_TRACE(fmt::format("Task: {} of Fragment: {} is running", task_id_, FragmentId()));
     //    infinity::BaseProfiler prof;
     //    prof.Begin();
     FragmentContext *fragment_context = (FragmentContext *)fragment_context_;
@@ -130,10 +130,10 @@ bool FragmentTask::QuitFromWorkerLoop() {
 
     auto expect_status = FragmentTaskStatus::kRunning;
     if (queue_state->source_queue_.Empty() && status_.compare_exchange_strong(expect_status, FragmentTaskStatus::kPending)) {
-        LOG_INFO(fmt::format("Task: {} of Fragment: {} quits from worker loop", task_id_, FragmentId()));
+        LOG_TRACE(fmt::format("Task: {} of Fragment: {} quits from worker loop", task_id_, FragmentId()));
         return true;
     }
-    LOG_INFO(fmt::format("Task: {} of Fragment: {} is still running", task_id_, FragmentId()));
+    LOG_TRACE(fmt::format("Task: {} of Fragment: {} is still running", task_id_, FragmentId()));
     return false;
 }
 
@@ -153,7 +153,7 @@ void FragmentTask::CompleteTask() {
         Error<SchedulerException>("Bug");
     }
     FragmentContext *fragment_context = (FragmentContext *)fragment_context_;
-    LOG_INFO(fmt::format("Task: {} of Fragment: {} is completed", task_id_, FragmentId()));
+    LOG_TRACE(fmt::format("Task: {} of Fragment: {} is completed", task_id_, FragmentId()));
     fragment_context->TryFinishFragment();
 }
 

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -121,7 +121,7 @@ bool FragmentTask::TryIntoWorkerLoop() {
 
 // Stream fragment source has no data
 bool FragmentTask::QuitFromWorkerLoop() {
-    return false; // FIXME
+    // return false; // FIXME
     // If reach here, child fragment must be stream
     if (source_state_->state_type_ != SourceStateType::kQueue) {
         // fragment's source is not from queue

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -44,7 +44,7 @@ void FragmentTask::Init() {
 }
 
 void FragmentTask::OnExecute(i64) {
-    LOG_TRACE(fmt::format("Task: {} of Fragment: {} is running", task_id_, FragmentId()));
+    LOG_INFO(fmt::format("Task: {} of Fragment: {} is running", task_id_, FragmentId()));
     //    infinity::BaseProfiler prof;
     //    prof.Begin();
     FragmentContext *fragment_context = (FragmentContext *)fragment_context_;
@@ -128,7 +128,7 @@ bool FragmentTask::QuitFromWorkerLoop() {
 
     auto expect_status = FragmentTaskStatus::kRunning;
     if (queue_state->source_queue_.Empty() && status_.compare_exchange_strong(expect_status, FragmentTaskStatus::kPending)) {
-        LOG_TRACE(fmt::format("Task: {} of Fragment: {} is quit from worker loop", task_id_, FragmentId()));
+        LOG_INFO(fmt::format("Task: {} of Fragment: {} quits from worker loop", task_id_, FragmentId()));
         return true;
     }
     return false;
@@ -147,7 +147,7 @@ void FragmentTask::CompleteTask() {
         status_ = FragmentTaskStatus::kFinished;
     }
     FragmentContext *fragment_context = (FragmentContext *)fragment_context_;
-    LOG_TRACE(fmt::format("Task: {} of Fragment: {} is completed", task_id_, FragmentId()));
+    LOG_INFO(fmt::format("Task: {} of Fragment: {} is completed", task_id_, FragmentId()));
     fragment_context->TryFinishFragment();
 }
 

--- a/src/scheduler/fragment_task.cppm
+++ b/src/scheduler/fragment_task.cppm
@@ -93,7 +93,9 @@ public:
     UniquePtr<SinkState> sink_state_{};
 
 private:
-    Atomic<FragmentTaskStatus> status_{FragmentTaskStatus::kPending};
+    std::mutex mutex_;
+
+    FragmentTaskStatus status_{FragmentTaskStatus::kPending};
 
     void *fragment_context_{};
     bool is_terminator_{false};

--- a/src/scheduler/fragment_task.cppm
+++ b/src/scheduler/fragment_task.cppm
@@ -70,10 +70,7 @@ public:
     [[nodiscard]] bool IsComplete();
 
     // TryInto and QuitFrom race on `status_`
-    bool TryIntoWorkerLoop() {
-        auto expect_status = FragmentTaskStatus::kPending;
-        return status_.compare_exchange_strong(expect_status, FragmentTaskStatus::kRunning);
-    }
+    bool TryIntoWorkerLoop();
 
     bool QuitFromWorkerLoop();
 

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -183,21 +183,16 @@ void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id
 
 void TaskScheduler::DumpPlanFragment(PlanFragment *root) {
     StdFunction<void(PlanFragment *)> TraverseFragmentTree = [&](PlanFragment *fragment) {
-        LOG_TRACE(fmt::format("Fragment id: {}, type: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType())));
         auto *fragment_ctx = fragment->GetContext();
-        for (auto &task : fragment_ctx->Tasks()) {
-            LOG_TRACE(fmt::format("Task id: {}, status: {}", task->TaskID(), FragmentTaskStatus2String(task->status())));
-        }
-        for (auto iter = fragment_ctx->GetOperators().begin(); iter != fragment_ctx->GetOperators().end(); ++iter) {
-            LOG_TRACE(fmt::format("Operator type: {}", PhysicalOperatorToString((*iter)->operator_type())));
-        }
+        LOG_INFO(fmt::format("Fragment id: {}, type: {}, ctx: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType()), u64(fragment_ctx)));
+        fragment_ctx->DumpFragmentCtx();
         for (auto &child : fragment->Children()) {
             TraverseFragmentTree(child.get());
         }
     };
-    LOG_TRACE(">>> DUMP START");
+    LOG_INFO(">>> DUMP START");
     TraverseFragmentTree(root);
-    LOG_TRACE(">>> DUMP END");
+    LOG_INFO(">>> DUMP END");
 }
 
 } // namespace infinity

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -106,6 +106,7 @@ void TaskScheduler::Schedule(PlanFragment *plan_fragment) {
     if (!initialized_) {
         Error<SchedulerException>("Scheduler isn't initialized");
     }
+    DumpPlanFragment(plan_fragment);
 
     Vector<PlanFragment *> fragments = GetStartFragments(plan_fragment);
     for (auto *plan_fragment : fragments) {
@@ -183,20 +184,21 @@ void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id
 
 void TaskScheduler::DumpPlanFragment(PlanFragment *root) {
     StdFunction<void(PlanFragment *)> TraverseFragmentTree = [&](PlanFragment *fragment) {
-        LOG_TRACE(fmt::format("Fragment id: {}, type: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType())));
+        LOG_INFO(fmt::format("Fragment id: {}, type: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType())));
         auto *fragment_ctx = fragment->GetContext();
         for (auto &task : fragment_ctx->Tasks()) {
-            LOG_TRACE(fmt::format("Task id: {}, status: {}", task->TaskID(), FragmentTaskStatus2String(task->status())));
+            LOG_INFO(fmt::format("Task id: {}, status: {}", task->TaskID(), FragmentTaskStatus2String(task->status())));
         }
         for (auto iter = fragment_ctx->GetOperators().begin(); iter != fragment_ctx->GetOperators().end(); ++iter) {
-            LOG_TRACE(fmt::format("Operator type: {}", PhysicalOperatorToString((*iter)->operator_type())));
+            LOG_INFO(fmt::format("Operator type: {}", PhysicalOperatorToString((*iter)->operator_type())));
         }
         for (auto &child : fragment->Children()) {
             TraverseFragmentTree(child.get());
         }
     };
+    LOG_INFO(">>> DUMP START");
     TraverseFragmentTree(root);
-    LOG_TRACE("");
+    LOG_INFO(">>> DUMP END");
 }
 
 } // namespace infinity

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -84,7 +84,6 @@ u64 TaskScheduler::FindLeastWorkloadWorker() {
     return min_workload_worker_id;
 }
 
-
 Vector<PlanFragment *> TaskScheduler::GetStartFragments(PlanFragment *plan_fragment) {
     Vector<PlanFragment *> leaf_fragments;
     StdFunction<void(PlanFragment *)> TraversePlanFragmentTree = [&](PlanFragment *root) {
@@ -106,7 +105,7 @@ void TaskScheduler::Schedule(PlanFragment *plan_fragment) {
     if (!initialized_) {
         Error<SchedulerException>("Scheduler isn't initialized");
     }
-    DumpPlanFragment(plan_fragment);
+    // DumpPlanFragment(plan_fragment);
 
     Vector<PlanFragment *> fragments = GetStartFragments(plan_fragment);
     for (auto *plan_fragment : fragments) {
@@ -184,21 +183,21 @@ void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id
 
 void TaskScheduler::DumpPlanFragment(PlanFragment *root) {
     StdFunction<void(PlanFragment *)> TraverseFragmentTree = [&](PlanFragment *fragment) {
-        LOG_INFO(fmt::format("Fragment id: {}, type: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType())));
+        LOG_TRACE(fmt::format("Fragment id: {}, type: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType())));
         auto *fragment_ctx = fragment->GetContext();
         for (auto &task : fragment_ctx->Tasks()) {
-            LOG_INFO(fmt::format("Task id: {}, status: {}", task->TaskID(), FragmentTaskStatus2String(task->status())));
+            LOG_TRACE(fmt::format("Task id: {}, status: {}", task->TaskID(), FragmentTaskStatus2String(task->status())));
         }
         for (auto iter = fragment_ctx->GetOperators().begin(); iter != fragment_ctx->GetOperators().end(); ++iter) {
-            LOG_INFO(fmt::format("Operator type: {}", PhysicalOperatorToString((*iter)->operator_type())));
+            LOG_TRACE(fmt::format("Operator type: {}", PhysicalOperatorToString((*iter)->operator_type())));
         }
         for (auto &child : fragment->Children()) {
             TraverseFragmentTree(child.get());
         }
     };
-    LOG_INFO(">>> DUMP START");
+    LOG_TRACE(">>> DUMP START");
     TraverseFragmentTree(root);
-    LOG_INFO(">>> DUMP END");
+    LOG_TRACE(">>> DUMP END");
 }
 
 } // namespace infinity

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -16,7 +16,6 @@ module;
 
 #include <list>
 #include <sched.h>
-#include <vector>
 
 import stl;
 import config;
@@ -31,6 +30,7 @@ import plan_fragment;
 import fragment_context;
 import default_values;
 import physical_operator_type;
+import physical_operator;
 
 module task_scheduler;
 
@@ -59,179 +59,139 @@ void TaskScheduler::Init(const Config *config_ptr) {
         Error<SchedulerException>("No cpu is used in scheduler");
     }
 
-    // Start coordinator
-    ready_queue_ = MakeUnique<FragmentTaskBlockQueue>();
-    coordinator_ = MakeUnique<Thread>(&TaskScheduler::CoordinatorLoop, this, ready_queue_.get(), 0);
-
-    ThreadUtil::pin(*coordinator_, 0);
-
     initialized_ = true;
 }
 
 void TaskScheduler::UnInit() {
     initialized_ = false;
     UniquePtr<FragmentTask> terminate_task = MakeUnique<FragmentTask>(true);
-    ready_queue_->Enqueue(terminate_task.get());
-    coordinator_->join();
+
     for (const auto &worker : worker_array_) {
         worker.queue_->Enqueue(terminate_task.get());
         worker.thread_->join();
     }
 }
 
-void TaskScheduler::Schedule(QueryContext *query_context, const Vector<FragmentTask *> &tasks, PlanFragment *plan_fragment) {
+Vector<PlanFragment *> TaskScheduler::GetStartFragments(PlanFragment *plan_fragment) {
+    Vector<PlanFragment *> leaf_fragments;
+    StdFunction<void(PlanFragment *)> TraversePlanFragmentTree = [&](PlanFragment *root) {
+        if (root->Children().empty()) {
+            leaf_fragments.emplace_back(root);
+            return;
+        }
+        for (auto &child : root->Children()) {
+            TraversePlanFragmentTree(child.get());
+        }
+    };
+    // Traverse the tree to get all leaf fragments
+    TraversePlanFragmentTree(plan_fragment);
+
+    return leaf_fragments;
+}
+
+void TaskScheduler::Schedule(PlanFragment *plan_fragment) {
     if (!initialized_) {
         Error<SchedulerException>("Scheduler isn't initialized");
     }
 
-    //    Vector<UniquePtr<PlanFragment>>& children = plan_fragment->Children();
-    //    if(!children.empty()) {
-    //        SchedulerError("Only support one fragment query")
-    //    }
-    // 1. Recursive traverse the fragment tree
-    // 2. Check the fragment
-    //    if the first op is SCAN op, then get all block entry and create the source type is kScan.
-    //    if the first op isn't SCAN op, fragment task source type is kQueue and a task_result_queue need to be created.
-    //    According to the fragment output type to set the correct fragment task sink type.
-    //    Set the queue of parent fragment task.
-    if (plan_fragment->GetOperators().empty()) {
-        Error<SchedulerException>("Empty fragment");
+    Vector<PlanFragment *> fragments = GetStartFragments(plan_fragment);
+    if (worker_workloads_[0] == 0) {
+        last_cpu_id_ = 0; // FIXME
     }
-    auto *last_operator = plan_fragment->GetOperators()[0];
-    switch (last_operator->operator_type()) {
-        case PhysicalOperatorType::kCreateIndexFinish: {
-            ScheduleRoundRobin(query_context, tasks, plan_fragment);
-            break;
-        }
-        default: {
-            ScheduleOneWorkerIfPossible(query_context, tasks, plan_fragment);
-            break;
-        }
-    }
-}
-
-void TaskScheduler::ScheduleOneWorkerPerQuery(QueryContext *query_context, const Vector<FragmentTask *> &tasks, PlanFragment *plan_fragment) {
-    LOG_TRACE(fmt::format("Schedule {} tasks of query id: {} into scheduler with OneWorkerPerQuery policy", tasks.size(), query_context->query_id()));
-    u64 worker_id = ProposedWorkerID(query_context->GetTxn()->TxnID());
-    for (const auto &fragment_task : tasks) {
-        ScheduleTask(fragment_task, worker_id);
-    }
-}
-
-void TaskScheduler::ScheduleOneWorkerIfPossible(QueryContext *query_context, const Vector<FragmentTask *> &tasks, PlanFragment *plan_fragment) {
-    // Schedule worker 0 if possible
-    u64 scheduled_worker = std::numeric_limits<u64>::max();;
-    u64 min_load_worker{0};
-    u64 min_work_load{std::numeric_limits<u64>::max()};
-    for(u64 proposed_worker = 0; proposed_worker < worker_count_; ++ proposed_worker) {
-        u64 current_work_load = worker_workloads_[proposed_worker];
-        if(current_work_load < 1) {
-            scheduled_worker = proposed_worker;
-            break;
-        } else {
-            if(current_work_load < min_work_load) {
-                min_load_worker = proposed_worker;
-                min_work_load = current_work_load;
+    u64 &worker_id = last_cpu_id_;
+    for (auto *plan_fragment : fragments) {
+        auto &tasks = plan_fragment->GetContext()->Tasks();
+        for (auto &task : tasks) {
+            // set the status to running
+            if (!task->TryIntoWorkerLoop()) {
+                Error<SchedulerException>("Task can't be scheduled");
             }
+            ScheduleTask(task.get(), worker_id);
+            ++worker_id;
+            worker_id %= worker_count_;
         }
-    }
-
-    if(scheduled_worker == std::numeric_limits<u64>::max()) {
-        scheduled_worker = min_load_worker;
-    }
-
-    worker_workloads_[scheduled_worker] += tasks.size();
-    LOG_TRACE(fmt::format("Schedule {} tasks of query id: {} into worker: {} with ScheduleOneWorkerIfPossible policy",
-                     tasks.size(),
-                     query_context->query_id(),
-                     scheduled_worker));
-    for (const auto &fragment_task : tasks) {
-        ScheduleTask(fragment_task, scheduled_worker);
     }
 }
 
-void TaskScheduler::ScheduleRoundRobin(QueryContext *query_context, const Vector<FragmentTask *> &tasks, PlanFragment *plan_fragment) {
-    LOG_TRACE(fmt::format("Schedule {} tasks of query id: {} into scheduler with RR policy", tasks.size(), query_context->query_id()));
-    u64 worker_id = 0;
-    for (const auto &fragment_task : tasks) {
-        ScheduleTask(fragment_task, worker_id);
-        worker_id++;
-        worker_id %= worker_count_;
+void TaskScheduler::ScheduleFragment(PlanFragment *plan_fragment) {
+    Vector<FragmentTask *> task_ptrs;
+    auto &tasks = plan_fragment->GetContext()->Tasks();
+    for (auto &task : tasks) {
+        if (task->TryIntoWorkerLoop()) {
+            task_ptrs.emplace_back(task.get());
+        }
     }
-}
-
-void TaskScheduler::ToReadyQueue(FragmentTask *task) {
-    if (!initialized_) {
-        Error<SchedulerException>("Scheduler isn't initialized");
-    }
-}
-
-void TaskScheduler::CoordinatorLoop(FragmentTaskBlockQueue *ready_queue, i64 cpu_id) {
-    FragmentTask *fragment_task{nullptr};
-    bool running{true};
-    u64 current_cpu_id{0};
-    HashSet<u64> fragment_task_ptr;
-    while (running) {
-        ready_queue->Dequeue(fragment_task);
-        if (auto iter = fragment_task_ptr.find(u64(fragment_task)); iter == fragment_task_ptr.end()) {
-            fragment_task_ptr.emplace(u64(fragment_task));
-        }
-
-        if (fragment_task->IsTerminator()) {
-            running = false;
-            continue;
-        }
-
-        if (!fragment_task->Ready()) {
-            ready_queue->Enqueue(fragment_task);
-            continue;
-        }
-
-        if (fragment_task->LastWorkerID() == -1) {
-            // Select an available worker to dispatch
-            u64 to_use_cpu_id = current_cpu_id;
-            ++current_cpu_id;
-            to_use_cpu_id %= worker_count_;
-            worker_array_[to_use_cpu_id].queue_->Enqueue(fragment_task);
+    // last_cpu_id_ = 0; // FIXME
+    u64 &worker_id = last_cpu_id_;
+    for (auto *task_ptr : task_ptrs) {
+        if (task_ptr->LastWorkerID() == -1) {
+            ScheduleTask(task_ptr, worker_id);
+            ++worker_id;
+            worker_id %= worker_count_;
         } else {
-            // Dispatch to the same worker
-            worker_array_[fragment_task->LastWorkerID()].queue_->Enqueue(fragment_task);
+            ScheduleTask(task_ptr, task_ptr->LastWorkerID());
         }
     }
+}
+
+void TaskScheduler::ScheduleTask(FragmentTask *task, u64 worker_id) {
+    ++worker_workloads_[worker_id];
+    worker_array_[worker_id].queue_->Enqueue(task);
 }
 
 void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id) {
-    FragmentTask *fragment_task{nullptr};
-    Vector<FragmentTask *> task_list;
-    task_list.reserve(DEFAULT_BLOCKING_QUEUE_SIZE);
-    bool running{true};
-    while (running) {
-        task_queue->DequeueBulk(task_list);
-        SizeT list_size = task_list.size();
-        for (SizeT idx = 0; idx < list_size; ++idx) {
-            fragment_task = task_list[idx];
-
-            if (fragment_task->IsTerminator()) {
-                running = false;
-                break;
-            }
-
-            if (!fragment_task->Ready()) {
-                ready_queue_->Enqueue(fragment_task);
-                continue;
-            }
-
-            fragment_task->OnExecute(worker_id);
-            fragment_task->SetLastWorkID(worker_id);
-            if (!fragment_task->IsComplete()) {
-                ready_queue_->Enqueue(fragment_task);
-            } else {
-                --worker_workloads_[worker_id];
-                fragment_task->TryCompleteFragment();
-            }
+    List<FragmentTask *> task_lists;
+    auto iter = task_lists.end();
+    while (true) {
+        Vector<FragmentTask *> dequeue_output;
+        if (task_lists.empty()) {
+            task_queue->DequeueBulk(dequeue_output);
+        } else {
+            task_queue->TryDequeueBulk(dequeue_output);
         }
-        task_list.clear();
+        if (!dequeue_output.empty()) {
+            task_lists.insert(task_lists.end(), dequeue_output.begin(), dequeue_output.end());
+        }
+        if (iter == task_lists.end()) {
+            iter = task_lists.begin();
+        }
+        auto &fragment_task = *iter;
+        if (fragment_task->IsTerminator()) {
+            break;
+        }
+
+        fragment_task->OnExecute(worker_id);
+        fragment_task->SetLastWorkID(worker_id);
+
+        if (fragment_task->IsComplete()) {
+            --worker_workloads_[worker_id];
+            fragment_task->CompleteTask();
+            iter = task_lists.erase(iter);
+        } else if (fragment_task->QuitFromWorkerLoop()) {
+            --worker_workloads_[worker_id];
+            iter = task_lists.erase(iter);
+        } else {
+            ++iter;
+        }
     }
+}
+
+void TaskScheduler::DumpPlanFragment(PlanFragment *root) {
+    StdFunction<void(PlanFragment *)> TraverseFragmentTree = [&](PlanFragment *fragment) {
+        LOG_TRACE(fmt::format("Fragment id: {}, type: {}", fragment->FragmentID(), FragmentType2String(fragment->GetFragmentType())));
+        auto *fragment_ctx = fragment->GetContext();
+        for (auto &task : fragment_ctx->Tasks()) {
+            LOG_TRACE(fmt::format("Task id: {}, status: {}", task->TaskID(), FragmentTaskStatus2String(task->status())));
+        }
+        for (auto iter = fragment_ctx->GetOperators().begin(); iter != fragment_ctx->GetOperators().end(); ++iter) {
+            LOG_TRACE(fmt::format("Operator type: {}", PhysicalOperatorToString((*iter)->operator_type())));
+        }
+        for (auto &child : fragment->Children()) {
+            TraverseFragmentTree(child.get());
+        }
+    };
+    TraverseFragmentTree(root);
+    LOG_TRACE("");
 }
 
 } // namespace infinity

--- a/src/scheduler/task_scheduler.cppm
+++ b/src/scheduler/task_scheduler.cppm
@@ -55,6 +55,8 @@ public:
     void DumpPlanFragment(PlanFragment *plan_fragment);
 
 private:
+    u64 FindLeastWorkloadWorker();
+
     Vector<PlanFragment *> GetStartFragments(PlanFragment* plan_fragment);
 
     void ScheduleTask(FragmentTask *task, u64 worker_id);
@@ -62,8 +64,6 @@ private:
     void WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id);
 
 private:
-    u64 last_cpu_id_{0};
-
     bool initialized_{false};
 
     Vector<Worker> worker_array_{};

--- a/src/unit_test/function/aggregate/avg_functions.cpp
+++ b/src/unit_test/function/aggregate/avg_functions.cpp
@@ -83,10 +83,11 @@ TEST_F(AvgFunctionTest, avg_func) {
             }
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, sum / row_count);
     }
@@ -119,10 +120,11 @@ TEST_F(AvgFunctionTest, avg_func) {
             EXPECT_EQ(v.value_.small_int, static_cast<SmallIntT>(i));
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, sum / row_count);
     }
@@ -155,10 +157,11 @@ TEST_F(AvgFunctionTest, avg_func) {
             EXPECT_EQ(v.value_.integer, static_cast<IntegerT>(2 * i));
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, sum / row_count);
     }
@@ -191,10 +194,11 @@ TEST_F(AvgFunctionTest, avg_func) {
             EXPECT_EQ(v.value_.big_int, static_cast<BigIntT>(2 * i));
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, sum / row_count);
     }
@@ -227,10 +231,11 @@ TEST_F(AvgFunctionTest, avg_func) {
             EXPECT_FLOAT_EQ(v.value_.float32, static_cast<FloatT>(2 * i));
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, sum / row_count);
     }
@@ -263,10 +268,11 @@ TEST_F(AvgFunctionTest, avg_func) {
             EXPECT_FLOAT_EQ(v.value_.float64, static_cast<DoubleT>(2 * i));
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, sum / row_count);
     }

--- a/src/unit_test/function/aggregate/count_functions.cpp
+++ b/src/unit_test/function/aggregate/count_functions.cpp
@@ -66,10 +66,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -93,10 +94,12 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -120,10 +123,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -148,10 +152,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -176,10 +181,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -206,10 +212,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -234,10 +241,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }
@@ -262,10 +270,11 @@ TEST_F(CountFunctionTest, count_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, row_count);
     }

--- a/src/unit_test/function/aggregate/max_functions.cpp
+++ b/src/unit_test/function/aggregate/max_functions.cpp
@@ -66,10 +66,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BooleanT result;
-        result = *(BooleanT *)func.finalize_func_(func.GetState());
+        result = *(BooleanT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, true);
     }
@@ -94,10 +95,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         TinyIntT result;
-        result = *(TinyIntT *)func.finalize_func_(func.GetState());
+        result = *(TinyIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, 127);
     }
@@ -128,10 +130,11 @@ TEST_F(MaxFunctionTest, max_func) {
             EXPECT_EQ(v.value_.small_int, static_cast<SmallIntT>(i));
         }
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         SmallIntT result;
-        result = *(SmallIntT *)func.finalize_func_(func.GetState());
+        result = *(SmallIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, row_count - 1);
     }
@@ -156,10 +159,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         IntegerT result;
-        result = *(IntegerT *)func.finalize_func_(func.GetState());
+        result = *(IntegerT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, 2 * (row_count - 1));
     }
@@ -184,10 +188,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, 2 * (row_count - 1));
     }
@@ -212,10 +217,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         FloatT result;
-        result = *(FloatT *)func.finalize_func_(func.GetState());
+        result = *(FloatT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, 2 * (row_count - 1));
     }
@@ -240,10 +246,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, 2 * (row_count - 1));
     }
@@ -270,10 +277,11 @@ TEST_F(MaxFunctionTest, max_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         HugeIntT result;
-        result = *(HugeIntT *)func.finalize_func_(func.GetState());
+        result = *(HugeIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result.lower, 2 * (row_count - 1));
     }

--- a/src/unit_test/function/aggregate/min_functions.cpp
+++ b/src/unit_test/function/aggregate/min_functions.cpp
@@ -66,10 +66,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BooleanT result;
-        result = *(BooleanT *)func.finalize_func_(func.GetState());
+        result = *(BooleanT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, false);
     }
@@ -94,10 +95,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         TinyIntT result;
-        result = *(TinyIntT *)func.finalize_func_(func.GetState());
+        result = *(TinyIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, -128);
     }
@@ -122,10 +124,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         SmallIntT result;
-        result = *(SmallIntT *)func.finalize_func_(func.GetState());
+        result = *(SmallIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, -std::numeric_limits<SmallIntT>::max());
     }
@@ -150,10 +153,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         IntegerT result;
-        result = *(IntegerT *)func.finalize_func_(func.GetState());
+        result = *(IntegerT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, -std::numeric_limits<IntegerT>::max());
     }
@@ -178,10 +182,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result, -std::numeric_limits<BigIntT>::max());
     }
@@ -206,10 +211,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         FloatT result;
-        result = *(FloatT *)func.finalize_func_(func.GetState());
+        result = *(FloatT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, FloatT(-2 * (i64)(row_count - 1)));
     }
@@ -234,10 +240,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(result, DoubleT(-2 * (i64)(row_count - 1)));
     }
@@ -264,10 +271,11 @@ TEST_F(MinFunctionTest, min_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         HugeIntT result;
-        result = *(HugeIntT *)func.finalize_func_(func.GetState());
+        result = *(HugeIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(result.lower, -2 * (row_count - 1));
     }

--- a/src/unit_test/function/aggregate/sum_functions.cpp
+++ b/src/unit_test/function/aggregate/sum_functions.cpp
@@ -68,10 +68,11 @@ TEST_F(SumFunctionTest, avg_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(sum, result);
     }
@@ -98,10 +99,11 @@ TEST_F(SumFunctionTest, avg_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(sum, result);
     }
@@ -128,10 +130,11 @@ TEST_F(SumFunctionTest, avg_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(sum, result);
     }
@@ -158,10 +161,11 @@ TEST_F(SumFunctionTest, avg_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         BigIntT result;
-        result = *(BigIntT *)func.finalize_func_(func.GetState());
+        result = *(BigIntT *)func.finalize_func_(data_state.get());
 
         EXPECT_EQ(sum, result);
     }
@@ -188,10 +192,11 @@ TEST_F(SumFunctionTest, avg_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(sum, result);
     }
@@ -218,10 +223,11 @@ TEST_F(SumFunctionTest, avg_func) {
         }
         data_block.Finalize();
 
-        func.init_func_(func.GetState());
-        func.update_func_(func.GetState(), data_block.column_vectors[0]);
+        auto data_state = func.InitState();
+        func.init_func_(data_state.get());
+        func.update_func_(data_state.get(), data_block.column_vectors[0]);
         DoubleT result;
-        result = *(DoubleT *)func.finalize_func_(func.GetState());
+        result = *(DoubleT *)func.finalize_func_(data_state.get());
 
         EXPECT_FLOAT_EQ(sum, result);
     }

--- a/src/unit_test/test_helper/sql_runner.cpp
+++ b/src/unit_test/test_helper/sql_runner.cpp
@@ -99,11 +99,10 @@ SharedPtr<DataTable> SQLRunner::Run(const String &sql_text, bool print) {
     // Fragment Builder, only for test now. plan fragment is same as pipeline.
     auto plan_fragment = query_context_ptr->fragment_builder()->BuildFragment(physical_plan.get());
 
-    Vector<FragmentTask *> tasks;
-    FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get(), tasks);
+    FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get());
 
     // Schedule the query tasks
-    query_context_ptr->scheduler()->Schedule(query_context_ptr.get(), tasks, plan_fragment.get());
+    query_context_ptr->scheduler()->Schedule(plan_fragment.get());
 
     // Initialize query result
     QueryResult query_result;

--- a/src/unit_test/test_helper/sql_runner.cpp
+++ b/src/unit_test/test_helper/sql_runner.cpp
@@ -97,9 +97,11 @@ SharedPtr<DataTable> SQLRunner::Run(const String &sql_text, bool print) {
 
     // Create execution pipeline
     // Fragment Builder, only for test now. plan fragment is same as pipeline.
-    auto plan_fragment = query_context_ptr->fragment_builder()->BuildFragment(physical_plan.get());
+    auto [fragment_n, plan_fragment] = query_context_ptr->fragment_builder()->BuildFragment(physical_plan.get());
 
-    FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get());
+    auto notifier = MakeUnique<Notifier>(fragment_n);
+
+    FragmentContext::BuildTask(query_context_ptr.get(), nullptr, plan_fragment.get(), notifier.get());
 
     // Schedule the query tasks
     query_context_ptr->scheduler()->Schedule(plan_fragment.get());

--- a/test/sql/dql/sort_by_function.slt
+++ b/test/sql/dql/sort_by_function.slt
@@ -1,4 +1,7 @@
 statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
 CREATE TABLE t1 (c1 int, c2 int);
 
 statement ok

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -33,9 +33,9 @@ def test_process(sqllogictest_bin: str, slt_dir: str, data_dir: str, copy_dir: s
         for filename in filenames:
             file = os.path.join(dirpath, filename)
 
-            filename = os.path.basename(file)
-            if "fulltext" in filename or "fusion" in filename:
-                continue
+            # filename = os.path.basename(file)
+            # if "fulltext" in filename or "fusion" in filename:
+            #     continue
 
             process = subprocess.run([sqllogictest_bin, file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output, error = process.stdout, process.stderr
@@ -128,5 +128,5 @@ if __name__ == "__main__":
     generate4(args.generate_if_exists, args.copy)
     generate5(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
-    # python_skd_test(python_test_dir)
+    python_skd_test(python_test_dir)
     test_process(args.path, args.test, args.data, args.copy)

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -32,6 +32,11 @@ def test_process(sqllogictest_bin: str, slt_dir: str, data_dir: str, copy_dir: s
     for dirpath, dirnames, filenames in os.walk(slt_dir):
         for filename in filenames:
             file = os.path.join(dirpath, filename)
+
+            filename = os.path.basename(file)
+            if "fulltext" in filename or "fusion" in filename:
+                continue
+
             process = subprocess.run([sqllogictest_bin, file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output, error = process.stdout, process.stderr
             if process.returncode != 0:
@@ -123,5 +128,5 @@ if __name__ == "__main__":
     generate4(args.generate_if_exists, args.copy)
     generate5(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
-    python_skd_test(python_test_dir)
+    # python_skd_test(python_test_dir)
     test_process(args.path, args.test, args.data, args.copy)


### PR DESCRIPTION
### What problem does this PR solve?

Refactor the scheduler.

Issue link:
https://github.com/infiniflow/infinity/issues/387
https://github.com/infiniflow/infinity/issues/407
### What is changed and how it works?
0. Remove coordinate thread.
1. Determine init fragments in `TaskScheduler::Schedule`. Init fragments are leaf fragments.
2. In `TaskScheduler::WorkerLoop`, when a fragment task finished, if `FragmentTask::IsComplete` return true, `FragmentTask::CompleteTask` is called, which calls `FragmentContext::TryFinishFragment`. The latter reduce the `unfinished_task_n_` in `FragmentContext` and when it is 0, it reduce its parent `FragmentContext`'s `unfinished_child_n_` by `FragmentContext::TryStartFragment`. If it returns true, then schedule that parent fragment by `TaskScheduler::ScheduleFragment`.
3. For `FragmentType::kParallelStream`,  the return value of `FragmentContext::TryStartFragment` will be ignored, and all its parent tasks that not in work loop can be scheduled in.
4. And for `FragmentType::kParallelStream`, if `FragmentContext::TryFinishFragment` return false, the task souce will be checked if there is more data. If not, this task will be scheduled out.

Fix bug:
1. `TableScan` return directly and not setcomplete because output block is filled. But when input block is used up, set complete can be done.
2. `AggExpression` has state in the expression not in ExpressionState, which causes data race in multi thread executor.
3. `FragmentCtx` lifetime control is changed because of the new scheduler.

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer