### PR TITLE
Fix sort functions

### DIFF
--- a/src/executor/operator/physical_merge_top.cpp
+++ b/src/executor/operator/physical_merge_top.cpp
@@ -62,8 +62,8 @@ void PhysicalMergeTop::Init() {
     if (sort_expr_count_ != sort_expressions_.size()) {
         Error<ExecutorException>("order_by_types_.size() != sort_expressions_.size()");
     }
-    // copy sort functions from PhysicalTop
-    sort_functions_ = (reinterpret_cast<PhysicalTop *>(left()))->GetInnerSortFunctions();
+    // copy compare function from PhysicalTop
+    prefer_left_function_ = (reinterpret_cast<PhysicalTop *>(left()))->GetInnerCompareFunction();
 }
 
 bool PhysicalMergeTop::Execute(QueryContext *, OperatorState *operator_state) {
@@ -110,19 +110,7 @@ bool PhysicalMergeTop::Execute(QueryContext *, OperatorState *operator_state) {
             } else {
                 auto &middle_data = eval_columns_middle[middle.block_id_];
                 auto &input_data = eval_columns_input[input.block_id_ - middle_block_cnt];
-                for (u32 i = 0; i < sort_expr_count_; ++i) {
-                    auto compare_result =
-                        sort_functions_[i](middle_data[i]->data(), middle.block_offset_, input_data[i]->data(), input.block_offset_);
-                    switch (compare_result) {
-                        case OrderBySingleResult::kPreferLeft:
-                            return true;
-                        case OrderBySingleResult::kPreferRight:
-                            return false;
-                        default:
-                            continue;
-                    }
-                }
-                return true;
+                return prefer_left_function_(middle_data, middle.block_offset_, input_data, input.block_offset_);
             }
         };
         // 1. get merged top ids

--- a/src/executor/operator/physical_merge_top.cpp
+++ b/src/executor/operator/physical_merge_top.cpp
@@ -110,7 +110,7 @@ bool PhysicalMergeTop::Execute(QueryContext *, OperatorState *operator_state) {
             } else {
                 auto &middle_data = eval_columns_middle[middle.block_id_];
                 auto &input_data = eval_columns_input[input.block_id_ - middle_block_cnt];
-                return prefer_left_function_(middle_data, middle.block_offset_, input_data, input.block_offset_);
+                return prefer_left_function_.Compare(middle_data, middle.block_offset_, input_data, input.block_offset_);
             }
         };
         // 1. get merged top ids

--- a/src/executor/operator/physical_merge_top.cppm
+++ b/src/executor/operator/physical_merge_top.cppm
@@ -66,13 +66,13 @@ public:
     }
 
 private:
-    SharedPtr<BaseTableRef> base_table_ref_;                                            // necessary for InputLoad
-    u32 limit_{};                                                                       // limit value
-    u32 offset_{};                                                                      // offset value
-    u32 sort_expr_count_{};                                                             // number of expressions to sort
-    Vector<OrderType> order_by_types_;                                                  // ASC or DESC
-    Vector<SharedPtr<BaseExpression>> sort_expressions_;                                // expressions to sort
-    Vector<StdFunction<OrderBySingleResult(void *, u32, void *, u32)>> sort_functions_; // sort functions
+    SharedPtr<BaseTableRef> base_table_ref_;             // necessary for InputLoad
+    u32 limit_{};                                        // limit value
+    u32 offset_{};                                       // offset value
+    u32 sort_expr_count_{};                              // number of expressions to sort
+    Vector<OrderType> order_by_types_;                   // ASC or DESC
+    Vector<SharedPtr<BaseExpression>> sort_expressions_; // expressions to sort
+    CompareTwoRowAndPreferLeft prefer_left_function_;    // compare function
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_sort.cpp
+++ b/src/executor/operator/physical_sort.cpp
@@ -62,7 +62,7 @@ public:
     bool operator()(BlockRawIndex left_index, BlockRawIndex right_index) {
         auto &left = eval_results_[left_index.block_idx];
         auto &right = eval_results_[right_index.block_idx];
-        return prefer_left_function_(left, left_index.offset, right, right_index.offset);
+        return prefer_left_function_.Compare(left, left_index.offset, right, right_index.offset);
     }
 
 private:

--- a/src/executor/operator/physical_sort.cppm
+++ b/src/executor/operator/physical_sort.cppm
@@ -14,6 +14,8 @@
 
 module;
 
+export module physical_sort;
+
 import stl;
 import parser;
 import query_context;
@@ -26,15 +28,9 @@ import data_table;
 import data_block;
 import load_meta;
 import infinity_exception;
-
-export module physical_sort;
+import physical_top;
 
 namespace infinity {
-
-struct BlockRawIndex {
-    SizeT block_idx;
-    SizeT offset;
-};
 
 export class PhysicalSort : public PhysicalOperator {
 public:
@@ -60,11 +56,15 @@ public:
         return left_->TaskletCount();
     }
 
+    // for OperatorState
+    inline auto const &GetSortExpressions() const { return expressions_; }
+
     Vector<SharedPtr<BaseExpression>> expressions_;
     Vector<OrderType> order_by_types_{};
 
 private:
     u64 input_table_index_{};
+    CompareTwoRowAndPreferLeft prefer_left_function_; // compare function
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_top.cppm
+++ b/src/executor/operator/physical_top.cppm
@@ -44,7 +44,7 @@ public:
         sort_expr_count_ = sort_functions_.size();
     }
     ~CompareTwoRowAndPreferLeft() = default;
-    bool operator()(const Vector<SharedPtr<ColumnVector>> &left, u32 left_id, const Vector<SharedPtr<ColumnVector>> &right, u32 right_id) const {
+    bool Compare(const Vector<SharedPtr<ColumnVector>> &left, u32 left_id, const Vector<SharedPtr<ColumnVector>> &right, u32 right_id) const {
         for (u32 i = 0; i < sort_expr_count_; ++i) {
             auto compare_result = sort_functions_[i](left[i], left_id, right[i], right_id);
             if (compare_result != std::strong_ordering::equal) {

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -191,7 +191,7 @@ export struct ProjectionOperatorState : public OperatorState {
 // Sort
 export struct SortOperatorState : public OperatorState {
     inline explicit SortOperatorState() : OperatorState(PhysicalOperatorType::kSort) {}
-
+    Vector<SharedPtr<ExpressionState>> expr_states_; // expression states
     Vector<UniquePtr<DataBlock>> unmerge_sorted_blocks_{};
 };
 

--- a/src/function/scalar/equals.cpp
+++ b/src/function/scalar/equals.cpp
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 module;
+
+#include <compare>
 #include <type_traits>
+
+module equals;
+
 import stl;
 import catalog;
 
@@ -23,44 +28,47 @@ import scalar_function_set;
 import parser;
 import third_party;
 
-module equals;
 
 namespace infinity {
 
 struct EqualsFunction {
     template <typename TA, typename TB, typename TC>
     static inline void Run(TA left, TB right, TC &result) {
-        if constexpr (std::is_same_v<std::remove_cv_t<TA>, u8> && std::is_same_v<std::remove_cv_t<TB>, u8> &&
-                      std::is_same_v<std::remove_cv_t<TC>, u8>) {
-            result = ~(left ^ right);
-        } else {
-            result = (left == right);
-        }
+        static_assert(false, "Unsupported type");
+    }
+};
+
+struct BooleanEqualsFunction {
+    // keep compatible with template Run call
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        static_assert(false, "Unsupported type");
     }
 };
 
 template <>
-inline void EqualsFunction::Run(VarcharT left, VarcharT right, bool &result) {
-    if (left.length_ != right.length_) {
-        result = false;
-        return;
-    }
-    if (left.IsInlined()) {
-        result = (std::memcmp(left.short_.data_, right.short_.data_, left.length_) == 0);
-        return;
-    } else {
-        // Both left and right are not inline
-        if(left.IsValue() && right.IsValue()) {
-            if (std::memcmp(left.value_.prefix_, right.value_.prefix_, VARCHAR_PREFIX_LEN) == 0) {
-                result = (std::memcmp(left.value_.ptr_, right.value_.ptr_, left.length_) == 0);
-                return;
-            }
-        } else {
-            Error<NotImplementException>("Column vector varchar can't be compared");
-        }
-    }
-    result = false;
+inline void BooleanEqualsFunction::Run<u8, u8, u8>(u8 left, u8 right, u8 &result) {
+    result = ~(left ^ right);
 }
+
+template <>
+inline void BooleanEqualsFunction::Run<bool, bool, bool>(bool left, bool right, bool &result) {
+    result = (left == right);
+}
+
+struct PODTypeEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        result.SetValue(left == right);
+    }
+};
+
+struct ColumnValueReaderTypeEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA &left, TB &right, TC &result) {
+        result.SetValue(CheckReaderValueEquality(left, right));
+    }
+};
 
 template <>
 inline void EqualsFunction::Run(MixedT, BigIntT, bool &) {
@@ -92,7 +100,7 @@ inline void EqualsFunction::Run(VarcharT left, MixedT right, bool &result) {
     EqualsFunction::Run(right, left, result);
 }
 
-template <typename CompareType>
+template <typename CompareType, typename EqualsFunction>
 static void GenerateEqualsFunction(SharedPtr<ScalarFunctionSet> &function_set_ptr, DataType data_type) {
     String func_name = "=";
     ScalarFunction equals_function(func_name,
@@ -107,27 +115,27 @@ void RegisterEqualsFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
 
     SharedPtr<ScalarFunctionSet> function_set_ptr = MakeShared<ScalarFunctionSet>(func_name);
 
-    GenerateEqualsFunction<BooleanT>(function_set_ptr, DataType(LogicalType::kBoolean));
-    GenerateEqualsFunction<TinyIntT>(function_set_ptr, DataType(LogicalType::kTinyInt));
-    GenerateEqualsFunction<SmallIntT>(function_set_ptr, DataType(LogicalType::kSmallInt));
-    GenerateEqualsFunction<IntegerT>(function_set_ptr, DataType(LogicalType::kInteger));
-    GenerateEqualsFunction<BigIntT>(function_set_ptr, DataType(LogicalType::kBigInt));
-    GenerateEqualsFunction<HugeIntT>(function_set_ptr, DataType(LogicalType::kHugeInt));
-    GenerateEqualsFunction<FloatT>(function_set_ptr, DataType(LogicalType::kFloat));
-    GenerateEqualsFunction<DoubleT>(function_set_ptr, DataType(LogicalType::kDouble));
+    GenerateEqualsFunction<BooleanT, BooleanEqualsFunction>(function_set_ptr, DataType(LogicalType::kBoolean));
+    GenerateEqualsFunction<TinyIntT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kTinyInt));
+    GenerateEqualsFunction<SmallIntT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kSmallInt));
+    GenerateEqualsFunction<IntegerT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kInteger));
+    GenerateEqualsFunction<BigIntT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kBigInt));
+    GenerateEqualsFunction<HugeIntT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kHugeInt));
+    GenerateEqualsFunction<FloatT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kFloat));
+    GenerateEqualsFunction<DoubleT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kDouble));
 
     //    GenerateEqualsFunction<Decimal16T>(function_set_ptr, DataType(LogicalType::kDecimal16));
     //    GenerateEqualsFunction<Decimal32T>(function_set_ptr, DataType(LogicalType::kDecimal32));
     //    GenerateEqualsFunction<Decimal64T>(function_set_ptr, DataType(LogicalType::kDecimal64));
     //    GenerateEqualsFunction<Decimal128T>(function_set_ptr, DataType(LogicalType::kDecimal128));
 
-    GenerateEqualsFunction<VarcharT>(function_set_ptr, DataType(LogicalType::kVarchar));
+    GenerateEqualsFunction<VarcharT, ColumnValueReaderTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kVarchar));
     //    GenerateEqualsFunction<CharT>(function_set_ptr, DataType(LogicalType::kChar));
 
-    GenerateEqualsFunction<DateT>(function_set_ptr, DataType(LogicalType::kDate));
-    GenerateEqualsFunction<TimeT>(function_set_ptr, DataType(LogicalType::kTime));
-    GenerateEqualsFunction<DateTimeT>(function_set_ptr, DataType(LogicalType::kDateTime));
-    GenerateEqualsFunction<TimestampT>(function_set_ptr, DataType(LogicalType::kTimestamp));
+    GenerateEqualsFunction<DateT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kDate));
+    GenerateEqualsFunction<TimeT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kTime));
+    GenerateEqualsFunction<DateTimeT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kDateTime));
+    GenerateEqualsFunction<TimestampT, PODTypeEqualsFunction>(function_set_ptr, DataType(LogicalType::kTimestamp));
     //    GenerateEqualsFunction<TimestampTZT>(function_set_ptr, DataType(LogicalType::kTimestampTZ));
     //    GenerateEqualsFunction<IntervalT>(function_set_ptr, DataType(LogicalType::kInterval));
 

--- a/src/function/scalar/greater_equals.cpp
+++ b/src/function/scalar/greater_equals.cpp
@@ -14,6 +14,9 @@
 
 module;
 
+#include <compare>
+module greater_equals;
+
 import stl;
 import catalog;
 
@@ -23,38 +26,28 @@ import scalar_function_set;
 import parser;
 import third_party;
 
-module greater_equals;
-
 namespace infinity {
 
 struct GreaterEqualsFunction {
     template <typename TA, typename TB, typename TC>
     static inline void Run(TA left, TB right, TC &result) {
-        result = left >= right;
+        static_assert(false, "Unsupported type");
     }
 };
 
-template <>
-inline void GreaterEqualsFunction::Run(VarcharT, VarcharT, bool &) {
-    Error<NotImplementException>("Not implement: varchar >= varchar");
+struct PODTypeGreaterEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        result.SetValue(left >= right);
+    }
+};
 
-//    if (left.IsInlined()) {
-//        if (right.IsInlined()) {
-//            result = (std::memcmp(left.prefix, right.prefix, VarcharT::INLINE_LENGTH) >= 0);
-//            return;
-//        }
-//    } else if (right.IsInlined()) {
-//        ;
-//    } else {
-//        // Both left and right are not inline
-//        u16 min_len = std::min(right.length, left.length);
-//        if (std::memcmp(left.prefix, right.prefix, VarcharT::PREFIX_LENGTH) >= 0) {
-//            result = (std::memcmp(left.ptr, right.ptr, min_len) >= 0);
-//            return;
-//        }
-//    }
-//    result = false;
-}
+struct ColumnValueReaderTypeGreaterEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA &left, TB &right, TC &result) {
+        result.SetValue(ThreeWayCompareReaderValue(left, right) != std::strong_ordering::less);
+    }
+};
 
 template <>
 inline void GreaterEqualsFunction::Run(MixedT, BigIntT, bool &) {
@@ -86,7 +79,7 @@ inline void GreaterEqualsFunction::Run(VarcharT left, MixedT right, bool &result
     GreaterEqualsFunction::Run(right, left, result);
 }
 
-template <typename CompareType>
+template <typename CompareType, typename GreaterEqualsFunction>
 static void GenerateGreaterEqualsFunction(SharedPtr<ScalarFunctionSet> &function_set_ptr, DataType data_type) {
     String func_name = ">=";
     ScalarFunction greater_equals_function(func_name,
@@ -101,26 +94,26 @@ void RegisterGreaterEqualsFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
 
     SharedPtr<ScalarFunctionSet> function_set_ptr = std::make_shared<ScalarFunctionSet>(func_name);
 
-    GenerateGreaterEqualsFunction<TinyIntT>(function_set_ptr, DataType(LogicalType::kTinyInt));
-    GenerateGreaterEqualsFunction<SmallIntT>(function_set_ptr, DataType(LogicalType::kSmallInt));
-    GenerateGreaterEqualsFunction<IntegerT>(function_set_ptr, DataType(LogicalType::kInteger));
-    GenerateGreaterEqualsFunction<BigIntT>(function_set_ptr, DataType(LogicalType::kBigInt));
-    GenerateGreaterEqualsFunction<HugeIntT>(function_set_ptr, DataType(LogicalType::kHugeInt));
-    GenerateGreaterEqualsFunction<FloatT>(function_set_ptr, DataType(LogicalType::kFloat));
-    GenerateGreaterEqualsFunction<DoubleT>(function_set_ptr, DataType(LogicalType::kDouble));
+    GenerateGreaterEqualsFunction<TinyIntT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kTinyInt));
+    GenerateGreaterEqualsFunction<SmallIntT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kSmallInt));
+    GenerateGreaterEqualsFunction<IntegerT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kInteger));
+    GenerateGreaterEqualsFunction<BigIntT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kBigInt));
+    GenerateGreaterEqualsFunction<HugeIntT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kHugeInt));
+    GenerateGreaterEqualsFunction<FloatT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kFloat));
+    GenerateGreaterEqualsFunction<DoubleT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kDouble));
 
     //    GenerateGreaterEqualsFunction<Decimal16T>(function_set_ptr, DataType(LogicalType::kDecimal16));
     //    GenerateGreaterEqualsFunction<Decimal32T>(function_set_ptr, DataType(LogicalType::kDecimal32));
     //    GenerateGreaterEqualsFunction<Decimal64T>(function_set_ptr, DataType(LogicalType::kDecimal64));
     //    GenerateGreaterEqualsFunction<Decimal128T>(function_set_ptr, DataType(LogicalType::kDecimal128));
 
-    GenerateGreaterEqualsFunction<VarcharT>(function_set_ptr, DataType(LogicalType::kVarchar));
+    GenerateGreaterEqualsFunction<VarcharT, ColumnValueReaderTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kVarchar));
     //    GenerateGreaterEqualsFunction<CharT>(function_set_ptr, DataType(LogicalType::kChar));
 
-    GenerateGreaterEqualsFunction<DateT>(function_set_ptr, DataType(LogicalType::kDate));
-    GenerateGreaterEqualsFunction<TimeT>(function_set_ptr, DataType(LogicalType::kTime));
-    GenerateGreaterEqualsFunction<DateTimeT>(function_set_ptr, DataType(LogicalType::kDateTime));
-    GenerateGreaterEqualsFunction<TimestampT>(function_set_ptr, DataType(LogicalType::kTimestamp));
+    GenerateGreaterEqualsFunction<DateT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kDate));
+    GenerateGreaterEqualsFunction<TimeT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kTime));
+    GenerateGreaterEqualsFunction<DateTimeT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kDateTime));
+    GenerateGreaterEqualsFunction<TimestampT, PODTypeGreaterEqualsFunction>(function_set_ptr, DataType(LogicalType::kTimestamp));
     //    GenerateGreaterEqualsFunction<TimestampTZT>(function_set_ptr, DataType(LogicalType::kTimestampTZ));
 
     //    GenerateGreaterEqualsFunction<MixedT>(function_set_ptr, DataType(LogicalType::kMixed));

--- a/src/function/scalar/inequals.cpp
+++ b/src/function/scalar/inequals.cpp
@@ -14,7 +14,10 @@
 
 module;
 
+#include <compare>
 #include <type_traits>
+
+module inequals;
 
 import stl;
 import catalog;
@@ -25,44 +28,46 @@ import scalar_function_set;
 import parser;
 import third_party;
 
-module inequals;
-
 namespace infinity {
 
 struct InEqualsFunction {
     template <typename TA, typename TB, typename TC>
     static inline void Run(TA left, TB right, TC &result) {
-        if constexpr (std::is_same_v<std::remove_cv_t<TA>, u8> && std::is_same_v<std::remove_cv_t<TB>, u8> &&
-                      std::is_same_v<std::remove_cv_t<TC>, u8>) {
-            result = (left ^ right);
-        } else {
-            result = (left != right);
-        }
+        static_assert(false, "Unsupported type");
+    }
+};
+
+struct BooleanInEqualsFunction {
+    // keep compatible with template Run call
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        static_assert(false, "Unsupported type");
     }
 };
 
 template <>
-inline void InEqualsFunction::Run(VarcharT left, VarcharT right, bool &result) {
-    if (left.length_ != right.length_) {
-        result = true;
-        return;
-    }
-    if (left.IsInlined()) {
-        result = (std::memcmp(left.short_.data_, right.short_.data_, left.length_) != 0);
-        return;
-    } else {
-        // Both left and right are not inline
-        if(left.IsValue() && right.IsValue()) {
-            if (std::memcmp(left.value_.prefix_, right.value_.prefix_, VARCHAR_PREFIX_LEN) != 0) {
-                result = (std::memcmp(left.value_.ptr_, right.value_.ptr_, left.length_) != 0);
-                return;
-            }
-        } else {
-            Error<NotImplementException>("Column vector varchar can't be compared");
-        }
-    }
-    result = true;
+inline void BooleanInEqualsFunction::Run<u8, u8, u8>(u8 left, u8 right, u8 &result) {
+    result = (left ^ right);
 }
+
+template <>
+inline void BooleanInEqualsFunction::Run<bool, bool, bool>(bool left, bool right, bool &result) {
+    result = (left != right);
+}
+
+struct PODTypeInEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        result.SetValue(left != right);
+    }
+};
+
+struct ColumnValueReaderTypeInEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA &left, TB &right, TC &result) {
+        result.SetValue(!CheckReaderValueEquality(left, right));
+    }
+};
 
 template <>
 inline void InEqualsFunction::Run(MixedT, BigIntT, bool &) {
@@ -94,7 +99,7 @@ inline void InEqualsFunction::Run(VarcharT left, MixedT right, bool &result) {
     InEqualsFunction::Run(right, left, result);
 }
 
-template <typename CompareType>
+template <typename CompareType, typename InEqualsFunction>
 static void GenerateInEqualsFunction(SharedPtr<ScalarFunctionSet> &function_set_ptr, DataType data_type) {
     String func_name = "<>";
     ScalarFunction inequals_function(func_name,
@@ -109,27 +114,27 @@ void RegisterInEqualsFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
 
     SharedPtr<ScalarFunctionSet> function_set_ptr = MakeShared<ScalarFunctionSet>(func_name);
 
-    GenerateInEqualsFunction<BooleanT>(function_set_ptr, DataType(LogicalType::kBoolean));
-    GenerateInEqualsFunction<TinyIntT>(function_set_ptr, DataType(LogicalType::kTinyInt));
-    GenerateInEqualsFunction<SmallIntT>(function_set_ptr, DataType(LogicalType::kSmallInt));
-    GenerateInEqualsFunction<IntegerT>(function_set_ptr, DataType(LogicalType::kInteger));
-    GenerateInEqualsFunction<BigIntT>(function_set_ptr, DataType(LogicalType::kBigInt));
-    GenerateInEqualsFunction<HugeIntT>(function_set_ptr, DataType(LogicalType::kHugeInt));
-    GenerateInEqualsFunction<FloatT>(function_set_ptr, DataType(LogicalType::kFloat));
-    GenerateInEqualsFunction<DoubleT>(function_set_ptr, DataType(LogicalType::kDouble));
+    GenerateInEqualsFunction<BooleanT, BooleanInEqualsFunction>(function_set_ptr, DataType(LogicalType::kBoolean));
+    GenerateInEqualsFunction<TinyIntT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kTinyInt));
+    GenerateInEqualsFunction<SmallIntT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kSmallInt));
+    GenerateInEqualsFunction<IntegerT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kInteger));
+    GenerateInEqualsFunction<BigIntT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kBigInt));
+    GenerateInEqualsFunction<HugeIntT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kHugeInt));
+    GenerateInEqualsFunction<FloatT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kFloat));
+    GenerateInEqualsFunction<DoubleT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kDouble));
 
     //    GenerateInEqualsFunction<Decimal16T>(function_set_ptr, DataType(LogicalType::kDecimal16));
     //    GenerateInEqualsFunction<Decimal32T>(function_set_ptr, DataType(LogicalType::kDecimal32));
     //    GenerateInEqualsFunction<Decimal64T>(function_set_ptr, DataType(LogicalType::kDecimal64));
     //    GenerateInEqualsFunction<Decimal128T>(function_set_ptr, DataType(LogicalType::kDecimal128));
 
-    GenerateInEqualsFunction<VarcharT>(function_set_ptr, DataType(LogicalType::kVarchar));
+    GenerateInEqualsFunction<VarcharT, ColumnValueReaderTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kVarchar));
     //    GenerateInEqualsFunction<CharT>(function_set_ptr, DataType(LogicalType::kChar));
 
-    GenerateInEqualsFunction<DateT>(function_set_ptr, DataType(LogicalType::kDate));
-    GenerateInEqualsFunction<TimeT>(function_set_ptr, DataType(LogicalType::kTime));
-    GenerateInEqualsFunction<DateTimeT>(function_set_ptr, DataType(LogicalType::kDateTime));
-    GenerateInEqualsFunction<TimestampT>(function_set_ptr, DataType(LogicalType::kTimestamp));
+    GenerateInEqualsFunction<DateT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kDate));
+    GenerateInEqualsFunction<TimeT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kTime));
+    GenerateInEqualsFunction<DateTimeT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kDateTime));
+    GenerateInEqualsFunction<TimestampT, PODTypeInEqualsFunction>(function_set_ptr, DataType(LogicalType::kTimestamp));
     //    GenerateInEqualsFunction<TimestampTZT>(function_set_ptr, DataType(LogicalType::kTimestampTZ));
     //    GenerateInEqualsFunction<IntervalT>(function_set_ptr, DataType(LogicalType::kInterval));
 

--- a/src/function/scalar/less.cpp
+++ b/src/function/scalar/less.cpp
@@ -14,6 +14,10 @@
 
 module;
 
+#include <compare>
+
+module less;
+
 import stl;
 import catalog;
 
@@ -23,37 +27,28 @@ import scalar_function_set;
 import parser;
 import third_party;
 
-module less;
-
 namespace infinity {
 
 struct LessFunction {
     template <typename TA, typename TB, typename TC>
     static inline void Run(TA left, TB right, TC &result) {
-        result = left < right;
+        static_assert(false, "Unsupported type");
     }
 };
 
-template <>
-inline void LessFunction::Run(VarcharT, VarcharT, bool &) {
-    Error<NotImplementException>("Not implement: varchar < varchar");
-//    if (left.IsInlined()) {
-//        if (right.IsInlined()) {
-//            result = (std::memcmp(left.prefix, right.prefix, VarcharT::INLINE_LENGTH) < 0);
-//            return;
-//        }
-//    } else if (right.IsInlined()) {
-//        ;
-//    } else {
-//        // Both left and right are not inline
-//        u16 min_len = std::min(right.length, left.length);
-//        if (std::memcmp(left.prefix, right.prefix, VarcharT::PREFIX_LENGTH) < 0) {
-//            result = (std::memcmp(left.ptr, right.ptr, min_len) < 0);
-//            return;
-//        }
-//    }
-//    result = false;
-}
+struct PODTypeLessFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        result.SetValue(left < right);
+    }
+};
+
+struct ColumnValueReaderTypeLessFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA &left, TB &right, TC &result) {
+        result.SetValue(ThreeWayCompareReaderValue(left, right) == std::strong_ordering::less);
+    }
+};
 
 template <>
 inline void LessFunction::Run(MixedT, BigIntT, bool &) {
@@ -85,7 +80,7 @@ inline void LessFunction::Run(VarcharT left, MixedT right, bool &result) {
     LessFunction::Run(right, left, result);
 }
 
-template <typename CompareType>
+template <typename CompareType, typename LessFunction>
 static void GenerateLessFunction(SharedPtr<ScalarFunctionSet> &function_set_ptr, DataType data_type) {
     String func_name = "<";
 
@@ -101,26 +96,26 @@ void RegisterLessFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
 
     SharedPtr<ScalarFunctionSet> function_set_ptr = MakeShared<ScalarFunctionSet>(func_name);
 
-    GenerateLessFunction<TinyIntT>(function_set_ptr, DataType(LogicalType::kTinyInt));
-    GenerateLessFunction<SmallIntT>(function_set_ptr, DataType(LogicalType::kSmallInt));
-    GenerateLessFunction<IntegerT>(function_set_ptr, DataType(LogicalType::kInteger));
-    GenerateLessFunction<BigIntT>(function_set_ptr, DataType(LogicalType::kBigInt));
-    GenerateLessFunction<HugeIntT>(function_set_ptr, DataType(LogicalType::kHugeInt));
-    GenerateLessFunction<FloatT>(function_set_ptr, DataType(LogicalType::kFloat));
-    GenerateLessFunction<DoubleT>(function_set_ptr, DataType(LogicalType::kDouble));
+    GenerateLessFunction<TinyIntT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kTinyInt));
+    GenerateLessFunction<SmallIntT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kSmallInt));
+    GenerateLessFunction<IntegerT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kInteger));
+    GenerateLessFunction<BigIntT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kBigInt));
+    GenerateLessFunction<HugeIntT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kHugeInt));
+    GenerateLessFunction<FloatT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kFloat));
+    GenerateLessFunction<DoubleT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kDouble));
 
     //    GenerateLessFunction<Decimal16T>(function_set_ptr, DataType(LogicalType::kDecimal16));
     //    GenerateLessFunction<Decimal32T>(function_set_ptr, DataType(LogicalType::kDecimal32));
     //    GenerateLessFunction<Decimal64T>(function_set_ptr, DataType(LogicalType::kDecimal64));
     //    GenerateLessFunction<Decimal128T>(function_set_ptr, DataType(LogicalType::kDecimal128));
 
-    GenerateLessFunction<VarcharT>(function_set_ptr, DataType(LogicalType::kVarchar));
+    GenerateLessFunction<VarcharT, ColumnValueReaderTypeLessFunction>(function_set_ptr, DataType(LogicalType::kVarchar));
     //    GenerateLessFunction<CharT>(function_set_ptr, DataType(LogicalType::kChar));
 
-    GenerateLessFunction<DateT>(function_set_ptr, DataType(LogicalType::kDate));
-    GenerateLessFunction<TimeT>(function_set_ptr, DataType(LogicalType::kTime));
-    GenerateLessFunction<DateTimeT>(function_set_ptr, DataType(LogicalType::kDateTime));
-    GenerateLessFunction<TimestampT>(function_set_ptr, DataType(LogicalType::kTimestamp));
+    GenerateLessFunction<DateT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kDate));
+    GenerateLessFunction<TimeT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kTime));
+    GenerateLessFunction<DateTimeT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kDateTime));
+    GenerateLessFunction<TimestampT, PODTypeLessFunction>(function_set_ptr, DataType(LogicalType::kTimestamp));
     //    GenerateLessFunction<TimestampTZT>(function_set_ptr, DataType(LogicalType::kTimestampTZ));
 
     //    GenerateEqualsFunction<MixedT>(function_set_ptr, DataType(LogicalType::kMixed));

--- a/src/function/scalar/less_equals.cpp
+++ b/src/function/scalar/less_equals.cpp
@@ -14,6 +14,9 @@
 
 module;
 
+#include <compare>
+module less_equals;
+
 import stl;
 import catalog;
 
@@ -23,37 +26,28 @@ import scalar_function_set;
 import parser;
 import third_party;
 
-module less_equals;
-
 namespace infinity {
 
 struct LessEqualsFunction {
     template <typename TA, typename TB, typename TC>
     static inline void Run(TA left, TB right, TC &result) {
-        result = left <= right;
+        static_assert(false, "Unsupported type");
     }
 };
 
-template <>
-inline void LessEqualsFunction::Run(VarcharT, VarcharT, bool &) {
-    Error<NotImplementException>("Not implement: varchar <= varchar");
-//    if (left.IsInlined()) {
-//        if (right.IsInlined()) {
-//            result = (std::memcmp(left.prefix, right.prefix, VarcharT::INLINE_LENGTH) <= 0);
-//            return;
-//        }
-//    } else if (right.IsInlined()) {
-//        ;
-//    } else {
-//        // Both left and right are not inline
-//        u16 min_len = std::min(right.length, left.length);
-//        if (std::memcmp(left.prefix, right.prefix, VarcharT::PREFIX_LENGTH) <= 0) {
-//            result = (std::memcmp(left.ptr, right.ptr, min_len) <= 0);
-//            return;
-//        }
-//    }
-//    result = false;
-}
+struct PODTypeLessEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA left, TB right, TC &result) {
+        result.SetValue(left <= right);
+    }
+};
+
+struct ColumnValueReaderTypeLessEqualsFunction {
+    template <typename TA, typename TB, typename TC>
+    static inline void Run(TA &left, TB &right, TC &result) {
+        result.SetValue(ThreeWayCompareReaderValue(left, right) != std::strong_ordering::greater);
+    }
+};
 
 template <>
 inline void LessEqualsFunction::Run(MixedT, BigIntT, bool &) {
@@ -85,7 +79,7 @@ inline void LessEqualsFunction::Run(VarcharT left, MixedT right, bool &result) {
     LessEqualsFunction::Run(right, left, result);
 }
 
-template <typename CompareType>
+template <typename CompareType, typename LessEqualsFunction>
 static void GenerateLessEqualsFunction(SharedPtr<ScalarFunctionSet> &function_set_ptr, DataType data_type) {
     String func_name = "<=";
     ScalarFunction less_function(func_name,
@@ -100,26 +94,26 @@ void RegisterLessEqualsFunction(const UniquePtr<NewCatalog> &catalog_ptr) {
 
     SharedPtr<ScalarFunctionSet> function_set_ptr = MakeShared<ScalarFunctionSet>(func_name);
 
-    GenerateLessEqualsFunction<TinyIntT>(function_set_ptr, DataType(LogicalType::kTinyInt));
-    GenerateLessEqualsFunction<SmallIntT>(function_set_ptr, DataType(LogicalType::kSmallInt));
-    GenerateLessEqualsFunction<IntegerT>(function_set_ptr, DataType(LogicalType::kInteger));
-    GenerateLessEqualsFunction<BigIntT>(function_set_ptr, DataType(LogicalType::kBigInt));
-    GenerateLessEqualsFunction<HugeIntT>(function_set_ptr, DataType(LogicalType::kHugeInt));
-    GenerateLessEqualsFunction<FloatT>(function_set_ptr, DataType(LogicalType::kFloat));
-    GenerateLessEqualsFunction<DoubleT>(function_set_ptr, DataType(LogicalType::kDouble));
+    GenerateLessEqualsFunction<TinyIntT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kTinyInt));
+    GenerateLessEqualsFunction<SmallIntT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kSmallInt));
+    GenerateLessEqualsFunction<IntegerT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kInteger));
+    GenerateLessEqualsFunction<BigIntT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kBigInt));
+    GenerateLessEqualsFunction<HugeIntT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kHugeInt));
+    GenerateLessEqualsFunction<FloatT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kFloat));
+    GenerateLessEqualsFunction<DoubleT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kDouble));
 
     //    GenerateLessEqualsFunction<Decimal16T>(function_set_ptr, DataType(LogicalType::kDecimal16));
     //    GenerateLessEqualsFunction<Decimal32T>(function_set_ptr, DataType(LogicalType::kDecimal32));
     //    GenerateLessEqualsFunction<Decimal64T>(function_set_ptr, DataType(LogicalType::kDecimal64));
     //    GenerateLessEqualsFunction<Decimal128T>(function_set_ptr, DataType(LogicalType::kDecimal128));
 
-    GenerateLessEqualsFunction<VarcharT>(function_set_ptr, DataType(LogicalType::kVarchar));
+    GenerateLessEqualsFunction<VarcharT, ColumnValueReaderTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kVarchar));
     //    GenerateLessEqualsFunction<CharT>(function_set_ptr, DataType(LogicalType::kChar));
 
-    GenerateLessEqualsFunction<DateT>(function_set_ptr, DataType(LogicalType::kDate));
-    GenerateLessEqualsFunction<TimeT>(function_set_ptr, DataType(LogicalType::kTime));
-    GenerateLessEqualsFunction<DateTimeT>(function_set_ptr, DataType(LogicalType::kDateTime));
-    GenerateLessEqualsFunction<TimestampT>(function_set_ptr, DataType(LogicalType::kTimestamp));
+    GenerateLessEqualsFunction<DateT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kDate));
+    GenerateLessEqualsFunction<TimeT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kTime));
+    GenerateLessEqualsFunction<DateTimeT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kDateTime));
+    GenerateLessEqualsFunction<TimestampT, PODTypeLessEqualsFunction>(function_set_ptr, DataType(LogicalType::kTimestamp));
     //    GenerateLessEqualsFunction<TimestampTZT>(function_set_ptr, DataType(LogicalType::kTimestampTZ));
 
     //    GenerateEqualsFunction<MixedT>(function_set_ptr, DataType(LogicalType::kMixed));

--- a/src/storage/column_vector/column_vector.cppm
+++ b/src/storage/column_vector/column_vector.cppm
@@ -194,23 +194,6 @@ private:
         }
     }
 
-    template <>
-    static void CopyValue<BooleanT>(const ColumnVector &dst, const ColumnVector &src, SizeT from, SizeT count) {
-        auto dst_tail = dst.tail_index_;
-        const VectorBuffer *src_buffer = src.buffer_.get();
-        auto dst_buffer = dst.buffer_.get();
-        if (dst_tail % 8 == 0 && from % 8 == 0) {
-            SizeT dst_byte_offset = dst_tail / 8;
-            SizeT src_byte_offset = from / 8;
-            SizeT byte_count = (count + 7) / 8; // copy to tail
-            std::memcpy(dst_buffer->GetData() + dst_byte_offset, src_buffer->GetData() + src_byte_offset, byte_count);
-        } else {
-            for (SizeT idx = 0; idx < count; ++idx) {
-                dst_buffer->SetCompactBit(dst_tail + idx, src_buffer->GetCompactBit(from + idx));
-            }
-        }
-    }
-
     // Used by Append by Ptr
     void SetByRawPtr(SizeT index, const_ptr_t raw_ptr);
 
@@ -240,6 +223,23 @@ public:
 
     [[nodiscard]] inline SizeT Size() const { return tail_index_; }
 };
+
+template <>
+void ColumnVector::CopyValue<BooleanT>(const ColumnVector &dst, const ColumnVector &src, SizeT from, SizeT count) {
+    auto dst_tail = dst.tail_index_;
+    const VectorBuffer *src_buffer = src.buffer_.get();
+    auto dst_buffer = dst.buffer_.get();
+    if (dst_tail % 8 == 0 && from % 8 == 0) {
+        SizeT dst_byte_offset = dst_tail / 8;
+        SizeT src_byte_offset = from / 8;
+        SizeT byte_count = (count + 7) / 8; // copy to tail
+        std::memcpy(dst_buffer->GetData() + dst_byte_offset, src_buffer->GetData() + src_byte_offset, byte_count);
+    } else {
+        for (SizeT idx = 0; idx < count; ++idx) {
+            dst_buffer->SetCompactBit(dst_tail + idx, src_buffer->GetCompactBit(from + idx));
+        }
+    }
+}
 
 template <typename DataT>
 inline void
@@ -705,28 +705,45 @@ export template <typename T, typename... U>
 concept IsAnyOf = (std::same_as<T, U> || ...);
 
 export template <typename ValueType>
-concept PointerFriendly = IsAnyOf<ValueType,
-                                  TinyIntT,
-                                  SmallIntT,
-                                  IntegerT,
-                                  BigIntT,
-                                  HugeIntT,
-                                  FloatT,
-                                  DoubleT,
-                                  DecimalT,
-                                  DateT,
-                                  TimeT,
-                                  DateTimeT,
-                                  TimestampT,
-                                  IntervalT,
-                                  RowID,
-                                  UuidT>;
+concept PODValueType = IsAnyOf<ValueType,
+                               TinyIntT,
+                               SmallIntT,
+                               IntegerT,
+                               BigIntT,
+                               HugeIntT,
+                               FloatT,
+                               DoubleT,
+                               DecimalT,
+                               DateT,
+                               TimeT,
+                               DateTimeT,
+                               TimestampT,
+                               IntervalT,
+                               RowID,
+                               UuidT>;
 
 export template <typename ValueType>
-concept BinaryGenerateBoolean = PointerFriendly<ValueType> or IsAnyOf<ValueType, BooleanT, VarcharT>;
+concept BinaryGenerateBoolean = PODValueType<ValueType> or IsAnyOf<ValueType, BooleanT, VarcharT>;
 
 template <typename Unsupported>
-class ColumnVectorPtrAndIdx {};
+class ColumnVectorPtrAndIdx {
+    static_assert(false, "Unsupported type");
+};
+
+// Return Iterator for POD ColumnVector
+// Now only support reading values from ColumnVector
+// used in cases like "where x > y" ( (int > int) -> bool )
+template <PODValueType FlatType>
+class ColumnVectorPtrAndIdx<FlatType> {
+public:
+    explicit ColumnVectorPtrAndIdx(const SharedPtr<ColumnVector> &col) : data_ptr_(reinterpret_cast<const FlatType *>(col->data())) {}
+    // Don't return reference
+    // keep compatibility with "Run(TA left, TB right, TC &result)"
+    FlatType operator[](u32 index) { return data_ptr_[index]; }
+
+private:
+    const FlatType *data_ptr_ = nullptr;
+};
 
 // Return Iterator for BooleanT ColumnVector
 // Now support writing BooleanT results to ColumnVector and comparing BooleanT values
@@ -737,39 +754,23 @@ class ColumnVectorPtrAndIdx<BooleanT> {
 
 public:
     explicit ColumnVectorPtrAndIdx(const SharedPtr<ColumnVector> &col) : buffer_(col->buffer_.get()) {}
-    auto &operator[](SizeT index) {
-        index_ = index;
+    auto &SetIndex(u32 index) {
+        idx_ = index;
         return *this;
     }
-    auto &operator=(bool value) {
-        buffer_->SetCompactBit(index_, value);
-        return *this;
-    }
-    friend std::strong_ordering operator<=>(const IteratorType &left, const IteratorType &right) {
-        return left.buffer_->GetCompactBit(left.index_) <=> right.buffer_->GetCompactBit(right.index_);
-    }
-    friend bool operator==(const IteratorType &left, const IteratorType &right) {
-        return left.buffer_->GetCompactBit(left.index_) == right.buffer_->GetCompactBit(right.index_);
+    auto &operator[](u32 index) { return SetIndex(index); }
+    void SetValue(bool value) { buffer_->SetCompactBit(idx_, value); }
+    inline bool GetValue() const { return buffer_->GetCompactBit(idx_); }
+    // Does not check type.
+    friend std::strong_ordering ThreeWayCompareReaderValue(const IteratorType &left, const IteratorType &right) {
+        bool left_value = left.GetValue();
+        bool right_value = right.GetValue();
+        return left_value <=> right_value;
     }
 
 private:
     VectorBuffer *buffer_ = nullptr;
-    SizeT index_ = {};
-};
-
-// Return Iterator for PointerFriendly ColumnVector
-// Now only support reading values from ColumnVector
-// used in cases like "where x > y" ( (int > int) -> bool )
-template <PointerFriendly FlatType>
-class ColumnVectorPtrAndIdx<FlatType> {
-public:
-    explicit ColumnVectorPtrAndIdx(const SharedPtr<ColumnVector> &col) : data_ptr_(reinterpret_cast<const FlatType *>(col->data())) {}
-    // Don't return reference
-    // keep compatibility with "Run(TA left, TB right, TC &result)"
-    auto &operator[](SizeT i) { return data_ptr_[i]; }
-
-private:
-    const FlatType *data_ptr_ = nullptr;
+    u32 idx_ = {};
 };
 
 // Return Iterator for VarcharT ColumnVector
@@ -782,21 +783,22 @@ class ColumnVectorPtrAndIdx<VarcharT> {
 public:
     explicit ColumnVectorPtrAndIdx(const SharedPtr<ColumnVector> &col)
         : data_ptr_(reinterpret_cast<const VarcharT *>(col->data())), fix_heap_mgr_(col->buffer_->fix_heap_mgr_.get()) {}
-    auto &operator[](SizeT i) {
-        idx_ = i;
+    auto &SetIndex(u32 index) {
+        idx_ = index;
         return *this;
     }
+    auto &operator[](u32 index) { return SetIndex(index); }
     // Does not check type.
-    friend std::strong_ordering operator<=>(const IteratorType &left, const IteratorType &right) {
+    friend std::strong_ordering ThreeWayCompareReaderValue(const IteratorType &left, const IteratorType &right) {
         const VarcharT &left_value = left.data_ptr_[left.idx_];
         const VarcharT &right_value = right.data_ptr_[right.idx_];
         auto left_length = static_cast<u32>(left_value.length_);
         auto right_length = static_cast<u32>(right_value.length_);
-        auto left_char_accessor = left.fix_heap_mgr_->GetNextCharAccessor(left_value);
-        auto right_char_accessor = right.fix_heap_mgr_->GetNextCharAccessor(right_value);
-        return compare_char_array(left_char_accessor, left_length, right_char_accessor, right_length);
+        auto left_char_iterator = left.fix_heap_mgr_->GetNextCharIterator(left_value);
+        auto right_char_iterator = right.fix_heap_mgr_->GetNextCharIterator(right_value);
+        return CompareCharArray(left_char_iterator, left_length, right_char_iterator, right_length);
     }
-    friend bool operator==(const IteratorType &left, const IteratorType &right) {
+    friend bool CheckReaderValueEquality(const IteratorType &left, const IteratorType &right) {
         const VarcharT &left_value = left.data_ptr_[left.idx_];
         const VarcharT &right_value = right.data_ptr_[right.idx_];
         auto left_length = static_cast<u32>(left_value.length_);
@@ -804,10 +806,10 @@ public:
         if (left_length != right_length) {
             return false;
         }
-        auto left_char_accessor = left.fix_heap_mgr_->GetNextCharAccessor(left_value);
-        auto right_char_accessor = right.fix_heap_mgr_->GetNextCharAccessor(right_value);
+        auto left_char_iterator = left.fix_heap_mgr_->GetNextCharIterator(left_value);
+        auto right_char_iterator = right.fix_heap_mgr_->GetNextCharIterator(right_value);
         for (u32 i = 0; i < left_length; ++i) {
-            if (left_char_accessor() != right_char_accessor()) {
+            if (left_char_iterator.GetNextChar() != right_char_iterator.GetNextChar()) {
                 return false;
             }
         }
@@ -817,11 +819,11 @@ public:
 private:
     const VarcharT *data_ptr_ = nullptr;
     FixHeapManager *fix_heap_mgr_ = nullptr;
-    SizeT idx_ = {};
-    static std::strong_ordering compare_char_array(auto &left_char_accessor, SizeT left_len, auto &right_char_accessor, SizeT right_len) {
-        for (SizeT i = 0, com_len = std::min(left_len, right_len); i < com_len; ++i) {
-            char left_char = left_char_accessor();
-            char right_char = right_char_accessor();
+    u32 idx_ = {};
+    static std::strong_ordering CompareCharArray(auto &left_char_iterator, u32 left_len, auto &right_char_iterator, u32 right_len) {
+        for (u32 i = 0, com_len = std::min(left_len, right_len); i < com_len; ++i) {
+            char left_char = left_char_iterator.GetNextChar();
+            char right_char = right_char_iterator.GetNextChar();
             if (left_char < right_char) {
                 return std::strong_ordering::less;
             } else if (left_char > right_char) {

--- a/src/storage/column_vector/fix_heap.cppm
+++ b/src/storage/column_vector/fix_heap.cppm
@@ -18,10 +18,13 @@ import global_resource_usage;
 import stl;
 import vector_heap_chunk;
 import default_values;
+import parser;
 
 export module fix_heap;
 
 namespace infinity {
+
+class VarcharNextCharAccessor;
 
 export struct FixHeapManager {
     // Use to store string.
@@ -59,6 +62,12 @@ public:
 
     [[nodiscard]] inline u64 total_mem() const { return current_chunk_size_ * (current_chunk_idx_ + 1); }
 
+public:
+    // Used when comparing two VarcharT variables.
+    // Only get next char, without copying it to buffer.
+    friend VarcharNextCharAccessor;
+    [[nodiscard]] VarcharNextCharAccessor GetNextCharAccessor(const VarcharT &varchar) const;
+
 private:
     // Allocate new chunk if current chunk is not enough.
     // return value: start chunk id and start offset of the chunk id
@@ -70,5 +79,37 @@ private:
     u64 current_chunk_idx_{0};
     u64 current_chunk_offset_{0};
 };
+
+class VarcharNextCharAccessor {
+public:
+    explicit VarcharNextCharAccessor(const FixHeapManager *heap_mgr, const VarcharT &varchar) {
+        if (varchar.IsInlined()) {
+            data_ptr_ = varchar.short_.data_;
+            remain_size_ = varchar.length_;
+        } else {
+            heap_mgr_ = heap_mgr;
+            chunk_id_ = varchar.vector_.chunk_id_;
+            data_ptr_ = heap_mgr_->chunks_[chunk_id_]->ptr_ + varchar.vector_.chunk_offset_;
+            remain_size_ = heap_mgr_->current_chunk_size() - varchar.vector_.chunk_offset_;
+        }
+    }
+
+    [[nodiscard]] inline char operator()() {
+        if (remain_size_ == 0) {
+            data_ptr_ = heap_mgr_->chunks_[++chunk_id_]->ptr_;
+            remain_size_ = heap_mgr_->current_chunk_size();
+        }
+        --remain_size_;
+        return *(data_ptr_++);
+    }
+
+private:
+    const char *data_ptr_{nullptr};
+    u64 remain_size_{0};
+    const FixHeapManager *heap_mgr_{nullptr};
+    u64 chunk_id_{0};
+};
+
+VarcharNextCharAccessor FixHeapManager::GetNextCharAccessor(const VarcharT &varchar) const { return VarcharNextCharAccessor(this, varchar); }
 
 } // namespace infinity

--- a/src/storage/column_vector/operator/binary_operator.cppm
+++ b/src/storage/column_vector/operator/binary_operator.cppm
@@ -14,7 +14,11 @@
 
 module;
 
+#include <concepts>
 #include <type_traits>
+
+export module binary_operator;
+
 import stl;
 import column_vector;
 import vector_buffer;
@@ -22,51 +26,534 @@ import parser;
 import infinity_exception;
 import bitmask;
 import bitmask_buffer;
-
-export module binary_operator;
+import third_party;
 
 namespace infinity {
 
-class BooleanPointer {
-    VectorBuffer *buffer_ = nullptr;
-    SizeT index_ = {};
-
+template <typename LeftType, typename RightType, typename Operator>
+    requires std::same_as<LeftType, RightType> // if they are not same, we need to implement a new function
+class BooleanResultBinaryOperator {
 public:
-    explicit BooleanPointer(VectorBuffer *buffer) : buffer_(buffer) {}
-
-    BooleanPointer &operator[](SizeT index) {
-        index_ = index;
-        return *this;
-    }
-
-    BooleanPointer &operator=(const BooleanT &value) {
-        buffer_->SetCompactBit(index_, value);
-        return *this;
-    }
-};
-
-export class BinaryOperator {
-public:
-    template <typename LeftType, typename RightType, typename ResultType, typename Operator>
     static void inline Execute(const SharedPtr<ColumnVector> &left,
                                const SharedPtr<ColumnVector> &right,
                                SharedPtr<ColumnVector> &result,
                                SizeT count,
                                void *state_ptr,
                                bool nullable) {
-        if constexpr (std::is_same_v<std::remove_cv_t<ResultType>, BooleanT>) {
-            if constexpr (std::is_same_v<std::remove_cv_t<LeftType>, BooleanT> ^ std::is_same_v<std::remove_cv_t<RightType>, BooleanT>) {
-                Error<TypeException>("Type mismatch: BinaryOperator applied to boolean and non-boolean type.");
-            } else if constexpr (std::is_same_v<std::remove_cv_t<LeftType>, BooleanT> && std::is_same_v<std::remove_cv_t<RightType>, BooleanT>) {
-                // (boolean (and / or) boolean) -> boolean
-                ExecuteBooleanSourceBinary<Operator>(left, right, result, count, state_ptr, nullable);
+        auto left_vector_type = left->vector_type();
+        auto right_vector_type = right->vector_type();
+        auto check_vector_type_valid = [](ColumnVectorType vector_type) {
+            // only support kFlat and kConstant
+            return vector_type == ColumnVectorType::kFlat || vector_type == ColumnVectorType::kConstant;
+        };
+        if (!check_vector_type_valid(left_vector_type) || !check_vector_type_valid(right_vector_type)) {
+            Error<TypeException>("Invalid input ColumnVectorType. Support only kFlat and kConstant.");
+        }
+        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
+        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+        if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kConstant) {
+            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                bool answer;
+                Operator::template Execute(ColumnValueReader<LeftType>(left)[0],
+                                           ColumnValueReader<RightType>(right)[0],
+                                           answer,
+                                           result_null.get(),
+                                           0,
+                                           state_ptr);
+                result->buffer_->SetCompactBit(0, answer);
+                result_null->SetAllTrue();
             } else {
-                // (x (> / >= / < / <= / == / !=) y) -> boolean
-                ExecuteBooleanResultBinary<LeftType, RightType, Operator>(left, right, result, count, state_ptr, nullable);
+                result_null->SetAllFalse();
             }
-            return;
+            result->Finalize(1);
+        } else if (left_vector_type == ColumnVectorType::kFlat && right_vector_type == ColumnVectorType::kFlat) {
+            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                result_null->SetAllTrue();
+                auto left_ptr = ColumnValueReader<LeftType>(left);
+                auto right_ptr = ColumnValueReader<RightType>(right);
+                BooleanColumnWriter result_ptr(result);
+                for (SizeT i = 0; i < count; ++i) {
+                    bool answer;
+                    Operator::template Execute(left_ptr[i], right_ptr[i], answer, result_null.get(), 0, state_ptr);
+                    result_ptr[i] = answer;
+                }
+            } else {
+                ResultBooleanExecuteWithNull(left, right, result, count, state_ptr);
+            }
+            result->Finalize(count);
+        } else if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kFlat) {
+            auto left_c = ColumnValueReader<LeftType>(left)[0];
+            if (nullable && !(left_null->IsAllTrue())) {
+                result_null->SetAllFalse();
+            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                result_null->SetAllTrue();
+                auto right_ptr = ColumnValueReader<RightType>(right);
+                BooleanColumnWriter result_ptr(result);
+                for (SizeT i = 0; i < count; ++i) {
+                    bool answer;
+                    Operator::template Execute(left_c, right_ptr[i], answer, result_null.get(), 0, state_ptr);
+                    result_ptr[i] = answer;
+                }
+            } else {
+                ResultBooleanExecuteWithNull(left_c, right, result, count, state_ptr);
+            }
+            result->Finalize(count);
+        } else if (left_vector_type == ColumnVectorType::kFlat && right_vector_type == ColumnVectorType::kConstant) {
+            auto right_c = ColumnValueReader<RightType>(right)[0];
+            if (nullable && !(right_null->IsAllTrue())) {
+                result_null->SetAllFalse();
+            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                result_null->SetAllTrue();
+                auto left_ptr = ColumnValueReader<LeftType>(left);
+                BooleanColumnWriter result_ptr(result);
+                for (SizeT i = 0; i < count; ++i) {
+                    bool answer;
+                    Operator::template Execute(left_ptr[i], right_c, answer, result_null.get(), 0, state_ptr);
+                    result_ptr[i] = answer;
+                }
+            } else {
+                ResultBooleanExecuteWithNull(left, right_c, result, count, state_ptr);
+            }
+            result->Finalize(count);
+        }
+    }
+
+private:
+    static inline void ResultBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
+                                                    const SharedPtr<ColumnVector> &right,
+                                                    SharedPtr<ColumnVector> &result,
+                                                    SizeT count,
+                                                    void *state_ptr) {
+        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
+        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+
+        if (left_null->IsAllTrue()) {
+            result_null->DeepCopy(*right_null);
+        } else {
+            result_null->DeepCopy(*left_null);
+            if (!(right_null->IsAllTrue())) {
+                result_null->Merge(*right_null);
+            }
         }
 
+        const u64 *result_null_data = result_null->GetData();
+        SizeT unit_count = BitmaskBuffer::UnitCount(count);
+        auto left_ptr = ColumnValueReader<LeftType>(left);
+        auto right_ptr = ColumnValueReader<RightType>(right);
+        BooleanColumnWriter result_ptr(result);
+        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
+        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
+            end_index = std::min(end_index, count);
+            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
+                // all data of 64 rows are not null
+                for (SizeT b = start_index; b < end_index; ++b) {
+                    bool answer;
+                    Operator::template Execute(left_ptr[b], right_ptr[b], answer, result_null.get(), 0, state_ptr);
+                    result_ptr[b] = answer;
+                }
+                start_index = end_index;
+            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
+                // all data of 64 rows are null
+                start_index = end_index;
+            } else {
+                for (bool answer; start_index < end_index; ++start_index) {
+                    if (result_null->IsTrue(start_index)) {
+                        // This row isn't null
+                        Operator::template Execute(left_ptr[start_index], right_ptr[start_index], answer, result_null.get(), start_index, state_ptr);
+                        result_ptr[start_index] = answer;
+                    }
+                }
+            }
+        }
+    }
+
+    static inline void ResultBooleanExecuteWithNull(auto left_constant,
+                                                    const SharedPtr<ColumnVector> &right,
+                                                    SharedPtr<ColumnVector> &result,
+                                                    SizeT count,
+                                                    void *state_ptr) {
+        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+
+        result_null->DeepCopy(*right_null);
+
+        const u64 *result_null_data = result_null->GetData();
+        SizeT unit_count = BitmaskBuffer::UnitCount(count);
+        auto right_ptr = ColumnValueReader<RightType>(right);
+        BooleanColumnWriter result_ptr(result);
+        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
+        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
+            end_index = std::min(end_index, count);
+            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
+                // all data of 64 rows are not null
+                for (SizeT b = start_index; b < end_index; ++b) {
+                    bool answer;
+                    Operator::template Execute(left_constant, right_ptr[b], answer, result_null.get(), 0, state_ptr);
+                    result_ptr[b] = answer;
+                }
+                start_index = end_index;
+            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
+                // all data of 64 rows are null
+                start_index = end_index;
+            } else {
+                for (bool answer; start_index < end_index; ++start_index) {
+                    if (result_null->IsTrue(start_index)) {
+                        // This row isn't null
+                        Operator::template Execute(left_constant, right_ptr[start_index], answer, result_null.get(), start_index, state_ptr);
+                        result_ptr[start_index] = answer;
+                    }
+                }
+            }
+        }
+    }
+
+    static inline void ResultBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
+                                                    auto right_constant,
+                                                    SharedPtr<ColumnVector> &result,
+                                                    SizeT count,
+                                                    void *state_ptr) {
+        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+
+        result_null->DeepCopy(*left_null);
+
+        const u64 *result_null_data = result_null->GetData();
+        SizeT unit_count = BitmaskBuffer::UnitCount(count);
+        auto left_ptr = ColumnValueReader<LeftType>(left);
+        BooleanColumnWriter result_ptr(result);
+        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
+        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
+            end_index = std::min(end_index, count);
+            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
+                // all data of 64 rows are not null
+                for (SizeT b = start_index; b < end_index; ++b) {
+                    bool answer;
+                    Operator::template Execute(left_ptr[b], right_constant, answer, result_null.get(), 0, state_ptr);
+                    result_ptr[b] = answer;
+                }
+                start_index = end_index;
+            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
+                // all data of 64 rows are null
+                start_index = end_index;
+            } else {
+                for (bool answer; start_index < end_index; ++start_index) {
+                    if (result_null->IsTrue(start_index)) {
+                        // This row isn't null
+                        Operator::template Execute(left_ptr[start_index], right_constant, answer, result_null.get(), start_index, state_ptr);
+                        result_ptr[start_index] = answer;
+                    }
+                }
+            }
+        }
+    }
+};
+
+template <typename Operator>
+class BooleanResultBinaryOperator<BooleanT, BooleanT, Operator> {
+public:
+    static void inline Execute(const SharedPtr<ColumnVector> &left,
+                               const SharedPtr<ColumnVector> &right,
+                               SharedPtr<ColumnVector> &result,
+                               SizeT count,
+                               void *state_ptr,
+                               bool nullable) {
+        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
+        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+        // check constants
+        auto left_vector_type = left->vector_type();
+        auto right_vector_type = right->vector_type();
+        // now only support ColumnVectorType::kConstant and ColumnVectorType::kCompactBit for Boolean
+        if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kConstant) {
+            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                bool answer;
+                Operator::template Execute(left->buffer_->GetCompactBit(0),
+                                           right->buffer_->GetCompactBit(0),
+                                           answer,
+                                           result_null.get(),
+                                           0,
+                                           state_ptr);
+                result->buffer_->SetCompactBit(0, answer);
+                result_null->SetAllTrue();
+            } else {
+                result_null->SetAllFalse();
+            }
+            result->Finalize(1);
+        } else if (left_vector_type == ColumnVectorType::kCompactBit && right_vector_type == ColumnVectorType::kCompactBit) {
+            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                result_null->SetAllTrue();
+                SizeT count_bytes = count / 8;
+                SizeT count_tail = count % 8;
+                auto left_u8 = reinterpret_cast<const u8 *>(left->data());
+                auto right_u8 = reinterpret_cast<const u8 *>(right->data());
+                auto result_u8 = reinterpret_cast<u8 *>(result->data());
+                for (SizeT i = 0; i < count_bytes; ++i) {
+                    Operator::template Execute(left_u8[i], right_u8[i], result_u8[i], result_null.get(), 0, state_ptr);
+                }
+                if (count_tail > 0) {
+                    u8 &tail_u8 = result_u8[count_bytes];
+                    u8 ans;
+                    Operator::template Execute(left_u8[count_bytes], right_u8[count_bytes], ans, result_null.get(), 0, state_ptr);
+                    u8 keep_mask = u8(0xff) << count_tail;
+                    tail_u8 = (tail_u8 & keep_mask) | (ans & ~keep_mask);
+                }
+            } else {
+                AllBooleanExecuteWithNull(left, right, result, count, state_ptr);
+            }
+            result->Finalize(count);
+        } else if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kCompactBit) {
+            bool left_value = left->buffer_->GetCompactBit(0);
+            u8 left_u8 = left_value ? u8(0xff) : u8(0x00);
+            if (nullable && !(left_null->IsAllTrue())) {
+                result_null->SetAllFalse();
+            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                result_null->SetAllTrue();
+                SizeT count_bytes = count / 8;
+                SizeT count_tail = count % 8;
+                auto right_u8 = reinterpret_cast<const u8 *>(right->data());
+                auto result_u8 = reinterpret_cast<u8 *>(result->data());
+                for (SizeT i = 0; i < count_bytes; ++i) {
+                    Operator::template Execute(left_u8, right_u8[i], result_u8[i], result_null.get(), 0, state_ptr);
+                }
+                if (count_tail > 0) {
+                    u8 &tail_u8 = result_u8[count_bytes];
+                    u8 ans;
+                    Operator::template Execute(left_u8, right_u8[count_bytes], ans, result_null.get(), 0, state_ptr);
+                    u8 keep_mask = u8(0xff) << count_tail;
+                    tail_u8 = (tail_u8 & keep_mask) | (ans & ~keep_mask);
+                }
+            } else {
+                AllBooleanExecuteWithNull(left_u8, right, result, count, state_ptr);
+            }
+            result->Finalize(count);
+        } else if (left_vector_type == ColumnVectorType::kCompactBit && right_vector_type == ColumnVectorType::kConstant) {
+            bool right_value = right->buffer_->GetCompactBit(0);
+            u8 right_u8 = right_value ? u8(0xff) : u8(0x00);
+            if (nullable && !(right_null->IsAllTrue())) {
+                result_null->SetAllFalse();
+            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
+                result_null->SetAllTrue();
+                SizeT count_bytes = count / 8;
+                SizeT count_tail = count % 8;
+                auto left_u8 = reinterpret_cast<const u8 *>(left->data());
+                auto result_u8 = reinterpret_cast<u8 *>(result->data());
+                for (SizeT i = 0; i < count_bytes; ++i) {
+                    Operator::template Execute(left_u8[i], right_u8, result_u8[i], result_null.get(), 0, state_ptr);
+                }
+                if (count_tail > 0) {
+                    u8 &tail_u8 = result_u8[count_bytes];
+                    u8 ans;
+                    Operator::template Execute(left_u8[count_bytes], right_u8, ans, result_null.get(), 0, state_ptr);
+                    u8 keep_mask = u8(0xff) << count_tail;
+                    tail_u8 = (tail_u8 & keep_mask) | (ans & ~keep_mask);
+                }
+            } else {
+                AllBooleanExecuteWithNull(left, right_u8, result, count, state_ptr);
+            }
+            result->Finalize(count);
+        } else {
+            Error<TypeException>("Wrong boolean operation.");
+        }
+    }
+
+private:
+    static void inline AllBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
+                                                 const SharedPtr<ColumnVector> &right,
+                                                 SharedPtr<ColumnVector> &result,
+                                                 SizeT count,
+                                                 void *state_ptr) {
+        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
+        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+
+        if (left_null->IsAllTrue()) {
+            result_null->DeepCopy(*right_null);
+        } else {
+            result_null->DeepCopy(*left_null);
+            if (!(right_null->IsAllTrue())) {
+                result_null->Merge(*right_null);
+            }
+        }
+
+        const u64 *result_null_data = result_null->GetData();
+        SizeT unit_count = BitmaskBuffer::UnitCount(count);
+        auto left_u8 = reinterpret_cast<const u8 *>(left->data());
+        auto right_u8 = reinterpret_cast<const u8 *>(right->data());
+        auto result_u8 = reinterpret_cast<u8 *>(result->data());
+        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
+        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
+            end_index = std::min(end_index, count);
+            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
+                // all data of 64 rows are not null
+                const SizeT e = end_index / 8, tail = end_index % 8;
+                for (SizeT b = start_index / 8; b < e; ++b) {
+                    Operator::template Execute(left_u8[b], right_u8[b], result_u8[b], result_null.get(), 0, state_ptr);
+                }
+                if (tail) {
+                    u8 tail_result;
+                    Operator::template Execute(left_u8[e], right_u8[e], tail_result, result_null.get(), 0, state_ptr);
+                    const u8 mask_keep = u8(0xff) << tail;
+                    result_u8[e] = (result_u8[e] & mask_keep) | (tail_result & ~mask_keep);
+                }
+                start_index = end_index;
+            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
+                // all data of 64 rows are null
+                start_index = end_index;
+            } else {
+                for (BooleanT answer; start_index < end_index; ++start_index) {
+                    if (result_null->IsTrue(start_index)) {
+                        // This row isn't null
+                        Operator::template Execute(left->buffer_->GetCompactBit(start_index),
+                                                   right->buffer_->GetCompactBit(start_index),
+                                                   answer,
+                                                   result_null.get(),
+                                                   start_index,
+                                                   state_ptr);
+                        result->buffer_->SetCompactBit(start_index, answer);
+                    }
+                }
+            }
+        }
+    }
+
+    static void inline AllBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
+                                                 const u8 right_u8,
+                                                 SharedPtr<ColumnVector> &result,
+                                                 SizeT count,
+                                                 void *state_ptr) {
+        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+
+        result_null->DeepCopy(*left_null);
+
+        const u64 *result_null_data = result_null->GetData();
+        SizeT unit_count = BitmaskBuffer::UnitCount(count);
+        auto left_u8 = reinterpret_cast<const u8 *>(left->data());
+        BooleanT right_boolean = (right_u8 & (u8(1)));
+        auto result_u8 = reinterpret_cast<u8 *>(result->data());
+        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
+        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
+            end_index = std::min(end_index, count);
+            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
+                // all data of 64 rows are not null
+                const SizeT e = end_index / 8, tail = end_index % 8;
+                for (SizeT b = start_index / 8; b < e; ++b) {
+                    Operator::template Execute(left_u8[b], right_u8, result_u8[b], result_null.get(), 0, state_ptr);
+                }
+                if (tail) {
+                    u8 tail_result;
+                    Operator::template Execute(left_u8[e], right_u8, tail_result, result_null.get(), 0, state_ptr);
+                    const u8 mask_keep = u8(0xff) << tail;
+                    result_u8[e] = (result_u8[e] & mask_keep) | (tail_result & ~mask_keep);
+                }
+                start_index = end_index;
+            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
+                // all data of 64 rows are null
+                start_index = end_index;
+            } else {
+                for (BooleanT answer; start_index < end_index; ++start_index) {
+                    if (result_null->IsTrue(start_index)) {
+                        // This row isn't null
+                        Operator::template Execute(left->buffer_->GetCompactBit(start_index),
+                                                   right_boolean,
+                                                   answer,
+                                                   result_null.get(),
+                                                   start_index,
+                                                   state_ptr);
+                        result->buffer_->SetCompactBit(start_index, answer);
+                    }
+                }
+            }
+        }
+    }
+
+    static void inline AllBooleanExecuteWithNull(const u8 left_u8,
+                                                 const SharedPtr<ColumnVector> &right,
+                                                 SharedPtr<ColumnVector> &result,
+                                                 SizeT count,
+                                                 void *state_ptr) {
+        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
+        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
+
+        result_null->DeepCopy(*right_null);
+
+        const u64 *result_null_data = result_null->GetData();
+        SizeT unit_count = BitmaskBuffer::UnitCount(count);
+        auto right_u8 = reinterpret_cast<const u8 *>(right->data());
+        BooleanT left_boolean = (left_u8 & (u8(1)));
+        auto result_u8 = reinterpret_cast<u8 *>(result->data());
+        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
+        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
+            end_index = std::min(end_index, count);
+            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
+                // all data of 64 rows are not null
+                const SizeT e = end_index / 8, tail = end_index % 8;
+                for (SizeT b = start_index / 8; b < e; ++b) {
+                    Operator::template Execute(left_u8, right_u8[b], result_u8[b], result_null.get(), 0, state_ptr);
+                }
+                if (tail) {
+                    u8 tail_result;
+                    Operator::template Execute(left_u8, right_u8[e], tail_result, result_null.get(), 0, state_ptr);
+                    const u8 mask_keep = u8(0xff) << tail;
+                    result_u8[e] = (result_u8[e] & mask_keep) | (tail_result & ~mask_keep);
+                }
+                start_index = end_index;
+            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
+                // all data of 64 rows are null
+                start_index = end_index;
+            } else {
+                for (BooleanT answer; start_index < end_index; ++start_index) {
+                    if (result_null->IsTrue(start_index)) {
+                        // This row isn't null
+                        Operator::template Execute(left_boolean,
+                                                   right->buffer_->GetCompactBit(start_index),
+                                                   answer,
+                                                   result_null.get(),
+                                                   start_index,
+                                                   state_ptr);
+                        result->buffer_->SetCompactBit(start_index, answer);
+                    }
+                }
+            }
+        }
+    }
+};
+
+export class BinaryOperator {
+public:
+    // TODO: MixedType is not handled now.
+    template <typename LeftType, typename RightType, typename ResultType, typename Operator>
+        requires IsAnyOf<MixedT, LeftType, RightType, ResultType>
+    static void inline Execute(const SharedPtr<ColumnVector> &left,
+                               const SharedPtr<ColumnVector> &right,
+                               SharedPtr<ColumnVector> &result,
+                               SizeT count,
+                               void *state_ptr,
+                               bool nullable) {
+        Error<TypeException>("MixedType needs to be specialized.");
+    }
+
+    // case for BinaryOperator which returns BooleanT result
+    template <BinaryGenerateBoolean LeftType, BinaryGenerateBoolean RightType, std::same_as<BooleanT> ResultType, typename Operator>
+    static void inline Execute(const SharedPtr<ColumnVector> &left,
+                               const SharedPtr<ColumnVector> &right,
+                               SharedPtr<ColumnVector> &result,
+                               SizeT count,
+                               void *state_ptr,
+                               bool nullable) {
+        return BooleanResultBinaryOperator<LeftType, RightType, Operator>::Execute(left, right, result, count, state_ptr, nullable);
+    }
+
+    // case for type which can be accessed by type_ptr[i]
+    template <PointerFriendly LeftType, PointerFriendly RightType, PointerFriendly ResultType, typename Operator>
+    static void inline Execute(const SharedPtr<ColumnVector> &left,
+                               const SharedPtr<ColumnVector> &right,
+                               SharedPtr<ColumnVector> &result,
+                               SizeT count,
+                               void *state_ptr,
+                               bool nullable) {
         switch (left->vector_type()) {
             case ColumnVectorType::kInvalid: {
                 Error<TypeException>("Invalid column vector type.");
@@ -591,497 +1078,6 @@ private:
                                                          void *,
                                                          bool) {
         Error<TypeException>("Not implemented.");
-    }
-
-    // function with Boolean type
-    template <typename Operator>
-    static void inline AllBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
-                                                 const SharedPtr<ColumnVector> &right,
-                                                 SharedPtr<ColumnVector> &result,
-                                                 SizeT count,
-                                                 void *state_ptr) {
-        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
-        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-
-        if (left_null->IsAllTrue()) {
-            result_null->DeepCopy(*right_null);
-        } else {
-            result_null->DeepCopy(*left_null);
-            if (!(right_null->IsAllTrue())) {
-                result_null->Merge(*right_null);
-            }
-        }
-
-        const u64 *result_null_data = result_null->GetData();
-        SizeT unit_count = BitmaskBuffer::UnitCount(count);
-        auto left_u8 = reinterpret_cast<const u8 *>(left->data());
-        auto right_u8 = reinterpret_cast<const u8 *>(right->data());
-        auto result_u8 = reinterpret_cast<u8 *>(result->data());
-        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
-        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
-            end_index = std::min(end_index, count);
-            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
-                // all data of 64 rows are not null
-                const SizeT e = end_index / 8, tail = end_index % 8;
-                for (SizeT b = start_index / 8; b < e; ++b) {
-                    Operator::template Execute(left_u8[b], right_u8[b], result_u8[b], result_null.get(), 0, state_ptr);
-                }
-                if (tail) {
-                    u8 tail_result;
-                    Operator::template Execute(left_u8[e], right_u8[e], tail_result, result_null.get(), 0, state_ptr);
-                    const u8 mask_keep = u8(0xff) << tail;
-                    result_u8[e] = (result_u8[e] & mask_keep) | (tail_result & ~mask_keep);
-                }
-                start_index = end_index;
-            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
-                // all data of 64 rows are null
-                start_index = end_index;
-            } else {
-                for (BooleanT answer; start_index < end_index; ++start_index) {
-                    if (result_null->IsTrue(start_index)) {
-                        // This row isn't null
-                        Operator::template Execute(left->buffer_->GetCompactBit(start_index),
-                                                   right->buffer_->GetCompactBit(start_index),
-                                                   answer,
-                                                   result_null.get(),
-                                                   start_index,
-                                                   state_ptr);
-                        result->buffer_->SetCompactBit(start_index, answer);
-                    }
-                }
-            }
-        }
-    }
-
-    template <typename Operator>
-    static void inline AllBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
-                                                 const u8 right_u8,
-                                                 SharedPtr<ColumnVector> &result,
-                                                 SizeT count,
-                                                 void *state_ptr) {
-        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-
-        result_null->DeepCopy(*left_null);
-
-        const u64 *result_null_data = result_null->GetData();
-        SizeT unit_count = BitmaskBuffer::UnitCount(count);
-        auto left_u8 = reinterpret_cast<const u8 *>(left->data());
-        BooleanT right_boolean = (right_u8 & (u8(1)));
-        auto result_u8 = reinterpret_cast<u8 *>(result->data());
-        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
-        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
-            end_index = std::min(end_index, count);
-            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
-                // all data of 64 rows are not null
-                const SizeT e = end_index / 8, tail = end_index % 8;
-                for (SizeT b = start_index / 8; b < e; ++b) {
-                    Operator::template Execute(left_u8[b], right_u8, result_u8[b], result_null.get(), 0, state_ptr);
-                }
-                if (tail) {
-                    u8 tail_result;
-                    Operator::template Execute(left_u8[e], right_u8, tail_result, result_null.get(), 0, state_ptr);
-                    const u8 mask_keep = u8(0xff) << tail;
-                    result_u8[e] = (result_u8[e] & mask_keep) | (tail_result & ~mask_keep);
-                }
-                start_index = end_index;
-            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
-                // all data of 64 rows are null
-                start_index = end_index;
-            } else {
-                for (BooleanT answer; start_index < end_index; ++start_index) {
-                    if (result_null->IsTrue(start_index)) {
-                        // This row isn't null
-                        Operator::template Execute(left->buffer_->GetCompactBit(start_index),
-                                                   right_boolean,
-                                                   answer,
-                                                   result_null.get(),
-                                                   start_index,
-                                                   state_ptr);
-                        result->buffer_->SetCompactBit(start_index, answer);
-                    }
-                }
-            }
-        }
-    }
-
-    template <typename Operator>
-    static void inline AllBooleanExecuteWithNull(const u8 left_u8,
-                                                 const SharedPtr<ColumnVector> &right,
-                                                 SharedPtr<ColumnVector> &result,
-                                                 SizeT count,
-                                                 void *state_ptr) {
-        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-
-        result_null->DeepCopy(*right_null);
-
-        const u64 *result_null_data = result_null->GetData();
-        SizeT unit_count = BitmaskBuffer::UnitCount(count);
-        auto right_u8 = reinterpret_cast<const u8 *>(right->data());
-        BooleanT left_boolean = (left_u8 & (u8(1)));
-        auto result_u8 = reinterpret_cast<u8 *>(result->data());
-        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
-        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
-            end_index = std::min(end_index, count);
-            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
-                // all data of 64 rows are not null
-                const SizeT e = end_index / 8, tail = end_index % 8;
-                for (SizeT b = start_index / 8; b < e; ++b) {
-                    Operator::template Execute(left_u8, right_u8[b], result_u8[b], result_null.get(), 0, state_ptr);
-                }
-                if (tail) {
-                    u8 tail_result;
-                    Operator::template Execute(left_u8, right_u8[e], tail_result, result_null.get(), 0, state_ptr);
-                    const u8 mask_keep = u8(0xff) << tail;
-                    result_u8[e] = (result_u8[e] & mask_keep) | (tail_result & ~mask_keep);
-                }
-                start_index = end_index;
-            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
-                // all data of 64 rows are null
-                start_index = end_index;
-            } else {
-                for (BooleanT answer; start_index < end_index; ++start_index) {
-                    if (result_null->IsTrue(start_index)) {
-                        // This row isn't null
-                        Operator::template Execute(left_boolean,
-                                                   right->buffer_->GetCompactBit(start_index),
-                                                   answer,
-                                                   result_null.get(),
-                                                   start_index,
-                                                   state_ptr);
-                        result->buffer_->SetCompactBit(start_index, answer);
-                    }
-                }
-            }
-        }
-    }
-
-    template <typename Operator>
-    static void inline ExecuteBooleanSourceBinary(const SharedPtr<ColumnVector> &left,
-                                                  const SharedPtr<ColumnVector> &right,
-                                                  SharedPtr<ColumnVector> &result,
-                                                  SizeT count,
-                                                  void *state_ptr,
-                                                  bool nullable) {
-        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
-        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-        // check constants
-        auto left_vector_type = left->vector_type();
-        auto right_vector_type = right->vector_type();
-        // now only support ColumnVectorType::kConstant and ColumnVectorType::kCompactBit for Boolean
-        if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kConstant) {
-            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                bool answer;
-                Operator::template Execute(left->buffer_->GetCompactBit(0),
-                                           right->buffer_->GetCompactBit(0),
-                                           answer,
-                                           result_null.get(),
-                                           0,
-                                           state_ptr);
-                result->buffer_->SetCompactBit(0, answer);
-                result_null->SetAllTrue();
-            } else {
-                result_null->SetAllFalse();
-            }
-            result->Finalize(1);
-        } else if (left_vector_type == ColumnVectorType::kCompactBit && right_vector_type == ColumnVectorType::kCompactBit) {
-            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                result_null->SetAllTrue();
-                SizeT count_bytes = count / 8;
-                SizeT count_tail = count % 8;
-                auto left_u8 = reinterpret_cast<const u8 *>(left->data());
-                auto right_u8 = reinterpret_cast<const u8 *>(right->data());
-                auto result_u8 = reinterpret_cast<u8 *>(result->data());
-                for (SizeT i = 0; i < count_bytes; ++i) {
-                    Operator::template Execute(left_u8[i], right_u8[i], result_u8[i], result_null.get(), 0, state_ptr);
-                }
-                if (count_tail > 0) {
-                    u8 &tail_u8 = result_u8[count_bytes];
-                    u8 ans;
-                    Operator::template Execute(left_u8[count_bytes], right_u8[count_bytes], ans, result_null.get(), 0, state_ptr);
-                    u8 keep_mask = u8(0xff) << count_tail;
-                    tail_u8 = (tail_u8 & keep_mask) | (ans & ~keep_mask);
-                }
-            } else {
-                AllBooleanExecuteWithNull<Operator>(left, right, result, count, state_ptr);
-            }
-            result->Finalize(count);
-        } else if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kCompactBit) {
-            bool left_value = left->buffer_->GetCompactBit(0);
-            u8 left_u8 = left_value ? u8(0xff) : u8(0x00);
-            if (nullable && !(left_null->IsAllTrue())) {
-                result_null->SetAllFalse();
-            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                result_null->SetAllTrue();
-                SizeT count_bytes = count / 8;
-                SizeT count_tail = count % 8;
-                auto right_u8 = reinterpret_cast<const u8 *>(right->data());
-                auto result_u8 = reinterpret_cast<u8 *>(result->data());
-                for (SizeT i = 0; i < count_bytes; ++i) {
-                    Operator::template Execute(left_u8, right_u8[i], result_u8[i], result_null.get(), 0, state_ptr);
-                }
-                if (count_tail > 0) {
-                    u8 &tail_u8 = result_u8[count_bytes];
-                    u8 ans;
-                    Operator::template Execute(left_u8, right_u8[count_bytes], ans, result_null.get(), 0, state_ptr);
-                    u8 keep_mask = u8(0xff) << count_tail;
-                    tail_u8 = (tail_u8 & keep_mask) | (ans & ~keep_mask);
-                }
-            } else {
-                AllBooleanExecuteWithNull<Operator>(left_u8, right, result, count, state_ptr);
-            }
-            result->Finalize(count);
-        } else if (left_vector_type == ColumnVectorType::kCompactBit && right_vector_type == ColumnVectorType::kConstant) {
-            bool right_value = right->buffer_->GetCompactBit(0);
-            u8 right_u8 = right_value ? u8(0xff) : u8(0x00);
-            if (nullable && !(right_null->IsAllTrue())) {
-                result_null->SetAllFalse();
-            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                result_null->SetAllTrue();
-                SizeT count_bytes = count / 8;
-                SizeT count_tail = count % 8;
-                auto left_u8 = reinterpret_cast<const u8 *>(left->data());
-                auto result_u8 = reinterpret_cast<u8 *>(result->data());
-                for (SizeT i = 0; i < count_bytes; ++i) {
-                    Operator::template Execute(left_u8[i], right_u8, result_u8[i], result_null.get(), 0, state_ptr);
-                }
-                if (count_tail > 0) {
-                    u8 &tail_u8 = result_u8[count_bytes];
-                    u8 ans;
-                    Operator::template Execute(left_u8[count_bytes], right_u8, ans, result_null.get(), 0, state_ptr);
-                    u8 keep_mask = u8(0xff) << count_tail;
-                    tail_u8 = (tail_u8 & keep_mask) | (ans & ~keep_mask);
-                }
-            } else {
-                AllBooleanExecuteWithNull<Operator>(left, right_u8, result, count, state_ptr);
-            }
-            result->Finalize(count);
-        } else {
-            Error<TypeException>("Wrong boolean operation.");
-        }
-    }
-
-    template <typename LeftType, typename RightType, typename Operator>
-    static inline void ResultBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
-                                                    const SharedPtr<ColumnVector> &right,
-                                                    SharedPtr<ColumnVector> &result,
-                                                    SizeT count,
-                                                    void *state_ptr) {
-        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
-        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-
-        if (left_null->IsAllTrue()) {
-            result_null->DeepCopy(*right_null);
-        } else {
-            result_null->DeepCopy(*left_null);
-            if (!(right_null->IsAllTrue())) {
-                result_null->Merge(*right_null);
-            }
-        }
-
-        const u64 *result_null_data = result_null->GetData();
-        SizeT unit_count = BitmaskBuffer::UnitCount(count);
-        auto left_ptr = reinterpret_cast<const LeftType *>(left->data());
-        auto right_ptr = reinterpret_cast<const RightType *>(right->data());
-        BooleanPointer result_ptr(result->buffer_.get());
-        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
-        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
-            end_index = std::min(end_index, count);
-            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
-                // all data of 64 rows are not null
-                for (SizeT b = start_index; b < end_index; ++b) {
-                    bool answer;
-                    Operator::template Execute(left_ptr[b], right_ptr[b], answer, result_null.get(), 0, state_ptr);
-                    result_ptr[b] = answer;
-                }
-                start_index = end_index;
-            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
-                // all data of 64 rows are null
-                start_index = end_index;
-            } else {
-                for (bool answer; start_index < end_index; ++start_index) {
-                    if (result_null->IsTrue(start_index)) {
-                        // This row isn't null
-                        Operator::template Execute(left_ptr[start_index], right_ptr[start_index], answer, result_null.get(), start_index, state_ptr);
-                        result_ptr[start_index] = answer;
-                    }
-                }
-            }
-        }
-    }
-
-    template <typename LeftType, typename RightType, typename Operator>
-    static inline void ResultBooleanExecuteWithNull(const LeftType left_constant,
-                                                    const SharedPtr<ColumnVector> &right,
-                                                    SharedPtr<ColumnVector> &result,
-                                                    SizeT count,
-                                                    void *state_ptr) {
-        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-
-        result_null->DeepCopy(*right_null);
-
-        const u64 *result_null_data = result_null->GetData();
-        SizeT unit_count = BitmaskBuffer::UnitCount(count);
-        auto right_ptr = reinterpret_cast<const RightType *>(right->data());
-        BooleanPointer result_ptr(result->buffer_.get());
-        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
-        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
-            end_index = std::min(end_index, count);
-            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
-                // all data of 64 rows are not null
-                for (SizeT b = start_index; b < end_index; ++b) {
-                    bool answer;
-                    Operator::template Execute(left_constant, right_ptr[b], answer, result_null.get(), 0, state_ptr);
-                    result_ptr[b] = answer;
-                }
-                start_index = end_index;
-            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
-                // all data of 64 rows are null
-                start_index = end_index;
-            } else {
-                for (bool answer; start_index < end_index; ++start_index) {
-                    if (result_null->IsTrue(start_index)) {
-                        // This row isn't null
-                        Operator::template Execute(left_constant, right_ptr[start_index], answer, result_null.get(), start_index, state_ptr);
-                        result_ptr[start_index] = answer;
-                    }
-                }
-            }
-        }
-    }
-
-    template <typename LeftType, typename RightType, typename Operator>
-    static inline void ResultBooleanExecuteWithNull(const SharedPtr<ColumnVector> &left,
-                                                    const RightType right_constant,
-                                                    SharedPtr<ColumnVector> &result,
-                                                    SizeT count,
-                                                    void *state_ptr) {
-        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-
-        result_null->DeepCopy(*left_null);
-
-        const u64 *result_null_data = result_null->GetData();
-        SizeT unit_count = BitmaskBuffer::UnitCount(count);
-        auto left_ptr = reinterpret_cast<const LeftType *>(left->data());
-        BooleanPointer result_ptr(result->buffer_.get());
-        static_assert(BitmaskBuffer::UNIT_BITS % 8 == 0, "static_assert: BitmaskBuffer::UNIT_BITS % 8 == 0");
-        for (SizeT i = 0, start_index = 0, end_index = BitmaskBuffer::UNIT_BITS; i < unit_count; ++i, end_index += BitmaskBuffer::UNIT_BITS) {
-            end_index = std::min(end_index, count);
-            if (result_null_data[i] == BitmaskBuffer::UNIT_MAX) {
-                // all data of 64 rows are not null
-                for (SizeT b = start_index; b < end_index; ++b) {
-                    bool answer;
-                    Operator::template Execute(left_ptr[b], right_constant, answer, result_null.get(), 0, state_ptr);
-                    result_ptr[b] = answer;
-                }
-                start_index = end_index;
-            } else if (result_null_data[i] == BitmaskBuffer::UNIT_MIN) {
-                // all data of 64 rows are null
-                start_index = end_index;
-            } else {
-                for (bool answer; start_index < end_index; ++start_index) {
-                    if (result_null->IsTrue(start_index)) {
-                        // This row isn't null
-                        Operator::template Execute(left_ptr[start_index], right_constant, answer, result_null.get(), start_index, state_ptr);
-                        result_ptr[start_index] = answer;
-                    }
-                }
-            }
-        }
-    }
-
-    template <typename LeftType, typename RightType, typename Operator>
-    static void inline ExecuteBooleanResultBinary(const SharedPtr<ColumnVector> &left,
-                                                  const SharedPtr<ColumnVector> &right,
-                                                  SharedPtr<ColumnVector> &result,
-                                                  SizeT count,
-                                                  void *state_ptr,
-                                                  bool nullable) {
-        static_assert(!std::is_same_v<std::remove_cv_t<LeftType>, BooleanT> && !std::is_same_v<std::remove_cv_t<RightType>, BooleanT>,
-                      "static_assert: ExecuteBooleanResultBinary should not be called with BooleanT input.");
-        auto left_vector_type = left->vector_type();
-        auto right_vector_type = right->vector_type();
-        auto check_vector_type_valid = [](ColumnVectorType vector_type) {
-            // only support kFlat and kConstant
-            return vector_type == ColumnVectorType::kFlat || vector_type == ColumnVectorType::kConstant;
-        };
-        if (!check_vector_type_valid(left_vector_type) || !check_vector_type_valid(right_vector_type)) {
-            Error<TypeException>("ExecuteBooleanResultBinary: Invalid input type.");
-        }
-        const SharedPtr<Bitmask> &left_null = left->nulls_ptr_;
-        const SharedPtr<Bitmask> &right_null = right->nulls_ptr_;
-        SharedPtr<Bitmask> &result_null = result->nulls_ptr_;
-        if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kConstant) {
-            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                bool answer;
-                Operator::template Execute(*(reinterpret_cast<const LeftType *>(left->data())),
-                                           *(reinterpret_cast<const RightType *>(right->data())),
-                                           answer,
-                                           result_null.get(),
-                                           0,
-                                           state_ptr);
-                result->buffer_->SetCompactBit(0, answer);
-                result_null->SetAllTrue();
-            } else {
-                result_null->SetAllFalse();
-            }
-            result->Finalize(1);
-        } else if (left_vector_type == ColumnVectorType::kFlat && right_vector_type == ColumnVectorType::kFlat) {
-            if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                result_null->SetAllTrue();
-                auto left_ptr = reinterpret_cast<const LeftType *>(left->data());
-                auto right_ptr = reinterpret_cast<const RightType *>(right->data());
-                BooleanPointer result_ptr(result->buffer_.get());
-                for (SizeT i = 0; i < count; ++i) {
-                    bool answer;
-                    Operator::template Execute(left_ptr[i], right_ptr[i], answer, result_null.get(), 0, state_ptr);
-                    result_ptr[i] = answer;
-                }
-            } else {
-                ResultBooleanExecuteWithNull<LeftType, RightType, Operator>(left, right, result, count, state_ptr);
-            }
-            result->Finalize(count);
-        } else if (left_vector_type == ColumnVectorType::kConstant && right_vector_type == ColumnVectorType::kFlat) {
-            auto left_c = *(reinterpret_cast<const LeftType *>(left->data()));
-            if (nullable && !(left_null->IsAllTrue())) {
-                result_null->SetAllFalse();
-            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                result_null->SetAllTrue();
-                auto right_ptr = reinterpret_cast<const RightType *>(right->data());
-                BooleanPointer result_ptr(result->buffer_.get());
-                for (SizeT i = 0; i < count; ++i) {
-                    bool answer;
-                    Operator::template Execute(left_c, right_ptr[i], answer, result_null.get(), 0, state_ptr);
-                    result_ptr[i] = answer;
-                }
-            } else {
-                ResultBooleanExecuteWithNull<LeftType, RightType, Operator>(left_c, right, result, count, state_ptr);
-            }
-            result->Finalize(count);
-        } else if (left_vector_type == ColumnVectorType::kFlat && right_vector_type == ColumnVectorType::kConstant) {
-            auto right_c = *(reinterpret_cast<const RightType *>(right->data()));
-            if (nullable && !(right_null->IsAllTrue())) {
-                result_null->SetAllFalse();
-            } else if (!nullable || (left_null->IsAllTrue() && right_null->IsAllTrue())) {
-                result_null->SetAllTrue();
-                auto left_ptr = reinterpret_cast<const LeftType *>(left->data());
-                BooleanPointer result_ptr(result->buffer_.get());
-                for (SizeT i = 0; i < count; ++i) {
-                    bool answer;
-                    Operator::template Execute(left_ptr[i], right_c, answer, result_null.get(), 0, state_ptr);
-                    result_ptr[i] = answer;
-                }
-            } else {
-                ResultBooleanExecuteWithNull<LeftType, RightType, Operator>(left, right_c, result, count, state_ptr);
-            }
-            result->Finalize(count);
-        }
     }
 };
 

--- a/src/storage/knnindex/knn_flat/knn_flat_l2_blas_reservoir.cppm
+++ b/src/storage/knnindex/knn_flat/knn_flat_l2_blas_reservoir.cppm
@@ -99,7 +99,7 @@ public:
                                                                    di,
                                                                    ip_block_.get());
                 }
-                for (i64 i = i0; i < i1; i++) {
+                for (SizeT i = i0; i < i1; i++) {
                     DistType *ip_line = ip_block_.get() + (i - i0) * (j1 - j0);
 
                     for (SizeT j = j0; j < j1; j++) {
@@ -161,7 +161,7 @@ public:
                                                                    di,
                                                                    ip_block_.get());
                 }
-                for (i64 i = i0; i < i1; i++) {
+                for (SizeT i = i0; i < i1; i++) {
                     DistType *ip_line = ip_block_.get() + (i - i0) * (j1 - j0);
 
                     for (SizeT j = j0; j < j1; j++) {

--- a/test/sql/dql/type/varchar.slt
+++ b/test/sql/dql/type/varchar.slt
@@ -1,0 +1,44 @@
+statement ok
+DROP TABLE IF EXISTS test_varchar_filter;
+
+statement ok
+CREATE TABLE test_varchar_filter (c1 varchar, c2 varchar, c3 integer);
+
+statement ok
+INSERT INTO test_varchar_filter VALUES ('abcddddd', 'abcddddd', 1), ('abcddddc', 'abcddddd', 2),
+ ('abcdddde', 'abcddddd', 3), ('abcdddde', 'abcdddde', 4);
+
+query I
+SELECT * FROM test_varchar_filter where c1 = c2;
+----
+abcddddd abcddddd 1
+abcdddde abcdddde 4
+
+query II
+SELECT * FROM test_varchar_filter where c1 = 'abcdddde';
+----
+abcdddde abcddddd 3
+abcdddde abcdddde 4
+
+query III
+SELECT * FROM test_varchar_filter where c1 < c2;
+----
+abcddddc abcddddd 2
+
+query IV
+SELECT * FROM test_varchar_filter where c2 >= c1;
+----
+abcddddd abcddddd 1
+abcddddc abcddddd 2
+abcdddde abcdddde 4
+
+query V
+SELECT * FROM test_varchar_filter ORDER BY c1 desc, c2;
+----
+abcdddde abcddddd 3
+abcdddde abcdddde 4
+abcddddd abcddddd 1
+abcddddc abcddddd 2
+
+statement ok
+DROP TABLE test_varchar_filter;

--- a/tools/generate_top_varchar.py
+++ b/tools/generate_top_varchar.py
@@ -1,0 +1,73 @@
+import os
+import argparse
+import random
+import string
+
+
+def my_get_random_string(i):
+    optional_common_prefix = "PrefixExample"
+    if i % 3 == 0:
+        return optional_common_prefix + ''.join(random.choices(string.ascii_letters, k=random.randint(1, 97)))
+    else:
+        return ''.join(random.choices(string.ascii_letters, k=random.randint(1, 97)))
+
+
+def generate(generate_if_exists: bool, copy_dir: str):
+    row_n = 10000
+    limit_offset = [[10, 9000], [10, 10], [8, 9995], [9000, 1000], [100000, 0]]
+    csv_dir = "./test/data/csv"
+    slt_dir = "./test/sql/dql"
+    csv_name = "/test_big_top_varchar.csv"
+    slt_name = "/big_top_varchar.slt"
+    table_name = "test_big_top_varchar"
+
+    csv_path = csv_dir + csv_name
+    slt_path = slt_dir + slt_name
+    copy_path = copy_dir + csv_name
+
+    os.makedirs(csv_dir, exist_ok=True)
+    os.makedirs(slt_dir, exist_ok=True)
+    if os.path.exists(csv_path) and os.path.exists(slt_path) and generate_if_exists:
+        print("File {} and {} already existed exists. Skip Generating.".format(slt_path, csv_path))
+        return
+    with (open(csv_path, "w") as top_csv_file, open(slt_path, "w") as top_slt_file):
+        x = [(my_get_random_string(i), i) for i in range(row_n)]
+        random.shuffle(x)
+        for s, i in x:
+            top_csv_file.write("{},{}\n".format(s, i))
+
+        top_slt_file.write("statement ok\n")
+        top_slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
+        top_slt_file.write("\n")
+        top_slt_file.write("statement ok\n")
+        top_slt_file.write("CREATE TABLE {} (c1 varchar, c2 integer);\n".format(table_name))
+        top_slt_file.write("\n")
+        top_slt_file.write("statement ok\n")
+        top_slt_file.write("COPY {} FROM '{}' WITH ( DELIMITER ',' );\n".format(table_name, copy_path))
+
+        x.sort()
+        for lim_off in limit_offset:
+            limit = lim_off[0]
+            offset = lim_off[1]
+            top_slt_file.write("\nquery I\n")
+            top_slt_file.write(
+                "SELECT * FROM {} order by c1, c2 limit {} offset {};\n".format(table_name, limit, offset))
+            top_slt_file.write("----\n")
+
+            limit = min(limit, row_n - offset)
+            for j in range(limit):
+                k = j + offset
+                top_slt_file.write("{} {}\n".format(x[k][0], x[k][1]))
+
+        top_slt_file.write("\n")
+        top_slt_file.write("statement ok\n")
+        top_slt_file.write("DROP TABLE {};\n".format(table_name))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate top data for test")
+
+    parser.add_argument("-g", "--generate", type=bool, default=False, dest="generate_if_exists", )
+    parser.add_argument("-c", "--copy", type=str, default="/tmp/infinity/test_data", dest="copy_dir", )
+    args = parser.parse_args()
+    generate(args.generate_if_exists, args.copy_dir)

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -9,6 +9,7 @@ from generate_sort import generate as generate3
 from generate_limit import generate as generate4
 from generate_aggregate import generate as generate5
 from generate_top import generate as generate6
+from generate_top_varchar import generate as generate7
 
 
 def python_skd_test(python_test_dir: str):
@@ -129,6 +130,7 @@ if __name__ == "__main__":
     generate4(args.generate_if_exists, args.copy)
     generate5(args.generate_if_exists, args.copy)
     generate6(args.generate_if_exists, args.copy)
+    generate7(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
     python_skd_test(python_test_dir)
     test_process(args.path, args.test, args.data, args.copy)


### PR DESCRIPTION
Add ColumnValueReader for columnvector and compare function for varchar ColumnValueReader

Compare VarcharT values by reading chars one by one, without copying string to buffer

Add slt for sorting varchar and comparing varchar

### What problem does this PR solve?

compare two varchars (treat varchar as char[] array, compare from front to end)
sort varchars

### What is changed and how it works?

Added BooleanColumnWriter and ColumnValueReader for ColumnVector
Added compare function  for ColumnValueReader
Added VarcharNextCharAccessor for accessing VarcharT members

### Code changes

- [x] Has Code change
- [x] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] slt