### PR TITLE
Add ShowTables, DescribeTable feature to InfinityService

### DIFF
--- a/python/infinity/db.py
+++ b/python/infinity/db.py
@@ -37,3 +37,6 @@ class Database(ABC):
     def get_table(self, table_name):
         pass  # implement get table logic here
 
+    @abstractmethod
+    def show_tables(self):
+        pass

--- a/python/infinity/remote_thrift/client.py
+++ b/python/infinity/remote_thrift/client.py
@@ -169,3 +169,6 @@ class ThriftInfinityClient:
     def show_variable(self, variable: ShowVariable):
         return self.client.ShowVariable(ShowVariableRequest(session_id=self.session_id,
                                                             variable_name=str(variable.value)))
+
+    def show_tables(self, db_name: str):
+        return self.client.ShowTables(ShowTablesRequest(session_id=self.session_id, db_name=db_name))

--- a/python/infinity/remote_thrift/db.py
+++ b/python/infinity/remote_thrift/db.py
@@ -17,7 +17,7 @@ from abc import ABC
 import infinity.remote_thrift.infinity_thrift_rpc.ttypes as ttypes
 from infinity.db import Database
 from infinity.remote_thrift.table import RemoteTable
-from infinity.remote_thrift.utils import check_valid_name
+from infinity.remote_thrift.utils import check_valid_name, select_res_to_polars
 
 
 def get_ordinary_info(column_big_info, column_defs, column_name, index):
@@ -148,7 +148,12 @@ class RemoteDatabase(Database, ABC):
 
     def describe_table(self, table_name):
         check_valid_name(table_name)
-        pass  # implement describe table logic here
+        res = self._conn.describe_table(
+            db_name=self._db_name, table_name=table_name)
+        if res.success is True:
+            return select_res_to_polars(res)
+        else:
+            raise Exception(res.error_msg)
 
     def get_table(self, table_name):
         check_valid_name(table_name)
@@ -158,3 +163,10 @@ class RemoteDatabase(Database, ABC):
             return RemoteTable(self._conn, self._db_name, table_name)
         else:
             raise Exception("Get Table Error")
+
+    def show_tables(self):
+        res = self._conn.show_tables(self._db_name)
+        if res.success is True:
+            return select_res_to_polars(res)
+        else:
+            raise Exception(res.error_msg)

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService-remote
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService-remote
@@ -37,11 +37,12 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('  CommonResponse Delete(DeleteRequest request)')
     print('  CommonResponse Update(UpdateRequest request)')
     print('  UploadResponse UploadFileChunk(FileChunk request)')
-    print('  SelectResponse ShowVariable(ShowVariableRequest request)')
     print('  ListDatabaseResponse ListDatabase(ListDatabaseRequest request)')
     print('  ListTableResponse ListTable(ListTableRequest request)')
-    print('  DescribeDatabaseResponse DescribeDatabase(DescribeDatabaseRequest request)')
-    print('  DescribeTableResponse DescribeTable(DescribeTableRequest request)')
+    print('  SelectResponse ShowVariable(ShowVariableRequest request)')
+    print('  SelectResponse DescribeTable(DescribeTableRequest request)')
+    print('  SelectResponse DescribeDatabase(DescribeDatabaseRequest request)')
+    print('  SelectResponse ShowTables(ShowTablesRequest request)')
     print('  CommonResponse GetDatabase(GetDatabaseRequest request)')
     print('  CommonResponse GetTable(GetTableRequest request)')
     print('  CommonResponse CreateIndex(CreateIndexRequest request)')
@@ -203,12 +204,6 @@ elif cmd == 'UploadFileChunk':
         sys.exit(1)
     pp.pprint(client.UploadFileChunk(eval(args[0]),))
 
-elif cmd == 'ShowVariable':
-    if len(args) != 1:
-        print('ShowVariable requires 1 args')
-        sys.exit(1)
-    pp.pprint(client.ShowVariable(eval(args[0]),))
-
 elif cmd == 'ListDatabase':
     if len(args) != 1:
         print('ListDatabase requires 1 args')
@@ -221,17 +216,29 @@ elif cmd == 'ListTable':
         sys.exit(1)
     pp.pprint(client.ListTable(eval(args[0]),))
 
-elif cmd == 'DescribeDatabase':
+elif cmd == 'ShowVariable':
     if len(args) != 1:
-        print('DescribeDatabase requires 1 args')
+        print('ShowVariable requires 1 args')
         sys.exit(1)
-    pp.pprint(client.DescribeDatabase(eval(args[0]),))
+    pp.pprint(client.ShowVariable(eval(args[0]),))
 
 elif cmd == 'DescribeTable':
     if len(args) != 1:
         print('DescribeTable requires 1 args')
         sys.exit(1)
     pp.pprint(client.DescribeTable(eval(args[0]),))
+
+elif cmd == 'DescribeDatabase':
+    if len(args) != 1:
+        print('DescribeDatabase requires 1 args')
+        sys.exit(1)
+    pp.pprint(client.DescribeDatabase(eval(args[0]),))
+
+elif cmd == 'ShowTables':
+    if len(args) != 1:
+        print('ShowTables requires 1 args')
+        sys.exit(1)
+    pp.pprint(client.ShowTables(eval(args[0]),))
 
 elif cmd == 'GetDatabase':
     if len(args) != 1:

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService.py
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService.py
@@ -118,14 +118,6 @@ class Iface(object):
         """
         pass
 
-    def ShowVariable(self, request):
-        """
-        Parameters:
-         - request
-
-        """
-        pass
-
     def ListDatabase(self, request):
         """
         Parameters:
@@ -142,7 +134,7 @@ class Iface(object):
         """
         pass
 
-    def DescribeDatabase(self, request):
+    def ShowVariable(self, request):
         """
         Parameters:
          - request
@@ -151,6 +143,22 @@ class Iface(object):
         pass
 
     def DescribeTable(self, request):
+        """
+        Parameters:
+         - request
+
+        """
+        pass
+
+    def DescribeDatabase(self, request):
+        """
+        Parameters:
+         - request
+
+        """
+        pass
+
+    def ShowTables(self, request):
         """
         Parameters:
          - request
@@ -608,38 +616,6 @@ class Client(Iface):
             return result.success
         raise TApplicationException(TApplicationException.MISSING_RESULT, "UploadFileChunk failed: unknown result")
 
-    def ShowVariable(self, request):
-        """
-        Parameters:
-         - request
-
-        """
-        self.send_ShowVariable(request)
-        return self.recv_ShowVariable()
-
-    def send_ShowVariable(self, request):
-        self._oprot.writeMessageBegin('ShowVariable', TMessageType.CALL, self._seqid)
-        args = ShowVariable_args()
-        args.request = request
-        args.write(self._oprot)
-        self._oprot.writeMessageEnd()
-        self._oprot.trans.flush()
-
-    def recv_ShowVariable(self):
-        iprot = self._iprot
-        (fname, mtype, rseqid) = iprot.readMessageBegin()
-        if mtype == TMessageType.EXCEPTION:
-            x = TApplicationException()
-            x.read(iprot)
-            iprot.readMessageEnd()
-            raise x
-        result = ShowVariable_result()
-        result.read(iprot)
-        iprot.readMessageEnd()
-        if result.success is not None:
-            return result.success
-        raise TApplicationException(TApplicationException.MISSING_RESULT, "ShowVariable failed: unknown result")
-
     def ListDatabase(self, request):
         """
         Parameters:
@@ -704,24 +680,24 @@ class Client(Iface):
             return result.success
         raise TApplicationException(TApplicationException.MISSING_RESULT, "ListTable failed: unknown result")
 
-    def DescribeDatabase(self, request):
+    def ShowVariable(self, request):
         """
         Parameters:
          - request
 
         """
-        self.send_DescribeDatabase(request)
-        return self.recv_DescribeDatabase()
+        self.send_ShowVariable(request)
+        return self.recv_ShowVariable()
 
-    def send_DescribeDatabase(self, request):
-        self._oprot.writeMessageBegin('DescribeDatabase', TMessageType.CALL, self._seqid)
-        args = DescribeDatabase_args()
+    def send_ShowVariable(self, request):
+        self._oprot.writeMessageBegin('ShowVariable', TMessageType.CALL, self._seqid)
+        args = ShowVariable_args()
         args.request = request
         args.write(self._oprot)
         self._oprot.writeMessageEnd()
         self._oprot.trans.flush()
 
-    def recv_DescribeDatabase(self):
+    def recv_ShowVariable(self):
         iprot = self._iprot
         (fname, mtype, rseqid) = iprot.readMessageBegin()
         if mtype == TMessageType.EXCEPTION:
@@ -729,12 +705,12 @@ class Client(Iface):
             x.read(iprot)
             iprot.readMessageEnd()
             raise x
-        result = DescribeDatabase_result()
+        result = ShowVariable_result()
         result.read(iprot)
         iprot.readMessageEnd()
         if result.success is not None:
             return result.success
-        raise TApplicationException(TApplicationException.MISSING_RESULT, "DescribeDatabase failed: unknown result")
+        raise TApplicationException(TApplicationException.MISSING_RESULT, "ShowVariable failed: unknown result")
 
     def DescribeTable(self, request):
         """
@@ -767,6 +743,70 @@ class Client(Iface):
         if result.success is not None:
             return result.success
         raise TApplicationException(TApplicationException.MISSING_RESULT, "DescribeTable failed: unknown result")
+
+    def DescribeDatabase(self, request):
+        """
+        Parameters:
+         - request
+
+        """
+        self.send_DescribeDatabase(request)
+        return self.recv_DescribeDatabase()
+
+    def send_DescribeDatabase(self, request):
+        self._oprot.writeMessageBegin('DescribeDatabase', TMessageType.CALL, self._seqid)
+        args = DescribeDatabase_args()
+        args.request = request
+        args.write(self._oprot)
+        self._oprot.writeMessageEnd()
+        self._oprot.trans.flush()
+
+    def recv_DescribeDatabase(self):
+        iprot = self._iprot
+        (fname, mtype, rseqid) = iprot.readMessageBegin()
+        if mtype == TMessageType.EXCEPTION:
+            x = TApplicationException()
+            x.read(iprot)
+            iprot.readMessageEnd()
+            raise x
+        result = DescribeDatabase_result()
+        result.read(iprot)
+        iprot.readMessageEnd()
+        if result.success is not None:
+            return result.success
+        raise TApplicationException(TApplicationException.MISSING_RESULT, "DescribeDatabase failed: unknown result")
+
+    def ShowTables(self, request):
+        """
+        Parameters:
+         - request
+
+        """
+        self.send_ShowTables(request)
+        return self.recv_ShowTables()
+
+    def send_ShowTables(self, request):
+        self._oprot.writeMessageBegin('ShowTables', TMessageType.CALL, self._seqid)
+        args = ShowTables_args()
+        args.request = request
+        args.write(self._oprot)
+        self._oprot.writeMessageEnd()
+        self._oprot.trans.flush()
+
+    def recv_ShowTables(self):
+        iprot = self._iprot
+        (fname, mtype, rseqid) = iprot.readMessageBegin()
+        if mtype == TMessageType.EXCEPTION:
+            x = TApplicationException()
+            x.read(iprot)
+            iprot.readMessageEnd()
+            raise x
+        result = ShowTables_result()
+        result.read(iprot)
+        iprot.readMessageEnd()
+        if result.success is not None:
+            return result.success
+        raise TApplicationException(TApplicationException.MISSING_RESULT, "ShowTables failed: unknown result")
 
     def GetDatabase(self, request):
         """
@@ -914,11 +954,12 @@ class Processor(Iface, TProcessor):
         self._processMap["Delete"] = Processor.process_Delete
         self._processMap["Update"] = Processor.process_Update
         self._processMap["UploadFileChunk"] = Processor.process_UploadFileChunk
-        self._processMap["ShowVariable"] = Processor.process_ShowVariable
         self._processMap["ListDatabase"] = Processor.process_ListDatabase
         self._processMap["ListTable"] = Processor.process_ListTable
-        self._processMap["DescribeDatabase"] = Processor.process_DescribeDatabase
+        self._processMap["ShowVariable"] = Processor.process_ShowVariable
         self._processMap["DescribeTable"] = Processor.process_DescribeTable
+        self._processMap["DescribeDatabase"] = Processor.process_DescribeDatabase
+        self._processMap["ShowTables"] = Processor.process_ShowTables
         self._processMap["GetDatabase"] = Processor.process_GetDatabase
         self._processMap["GetTable"] = Processor.process_GetTable
         self._processMap["CreateIndex"] = Processor.process_CreateIndex
@@ -1244,29 +1285,6 @@ class Processor(Iface, TProcessor):
         oprot.writeMessageEnd()
         oprot.trans.flush()
 
-    def process_ShowVariable(self, seqid, iprot, oprot):
-        args = ShowVariable_args()
-        args.read(iprot)
-        iprot.readMessageEnd()
-        result = ShowVariable_result()
-        try:
-            result.success = self._handler.ShowVariable(args.request)
-            msg_type = TMessageType.REPLY
-        except TTransport.TTransportException:
-            raise
-        except TApplicationException as ex:
-            logging.exception('TApplication exception in handler')
-            msg_type = TMessageType.EXCEPTION
-            result = ex
-        except Exception:
-            logging.exception('Unexpected exception in handler')
-            msg_type = TMessageType.EXCEPTION
-            result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
-        oprot.writeMessageBegin("ShowVariable", msg_type, seqid)
-        result.write(oprot)
-        oprot.writeMessageEnd()
-        oprot.trans.flush()
-
     def process_ListDatabase(self, seqid, iprot, oprot):
         args = ListDatabase_args()
         args.read(iprot)
@@ -1313,13 +1331,13 @@ class Processor(Iface, TProcessor):
         oprot.writeMessageEnd()
         oprot.trans.flush()
 
-    def process_DescribeDatabase(self, seqid, iprot, oprot):
-        args = DescribeDatabase_args()
+    def process_ShowVariable(self, seqid, iprot, oprot):
+        args = ShowVariable_args()
         args.read(iprot)
         iprot.readMessageEnd()
-        result = DescribeDatabase_result()
+        result = ShowVariable_result()
         try:
-            result.success = self._handler.DescribeDatabase(args.request)
+            result.success = self._handler.ShowVariable(args.request)
             msg_type = TMessageType.REPLY
         except TTransport.TTransportException:
             raise
@@ -1331,7 +1349,7 @@ class Processor(Iface, TProcessor):
             logging.exception('Unexpected exception in handler')
             msg_type = TMessageType.EXCEPTION
             result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
-        oprot.writeMessageBegin("DescribeDatabase", msg_type, seqid)
+        oprot.writeMessageBegin("ShowVariable", msg_type, seqid)
         result.write(oprot)
         oprot.writeMessageEnd()
         oprot.trans.flush()
@@ -1355,6 +1373,52 @@ class Processor(Iface, TProcessor):
             msg_type = TMessageType.EXCEPTION
             result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
         oprot.writeMessageBegin("DescribeTable", msg_type, seqid)
+        result.write(oprot)
+        oprot.writeMessageEnd()
+        oprot.trans.flush()
+
+    def process_DescribeDatabase(self, seqid, iprot, oprot):
+        args = DescribeDatabase_args()
+        args.read(iprot)
+        iprot.readMessageEnd()
+        result = DescribeDatabase_result()
+        try:
+            result.success = self._handler.DescribeDatabase(args.request)
+            msg_type = TMessageType.REPLY
+        except TTransport.TTransportException:
+            raise
+        except TApplicationException as ex:
+            logging.exception('TApplication exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = ex
+        except Exception:
+            logging.exception('Unexpected exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
+        oprot.writeMessageBegin("DescribeDatabase", msg_type, seqid)
+        result.write(oprot)
+        oprot.writeMessageEnd()
+        oprot.trans.flush()
+
+    def process_ShowTables(self, seqid, iprot, oprot):
+        args = ShowTables_args()
+        args.read(iprot)
+        iprot.readMessageEnd()
+        result = ShowTables_result()
+        try:
+            result.success = self._handler.ShowTables(args.request)
+            msg_type = TMessageType.REPLY
+        except TTransport.TTransportException:
+            raise
+        except TApplicationException as ex:
+            logging.exception('TApplication exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = ex
+        except Exception:
+            logging.exception('Unexpected exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
+        oprot.writeMessageBegin("ShowTables", msg_type, seqid)
         result.write(oprot)
         oprot.writeMessageEnd()
         oprot.trans.flush()
@@ -3059,131 +3123,6 @@ UploadFileChunk_result.thrift_spec = (
 )
 
 
-class ShowVariable_args(object):
-    """
-    Attributes:
-     - request
-
-    """
-
-
-    def __init__(self, request=None,):
-        self.request = request
-
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.STRUCT:
-                    self.request = ShowVariableRequest()
-                    self.request.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
-
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('ShowVariable_args')
-        if self.request is not None:
-            oprot.writeFieldBegin('request', TType.STRUCT, 1)
-            self.request.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
-
-    def validate(self):
-        return
-
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
-all_structs.append(ShowVariable_args)
-ShowVariable_args.thrift_spec = (
-    None,  # 0
-    (1, TType.STRUCT, 'request', [ShowVariableRequest, None], None, ),  # 1
-)
-
-
-class ShowVariable_result(object):
-    """
-    Attributes:
-     - success
-
-    """
-
-
-    def __init__(self, success=None,):
-        self.success = success
-
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 0:
-                if ftype == TType.STRUCT:
-                    self.success = SelectResponse()
-                    self.success.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
-
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('ShowVariable_result')
-        if self.success is not None:
-            oprot.writeFieldBegin('success', TType.STRUCT, 0)
-            self.success.write(oprot)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
-
-    def validate(self):
-        return
-
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
-all_structs.append(ShowVariable_result)
-ShowVariable_result.thrift_spec = (
-    (0, TType.STRUCT, 'success', [SelectResponse, None], None, ),  # 0
-)
-
-
 class ListDatabase_args(object):
     """
     Attributes:
@@ -3434,7 +3373,7 @@ ListTable_result.thrift_spec = (
 )
 
 
-class DescribeDatabase_args(object):
+class ShowVariable_args(object):
     """
     Attributes:
      - request
@@ -3456,7 +3395,7 @@ class DescribeDatabase_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRUCT:
-                    self.request = DescribeDatabaseRequest()
+                    self.request = ShowVariableRequest()
                     self.request.read(iprot)
                 else:
                     iprot.skip(ftype)
@@ -3469,7 +3408,7 @@ class DescribeDatabase_args(object):
         if oprot._fast_encode is not None and self.thrift_spec is not None:
             oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
             return
-        oprot.writeStructBegin('DescribeDatabase_args')
+        oprot.writeStructBegin('ShowVariable_args')
         if self.request is not None:
             oprot.writeFieldBegin('request', TType.STRUCT, 1)
             self.request.write(oprot)
@@ -3490,14 +3429,14 @@ class DescribeDatabase_args(object):
 
     def __ne__(self, other):
         return not (self == other)
-all_structs.append(DescribeDatabase_args)
-DescribeDatabase_args.thrift_spec = (
+all_structs.append(ShowVariable_args)
+ShowVariable_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRUCT, 'request', [DescribeDatabaseRequest, None], None, ),  # 1
+    (1, TType.STRUCT, 'request', [ShowVariableRequest, None], None, ),  # 1
 )
 
 
-class DescribeDatabase_result(object):
+class ShowVariable_result(object):
     """
     Attributes:
      - success
@@ -3519,7 +3458,7 @@ class DescribeDatabase_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRUCT:
-                    self.success = DescribeDatabaseResponse()
+                    self.success = SelectResponse()
                     self.success.read(iprot)
                 else:
                     iprot.skip(ftype)
@@ -3532,7 +3471,7 @@ class DescribeDatabase_result(object):
         if oprot._fast_encode is not None and self.thrift_spec is not None:
             oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
             return
-        oprot.writeStructBegin('DescribeDatabase_result')
+        oprot.writeStructBegin('ShowVariable_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRUCT, 0)
             self.success.write(oprot)
@@ -3553,9 +3492,9 @@ class DescribeDatabase_result(object):
 
     def __ne__(self, other):
         return not (self == other)
-all_structs.append(DescribeDatabase_result)
-DescribeDatabase_result.thrift_spec = (
-    (0, TType.STRUCT, 'success', [DescribeDatabaseResponse, None], None, ),  # 0
+all_structs.append(ShowVariable_result)
+ShowVariable_result.thrift_spec = (
+    (0, TType.STRUCT, 'success', [SelectResponse, None], None, ),  # 0
 )
 
 
@@ -3644,7 +3583,7 @@ class DescribeTable_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRUCT:
-                    self.success = DescribeTableResponse()
+                    self.success = SelectResponse()
                     self.success.read(iprot)
                 else:
                     iprot.skip(ftype)
@@ -3680,7 +3619,257 @@ class DescribeTable_result(object):
         return not (self == other)
 all_structs.append(DescribeTable_result)
 DescribeTable_result.thrift_spec = (
-    (0, TType.STRUCT, 'success', [DescribeTableResponse, None], None, ),  # 0
+    (0, TType.STRUCT, 'success', [SelectResponse, None], None, ),  # 0
+)
+
+
+class DescribeDatabase_args(object):
+    """
+    Attributes:
+     - request
+
+    """
+
+
+    def __init__(self, request=None,):
+        self.request = request
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.STRUCT:
+                    self.request = DescribeDatabaseRequest()
+                    self.request.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('DescribeDatabase_args')
+        if self.request is not None:
+            oprot.writeFieldBegin('request', TType.STRUCT, 1)
+            self.request.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(DescribeDatabase_args)
+DescribeDatabase_args.thrift_spec = (
+    None,  # 0
+    (1, TType.STRUCT, 'request', [DescribeDatabaseRequest, None], None, ),  # 1
+)
+
+
+class DescribeDatabase_result(object):
+    """
+    Attributes:
+     - success
+
+    """
+
+
+    def __init__(self, success=None,):
+        self.success = success
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 0:
+                if ftype == TType.STRUCT:
+                    self.success = SelectResponse()
+                    self.success.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('DescribeDatabase_result')
+        if self.success is not None:
+            oprot.writeFieldBegin('success', TType.STRUCT, 0)
+            self.success.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(DescribeDatabase_result)
+DescribeDatabase_result.thrift_spec = (
+    (0, TType.STRUCT, 'success', [SelectResponse, None], None, ),  # 0
+)
+
+
+class ShowTables_args(object):
+    """
+    Attributes:
+     - request
+
+    """
+
+
+    def __init__(self, request=None,):
+        self.request = request
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.STRUCT:
+                    self.request = ShowTablesRequest()
+                    self.request.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ShowTables_args')
+        if self.request is not None:
+            oprot.writeFieldBegin('request', TType.STRUCT, 1)
+            self.request.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(ShowTables_args)
+ShowTables_args.thrift_spec = (
+    None,  # 0
+    (1, TType.STRUCT, 'request', [ShowTablesRequest, None], None, ),  # 1
+)
+
+
+class ShowTables_result(object):
+    """
+    Attributes:
+     - success
+
+    """
+
+
+    def __init__(self, success=None,):
+        self.success = success
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 0:
+                if ftype == TType.STRUCT:
+                    self.success = SelectResponse()
+                    self.success.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ShowTables_result')
+        if self.success is not None:
+            oprot.writeFieldBegin('success', TType.STRUCT, 0)
+            self.success.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(ShowTables_result)
+ShowTables_result.thrift_spec = (
+    (0, TType.STRUCT, 'success', [SelectResponse, None], None, ),  # 0
 )
 
 

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/infinity.thrift
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/infinity.thrift
@@ -457,6 +457,11 @@ struct ShowVariableRequest{
 2: string variable_name,
 }
 
+struct ShowTablesRequest{
+1: i64 session_id,
+2: string db_name,
+}
+
 // Service
 service InfinityService {
 CommonResponse Connect(),
@@ -473,13 +478,14 @@ SelectResponse Explain(1:ExplainRequest request),
 CommonResponse Delete(1:DeleteRequest request),
 CommonResponse Update(1:UpdateRequest request),
 UploadResponse UploadFileChunk(1:FileChunk request),
-SelectResponse ShowVariable(1:ShowVariableRequest request),
 
 ListDatabaseResponse ListDatabase(1:ListDatabaseRequest request),
 ListTableResponse ListTable(1:ListTableRequest request),
 
-DescribeDatabaseResponse DescribeDatabase(1:DescribeDatabaseRequest request),
-DescribeTableResponse DescribeTable(1:DescribeTableRequest request),
+SelectResponse ShowVariable(1:ShowVariableRequest request),
+SelectResponse DescribeTable(1:DescribeTableRequest request),
+SelectResponse DescribeDatabase(1:DescribeDatabaseRequest request),
+SelectResponse ShowTables(1:ShowTablesRequest request),
 
 CommonResponse GetDatabase(1:GetDatabaseRequest request),
 CommonResponse GetTable(1:GetTableRequest request),

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/ttypes.py
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/ttypes.py
@@ -5393,6 +5393,74 @@ class ShowVariableRequest(object):
 
     def __ne__(self, other):
         return not (self == other)
+
+
+class ShowTablesRequest(object):
+    """
+    Attributes:
+     - session_id
+     - db_name
+
+    """
+
+
+    def __init__(self, session_id=None, db_name=None,):
+        self.session_id = session_id
+        self.db_name = db_name
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.I64:
+                    self.session_id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRING:
+                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ShowTablesRequest')
+        if self.session_id is not None:
+            oprot.writeFieldBegin('session_id', TType.I64, 1)
+            oprot.writeI64(self.session_id)
+            oprot.writeFieldEnd()
+        if self.db_name is not None:
+            oprot.writeFieldBegin('db_name', TType.STRING, 2)
+            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
 all_structs.append(Option)
 Option.thrift_spec = (
 )
@@ -5831,6 +5899,12 @@ ShowVariableRequest.thrift_spec = (
     None,  # 0
     (1, TType.I64, 'session_id', None, None, ),  # 1
     (2, TType.STRING, 'variable_name', 'UTF8', None, ),  # 2
+)
+all_structs.append(ShowTablesRequest)
+ShowTablesRequest.thrift_spec = (
+    None,  # 0
+    (1, TType.I64, 'session_id', None, None, ),  # 1
+    (2, TType.STRING, 'db_name', 'UTF8', None, ),  # 2
 )
 fix_spec(all_structs)
 del all_structs

--- a/python/infinity/remote_thrift/utils.py
+++ b/python/infinity/remote_thrift/utils.py
@@ -146,7 +146,7 @@ def check_valid_name(name):
         return True
 
 
-def select_res_to_polars(res):
+def select_res_to_polars(res) -> pl.DataFrame:
     df_dict = {}
     data_dict, data_type_dict = build_result(res)
     for k, v in data_dict.items():

--- a/python/infinity/table.py
+++ b/python/infinity/table.py
@@ -20,6 +20,34 @@ import infinity.remote_thrift.infinity_thrift_rpc.ttypes as ttypes
 from infinity.index import IndexInfo
 
 
+class ExplainType(Enum):
+    Analyze = 1
+    Ast = 2
+    UnOpt = 3
+    Opt = 4
+    Physical = 5
+    Pipeline = 6
+    Fragment = 7
+
+    def to_ttype(self):
+        if self is ExplainType.Ast:
+            return ttypes.ExplainType.Ast
+        elif self is ExplainType.Analyze:
+            return ttypes.ExplainType.Analyze
+        elif self is ExplainType.UnOpt:
+            return ttypes.ExplainType.UnOpt
+        elif self is ExplainType.Opt:
+            return ttypes.ExplainType.Opt
+        elif self is ExplainType.Physical:
+            return ttypes.ExplainType.Physical
+        elif self is ExplainType.Pipeline:
+            return ttypes.ExplainType.Pipeline
+        elif self is ExplainType.Fragment:
+            return ttypes.ExplainType.Fragment
+        else:
+            raise Exception("Unknown explain type")
+
+
 class Table(ABC):
 
     @abstractmethod
@@ -50,30 +78,6 @@ class Table(ABC):
     def _execute_query(self, query):
         pass
 
-
-class ExplainType(Enum):
-    Analyze = 1
-    Ast = 2
-    UnOpt = 3
-    Opt = 4
-    Physical = 5
-    Pipeline = 6
-    Fragment = 7
-
-    def to_ttype(self):
-        if self is ExplainType.Ast:
-            return ttypes.ExplainType.Ast
-        elif self is ExplainType.Analyze:
-            return ttypes.ExplainType.Analyze
-        elif self is ExplainType.UnOpt:
-            return ttypes.ExplainType.UnOpt
-        elif self is ExplainType.Opt:
-            return ttypes.ExplainType.Opt
-        elif self is ExplainType.Physical:
-            return ttypes.ExplainType.Physical
-        elif self is ExplainType.Pipeline:
-            return ttypes.ExplainType.Pipeline
-        elif self is ExplainType.Fragment:
-            return ttypes.ExplainType.Fragment
-        else:
-            raise Exception("Unknown explain type")
+    @abstractmethod
+    def _explain_query(self, query):
+        pass

--- a/python/test/test_describe.py
+++ b/python/test/test_describe.py
@@ -1,0 +1,33 @@
+# Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import polars as pl
+
+import common_values
+import infinity
+
+
+class TestDescribe:
+
+    def test_describe_table(self):
+        infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
+
+        db = infinity_obj.get_database("default")
+        db.drop_table("test_describe_table")
+        db.create_table(
+            "test_describe_table", {"num": "integer", "body": "varchar", "vec": "vector,5,float"}, None)
+        with pl.Config(fmt_str_lengths=1000):
+            res = db.describe_table("test_describe_table")
+            print(res)
+            # check the polars dataframe
+            assert res.columns == ["column_name", "column_type", "constraint"]

--- a/python/test/test_show_tables.py
+++ b/python/test/test_show_tables.py
@@ -1,0 +1,32 @@
+# Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import polars as pl
+
+import common_values
+import infinity
+
+
+class TestShowTables:
+
+    def test_show_tables(self):
+        infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
+
+        db = infinity_obj.get_database("default")
+
+        with pl.Config(fmt_str_lengths=1000):
+            res = db.show_tables()
+            print(res)
+            # check the polars dataframe
+            assert res.columns == ["database", "table", "type", "column_count", "row_count", "segment_count",
+                                   "block_count", "segment_capacity"]

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -26,10 +26,8 @@ import parser;
 
 namespace infinity {
 
-QueryResult Database::CreateTable(const String &table_name,
-                                  Vector<ColumnDef *> column_defs,
-                                  Vector<TableConstraint *> constraints,
-                                  const CreateTableOptions &) {
+QueryResult
+Database::CreateTable(const String &table_name, Vector<ColumnDef *> column_defs, Vector<TableConstraint *> constraints, const CreateTableOptions &) {
     UniquePtr<QueryContext> query_context_ptr = MakeUnique<QueryContext>(session_.get());
     query_context_ptr->Init(InfinityContext::instance().config(),
                             InfinityContext::instance().task_scheduler(),
@@ -77,7 +75,7 @@ QueryResult Database::ListTables() {
     return result;
 }
 
-QueryResult Database::DescribeTable(const String &) {
+QueryResult Database::DescribeTable(const String &table_name) {
     UniquePtr<QueryContext> query_context_ptr = MakeUnique<QueryContext>(session_.get());
     query_context_ptr->Init(InfinityContext::instance().config(),
                             InfinityContext::instance().task_scheduler(),
@@ -85,7 +83,23 @@ QueryResult Database::DescribeTable(const String &) {
                             InfinityContext::instance().resource_manager(),
                             InfinityContext::instance().session_manager());
     UniquePtr<ShowStatement> show_statement = MakeUnique<ShowStatement>();
+    show_statement->schema_name_ = db_name_;
+    show_statement->table_name_ = table_name;
     show_statement->show_type_ = ShowStmtType::kColumns;
+    QueryResult result = query_context_ptr->QueryStatement(show_statement.get());
+    return result;
+}
+
+QueryResult Database::ShowTables() {
+    UniquePtr<QueryContext> query_context_ptr = MakeUnique<QueryContext>(session_.get());
+    query_context_ptr->Init(InfinityContext::instance().config(),
+                            InfinityContext::instance().task_scheduler(),
+                            InfinityContext::instance().storage(),
+                            InfinityContext::instance().resource_manager(),
+                            InfinityContext::instance().session_manager());
+    UniquePtr<ShowStatement> show_statement = MakeUnique<ShowStatement>();
+    show_statement->schema_name_ = db_name_;
+    show_statement->show_type_ = ShowStmtType::kTables;
     QueryResult result = query_context_ptr->QueryStatement(show_statement.get());
     return result;
 }
@@ -99,7 +113,7 @@ UniquePtr<Table> Database::GetTable(const String &table_name) {
                             InfinityContext::instance().session_manager());
     UniquePtr<CommandStatement> command_statement = MakeUnique<CommandStatement>();
     command_statement->command_info_ = MakeUnique<CheckTable>(table_name.c_str());
-    QueryResult result= query_context_ptr->QueryStatement(command_statement.get());
+    QueryResult result = query_context_ptr->QueryStatement(command_statement.get());
     if (result.status_.ok()) {
         return MakeUnique<Table>(table_name, session_);
     } else {

--- a/src/main/database.cppm
+++ b/src/main/database.cppm
@@ -39,6 +39,8 @@ public:
 
     QueryResult DescribeTable(const String &table_name);
 
+    QueryResult ShowTables();
+
     UniquePtr<Table> GetTable(const String &table_name);
 
     [[nodiscard]] const String &db_name() const { return db_name_; }

--- a/src/network/infinity_thrift/InfinityService.cpp
+++ b/src/network/infinity_thrift/InfinityService.cpp
@@ -2419,193 +2419,6 @@ uint32_t InfinityService_UploadFileChunk_presult::read(::apache::thrift::protoco
 }
 
 
-InfinityService_ShowVariable_args::~InfinityService_ShowVariable_args() noexcept {
-}
-
-
-uint32_t InfinityService_ShowVariable_args::read(::apache::thrift::protocol::TProtocol* iprot) {
-
-  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-  uint32_t xfer = 0;
-  std::string fname;
-  ::apache::thrift::protocol::TType ftype;
-  int16_t fid;
-
-  xfer += iprot->readStructBegin(fname);
-
-  using ::apache::thrift::protocol::TProtocolException;
-
-
-  while (true)
-  {
-    xfer += iprot->readFieldBegin(fname, ftype, fid);
-    if (ftype == ::apache::thrift::protocol::T_STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 1:
-        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-          xfer += this->request.read(iprot);
-          this->__isset.request = true;
-        } else {
-          xfer += iprot->skip(ftype);
-        }
-        break;
-      default:
-        xfer += iprot->skip(ftype);
-        break;
-    }
-    xfer += iprot->readFieldEnd();
-  }
-
-  xfer += iprot->readStructEnd();
-
-  return xfer;
-}
-
-uint32_t InfinityService_ShowVariable_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
-  uint32_t xfer = 0;
-  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-  xfer += oprot->writeStructBegin("InfinityService_ShowVariable_args");
-
-  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
-  xfer += this->request.write(oprot);
-  xfer += oprot->writeFieldEnd();
-
-  xfer += oprot->writeFieldStop();
-  xfer += oprot->writeStructEnd();
-  return xfer;
-}
-
-
-InfinityService_ShowVariable_pargs::~InfinityService_ShowVariable_pargs() noexcept {
-}
-
-
-uint32_t InfinityService_ShowVariable_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
-  uint32_t xfer = 0;
-  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-  xfer += oprot->writeStructBegin("InfinityService_ShowVariable_pargs");
-
-  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
-  xfer += (*(this->request)).write(oprot);
-  xfer += oprot->writeFieldEnd();
-
-  xfer += oprot->writeFieldStop();
-  xfer += oprot->writeStructEnd();
-  return xfer;
-}
-
-
-InfinityService_ShowVariable_result::~InfinityService_ShowVariable_result() noexcept {
-}
-
-
-uint32_t InfinityService_ShowVariable_result::read(::apache::thrift::protocol::TProtocol* iprot) {
-
-  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-  uint32_t xfer = 0;
-  std::string fname;
-  ::apache::thrift::protocol::TType ftype;
-  int16_t fid;
-
-  xfer += iprot->readStructBegin(fname);
-
-  using ::apache::thrift::protocol::TProtocolException;
-
-
-  while (true)
-  {
-    xfer += iprot->readFieldBegin(fname, ftype, fid);
-    if (ftype == ::apache::thrift::protocol::T_STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 0:
-        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-          xfer += this->success.read(iprot);
-          this->__isset.success = true;
-        } else {
-          xfer += iprot->skip(ftype);
-        }
-        break;
-      default:
-        xfer += iprot->skip(ftype);
-        break;
-    }
-    xfer += iprot->readFieldEnd();
-  }
-
-  xfer += iprot->readStructEnd();
-
-  return xfer;
-}
-
-uint32_t InfinityService_ShowVariable_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
-
-  uint32_t xfer = 0;
-
-  xfer += oprot->writeStructBegin("InfinityService_ShowVariable_result");
-
-  if (this->__isset.success) {
-    xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_STRUCT, 0);
-    xfer += this->success.write(oprot);
-    xfer += oprot->writeFieldEnd();
-  }
-  xfer += oprot->writeFieldStop();
-  xfer += oprot->writeStructEnd();
-  return xfer;
-}
-
-
-InfinityService_ShowVariable_presult::~InfinityService_ShowVariable_presult() noexcept {
-}
-
-
-uint32_t InfinityService_ShowVariable_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
-
-  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
-  uint32_t xfer = 0;
-  std::string fname;
-  ::apache::thrift::protocol::TType ftype;
-  int16_t fid;
-
-  xfer += iprot->readStructBegin(fname);
-
-  using ::apache::thrift::protocol::TProtocolException;
-
-
-  while (true)
-  {
-    xfer += iprot->readFieldBegin(fname, ftype, fid);
-    if (ftype == ::apache::thrift::protocol::T_STOP) {
-      break;
-    }
-    switch (fid)
-    {
-      case 0:
-        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
-          xfer += (*(this->success)).read(iprot);
-          this->__isset.success = true;
-        } else {
-          xfer += iprot->skip(ftype);
-        }
-        break;
-      default:
-        xfer += iprot->skip(ftype);
-        break;
-    }
-    xfer += iprot->readFieldEnd();
-  }
-
-  xfer += iprot->readStructEnd();
-
-  return xfer;
-}
-
-
 InfinityService_ListDatabase_args::~InfinityService_ListDatabase_args() noexcept {
 }
 
@@ -2980,11 +2793,11 @@ uint32_t InfinityService_ListTable_presult::read(::apache::thrift::protocol::TPr
 }
 
 
-InfinityService_DescribeDatabase_args::~InfinityService_DescribeDatabase_args() noexcept {
+InfinityService_ShowVariable_args::~InfinityService_ShowVariable_args() noexcept {
 }
 
 
-uint32_t InfinityService_DescribeDatabase_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+uint32_t InfinityService_ShowVariable_args::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
   uint32_t xfer = 0;
@@ -3025,10 +2838,10 @@ uint32_t InfinityService_DescribeDatabase_args::read(::apache::thrift::protocol:
   return xfer;
 }
 
-uint32_t InfinityService_DescribeDatabase_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+uint32_t InfinityService_ShowVariable_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
   uint32_t xfer = 0;
   ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-  xfer += oprot->writeStructBegin("InfinityService_DescribeDatabase_args");
+  xfer += oprot->writeStructBegin("InfinityService_ShowVariable_args");
 
   xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
   xfer += this->request.write(oprot);
@@ -3040,14 +2853,14 @@ uint32_t InfinityService_DescribeDatabase_args::write(::apache::thrift::protocol
 }
 
 
-InfinityService_DescribeDatabase_pargs::~InfinityService_DescribeDatabase_pargs() noexcept {
+InfinityService_ShowVariable_pargs::~InfinityService_ShowVariable_pargs() noexcept {
 }
 
 
-uint32_t InfinityService_DescribeDatabase_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+uint32_t InfinityService_ShowVariable_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
   uint32_t xfer = 0;
   ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
-  xfer += oprot->writeStructBegin("InfinityService_DescribeDatabase_pargs");
+  xfer += oprot->writeStructBegin("InfinityService_ShowVariable_pargs");
 
   xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
   xfer += (*(this->request)).write(oprot);
@@ -3059,11 +2872,11 @@ uint32_t InfinityService_DescribeDatabase_pargs::write(::apache::thrift::protoco
 }
 
 
-InfinityService_DescribeDatabase_result::~InfinityService_DescribeDatabase_result() noexcept {
+InfinityService_ShowVariable_result::~InfinityService_ShowVariable_result() noexcept {
 }
 
 
-uint32_t InfinityService_DescribeDatabase_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+uint32_t InfinityService_ShowVariable_result::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
   uint32_t xfer = 0;
@@ -3104,11 +2917,11 @@ uint32_t InfinityService_DescribeDatabase_result::read(::apache::thrift::protoco
   return xfer;
 }
 
-uint32_t InfinityService_DescribeDatabase_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+uint32_t InfinityService_ShowVariable_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
 
   uint32_t xfer = 0;
 
-  xfer += oprot->writeStructBegin("InfinityService_DescribeDatabase_result");
+  xfer += oprot->writeStructBegin("InfinityService_ShowVariable_result");
 
   if (this->__isset.success) {
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_STRUCT, 0);
@@ -3121,11 +2934,11 @@ uint32_t InfinityService_DescribeDatabase_result::write(::apache::thrift::protoc
 }
 
 
-InfinityService_DescribeDatabase_presult::~InfinityService_DescribeDatabase_presult() noexcept {
+InfinityService_ShowVariable_presult::~InfinityService_ShowVariable_presult() noexcept {
 }
 
 
-uint32_t InfinityService_DescribeDatabase_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+uint32_t InfinityService_ShowVariable_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
   uint32_t xfer = 0;
@@ -3313,6 +3126,380 @@ InfinityService_DescribeTable_presult::~InfinityService_DescribeTable_presult() 
 
 
 uint32_t InfinityService_DescribeTable_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += (*(this->success)).read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+
+InfinityService_DescribeDatabase_args::~InfinityService_DescribeDatabase_args() noexcept {
+}
+
+
+uint32_t InfinityService_DescribeDatabase_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->request.read(iprot);
+          this->__isset.request = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t InfinityService_DescribeDatabase_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("InfinityService_DescribeDatabase_args");
+
+  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->request.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_DescribeDatabase_pargs::~InfinityService_DescribeDatabase_pargs() noexcept {
+}
+
+
+uint32_t InfinityService_DescribeDatabase_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("InfinityService_DescribeDatabase_pargs");
+
+  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += (*(this->request)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_DescribeDatabase_result::~InfinityService_DescribeDatabase_result() noexcept {
+}
+
+
+uint32_t InfinityService_DescribeDatabase_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->success.read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t InfinityService_DescribeDatabase_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+
+  uint32_t xfer = 0;
+
+  xfer += oprot->writeStructBegin("InfinityService_DescribeDatabase_result");
+
+  if (this->__isset.success) {
+    xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_STRUCT, 0);
+    xfer += this->success.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_DescribeDatabase_presult::~InfinityService_DescribeDatabase_presult() noexcept {
+}
+
+
+uint32_t InfinityService_DescribeDatabase_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += (*(this->success)).read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+
+InfinityService_ShowTables_args::~InfinityService_ShowTables_args() noexcept {
+}
+
+
+uint32_t InfinityService_ShowTables_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->request.read(iprot);
+          this->__isset.request = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t InfinityService_ShowTables_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("InfinityService_ShowTables_args");
+
+  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->request.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_ShowTables_pargs::~InfinityService_ShowTables_pargs() noexcept {
+}
+
+
+uint32_t InfinityService_ShowTables_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("InfinityService_ShowTables_pargs");
+
+  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += (*(this->request)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_ShowTables_result::~InfinityService_ShowTables_result() noexcept {
+}
+
+
+uint32_t InfinityService_ShowTables_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->success.read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t InfinityService_ShowTables_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+
+  uint32_t xfer = 0;
+
+  xfer += oprot->writeStructBegin("InfinityService_ShowTables_result");
+
+  if (this->__isset.success) {
+    xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_STRUCT, 0);
+    xfer += this->success.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_ShowTables_presult::~InfinityService_ShowTables_presult() noexcept {
+}
+
+
+uint32_t InfinityService_ShowTables_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
   uint32_t xfer = 0;
@@ -4854,64 +5041,6 @@ void InfinityServiceClient::recv_UploadFileChunk(UploadResponse& _return)
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "UploadFileChunk failed: unknown result");
 }
 
-void InfinityServiceClient::ShowVariable(SelectResponse& _return, const ShowVariableRequest& request)
-{
-  send_ShowVariable(request);
-  recv_ShowVariable(_return);
-}
-
-void InfinityServiceClient::send_ShowVariable(const ShowVariableRequest& request)
-{
-  int32_t cseqid = 0;
-  oprot_->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_CALL, cseqid);
-
-  InfinityService_ShowVariable_pargs args;
-  args.request = &request;
-  args.write(oprot_);
-
-  oprot_->writeMessageEnd();
-  oprot_->getTransport()->writeEnd();
-  oprot_->getTransport()->flush();
-}
-
-void InfinityServiceClient::recv_ShowVariable(SelectResponse& _return)
-{
-
-  int32_t rseqid = 0;
-  std::string fname;
-  ::apache::thrift::protocol::TMessageType mtype;
-
-  iprot_->readMessageBegin(fname, mtype, rseqid);
-  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
-    ::apache::thrift::TApplicationException x;
-    x.read(iprot_);
-    iprot_->readMessageEnd();
-    iprot_->getTransport()->readEnd();
-    throw x;
-  }
-  if (mtype != ::apache::thrift::protocol::T_REPLY) {
-    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
-    iprot_->readMessageEnd();
-    iprot_->getTransport()->readEnd();
-  }
-  if (fname.compare("ShowVariable") != 0) {
-    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
-    iprot_->readMessageEnd();
-    iprot_->getTransport()->readEnd();
-  }
-  InfinityService_ShowVariable_presult result;
-  result.success = &_return;
-  result.read(iprot_);
-  iprot_->readMessageEnd();
-  iprot_->getTransport()->readEnd();
-
-  if (result.__isset.success) {
-    // _return pointer has now been filled
-    return;
-  }
-  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ShowVariable failed: unknown result");
-}
-
 void InfinityServiceClient::ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request)
 {
   send_ListDatabase(request);
@@ -5028,7 +5157,123 @@ void InfinityServiceClient::recv_ListTable(ListTableResponse& _return)
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ListTable failed: unknown result");
 }
 
-void InfinityServiceClient::DescribeDatabase(DescribeDatabaseResponse& _return, const DescribeDatabaseRequest& request)
+void InfinityServiceClient::ShowVariable(SelectResponse& _return, const ShowVariableRequest& request)
+{
+  send_ShowVariable(request);
+  recv_ShowVariable(_return);
+}
+
+void InfinityServiceClient::send_ShowVariable(const ShowVariableRequest& request)
+{
+  int32_t cseqid = 0;
+  oprot_->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  InfinityService_ShowVariable_pargs args;
+  args.request = &request;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->writeEnd();
+  oprot_->getTransport()->flush();
+}
+
+void InfinityServiceClient::recv_ShowVariable(SelectResponse& _return)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  iprot_->readMessageBegin(fname, mtype, rseqid);
+  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+    ::apache::thrift::TApplicationException x;
+    x.read(iprot_);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw x;
+  }
+  if (mtype != ::apache::thrift::protocol::T_REPLY) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+  }
+  if (fname.compare("ShowVariable") != 0) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+  }
+  InfinityService_ShowVariable_presult result;
+  result.success = &_return;
+  result.read(iprot_);
+  iprot_->readMessageEnd();
+  iprot_->getTransport()->readEnd();
+
+  if (result.__isset.success) {
+    // _return pointer has now been filled
+    return;
+  }
+  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ShowVariable failed: unknown result");
+}
+
+void InfinityServiceClient::DescribeTable(SelectResponse& _return, const DescribeTableRequest& request)
+{
+  send_DescribeTable(request);
+  recv_DescribeTable(_return);
+}
+
+void InfinityServiceClient::send_DescribeTable(const DescribeTableRequest& request)
+{
+  int32_t cseqid = 0;
+  oprot_->writeMessageBegin("DescribeTable", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  InfinityService_DescribeTable_pargs args;
+  args.request = &request;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->writeEnd();
+  oprot_->getTransport()->flush();
+}
+
+void InfinityServiceClient::recv_DescribeTable(SelectResponse& _return)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  iprot_->readMessageBegin(fname, mtype, rseqid);
+  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+    ::apache::thrift::TApplicationException x;
+    x.read(iprot_);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw x;
+  }
+  if (mtype != ::apache::thrift::protocol::T_REPLY) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+  }
+  if (fname.compare("DescribeTable") != 0) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+  }
+  InfinityService_DescribeTable_presult result;
+  result.success = &_return;
+  result.read(iprot_);
+  iprot_->readMessageEnd();
+  iprot_->getTransport()->readEnd();
+
+  if (result.__isset.success) {
+    // _return pointer has now been filled
+    return;
+  }
+  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "DescribeTable failed: unknown result");
+}
+
+void InfinityServiceClient::DescribeDatabase(SelectResponse& _return, const DescribeDatabaseRequest& request)
 {
   send_DescribeDatabase(request);
   recv_DescribeDatabase(_return);
@@ -5048,7 +5293,7 @@ void InfinityServiceClient::send_DescribeDatabase(const DescribeDatabaseRequest&
   oprot_->getTransport()->flush();
 }
 
-void InfinityServiceClient::recv_DescribeDatabase(DescribeDatabaseResponse& _return)
+void InfinityServiceClient::recv_DescribeDatabase(SelectResponse& _return)
 {
 
   int32_t rseqid = 0;
@@ -5086,18 +5331,18 @@ void InfinityServiceClient::recv_DescribeDatabase(DescribeDatabaseResponse& _ret
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "DescribeDatabase failed: unknown result");
 }
 
-void InfinityServiceClient::DescribeTable(DescribeTableResponse& _return, const DescribeTableRequest& request)
+void InfinityServiceClient::ShowTables(SelectResponse& _return, const ShowTablesRequest& request)
 {
-  send_DescribeTable(request);
-  recv_DescribeTable(_return);
+  send_ShowTables(request);
+  recv_ShowTables(_return);
 }
 
-void InfinityServiceClient::send_DescribeTable(const DescribeTableRequest& request)
+void InfinityServiceClient::send_ShowTables(const ShowTablesRequest& request)
 {
   int32_t cseqid = 0;
-  oprot_->writeMessageBegin("DescribeTable", ::apache::thrift::protocol::T_CALL, cseqid);
+  oprot_->writeMessageBegin("ShowTables", ::apache::thrift::protocol::T_CALL, cseqid);
 
-  InfinityService_DescribeTable_pargs args;
+  InfinityService_ShowTables_pargs args;
   args.request = &request;
   args.write(oprot_);
 
@@ -5106,7 +5351,7 @@ void InfinityServiceClient::send_DescribeTable(const DescribeTableRequest& reque
   oprot_->getTransport()->flush();
 }
 
-void InfinityServiceClient::recv_DescribeTable(DescribeTableResponse& _return)
+void InfinityServiceClient::recv_ShowTables(SelectResponse& _return)
 {
 
   int32_t rseqid = 0;
@@ -5126,12 +5371,12 @@ void InfinityServiceClient::recv_DescribeTable(DescribeTableResponse& _return)
     iprot_->readMessageEnd();
     iprot_->getTransport()->readEnd();
   }
-  if (fname.compare("DescribeTable") != 0) {
+  if (fname.compare("ShowTables") != 0) {
     iprot_->skip(::apache::thrift::protocol::T_STRUCT);
     iprot_->readMessageEnd();
     iprot_->getTransport()->readEnd();
   }
-  InfinityService_DescribeTable_presult result;
+  InfinityService_ShowTables_presult result;
   result.success = &_return;
   result.read(iprot_);
   iprot_->readMessageEnd();
@@ -5141,7 +5386,7 @@ void InfinityServiceClient::recv_DescribeTable(DescribeTableResponse& _return)
     // _return pointer has now been filled
     return;
   }
-  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "DescribeTable failed: unknown result");
+  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ShowTables failed: unknown result");
 }
 
 void InfinityServiceClient::GetDatabase(CommonResponse& _return, const GetDatabaseRequest& request)
@@ -6097,60 +6342,6 @@ void InfinityServiceProcessor::process_UploadFileChunk(int32_t seqid, ::apache::
   }
 }
 
-void InfinityServiceProcessor::process_ShowVariable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
-{
-  void* ctx = nullptr;
-  if (this->eventHandler_.get() != nullptr) {
-    ctx = this->eventHandler_->getContext("InfinityService.ShowVariable", callContext);
-  }
-  ::apache::thrift::TProcessorContextFreer freer(this->eventHandler_.get(), ctx, "InfinityService.ShowVariable");
-
-  if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->preRead(ctx, "InfinityService.ShowVariable");
-  }
-
-  InfinityService_ShowVariable_args args;
-  args.read(iprot);
-  iprot->readMessageEnd();
-  uint32_t bytes = iprot->getTransport()->readEnd();
-
-  if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->postRead(ctx, "InfinityService.ShowVariable", bytes);
-  }
-
-  InfinityService_ShowVariable_result result;
-  try {
-    iface_->ShowVariable(result.success, args.request);
-    result.__isset.success = true;
-  } catch (const std::exception& e) {
-    if (this->eventHandler_.get() != nullptr) {
-      this->eventHandler_->handlerError(ctx, "InfinityService.ShowVariable");
-    }
-
-    ::apache::thrift::TApplicationException x(e.what());
-    oprot->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_EXCEPTION, seqid);
-    x.write(oprot);
-    oprot->writeMessageEnd();
-    oprot->getTransport()->writeEnd();
-    oprot->getTransport()->flush();
-    return;
-  }
-
-  if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->preWrite(ctx, "InfinityService.ShowVariable");
-  }
-
-  oprot->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_REPLY, seqid);
-  result.write(oprot);
-  oprot->writeMessageEnd();
-  bytes = oprot->getTransport()->writeEnd();
-  oprot->getTransport()->flush();
-
-  if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->postWrite(ctx, "InfinityService.ShowVariable", bytes);
-  }
-}
-
 void InfinityServiceProcessor::process_ListDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
 {
   void* ctx = nullptr;
@@ -6259,38 +6450,38 @@ void InfinityServiceProcessor::process_ListTable(int32_t seqid, ::apache::thrift
   }
 }
 
-void InfinityServiceProcessor::process_DescribeDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
+void InfinityServiceProcessor::process_ShowVariable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
 {
   void* ctx = nullptr;
   if (this->eventHandler_.get() != nullptr) {
-    ctx = this->eventHandler_->getContext("InfinityService.DescribeDatabase", callContext);
+    ctx = this->eventHandler_->getContext("InfinityService.ShowVariable", callContext);
   }
-  ::apache::thrift::TProcessorContextFreer freer(this->eventHandler_.get(), ctx, "InfinityService.DescribeDatabase");
+  ::apache::thrift::TProcessorContextFreer freer(this->eventHandler_.get(), ctx, "InfinityService.ShowVariable");
 
   if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->preRead(ctx, "InfinityService.DescribeDatabase");
+    this->eventHandler_->preRead(ctx, "InfinityService.ShowVariable");
   }
 
-  InfinityService_DescribeDatabase_args args;
+  InfinityService_ShowVariable_args args;
   args.read(iprot);
   iprot->readMessageEnd();
   uint32_t bytes = iprot->getTransport()->readEnd();
 
   if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->postRead(ctx, "InfinityService.DescribeDatabase", bytes);
+    this->eventHandler_->postRead(ctx, "InfinityService.ShowVariable", bytes);
   }
 
-  InfinityService_DescribeDatabase_result result;
+  InfinityService_ShowVariable_result result;
   try {
-    iface_->DescribeDatabase(result.success, args.request);
+    iface_->ShowVariable(result.success, args.request);
     result.__isset.success = true;
   } catch (const std::exception& e) {
     if (this->eventHandler_.get() != nullptr) {
-      this->eventHandler_->handlerError(ctx, "InfinityService.DescribeDatabase");
+      this->eventHandler_->handlerError(ctx, "InfinityService.ShowVariable");
     }
 
     ::apache::thrift::TApplicationException x(e.what());
-    oprot->writeMessageBegin("DescribeDatabase", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    oprot->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_EXCEPTION, seqid);
     x.write(oprot);
     oprot->writeMessageEnd();
     oprot->getTransport()->writeEnd();
@@ -6299,17 +6490,17 @@ void InfinityServiceProcessor::process_DescribeDatabase(int32_t seqid, ::apache:
   }
 
   if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->preWrite(ctx, "InfinityService.DescribeDatabase");
+    this->eventHandler_->preWrite(ctx, "InfinityService.ShowVariable");
   }
 
-  oprot->writeMessageBegin("DescribeDatabase", ::apache::thrift::protocol::T_REPLY, seqid);
+  oprot->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_REPLY, seqid);
   result.write(oprot);
   oprot->writeMessageEnd();
   bytes = oprot->getTransport()->writeEnd();
   oprot->getTransport()->flush();
 
   if (this->eventHandler_.get() != nullptr) {
-    this->eventHandler_->postWrite(ctx, "InfinityService.DescribeDatabase", bytes);
+    this->eventHandler_->postWrite(ctx, "InfinityService.ShowVariable", bytes);
   }
 }
 
@@ -6364,6 +6555,114 @@ void InfinityServiceProcessor::process_DescribeTable(int32_t seqid, ::apache::th
 
   if (this->eventHandler_.get() != nullptr) {
     this->eventHandler_->postWrite(ctx, "InfinityService.DescribeTable", bytes);
+  }
+}
+
+void InfinityServiceProcessor::process_DescribeDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
+{
+  void* ctx = nullptr;
+  if (this->eventHandler_.get() != nullptr) {
+    ctx = this->eventHandler_->getContext("InfinityService.DescribeDatabase", callContext);
+  }
+  ::apache::thrift::TProcessorContextFreer freer(this->eventHandler_.get(), ctx, "InfinityService.DescribeDatabase");
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->preRead(ctx, "InfinityService.DescribeDatabase");
+  }
+
+  InfinityService_DescribeDatabase_args args;
+  args.read(iprot);
+  iprot->readMessageEnd();
+  uint32_t bytes = iprot->getTransport()->readEnd();
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->postRead(ctx, "InfinityService.DescribeDatabase", bytes);
+  }
+
+  InfinityService_DescribeDatabase_result result;
+  try {
+    iface_->DescribeDatabase(result.success, args.request);
+    result.__isset.success = true;
+  } catch (const std::exception& e) {
+    if (this->eventHandler_.get() != nullptr) {
+      this->eventHandler_->handlerError(ctx, "InfinityService.DescribeDatabase");
+    }
+
+    ::apache::thrift::TApplicationException x(e.what());
+    oprot->writeMessageBegin("DescribeDatabase", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    x.write(oprot);
+    oprot->writeMessageEnd();
+    oprot->getTransport()->writeEnd();
+    oprot->getTransport()->flush();
+    return;
+  }
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->preWrite(ctx, "InfinityService.DescribeDatabase");
+  }
+
+  oprot->writeMessageBegin("DescribeDatabase", ::apache::thrift::protocol::T_REPLY, seqid);
+  result.write(oprot);
+  oprot->writeMessageEnd();
+  bytes = oprot->getTransport()->writeEnd();
+  oprot->getTransport()->flush();
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->postWrite(ctx, "InfinityService.DescribeDatabase", bytes);
+  }
+}
+
+void InfinityServiceProcessor::process_ShowTables(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
+{
+  void* ctx = nullptr;
+  if (this->eventHandler_.get() != nullptr) {
+    ctx = this->eventHandler_->getContext("InfinityService.ShowTables", callContext);
+  }
+  ::apache::thrift::TProcessorContextFreer freer(this->eventHandler_.get(), ctx, "InfinityService.ShowTables");
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->preRead(ctx, "InfinityService.ShowTables");
+  }
+
+  InfinityService_ShowTables_args args;
+  args.read(iprot);
+  iprot->readMessageEnd();
+  uint32_t bytes = iprot->getTransport()->readEnd();
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->postRead(ctx, "InfinityService.ShowTables", bytes);
+  }
+
+  InfinityService_ShowTables_result result;
+  try {
+    iface_->ShowTables(result.success, args.request);
+    result.__isset.success = true;
+  } catch (const std::exception& e) {
+    if (this->eventHandler_.get() != nullptr) {
+      this->eventHandler_->handlerError(ctx, "InfinityService.ShowTables");
+    }
+
+    ::apache::thrift::TApplicationException x(e.what());
+    oprot->writeMessageBegin("ShowTables", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    x.write(oprot);
+    oprot->writeMessageEnd();
+    oprot->getTransport()->writeEnd();
+    oprot->getTransport()->flush();
+    return;
+  }
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->preWrite(ctx, "InfinityService.ShowTables");
+  }
+
+  oprot->writeMessageBegin("ShowTables", ::apache::thrift::protocol::T_REPLY, seqid);
+  result.write(oprot);
+  oprot->writeMessageEnd();
+  bytes = oprot->getTransport()->writeEnd();
+  oprot->getTransport()->flush();
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->postWrite(ctx, "InfinityService.ShowTables", bytes);
   }
 }
 
@@ -7681,90 +7980,6 @@ void InfinityServiceConcurrentClient::recv_UploadFileChunk(UploadResponse& _retu
   } // end while(true)
 }
 
-void InfinityServiceConcurrentClient::ShowVariable(SelectResponse& _return, const ShowVariableRequest& request)
-{
-  int32_t seqid = send_ShowVariable(request);
-  recv_ShowVariable(_return, seqid);
-}
-
-int32_t InfinityServiceConcurrentClient::send_ShowVariable(const ShowVariableRequest& request)
-{
-  int32_t cseqid = this->sync_->generateSeqId();
-  ::apache::thrift::async::TConcurrentSendSentry sentry(this->sync_.get());
-  oprot_->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_CALL, cseqid);
-
-  InfinityService_ShowVariable_pargs args;
-  args.request = &request;
-  args.write(oprot_);
-
-  oprot_->writeMessageEnd();
-  oprot_->getTransport()->writeEnd();
-  oprot_->getTransport()->flush();
-
-  sentry.commit();
-  return cseqid;
-}
-
-void InfinityServiceConcurrentClient::recv_ShowVariable(SelectResponse& _return, const int32_t seqid)
-{
-
-  int32_t rseqid = 0;
-  std::string fname;
-  ::apache::thrift::protocol::TMessageType mtype;
-
-  // the read mutex gets dropped and reacquired as part of waitForWork()
-  // The destructor of this sentry wakes up other clients
-  ::apache::thrift::async::TConcurrentRecvSentry sentry(this->sync_.get(), seqid);
-
-  while(true) {
-    if(!this->sync_->getPending(fname, mtype, rseqid)) {
-      iprot_->readMessageBegin(fname, mtype, rseqid);
-    }
-    if(seqid == rseqid) {
-      if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
-        ::apache::thrift::TApplicationException x;
-        x.read(iprot_);
-        iprot_->readMessageEnd();
-        iprot_->getTransport()->readEnd();
-        sentry.commit();
-        throw x;
-      }
-      if (mtype != ::apache::thrift::protocol::T_REPLY) {
-        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
-        iprot_->readMessageEnd();
-        iprot_->getTransport()->readEnd();
-      }
-      if (fname.compare("ShowVariable") != 0) {
-        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
-        iprot_->readMessageEnd();
-        iprot_->getTransport()->readEnd();
-
-        // in a bad state, don't commit
-        using ::apache::thrift::protocol::TProtocolException;
-        throw TProtocolException(TProtocolException::INVALID_DATA);
-      }
-      InfinityService_ShowVariable_presult result;
-      result.success = &_return;
-      result.read(iprot_);
-      iprot_->readMessageEnd();
-      iprot_->getTransport()->readEnd();
-
-      if (result.__isset.success) {
-        // _return pointer has now been filled
-        sentry.commit();
-        return;
-      }
-      // in a bad state, don't commit
-      throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ShowVariable failed: unknown result");
-    }
-    // seqid != rseqid
-    this->sync_->updatePending(fname, mtype, rseqid);
-
-    // this will temporarily unlock the readMutex, and let other clients get work done
-    this->sync_->waitForWork(seqid);
-  } // end while(true)
-}
-
 void InfinityServiceConcurrentClient::ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request)
 {
   int32_t seqid = send_ListDatabase(request);
@@ -7933,7 +8148,175 @@ void InfinityServiceConcurrentClient::recv_ListTable(ListTableResponse& _return,
   } // end while(true)
 }
 
-void InfinityServiceConcurrentClient::DescribeDatabase(DescribeDatabaseResponse& _return, const DescribeDatabaseRequest& request)
+void InfinityServiceConcurrentClient::ShowVariable(SelectResponse& _return, const ShowVariableRequest& request)
+{
+  int32_t seqid = send_ShowVariable(request);
+  recv_ShowVariable(_return, seqid);
+}
+
+int32_t InfinityServiceConcurrentClient::send_ShowVariable(const ShowVariableRequest& request)
+{
+  int32_t cseqid = this->sync_->generateSeqId();
+  ::apache::thrift::async::TConcurrentSendSentry sentry(this->sync_.get());
+  oprot_->writeMessageBegin("ShowVariable", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  InfinityService_ShowVariable_pargs args;
+  args.request = &request;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->writeEnd();
+  oprot_->getTransport()->flush();
+
+  sentry.commit();
+  return cseqid;
+}
+
+void InfinityServiceConcurrentClient::recv_ShowVariable(SelectResponse& _return, const int32_t seqid)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  // the read mutex gets dropped and reacquired as part of waitForWork()
+  // The destructor of this sentry wakes up other clients
+  ::apache::thrift::async::TConcurrentRecvSentry sentry(this->sync_.get(), seqid);
+
+  while(true) {
+    if(!this->sync_->getPending(fname, mtype, rseqid)) {
+      iprot_->readMessageBegin(fname, mtype, rseqid);
+    }
+    if(seqid == rseqid) {
+      if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+        ::apache::thrift::TApplicationException x;
+        x.read(iprot_);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+        sentry.commit();
+        throw x;
+      }
+      if (mtype != ::apache::thrift::protocol::T_REPLY) {
+        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+      }
+      if (fname.compare("ShowVariable") != 0) {
+        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+
+        // in a bad state, don't commit
+        using ::apache::thrift::protocol::TProtocolException;
+        throw TProtocolException(TProtocolException::INVALID_DATA);
+      }
+      InfinityService_ShowVariable_presult result;
+      result.success = &_return;
+      result.read(iprot_);
+      iprot_->readMessageEnd();
+      iprot_->getTransport()->readEnd();
+
+      if (result.__isset.success) {
+        // _return pointer has now been filled
+        sentry.commit();
+        return;
+      }
+      // in a bad state, don't commit
+      throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ShowVariable failed: unknown result");
+    }
+    // seqid != rseqid
+    this->sync_->updatePending(fname, mtype, rseqid);
+
+    // this will temporarily unlock the readMutex, and let other clients get work done
+    this->sync_->waitForWork(seqid);
+  } // end while(true)
+}
+
+void InfinityServiceConcurrentClient::DescribeTable(SelectResponse& _return, const DescribeTableRequest& request)
+{
+  int32_t seqid = send_DescribeTable(request);
+  recv_DescribeTable(_return, seqid);
+}
+
+int32_t InfinityServiceConcurrentClient::send_DescribeTable(const DescribeTableRequest& request)
+{
+  int32_t cseqid = this->sync_->generateSeqId();
+  ::apache::thrift::async::TConcurrentSendSentry sentry(this->sync_.get());
+  oprot_->writeMessageBegin("DescribeTable", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  InfinityService_DescribeTable_pargs args;
+  args.request = &request;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->writeEnd();
+  oprot_->getTransport()->flush();
+
+  sentry.commit();
+  return cseqid;
+}
+
+void InfinityServiceConcurrentClient::recv_DescribeTable(SelectResponse& _return, const int32_t seqid)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  // the read mutex gets dropped and reacquired as part of waitForWork()
+  // The destructor of this sentry wakes up other clients
+  ::apache::thrift::async::TConcurrentRecvSentry sentry(this->sync_.get(), seqid);
+
+  while(true) {
+    if(!this->sync_->getPending(fname, mtype, rseqid)) {
+      iprot_->readMessageBegin(fname, mtype, rseqid);
+    }
+    if(seqid == rseqid) {
+      if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+        ::apache::thrift::TApplicationException x;
+        x.read(iprot_);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+        sentry.commit();
+        throw x;
+      }
+      if (mtype != ::apache::thrift::protocol::T_REPLY) {
+        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+      }
+      if (fname.compare("DescribeTable") != 0) {
+        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+
+        // in a bad state, don't commit
+        using ::apache::thrift::protocol::TProtocolException;
+        throw TProtocolException(TProtocolException::INVALID_DATA);
+      }
+      InfinityService_DescribeTable_presult result;
+      result.success = &_return;
+      result.read(iprot_);
+      iprot_->readMessageEnd();
+      iprot_->getTransport()->readEnd();
+
+      if (result.__isset.success) {
+        // _return pointer has now been filled
+        sentry.commit();
+        return;
+      }
+      // in a bad state, don't commit
+      throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "DescribeTable failed: unknown result");
+    }
+    // seqid != rseqid
+    this->sync_->updatePending(fname, mtype, rseqid);
+
+    // this will temporarily unlock the readMutex, and let other clients get work done
+    this->sync_->waitForWork(seqid);
+  } // end while(true)
+}
+
+void InfinityServiceConcurrentClient::DescribeDatabase(SelectResponse& _return, const DescribeDatabaseRequest& request)
 {
   int32_t seqid = send_DescribeDatabase(request);
   recv_DescribeDatabase(_return, seqid);
@@ -7957,7 +8340,7 @@ int32_t InfinityServiceConcurrentClient::send_DescribeDatabase(const DescribeDat
   return cseqid;
 }
 
-void InfinityServiceConcurrentClient::recv_DescribeDatabase(DescribeDatabaseResponse& _return, const int32_t seqid)
+void InfinityServiceConcurrentClient::recv_DescribeDatabase(SelectResponse& _return, const int32_t seqid)
 {
 
   int32_t rseqid = 0;
@@ -8017,19 +8400,19 @@ void InfinityServiceConcurrentClient::recv_DescribeDatabase(DescribeDatabaseResp
   } // end while(true)
 }
 
-void InfinityServiceConcurrentClient::DescribeTable(DescribeTableResponse& _return, const DescribeTableRequest& request)
+void InfinityServiceConcurrentClient::ShowTables(SelectResponse& _return, const ShowTablesRequest& request)
 {
-  int32_t seqid = send_DescribeTable(request);
-  recv_DescribeTable(_return, seqid);
+  int32_t seqid = send_ShowTables(request);
+  recv_ShowTables(_return, seqid);
 }
 
-int32_t InfinityServiceConcurrentClient::send_DescribeTable(const DescribeTableRequest& request)
+int32_t InfinityServiceConcurrentClient::send_ShowTables(const ShowTablesRequest& request)
 {
   int32_t cseqid = this->sync_->generateSeqId();
   ::apache::thrift::async::TConcurrentSendSentry sentry(this->sync_.get());
-  oprot_->writeMessageBegin("DescribeTable", ::apache::thrift::protocol::T_CALL, cseqid);
+  oprot_->writeMessageBegin("ShowTables", ::apache::thrift::protocol::T_CALL, cseqid);
 
-  InfinityService_DescribeTable_pargs args;
+  InfinityService_ShowTables_pargs args;
   args.request = &request;
   args.write(oprot_);
 
@@ -8041,7 +8424,7 @@ int32_t InfinityServiceConcurrentClient::send_DescribeTable(const DescribeTableR
   return cseqid;
 }
 
-void InfinityServiceConcurrentClient::recv_DescribeTable(DescribeTableResponse& _return, const int32_t seqid)
+void InfinityServiceConcurrentClient::recv_ShowTables(SelectResponse& _return, const int32_t seqid)
 {
 
   int32_t rseqid = 0;
@@ -8070,7 +8453,7 @@ void InfinityServiceConcurrentClient::recv_DescribeTable(DescribeTableResponse& 
         iprot_->readMessageEnd();
         iprot_->getTransport()->readEnd();
       }
-      if (fname.compare("DescribeTable") != 0) {
+      if (fname.compare("ShowTables") != 0) {
         iprot_->skip(::apache::thrift::protocol::T_STRUCT);
         iprot_->readMessageEnd();
         iprot_->getTransport()->readEnd();
@@ -8079,7 +8462,7 @@ void InfinityServiceConcurrentClient::recv_DescribeTable(DescribeTableResponse& 
         using ::apache::thrift::protocol::TProtocolException;
         throw TProtocolException(TProtocolException::INVALID_DATA);
       }
-      InfinityService_DescribeTable_presult result;
+      InfinityService_ShowTables_presult result;
       result.success = &_return;
       result.read(iprot_);
       iprot_->readMessageEnd();
@@ -8091,7 +8474,7 @@ void InfinityServiceConcurrentClient::recv_DescribeTable(DescribeTableResponse& 
         return;
       }
       // in a bad state, don't commit
-      throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "DescribeTable failed: unknown result");
+      throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ShowTables failed: unknown result");
     }
     // seqid != rseqid
     this->sync_->updatePending(fname, mtype, rseqid);

--- a/src/network/infinity_thrift/InfinityService.h
+++ b/src/network/infinity_thrift/InfinityService.h
@@ -35,11 +35,12 @@ class InfinityServiceIf {
   virtual void Delete(CommonResponse& _return, const DeleteRequest& request) = 0;
   virtual void Update(CommonResponse& _return, const UpdateRequest& request) = 0;
   virtual void UploadFileChunk(UploadResponse& _return, const FileChunk& request) = 0;
-  virtual void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) = 0;
   virtual void ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request) = 0;
   virtual void ListTable(ListTableResponse& _return, const ListTableRequest& request) = 0;
-  virtual void DescribeDatabase(DescribeDatabaseResponse& _return, const DescribeDatabaseRequest& request) = 0;
-  virtual void DescribeTable(DescribeTableResponse& _return, const DescribeTableRequest& request) = 0;
+  virtual void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) = 0;
+  virtual void DescribeTable(SelectResponse& _return, const DescribeTableRequest& request) = 0;
+  virtual void DescribeDatabase(SelectResponse& _return, const DescribeDatabaseRequest& request) = 0;
+  virtual void ShowTables(SelectResponse& _return, const ShowTablesRequest& request) = 0;
   virtual void GetDatabase(CommonResponse& _return, const GetDatabaseRequest& request) = 0;
   virtual void GetTable(CommonResponse& _return, const GetTableRequest& request) = 0;
   virtual void CreateIndex(CommonResponse& _return, const CreateIndexRequest& request) = 0;
@@ -112,19 +113,22 @@ class InfinityServiceNull : virtual public InfinityServiceIf {
   void UploadFileChunk(UploadResponse& /* _return */, const FileChunk& /* request */) override {
     return;
   }
-  void ShowVariable(SelectResponse& /* _return */, const ShowVariableRequest& /* request */) override {
-    return;
-  }
   void ListDatabase(ListDatabaseResponse& /* _return */, const ListDatabaseRequest& /* request */) override {
     return;
   }
   void ListTable(ListTableResponse& /* _return */, const ListTableRequest& /* request */) override {
     return;
   }
-  void DescribeDatabase(DescribeDatabaseResponse& /* _return */, const DescribeDatabaseRequest& /* request */) override {
+  void ShowVariable(SelectResponse& /* _return */, const ShowVariableRequest& /* request */) override {
     return;
   }
-  void DescribeTable(DescribeTableResponse& /* _return */, const DescribeTableRequest& /* request */) override {
+  void DescribeTable(SelectResponse& /* _return */, const DescribeTableRequest& /* request */) override {
+    return;
+  }
+  void DescribeDatabase(SelectResponse& /* _return */, const DescribeDatabaseRequest& /* request */) override {
+    return;
+  }
+  void ShowTables(SelectResponse& /* _return */, const ShowTablesRequest& /* request */) override {
     return;
   }
   void GetDatabase(CommonResponse& /* _return */, const GetDatabaseRequest& /* request */) override {
@@ -1481,110 +1485,6 @@ class InfinityService_UploadFileChunk_presult {
 
 };
 
-typedef struct _InfinityService_ShowVariable_args__isset {
-  _InfinityService_ShowVariable_args__isset() : request(false) {}
-  bool request :1;
-} _InfinityService_ShowVariable_args__isset;
-
-class InfinityService_ShowVariable_args {
- public:
-
-  InfinityService_ShowVariable_args(const InfinityService_ShowVariable_args&);
-  InfinityService_ShowVariable_args& operator=(const InfinityService_ShowVariable_args&);
-  InfinityService_ShowVariable_args() noexcept {
-  }
-
-  virtual ~InfinityService_ShowVariable_args() noexcept;
-  ShowVariableRequest request;
-
-  _InfinityService_ShowVariable_args__isset __isset;
-
-  void __set_request(const ShowVariableRequest& val);
-
-  bool operator == (const InfinityService_ShowVariable_args & rhs) const
-  {
-    if (!(request == rhs.request))
-      return false;
-    return true;
-  }
-  bool operator != (const InfinityService_ShowVariable_args &rhs) const {
-    return !(*this == rhs);
-  }
-
-  bool operator < (const InfinityService_ShowVariable_args & ) const;
-
-  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
-  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
-
-};
-
-
-class InfinityService_ShowVariable_pargs {
- public:
-
-
-  virtual ~InfinityService_ShowVariable_pargs() noexcept;
-  const ShowVariableRequest* request;
-
-  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
-
-};
-
-typedef struct _InfinityService_ShowVariable_result__isset {
-  _InfinityService_ShowVariable_result__isset() : success(false) {}
-  bool success :1;
-} _InfinityService_ShowVariable_result__isset;
-
-class InfinityService_ShowVariable_result {
- public:
-
-  InfinityService_ShowVariable_result(const InfinityService_ShowVariable_result&);
-  InfinityService_ShowVariable_result& operator=(const InfinityService_ShowVariable_result&);
-  InfinityService_ShowVariable_result() noexcept {
-  }
-
-  virtual ~InfinityService_ShowVariable_result() noexcept;
-  SelectResponse success;
-
-  _InfinityService_ShowVariable_result__isset __isset;
-
-  void __set_success(const SelectResponse& val);
-
-  bool operator == (const InfinityService_ShowVariable_result & rhs) const
-  {
-    if (!(success == rhs.success))
-      return false;
-    return true;
-  }
-  bool operator != (const InfinityService_ShowVariable_result &rhs) const {
-    return !(*this == rhs);
-  }
-
-  bool operator < (const InfinityService_ShowVariable_result & ) const;
-
-  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
-  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
-
-};
-
-typedef struct _InfinityService_ShowVariable_presult__isset {
-  _InfinityService_ShowVariable_presult__isset() : success(false) {}
-  bool success :1;
-} _InfinityService_ShowVariable_presult__isset;
-
-class InfinityService_ShowVariable_presult {
- public:
-
-
-  virtual ~InfinityService_ShowVariable_presult() noexcept;
-  SelectResponse* success;
-
-  _InfinityService_ShowVariable_presult__isset __isset;
-
-  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
-
-};
-
 typedef struct _InfinityService_ListDatabase_args__isset {
   _InfinityService_ListDatabase_args__isset() : request(false) {}
   bool request :1;
@@ -1793,37 +1693,37 @@ class InfinityService_ListTable_presult {
 
 };
 
-typedef struct _InfinityService_DescribeDatabase_args__isset {
-  _InfinityService_DescribeDatabase_args__isset() : request(false) {}
+typedef struct _InfinityService_ShowVariable_args__isset {
+  _InfinityService_ShowVariable_args__isset() : request(false) {}
   bool request :1;
-} _InfinityService_DescribeDatabase_args__isset;
+} _InfinityService_ShowVariable_args__isset;
 
-class InfinityService_DescribeDatabase_args {
+class InfinityService_ShowVariable_args {
  public:
 
-  InfinityService_DescribeDatabase_args(const InfinityService_DescribeDatabase_args&);
-  InfinityService_DescribeDatabase_args& operator=(const InfinityService_DescribeDatabase_args&);
-  InfinityService_DescribeDatabase_args() noexcept {
+  InfinityService_ShowVariable_args(const InfinityService_ShowVariable_args&);
+  InfinityService_ShowVariable_args& operator=(const InfinityService_ShowVariable_args&);
+  InfinityService_ShowVariable_args() noexcept {
   }
 
-  virtual ~InfinityService_DescribeDatabase_args() noexcept;
-  DescribeDatabaseRequest request;
+  virtual ~InfinityService_ShowVariable_args() noexcept;
+  ShowVariableRequest request;
 
-  _InfinityService_DescribeDatabase_args__isset __isset;
+  _InfinityService_ShowVariable_args__isset __isset;
 
-  void __set_request(const DescribeDatabaseRequest& val);
+  void __set_request(const ShowVariableRequest& val);
 
-  bool operator == (const InfinityService_DescribeDatabase_args & rhs) const
+  bool operator == (const InfinityService_ShowVariable_args & rhs) const
   {
     if (!(request == rhs.request))
       return false;
     return true;
   }
-  bool operator != (const InfinityService_DescribeDatabase_args &rhs) const {
+  bool operator != (const InfinityService_ShowVariable_args &rhs) const {
     return !(*this == rhs);
   }
 
-  bool operator < (const InfinityService_DescribeDatabase_args & ) const;
+  bool operator < (const InfinityService_ShowVariable_args & ) const;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
@@ -1831,67 +1731,67 @@ class InfinityService_DescribeDatabase_args {
 };
 
 
-class InfinityService_DescribeDatabase_pargs {
+class InfinityService_ShowVariable_pargs {
  public:
 
 
-  virtual ~InfinityService_DescribeDatabase_pargs() noexcept;
-  const DescribeDatabaseRequest* request;
+  virtual ~InfinityService_ShowVariable_pargs() noexcept;
+  const ShowVariableRequest* request;
 
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
 
 };
 
-typedef struct _InfinityService_DescribeDatabase_result__isset {
-  _InfinityService_DescribeDatabase_result__isset() : success(false) {}
+typedef struct _InfinityService_ShowVariable_result__isset {
+  _InfinityService_ShowVariable_result__isset() : success(false) {}
   bool success :1;
-} _InfinityService_DescribeDatabase_result__isset;
+} _InfinityService_ShowVariable_result__isset;
 
-class InfinityService_DescribeDatabase_result {
+class InfinityService_ShowVariable_result {
  public:
 
-  InfinityService_DescribeDatabase_result(const InfinityService_DescribeDatabase_result&);
-  InfinityService_DescribeDatabase_result& operator=(const InfinityService_DescribeDatabase_result&);
-  InfinityService_DescribeDatabase_result() noexcept {
+  InfinityService_ShowVariable_result(const InfinityService_ShowVariable_result&);
+  InfinityService_ShowVariable_result& operator=(const InfinityService_ShowVariable_result&);
+  InfinityService_ShowVariable_result() noexcept {
   }
 
-  virtual ~InfinityService_DescribeDatabase_result() noexcept;
-  DescribeDatabaseResponse success;
+  virtual ~InfinityService_ShowVariable_result() noexcept;
+  SelectResponse success;
 
-  _InfinityService_DescribeDatabase_result__isset __isset;
+  _InfinityService_ShowVariable_result__isset __isset;
 
-  void __set_success(const DescribeDatabaseResponse& val);
+  void __set_success(const SelectResponse& val);
 
-  bool operator == (const InfinityService_DescribeDatabase_result & rhs) const
+  bool operator == (const InfinityService_ShowVariable_result & rhs) const
   {
     if (!(success == rhs.success))
       return false;
     return true;
   }
-  bool operator != (const InfinityService_DescribeDatabase_result &rhs) const {
+  bool operator != (const InfinityService_ShowVariable_result &rhs) const {
     return !(*this == rhs);
   }
 
-  bool operator < (const InfinityService_DescribeDatabase_result & ) const;
+  bool operator < (const InfinityService_ShowVariable_result & ) const;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
 
 };
 
-typedef struct _InfinityService_DescribeDatabase_presult__isset {
-  _InfinityService_DescribeDatabase_presult__isset() : success(false) {}
+typedef struct _InfinityService_ShowVariable_presult__isset {
+  _InfinityService_ShowVariable_presult__isset() : success(false) {}
   bool success :1;
-} _InfinityService_DescribeDatabase_presult__isset;
+} _InfinityService_ShowVariable_presult__isset;
 
-class InfinityService_DescribeDatabase_presult {
+class InfinityService_ShowVariable_presult {
  public:
 
 
-  virtual ~InfinityService_DescribeDatabase_presult() noexcept;
-  DescribeDatabaseResponse* success;
+  virtual ~InfinityService_ShowVariable_presult() noexcept;
+  SelectResponse* success;
 
-  _InfinityService_DescribeDatabase_presult__isset __isset;
+  _InfinityService_ShowVariable_presult__isset __isset;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
 
@@ -1960,11 +1860,11 @@ class InfinityService_DescribeTable_result {
   }
 
   virtual ~InfinityService_DescribeTable_result() noexcept;
-  DescribeTableResponse success;
+  SelectResponse success;
 
   _InfinityService_DescribeTable_result__isset __isset;
 
-  void __set_success(const DescribeTableResponse& val);
+  void __set_success(const SelectResponse& val);
 
   bool operator == (const InfinityService_DescribeTable_result & rhs) const
   {
@@ -1993,9 +1893,217 @@ class InfinityService_DescribeTable_presult {
 
 
   virtual ~InfinityService_DescribeTable_presult() noexcept;
-  DescribeTableResponse* success;
+  SelectResponse* success;
 
   _InfinityService_DescribeTable_presult__isset __isset;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+
+};
+
+typedef struct _InfinityService_DescribeDatabase_args__isset {
+  _InfinityService_DescribeDatabase_args__isset() : request(false) {}
+  bool request :1;
+} _InfinityService_DescribeDatabase_args__isset;
+
+class InfinityService_DescribeDatabase_args {
+ public:
+
+  InfinityService_DescribeDatabase_args(const InfinityService_DescribeDatabase_args&);
+  InfinityService_DescribeDatabase_args& operator=(const InfinityService_DescribeDatabase_args&);
+  InfinityService_DescribeDatabase_args() noexcept {
+  }
+
+  virtual ~InfinityService_DescribeDatabase_args() noexcept;
+  DescribeDatabaseRequest request;
+
+  _InfinityService_DescribeDatabase_args__isset __isset;
+
+  void __set_request(const DescribeDatabaseRequest& val);
+
+  bool operator == (const InfinityService_DescribeDatabase_args & rhs) const
+  {
+    if (!(request == rhs.request))
+      return false;
+    return true;
+  }
+  bool operator != (const InfinityService_DescribeDatabase_args &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const InfinityService_DescribeDatabase_args & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class InfinityService_DescribeDatabase_pargs {
+ public:
+
+
+  virtual ~InfinityService_DescribeDatabase_pargs() noexcept;
+  const DescribeDatabaseRequest* request;
+
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _InfinityService_DescribeDatabase_result__isset {
+  _InfinityService_DescribeDatabase_result__isset() : success(false) {}
+  bool success :1;
+} _InfinityService_DescribeDatabase_result__isset;
+
+class InfinityService_DescribeDatabase_result {
+ public:
+
+  InfinityService_DescribeDatabase_result(const InfinityService_DescribeDatabase_result&);
+  InfinityService_DescribeDatabase_result& operator=(const InfinityService_DescribeDatabase_result&);
+  InfinityService_DescribeDatabase_result() noexcept {
+  }
+
+  virtual ~InfinityService_DescribeDatabase_result() noexcept;
+  SelectResponse success;
+
+  _InfinityService_DescribeDatabase_result__isset __isset;
+
+  void __set_success(const SelectResponse& val);
+
+  bool operator == (const InfinityService_DescribeDatabase_result & rhs) const
+  {
+    if (!(success == rhs.success))
+      return false;
+    return true;
+  }
+  bool operator != (const InfinityService_DescribeDatabase_result &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const InfinityService_DescribeDatabase_result & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _InfinityService_DescribeDatabase_presult__isset {
+  _InfinityService_DescribeDatabase_presult__isset() : success(false) {}
+  bool success :1;
+} _InfinityService_DescribeDatabase_presult__isset;
+
+class InfinityService_DescribeDatabase_presult {
+ public:
+
+
+  virtual ~InfinityService_DescribeDatabase_presult() noexcept;
+  SelectResponse* success;
+
+  _InfinityService_DescribeDatabase_presult__isset __isset;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+
+};
+
+typedef struct _InfinityService_ShowTables_args__isset {
+  _InfinityService_ShowTables_args__isset() : request(false) {}
+  bool request :1;
+} _InfinityService_ShowTables_args__isset;
+
+class InfinityService_ShowTables_args {
+ public:
+
+  InfinityService_ShowTables_args(const InfinityService_ShowTables_args&);
+  InfinityService_ShowTables_args& operator=(const InfinityService_ShowTables_args&);
+  InfinityService_ShowTables_args() noexcept {
+  }
+
+  virtual ~InfinityService_ShowTables_args() noexcept;
+  ShowTablesRequest request;
+
+  _InfinityService_ShowTables_args__isset __isset;
+
+  void __set_request(const ShowTablesRequest& val);
+
+  bool operator == (const InfinityService_ShowTables_args & rhs) const
+  {
+    if (!(request == rhs.request))
+      return false;
+    return true;
+  }
+  bool operator != (const InfinityService_ShowTables_args &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const InfinityService_ShowTables_args & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class InfinityService_ShowTables_pargs {
+ public:
+
+
+  virtual ~InfinityService_ShowTables_pargs() noexcept;
+  const ShowTablesRequest* request;
+
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _InfinityService_ShowTables_result__isset {
+  _InfinityService_ShowTables_result__isset() : success(false) {}
+  bool success :1;
+} _InfinityService_ShowTables_result__isset;
+
+class InfinityService_ShowTables_result {
+ public:
+
+  InfinityService_ShowTables_result(const InfinityService_ShowTables_result&);
+  InfinityService_ShowTables_result& operator=(const InfinityService_ShowTables_result&);
+  InfinityService_ShowTables_result() noexcept {
+  }
+
+  virtual ~InfinityService_ShowTables_result() noexcept;
+  SelectResponse success;
+
+  _InfinityService_ShowTables_result__isset __isset;
+
+  void __set_success(const SelectResponse& val);
+
+  bool operator == (const InfinityService_ShowTables_result & rhs) const
+  {
+    if (!(success == rhs.success))
+      return false;
+    return true;
+  }
+  bool operator != (const InfinityService_ShowTables_result &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const InfinityService_ShowTables_result & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _InfinityService_ShowTables_presult__isset {
+  _InfinityService_ShowTables_presult__isset() : success(false) {}
+  bool success :1;
+} _InfinityService_ShowTables_presult__isset;
+
+class InfinityService_ShowTables_presult {
+ public:
+
+
+  virtual ~InfinityService_ShowTables_presult() noexcept;
+  SelectResponse* success;
+
+  _InfinityService_ShowTables_presult__isset __isset;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
 
@@ -2481,21 +2589,24 @@ class InfinityServiceClient : virtual public InfinityServiceIf {
   void UploadFileChunk(UploadResponse& _return, const FileChunk& request) override;
   void send_UploadFileChunk(const FileChunk& request);
   void recv_UploadFileChunk(UploadResponse& _return);
-  void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override;
-  void send_ShowVariable(const ShowVariableRequest& request);
-  void recv_ShowVariable(SelectResponse& _return);
   void ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request) override;
   void send_ListDatabase(const ListDatabaseRequest& request);
   void recv_ListDatabase(ListDatabaseResponse& _return);
   void ListTable(ListTableResponse& _return, const ListTableRequest& request) override;
   void send_ListTable(const ListTableRequest& request);
   void recv_ListTable(ListTableResponse& _return);
-  void DescribeDatabase(DescribeDatabaseResponse& _return, const DescribeDatabaseRequest& request) override;
-  void send_DescribeDatabase(const DescribeDatabaseRequest& request);
-  void recv_DescribeDatabase(DescribeDatabaseResponse& _return);
-  void DescribeTable(DescribeTableResponse& _return, const DescribeTableRequest& request) override;
+  void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override;
+  void send_ShowVariable(const ShowVariableRequest& request);
+  void recv_ShowVariable(SelectResponse& _return);
+  void DescribeTable(SelectResponse& _return, const DescribeTableRequest& request) override;
   void send_DescribeTable(const DescribeTableRequest& request);
-  void recv_DescribeTable(DescribeTableResponse& _return);
+  void recv_DescribeTable(SelectResponse& _return);
+  void DescribeDatabase(SelectResponse& _return, const DescribeDatabaseRequest& request) override;
+  void send_DescribeDatabase(const DescribeDatabaseRequest& request);
+  void recv_DescribeDatabase(SelectResponse& _return);
+  void ShowTables(SelectResponse& _return, const ShowTablesRequest& request) override;
+  void send_ShowTables(const ShowTablesRequest& request);
+  void recv_ShowTables(SelectResponse& _return);
   void GetDatabase(CommonResponse& _return, const GetDatabaseRequest& request) override;
   void send_GetDatabase(const GetDatabaseRequest& request);
   void recv_GetDatabase(CommonResponse& _return);
@@ -2536,11 +2647,12 @@ class InfinityServiceProcessor : public ::apache::thrift::TDispatchProcessor {
   void process_Delete(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_Update(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_UploadFileChunk(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
-  void process_ShowVariable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ListDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ListTable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
-  void process_DescribeDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
+  void process_ShowVariable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_DescribeTable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
+  void process_DescribeDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
+  void process_ShowTables(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_GetDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_GetTable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_CreateIndex(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
@@ -2561,11 +2673,12 @@ class InfinityServiceProcessor : public ::apache::thrift::TDispatchProcessor {
     processMap_["Delete"] = &InfinityServiceProcessor::process_Delete;
     processMap_["Update"] = &InfinityServiceProcessor::process_Update;
     processMap_["UploadFileChunk"] = &InfinityServiceProcessor::process_UploadFileChunk;
-    processMap_["ShowVariable"] = &InfinityServiceProcessor::process_ShowVariable;
     processMap_["ListDatabase"] = &InfinityServiceProcessor::process_ListDatabase;
     processMap_["ListTable"] = &InfinityServiceProcessor::process_ListTable;
-    processMap_["DescribeDatabase"] = &InfinityServiceProcessor::process_DescribeDatabase;
+    processMap_["ShowVariable"] = &InfinityServiceProcessor::process_ShowVariable;
     processMap_["DescribeTable"] = &InfinityServiceProcessor::process_DescribeTable;
+    processMap_["DescribeDatabase"] = &InfinityServiceProcessor::process_DescribeDatabase;
+    processMap_["ShowTables"] = &InfinityServiceProcessor::process_ShowTables;
     processMap_["GetDatabase"] = &InfinityServiceProcessor::process_GetDatabase;
     processMap_["GetTable"] = &InfinityServiceProcessor::process_GetTable;
     processMap_["CreateIndex"] = &InfinityServiceProcessor::process_CreateIndex;
@@ -2728,16 +2841,6 @@ class InfinityServiceMultiface : virtual public InfinityServiceIf {
     return;
   }
 
-  void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override {
-    size_t sz = ifaces_.size();
-    size_t i = 0;
-    for (; i < (sz - 1); ++i) {
-      ifaces_[i]->ShowVariable(_return, request);
-    }
-    ifaces_[i]->ShowVariable(_return, request);
-    return;
-  }
-
   void ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request) override {
     size_t sz = ifaces_.size();
     size_t i = 0;
@@ -2758,7 +2861,27 @@ class InfinityServiceMultiface : virtual public InfinityServiceIf {
     return;
   }
 
-  void DescribeDatabase(DescribeDatabaseResponse& _return, const DescribeDatabaseRequest& request) override {
+  void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override {
+    size_t sz = ifaces_.size();
+    size_t i = 0;
+    for (; i < (sz - 1); ++i) {
+      ifaces_[i]->ShowVariable(_return, request);
+    }
+    ifaces_[i]->ShowVariable(_return, request);
+    return;
+  }
+
+  void DescribeTable(SelectResponse& _return, const DescribeTableRequest& request) override {
+    size_t sz = ifaces_.size();
+    size_t i = 0;
+    for (; i < (sz - 1); ++i) {
+      ifaces_[i]->DescribeTable(_return, request);
+    }
+    ifaces_[i]->DescribeTable(_return, request);
+    return;
+  }
+
+  void DescribeDatabase(SelectResponse& _return, const DescribeDatabaseRequest& request) override {
     size_t sz = ifaces_.size();
     size_t i = 0;
     for (; i < (sz - 1); ++i) {
@@ -2768,13 +2891,13 @@ class InfinityServiceMultiface : virtual public InfinityServiceIf {
     return;
   }
 
-  void DescribeTable(DescribeTableResponse& _return, const DescribeTableRequest& request) override {
+  void ShowTables(SelectResponse& _return, const ShowTablesRequest& request) override {
     size_t sz = ifaces_.size();
     size_t i = 0;
     for (; i < (sz - 1); ++i) {
-      ifaces_[i]->DescribeTable(_return, request);
+      ifaces_[i]->ShowTables(_return, request);
     }
-    ifaces_[i]->DescribeTable(_return, request);
+    ifaces_[i]->ShowTables(_return, request);
     return;
   }
 
@@ -2889,21 +3012,24 @@ class InfinityServiceConcurrentClient : virtual public InfinityServiceIf {
   void UploadFileChunk(UploadResponse& _return, const FileChunk& request) override;
   int32_t send_UploadFileChunk(const FileChunk& request);
   void recv_UploadFileChunk(UploadResponse& _return, const int32_t seqid);
-  void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override;
-  int32_t send_ShowVariable(const ShowVariableRequest& request);
-  void recv_ShowVariable(SelectResponse& _return, const int32_t seqid);
   void ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request) override;
   int32_t send_ListDatabase(const ListDatabaseRequest& request);
   void recv_ListDatabase(ListDatabaseResponse& _return, const int32_t seqid);
   void ListTable(ListTableResponse& _return, const ListTableRequest& request) override;
   int32_t send_ListTable(const ListTableRequest& request);
   void recv_ListTable(ListTableResponse& _return, const int32_t seqid);
-  void DescribeDatabase(DescribeDatabaseResponse& _return, const DescribeDatabaseRequest& request) override;
-  int32_t send_DescribeDatabase(const DescribeDatabaseRequest& request);
-  void recv_DescribeDatabase(DescribeDatabaseResponse& _return, const int32_t seqid);
-  void DescribeTable(DescribeTableResponse& _return, const DescribeTableRequest& request) override;
+  void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override;
+  int32_t send_ShowVariable(const ShowVariableRequest& request);
+  void recv_ShowVariable(SelectResponse& _return, const int32_t seqid);
+  void DescribeTable(SelectResponse& _return, const DescribeTableRequest& request) override;
   int32_t send_DescribeTable(const DescribeTableRequest& request);
-  void recv_DescribeTable(DescribeTableResponse& _return, const int32_t seqid);
+  void recv_DescribeTable(SelectResponse& _return, const int32_t seqid);
+  void DescribeDatabase(SelectResponse& _return, const DescribeDatabaseRequest& request) override;
+  int32_t send_DescribeDatabase(const DescribeDatabaseRequest& request);
+  void recv_DescribeDatabase(SelectResponse& _return, const int32_t seqid);
+  void ShowTables(SelectResponse& _return, const ShowTablesRequest& request) override;
+  int32_t send_ShowTables(const ShowTablesRequest& request);
+  void recv_ShowTables(SelectResponse& _return, const int32_t seqid);
   void GetDatabase(CommonResponse& _return, const GetDatabaseRequest& request) override;
   int32_t send_GetDatabase(const GetDatabaseRequest& request);
   void recv_GetDatabase(CommonResponse& _return, const int32_t seqid);

--- a/src/network/infinity_thrift/infinity_types.cpp
+++ b/src/network/infinity_thrift/infinity_types.cpp
@@ -9159,4 +9159,116 @@ void ShowVariableRequest::printTo(std::ostream& out) const {
   out << ")";
 }
 
+
+ShowTablesRequest::~ShowTablesRequest() noexcept {
+}
+
+
+void ShowTablesRequest::__set_session_id(const int64_t val) {
+  this->session_id = val;
+}
+
+void ShowTablesRequest::__set_db_name(const std::string& val) {
+  this->db_name = val;
+}
+std::ostream& operator<<(std::ostream& out, const ShowTablesRequest& obj)
+{
+  obj.printTo(out);
+  return out;
+}
+
+
+uint32_t ShowTablesRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->session_id);
+          this->__isset.session_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->db_name);
+          this->__isset.db_name = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t ShowTablesRequest::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("ShowTablesRequest");
+
+  xfer += oprot->writeFieldBegin("session_id", ::apache::thrift::protocol::T_I64, 1);
+  xfer += oprot->writeI64(this->session_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("db_name", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeString(this->db_name);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(ShowTablesRequest &a, ShowTablesRequest &b) {
+  using ::std::swap;
+  swap(a.session_id, b.session_id);
+  swap(a.db_name, b.db_name);
+  swap(a.__isset, b.__isset);
+}
+
+ShowTablesRequest::ShowTablesRequest(const ShowTablesRequest& other331) {
+  session_id = other331.session_id;
+  db_name = other331.db_name;
+  __isset = other331.__isset;
+}
+ShowTablesRequest& ShowTablesRequest::operator=(const ShowTablesRequest& other332) {
+  session_id = other332.session_id;
+  db_name = other332.db_name;
+  __isset = other332.__isset;
+  return *this;
+}
+void ShowTablesRequest::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "ShowTablesRequest(";
+  out << "session_id=" << to_string(session_id);
+  out << ", " << "db_name=" << to_string(db_name);
+  out << ")";
+}
+
 } // namespace

--- a/src/network/infinity_thrift/infinity_types.h
+++ b/src/network/infinity_thrift/infinity_types.h
@@ -304,6 +304,8 @@ class UpdateRequest;
 
 class ShowVariableRequest;
 
+class ShowTablesRequest;
+
 
 class Option : public virtual ::apache::thrift::TBase {
  public:
@@ -3708,6 +3710,56 @@ class ShowVariableRequest : public virtual ::apache::thrift::TBase {
 void swap(ShowVariableRequest &a, ShowVariableRequest &b);
 
 std::ostream& operator<<(std::ostream& out, const ShowVariableRequest& obj);
+
+typedef struct _ShowTablesRequest__isset {
+  _ShowTablesRequest__isset() : session_id(false), db_name(false) {}
+  bool session_id :1;
+  bool db_name :1;
+} _ShowTablesRequest__isset;
+
+class ShowTablesRequest : public virtual ::apache::thrift::TBase {
+ public:
+
+  ShowTablesRequest(const ShowTablesRequest&);
+  ShowTablesRequest& operator=(const ShowTablesRequest&);
+  ShowTablesRequest() noexcept
+                    : session_id(0),
+                      db_name() {
+  }
+
+  virtual ~ShowTablesRequest() noexcept;
+  int64_t session_id;
+  std::string db_name;
+
+  _ShowTablesRequest__isset __isset;
+
+  void __set_session_id(const int64_t val);
+
+  void __set_db_name(const std::string& val);
+
+  bool operator == (const ShowTablesRequest & rhs) const
+  {
+    if (!(session_id == rhs.session_id))
+      return false;
+    if (!(db_name == rhs.db_name))
+      return false;
+    return true;
+  }
+  bool operator != (const ShowTablesRequest &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const ShowTablesRequest & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot) override;
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const override;
+
+  virtual void printTo(std::ostream& out) const;
+};
+
+void swap(ShowTablesRequest &a, ShowTablesRequest &b);
+
+std::ostream& operator<<(std::ostream& out, const ShowTablesRequest& obj);
 
 } // namespace
 

--- a/src/network/thrift_server.cpp
+++ b/src/network/thrift_server.cpp
@@ -634,15 +634,46 @@ public:
         }
     }
 
-    void DescribeDatabase(infinity_thrift_rpc::DescribeDatabaseResponse &response,
-                          const infinity_thrift_rpc::DescribeDatabaseRequest &request) override {
+    void DescribeDatabase(infinity_thrift_rpc::SelectResponse &response, const infinity_thrift_rpc::DescribeDatabaseRequest &request) override {
         // Your implementation goes here
         printf("DescribeDatabase\n");
     }
 
-    void DescribeTable(infinity_thrift_rpc::DescribeTableResponse &response, const infinity_thrift_rpc::DescribeTableRequest &request) override {
-        // Your implementation goes here
-        printf("DescribeTable\n");
+    void DescribeTable(infinity_thrift_rpc::SelectResponse &response, const infinity_thrift_rpc::DescribeTableRequest &request) override {
+        auto infinity = GetInfinityBySessionID(request.session_id);
+        auto database = infinity->GetDatabase(request.db_name);
+        String table_name = request.table_name;
+
+        const QueryResult result = database->DescribeTable(table_name);
+
+        if (result.IsOk()) {
+            auto &columns = response.column_fields;
+            columns.resize(result.result_table_->ColumnCount());
+            ProcessDataBlocks(result, response, columns);
+            response.__set_success(true);
+        } else {
+            response.__set_success(false);
+            response.__set_error_msg(result.ErrorStr());
+            LOG_ERROR(fmt::format("THRIFT ERROR: {}", result.ErrorStr()));
+        }
+    }
+
+    void ShowTables(infinity_thrift_rpc::SelectResponse &response, const infinity_thrift_rpc::ShowTablesRequest &request) override {
+        auto infinity = GetInfinityBySessionID(request.session_id);
+        auto database = infinity->GetDatabase(request.db_name);
+
+        const QueryResult result = database->ShowTables();
+
+        if (result.IsOk()) {
+            auto &columns = response.column_fields;
+            columns.resize(result.result_table_->ColumnCount());
+            ProcessDataBlocks(result, response, columns);
+            response.__set_success(true);
+        } else {
+            response.__set_success(false);
+            response.__set_error_msg(result.ErrorStr());
+            LOG_ERROR(fmt::format("THRIFT ERROR: {}", result.ErrorStr()));
+        }
     }
 
     void GetDatabase(infinity_thrift_rpc::CommonResponse &response, const infinity_thrift_rpc::GetDatabaseRequest &request) override {

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -345,22 +345,23 @@ void SegmentEntry::FlushDataToDisk(TxnTimeStamp max_commit_ts, bool is_full_chec
                 block_entries.push_back(static_cast<BlockEntry *>(block_entry.get()));
             }
         }
-    }
-    if (block_entries.empty()) {
-        return;
-    }
-    for (BlockEntry *block_entry : block_entries) {
-        LOG_TRACE(fmt::format("Before Flush: block_entry checkpoint ts: {}, min_row_ts: {}, max_row_ts: {} || max_commit_ts: {}",
-                              block_entry->checkpoint_ts(),
-                              block_entry->min_row_ts(),
-                              block_entry->max_row_ts(),
-                              max_commit_ts));
-        block_entry->Flush(max_commit_ts);
-        LOG_TRACE(fmt::format("Finish Flush: block_entry checkpoint ts: {}, min_row_ts: {}, max_row_ts: {} || max_commit_ts: {}",
-                              block_entry->checkpoint_ts(),
-                              block_entry->min_row_ts(),
-                              block_entry->max_row_ts(),
-                              max_commit_ts));
+
+        if (block_entries.empty()) {
+            return;
+        }
+        for (BlockEntry *block_entry : block_entries) {
+            LOG_TRACE(fmt::format("Before Flush: block_entry checkpoint ts: {}, min_row_ts: {}, max_row_ts: {} || max_commit_ts: {}",
+                                  block_entry->checkpoint_ts(),
+                                  block_entry->min_row_ts(),
+                                  block_entry->max_row_ts(),
+                                  max_commit_ts));
+            block_entry->Flush(max_commit_ts);
+            LOG_TRACE(fmt::format("Finish Flush: block_entry checkpoint ts: {}, min_row_ts: {}, max_row_ts: {} || max_commit_ts: {}",
+                                  block_entry->checkpoint_ts(),
+                                  block_entry->min_row_ts(),
+                                  block_entry->max_row_ts(),
+                                  max_commit_ts));
+        }
     }
 }
 


### PR DESCRIPTION
A ShowTables request and response structure has been added to the InfinityService, including rpc methods and error handling. The logic for implementing the ShowTables request has been added to the thrift server. This update also refactors DescribeTable and DescribeDatabase to return a SelectResponse object instead of separate response types.

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer