### PR TITLE
Fix linking test_hnsw_bitmask error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,6 +383,8 @@ target_link_libraries(test_hnsw
 
 add_executable(test_hnsw_bitmask "${CMAKE_CURRENT_SOURCE_DIR}/unit_test/test_hnsw_bitmask.cpp")
 
+target_link_directories(test_hnsw_bitmask PUBLIC "${CMAKE_BINARY_DIR}/lib")
+
 target_link_libraries(test_hnsw_bitmask
     infinity_core
     sql_parser


### PR DESCRIPTION
### What problem does this PR solve?
Wrong thrift library path.

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer