### PR TITLE
Optimize fst builder

### DIFF
--- a/src/storage/invertedindex/fst/build.cpp
+++ b/src/storage/invertedindex/fst/build.cpp
@@ -61,7 +61,8 @@ void FstBuilder::InsertOutput(u8 *bs_ptr, SizeT bs_len, u64 val) {
 
 void FstBuilder::CompileFrom(SizeT istate) {
     SizeT addr = NONE_ADDRESS;
-    while (istate + 1 < unfinished_.Len()) {
+    SizeT remained = unfinished_.Len() - (istate + 1);
+    for (SizeT i = 0; i < remained; i++) {
         if (addr == NONE_ADDRESS) {
             UniquePtr<BuilderNode> node = unfinished_.PopEmpty();
             addr = Compile(*node);

--- a/src/storage/invertedindex/fst/build.cpp
+++ b/src/storage/invertedindex/fst/build.cpp
@@ -26,8 +26,9 @@ namespace infinity {
 
 void FstBuilder::Finish() {
     CompileFrom(0);
-    UniquePtr<BuilderNode> root_node = unfinished_.PopRoot();
-    SizeT root_addr = Compile(*root_node);
+    BuilderNode &root_node = unfinished_.TopNode();
+    SizeT root_addr = Compile(root_node);
+    unfinished_.Pop();
     IoWriteU64LE(len_, wtr_);
     IoWriteU64LE(root_addr, wtr_);
     u32 sum = wtr_.MaskedChecksum();
@@ -63,14 +64,13 @@ void FstBuilder::CompileFrom(SizeT istate) {
     SizeT addr = NONE_ADDRESS;
     SizeT remained = unfinished_.Len() - (istate + 1);
     for (SizeT i = 0; i < remained; i++) {
-        if (addr == NONE_ADDRESS) {
-            UniquePtr<BuilderNode> node = unfinished_.PopEmpty();
-            addr = Compile(*node);
-        } else {
-            UniquePtr<BuilderNode> node = unfinished_.PopFreeze(addr);
-            addr = Compile(*node);
+        if (addr != NONE_ADDRESS) {
+            unfinished_.TopLastFreeze(addr);
         }
+        BuilderNode &node = unfinished_.TopNode();
+        addr = Compile(node);
         assert(addr != NONE_ADDRESS);
+        unfinished_.Pop();
     }
     unfinished_.TopLastFreeze(addr);
 }


### PR DESCRIPTION
### What problem does this PR solve?

Optimized fst builder futher. phase 4 of https://github.com/infiniflow/infinity/issues/359

Issue link:

### What is changed and how it works?


Original CSV file: 12.3 GB

|  | https://github.com/BurntSushi/fst/blob/master/fst-bin/src/cmd/map.rs | https://github.com/infiniflow/infinity/blob/main/benchmark/fst/fst.cpp |
| ---- | ---- | ---- |
| Build time cost | 247 s | 165 s |
| Peak memory cost | 30 MB | 19 MB |
| FST size built out | 2.83 GB | 2.89 GB |

perf report of the original rust version:

![image](https://github.com/infiniflow/infinity/assets/153784/5bc858e3-d102-4de1-9fc0-e9723f12cae2)

perf report of the C++ port:

![image](https://github.com/infiniflow/infinity/assets/153784/81260e2a-fb45-4c0a-b915-8c4f8042dde9)


### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer