### PR TITLE
Add block size constraint in insert test

### DIFF
--- a/python/test/test_insert.py
+++ b/python/test/test_insert.py
@@ -214,4 +214,16 @@ class TestInsert:
         assert res.success
         res = table_obj.insert([{"c1": [-9999999.988] * 65535}])
         assert res.success
-        db_obj.drop_table("test_insert_big_embedding_float")
+        res = db_obj.drop_table("test_insert_big_embedding_float")
+        assert res.success
+
+    def test_insert_exceed_block_size(self):
+        infinity_obj = infinity.connect(REMOTE_HOST)
+        db_obj = infinity_obj.get_database("default")
+        db_obj.drop_table("test_insert_exceed_block_size", True)
+        table_obj = db_obj.create_table("test_insert_exceed_block_size", {
+            "c1": "float"}, None)
+        assert table_obj
+        values = [{"c1": 1} for _ in range(8193)]
+        res = table_obj.insert(values)
+        assert res.success is False

--- a/src/executor/operator/physical_insert.cpp
+++ b/src/executor/operator/physical_insert.cpp
@@ -28,6 +28,7 @@ import data_block;
 import third_party;
 import expression_evaluator;
 import base_expression;
+import default_values;
 
 import infinity_exception;
 import catalog;
@@ -44,7 +45,12 @@ bool PhysicalInsert::Execute(QueryContext *query_context, OperatorState *operato
     SizeT table_collection_column_count = table_entry_->ColumnCount();
     if (column_count != table_collection_column_count) {
         Error<ExecutorException>(
-            fmt::format("Insert values count{} isn't matched with table column count{}.", column_count, table_collection_column_count));
+            fmt::format("Insert values count {} isn't matched with table column count {}.", column_count, table_collection_column_count));
+        ;
+    }
+    if (row_count > DEFAULT_BLOCK_CAPACITY) {
+        Error<ExecutorException>(
+            fmt::format("Insert values row count {} is larger than default block capacity {}.", row_count, DEFAULT_BLOCK_CAPACITY));
         ;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Added an additional test case in test_insert.py to handle inserts that exceed the block size limit. Also, ensured that the table drop operation is successful in the test. Updated the physical_insert.cpp to throw an error when the number of insert rows is larger than the default block capacity.


Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer