### PR TITLE
Support user-specified delimiter for importing csv file in python sdk

### DIFF
--- a/src/main/table.cpp
+++ b/src/main/table.cpp
@@ -105,7 +105,7 @@ QueryResult Table::Import(const String &path, ImportOptions import_options) {
 
     import_statement->header_ = false;
     import_statement->copy_file_type_ = import_options.copy_file_type_;
-    import_statement->delimiter_ = ',';
+    import_statement->delimiter_ = import_options.delimiter_;
 
     QueryResult result = query_context_ptr->QueryStatement(import_statement.get());
     return result;

--- a/src/network/thrift_server.cpp
+++ b/src/network/thrift_server.cpp
@@ -200,6 +200,7 @@ public:
 
         ImportOptions import_options;
         import_options.copy_file_type_ = GetCopyFileType(request.import_option.copy_file_type);
+        import_options.delimiter_ = request.import_option.delimiter[0];
 
         const QueryResult result = table->Import(path.c_str(), import_options);
         ProcessCommonResult(response, result);

--- a/src/network/thrift_server.cpp
+++ b/src/network/thrift_server.cpp
@@ -200,7 +200,11 @@ public:
 
         ImportOptions import_options;
         import_options.copy_file_type_ = GetCopyFileType(request.import_option.copy_file_type);
-        import_options.delimiter_ = request.import_option.delimiter[0];
+        auto &delimiter_string = request.import_option.delimiter;
+        if (delimiter_string.size() != 1) {
+            Error<NetworkException>("Delimiter size must be 1");
+        }
+        import_options.delimiter_ = delimiter_string[0];
 
         const QueryResult result = table->Import(path.c_str(), import_options);
         ProcessCommonResult(response, result);


### PR DESCRIPTION
### What problem does this PR solve?

Support user-specified delimiter for importing csv file in python sdk

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer