### PR TITLE
Fix catalog datarace.

### DIFF
--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -333,6 +333,7 @@ export {
     using ai64 = std::atomic_int64_t;
     using aptr = std::atomic_uintptr_t;
     using atomic_bool = std::atomic_bool;
+    using atomic_flag = std::atomic_flag;
 
     template <typename T>
     using Atomic = std::atomic<T>;

--- a/src/executor/operator/physical_create_index_prepare.cpp
+++ b/src/executor/operator/physical_create_index_prepare.cpp
@@ -31,7 +31,6 @@ import status;
 import infinity_exception;
 import index_base;
 import index_file_worker;
-import segment_iter;
 import buffer_manager;
 import buffer_handle;
 import index_hnsw;

--- a/src/executor/operator/physical_match.cpp
+++ b/src/executor/operator/physical_match.cpp
@@ -117,7 +117,7 @@ bool PhysicalMatch::Execute(QueryContext *query_context, OperatorState *operator
         u16 block_id = segment_offset / DEFAULT_BLOCK_CAPACITY;
         u16 block_offset = segment_offset % DEFAULT_BLOCK_CAPACITY;
 
-        const BlockEntry *block_entry = base_table_ref_->table_entry_ptr_->GetBlockEntryByID(segment_id, block_id, begin_ts);
+        const BlockEntry *block_entry = base_table_ref_->block_index_->GetBlockEntry(segment_id, block_id);
 
         SizeT column_id = 0;
         for (; column_id < column_n; ++column_id) {

--- a/src/executor/operator/physical_show.cpp
+++ b/src/executor/operator/physical_show.cpp
@@ -53,6 +53,7 @@ import utility;
 import buffer_manager;
 import session_manager;
 import compilation_config;
+import catalog_iterator;
 
 namespace infinity {
 
@@ -720,40 +721,38 @@ void PhysicalShow::ExecuteShowSegments(QueryContext *query_context, ShowOperator
     output_block_ptr->Init(column_types);
 
     if (segment_id_.has_value() && block_id_.has_value()) {
-        auto iter = table_entry->segment_map().find(*segment_id_);
+        if (auto iter = table_entry->segment_map().find(*segment_id_); iter != table_entry->segment_map().end()) {
+            auto *segment_entry = iter->second.get();
+            auto *block_entry = segment_entry->GetBlockEntryByID(*block_id_);
+            if (block_entry != nullptr) {
+                auto version_path = block_entry->VersionFilePath();
 
-        const auto &block_entries = iter->second->block_entries();
+                chuck_filling(LocalFileSystem::GetFileSizeByPath, version_path);
+                SizeT column_count = table_entry->ColumnCount();
+                for (SizeT column_id = 0; column_id < column_count; ++column_id) {
+                    auto block_column_entry = block_entry->GetColumnBlockEntry(column_id);
+                    auto col_file_path = block_column_entry->FilePath();
 
-        if (iter != table_entry->segment_map().end() && block_entries.size() > *block_id_) {
-            auto block = block_entries[*block_id_];
-            auto version_path = block->VersionFilePath();
-
-            chuck_filling(LocalFileSystem::GetFileSizeByPath, version_path);
-            SizeT column_count = table_entry->ColumnCount();
-            for (SizeT column_id = 0; column_id < column_count; ++column_id) {
-                auto block_column_entry = block->GetColumnBlockEntry(column_id);
-                auto col_file_path = block_column_entry->FilePath();
-
-                chuck_filling(LocalFileSystem::GetFileSizeByPath, col_file_path);
-                for (auto &outline : block_column_entry->OutlinePaths()) {
-                    chuck_filling(LocalFileSystem::GetFileSizeByPath, outline);
+                    chuck_filling(LocalFileSystem::GetFileSizeByPath, col_file_path);
+                    for (auto &outline : block_column_entry->OutlinePaths()) {
+                        chuck_filling(LocalFileSystem::GetFileSizeByPath, outline);
+                    }
                 }
             }
         }
     } else if (segment_id_.has_value()) {
         auto iter = table_entry->segment_map().find(*segment_id_);
-        const auto &block_entries = iter->second->block_entries();
-
         if (iter != table_entry->segment_map().end()) {
-            for (auto &entry : block_entries) {
-                auto dir_path = entry->DirPath();
+            auto block_entry_iter = BlockEntryIter(iter->second.get());
+            for (auto *block_entry = block_entry_iter.Next(); block_entry != nullptr; block_entry = block_entry_iter.Next()) {
+                auto dir_path = block_entry->DirPath();
 
                 chuck_filling(LocalFileSystem::GetFolderSizeByPath, dir_path);
             }
         }
     } else {
         for (auto &[_, segment] : table_entry->segment_map()) {
-            const auto &dir_path = segment->segment_dir();
+            const auto &dir_path = *segment->segment_dir();
 
             chuck_filling(LocalFileSystem::GetFolderSizeByPath, dir_path);
         }

--- a/src/executor/physical_operator.cpp
+++ b/src/executor/physical_operator.cpp
@@ -73,7 +73,7 @@ void PhysicalOperator::InputLoad(QueryContext *query_context, OperatorState *ope
             u16 block_id = segment_offset / DEFAULT_BLOCK_CAPACITY;
             u16 block_offset = segment_offset % DEFAULT_BLOCK_CAPACITY;
 
-            const BlockEntry *block_entry = table_ref->table_entry_ptr_->GetBlockEntryByID(segment_id, block_id, begin_ts);
+            const BlockEntry *block_entry = table_ref->block_index_->GetBlockEntry(segment_id, block_id);
             for (SizeT k = 0; k < load_column_count; ++k) {
                 auto binding = load_metas[k].binding_;
                 BlockColumnEntry *block_column_ptr = block_entry->GetColumnBlockEntry(binding.column_idx);

--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -35,6 +35,7 @@ import bg_task;
 import wal;
 import global_block_id;
 import block_index;
+import catalog_iterator;
 
 namespace infinity {
 
@@ -154,10 +155,10 @@ void CompactSegmentsTask::SaveSegmentsData(Vector<Pair<SharedPtr<SegmentEntry>, 
             old_segment->SetNoDelete(begin_ts);
         }
 
-        u16 last_block_row_count = new_segment->block_entries().back()->row_count();
-        segment_infos.emplace_back(WalSegmentInfo{new_segment->segment_dir(),
+        const auto [block_cnt, last_block_row_count] = new_segment->GetWalInfo();
+        segment_infos.emplace_back(WalSegmentInfo{*new_segment->segment_dir(),
                                                   new_segment->segment_id(),
-                                                  static_cast<u16>(new_segment->block_entries().size()),
+                                                  static_cast<u16>(block_cnt),
                                                   DEFAULT_BLOCK_CAPACITY, // TODO: store block capacity in segment entry
                                                   last_block_row_count});
         for (auto *old_segment : old_segments) {
@@ -203,7 +204,8 @@ SharedPtr<SegmentEntry> CompactSegmentsTask::CompactSegmentsToOne(RowIDRemapper 
 
     auto new_block = BlockEntry::NewBlockEntry(new_segment.get(), 0, 0, column_count, txn_);
     for (auto *old_segment : segments) {
-        for (auto &old_block : old_segment->block_entries()) {
+        BlockEntryIter block_entry_iter(old_segment);
+        for (auto *old_block = block_entry_iter.Next(); old_block; old_block = block_entry_iter.Next()) {
             Vector<ColumnVector> input_column_vectors;
             for (ColumnID column_id = 0; column_id < column_count; ++column_id) {
                 auto *column_block_entry = old_block->GetColumnBlockEntry(column_id);
@@ -231,8 +233,7 @@ SharedPtr<SegmentEntry> CompactSegmentsTask::CompactSegmentsToOne(RowIDRemapper 
                     read_size -= read_size1;
                     new_segment->AppendBlockEntry(std::move(new_block));
 
-                    BlockID next_block_id = new_segment->block_entries().size();
-                    new_block = BlockEntry::NewBlockEntry(new_segment.get(), next_block_id, 0, column_count, txn_);
+                    new_block = BlockEntry::NewBlockEntry(new_segment.get(), new_segment->GetNextBlockID(), 0, column_count, txn_);
                 }
                 block_entry_append(row_begin, read_size);
             }

--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -150,7 +150,7 @@ void CompactSegmentsTask::SaveSegmentsData(Vector<Pair<SharedPtr<SegmentEntry>, 
 
     TxnTimeStamp begin_ts = txn_->BeginTS();
     for (auto &[new_segment, old_segments] : segment_data) {
-        new_segment->FlushData();
+        new_segment->FlushNewData();
         for (auto *old_segment : old_segments) {
             old_segment->SetNoDelete(begin_ts);
         }
@@ -196,7 +196,7 @@ Vector<SegmentEntry *> CompactSegmentsTask::PickSegmentsToCompact() {
 
 SharedPtr<SegmentEntry> CompactSegmentsTask::CompactSegmentsToOne(RowIDRemapper &remapper, const Vector<SegmentEntry *> &segments) {
     auto *table_entry = table_ref_->table_entry_ptr_;
-    auto new_segment = SegmentEntry::NewSegmentEntry(table_entry, NewCatalog::GetNextSegmentID(table_entry), txn_);
+    auto new_segment = SegmentEntry::NewSegmentEntry(table_entry, NewCatalog::GetNextSegmentID(table_entry), txn_, true);
 
     TxnTimeStamp begin_ts = txn_->BeginTS();
     SizeT column_count = table_entry->ColumnCount();

--- a/src/storage/common/block_index.cpp
+++ b/src/storage/common/block_index.cpp
@@ -17,6 +17,7 @@ module;
 import stl;
 import catalog;
 import global_block_id;
+import catalog_iterator;
 
 module block_index;
 
@@ -26,17 +27,16 @@ void BlockIndex::Insert(SegmentEntry *segment_entry, TxnTimeStamp timestamp, boo
     if (!check_ts || (timestamp >= segment_entry->min_row_ts() && timestamp <= segment_entry->deprecate_ts())) {
         u32 segment_id = segment_entry->segment_id();
         segments_.emplace_back(segment_entry);
-        const auto &block_entries = segment_entry->block_entries();
         segment_index_.emplace(segment_id, segment_entry);
-        if (block_entries.empty()) {
-            return;
-        }
-        segment_block_index_[segment_id].reserve(block_entries.size());
-        SizeT block_count = block_entries.size();
-        for (SizeT idx = 0; idx < block_count; ++idx) {
-            const auto &block_entry = block_entries[idx];
+
+        auto block_entry_iter = BlockEntryIter(segment_entry);
+        while (true) {
+            auto *block_entry = block_entry_iter.Next();
+            if (block_entry == nullptr) {
+                break;
+            }
             if (timestamp >= block_entry->min_row_ts()) {
-                segment_block_index_[segment_id].emplace(block_entry->block_id(), block_entry.get());
+                segment_block_index_[segment_id].emplace(block_entry->block_id(), block_entry);
                 global_blocks_.emplace_back(GlobalBlockID{segment_id, block_entry->block_id()});
             }
         }

--- a/src/storage/common/block_index.cppm
+++ b/src/storage/common/block_index.cppm
@@ -36,8 +36,8 @@ export struct BlockIndex {
     BlockEntry *GetBlockEntry(u32 segment_id, u16 block_id) const;
 
     Vector<SegmentEntry *> segments_;
-    HashMap<u32, SegmentEntry *> segment_index_;
-    HashMap<u32, HashMap<u16, BlockEntry *>> segment_block_index_;
+    HashMap<SegmentID, SegmentEntry *> segment_index_;
+    HashMap<SegmentID, HashMap<BlockID, BlockEntry *>> segment_block_index_;
     Vector<GlobalBlockID> global_blocks_;
 };
 

--- a/src/storage/invertedindex/iresearch/datastore.cpp
+++ b/src/storage/invertedindex/iresearch/datastore.cpp
@@ -59,6 +59,7 @@ import local_file_system;
 import buffer_manager;
 import index_full_text;
 import infinity_exception;
+import catalog_iterator;
 
 module iresearch_datastore;
 
@@ -312,8 +313,8 @@ void IRSDataStore::BatchInsert(TableEntry *table_entry, const IndexDef *index_de
         }
     }
 
-    const auto &block_entries = segment_entry->block_entries();
-    for (const auto &block_entry : block_entries) {
+    auto block_entry_iter = BlockEntryIter(segment_entry);
+    for (const auto *block_entry = block_entry_iter.Next(); block_entry; block_entry = block_entry_iter.Next()) {
         auto ctx = index_writer_->GetBatch();
         for (SizeT i = 0; i < block_entry->row_count(); ++i) {
             auto doc = ctx.Insert(RowID2DocID(segment_id, block_entry->block_id(), i));

--- a/src/storage/knn_index/knn_hnsw/hnsw_alg.cppm
+++ b/src/storage/knn_index/knn_hnsw/hnsw_alg.cppm
@@ -293,8 +293,8 @@ private:
 
 public:
     template <DataIteratorConcept<const DataType *, LabelType> Iterator>
-    void InsertVecs(Iterator iter, SizeT insert_n) {
-        VertexType start_i = StoreData(iter, insert_n);
+    void InsertVecs(Iterator &&iter, SizeT insert_n) {
+        VertexType start_i = StoreData(std::move(iter), insert_n);
         for (VertexType vertex_i = start_i; vertex_i < VertexType(start_i + insert_n); ++vertex_i) {
             Build(vertex_i);
         }
@@ -309,8 +309,8 @@ public:
     }
 
     template <DataIteratorConcept<const DataType *, LabelType> Iterator>
-    VertexType StoreData(Iterator iter, SizeT insert_n) {
-        return data_store_.AddVec(iter, insert_n);
+    VertexType StoreData(Iterator &&iter, SizeT insert_n) {
+        return data_store_.AddVec(std::move(iter), insert_n);
     }
 
     VertexType StoreDataRaw(const DataType *query, SizeT insert_n) {

--- a/src/storage/knn_index/knn_hnsw/lvq_store.cppm
+++ b/src/storage/knn_index/knn_hnsw/lvq_store.cppm
@@ -211,7 +211,7 @@ private:
 
     // TODO SIMD optimization here
     template <DataIteratorConcept<const DataType *, LabelType> Iterator>
-    SizeT MergeCompress(Iterator query_iter, SizeT vec_num) {
+    SizeT MergeCompress(Iterator &&query_iter, SizeT vec_num) {
         SizeT compress_n = meta_.cur_vec_num();
         if (auto ret = meta_.AllocateVec(vec_num + plain_data_.cur_vec_num()); ret > max_vec_num()) {
             UnrecoverableError("exceed max vec num");
@@ -230,7 +230,7 @@ private:
                 mean[j] += buffer_vecs[j];
             }
         }
-        Iterator query_iter1 = query_iter;
+        Iterator query_iter1 = query_iter; // copy here
 
         SizeT actual_size = 0;
         while (true) {
@@ -276,11 +276,12 @@ public:
     }
 
     template <DataIteratorConcept<const DataType *, LabelType> Iterator>
-    SizeT AddVec(Iterator query_iter, SizeT vec_num) {
+    SizeT AddVec(Iterator &&query_iter, SizeT vec_num) {
+        Iterator query_iter1 = query_iter; // copy here
         try {
-            return meta_.cur_vec_num() + plain_data_.AddVec(query_iter, vec_num);
+            return meta_.cur_vec_num() + plain_data_.AddVec(std::move(query_iter), vec_num);
         } catch (const UnrecoverableException &) {
-            return MergeCompress(std::move(query_iter), vec_num);
+            return MergeCompress(std::move(query_iter1), vec_num);
         }
     }
 

--- a/src/storage/knn_index/knn_hnsw/plain_store.cppm
+++ b/src/storage/knn_index/knn_hnsw/plain_store.cppm
@@ -70,7 +70,7 @@ public:
     SizeT AddVec(const DataType *vec, SizeT vec_num) { return AddVec(DenseVectorIterator(vec, dim()), vec_num); }
 
     template <DataIteratorConcept<const DataType *, LabelType> Iterator>
-    SizeT AddVec(Iterator query_iter, SizeT vec_num) {
+    SizeT AddVec(Iterator &&query_iter, SizeT vec_num) {
         SizeT new_idx = meta_.AllocateVec(vec_num);
         DataType *ptr = ptr_.get() + new_idx * dim();
 

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -591,7 +591,7 @@ void NewCatalog::LoadFromEntry(NewCatalog *catalog, const String &catalog_path, 
                                                                           check_point_ts,
                                                                           check_point_row_count,
                                                                           buffer_mgr);
-                segment_entry->block_entries().push_back(std::move(block_entry));
+                segment_entry->AppendBlockEntry(std::move(block_entry)); // Untested: this add row count in segment
                 break;
             }
             case CatalogDeltaOpType::ADD_COLUMN_ENTRY: {

--- a/src/storage/meta/entry/block_column_entry.cppm
+++ b/src/storage/meta/entry/block_column_entry.cppm
@@ -64,12 +64,27 @@ public:
 
     ColumnVector GetColumnVector(BufferManager *buffer_mgr);
 
+    void AppendOutlineBuffer(BufferObj *buffer) {
+        std::unique_lock lock(mutex_);
+        outline_buffers_.emplace_back(buffer);
+    }
+
+    BufferObj *GetOutlineBuffer(SizeT idx) const {
+        std::shared_lock lock(mutex_);
+        return outline_buffers_[idx];
+    }
+
+    SizeT OutlineBufferCount() const {
+        std::shared_lock lock(mutex_);
+        return outline_buffers_.size();
+    }
+
 public:
     void Append(const ColumnVector *input_column_vector, u16 input_offset, SizeT append_rows, BufferManager *buffer_mgr);
 
     static void Flush(BlockColumnEntry *block_column_entry, SizeT row_count);
 
-protected:
+private:
     const BlockEntry *block_entry_{nullptr};
     ColumnID column_id_{};
     SharedPtr<DataType> column_type_{};
@@ -78,7 +93,7 @@ protected:
     SharedPtr<String> base_dir_{};
     SharedPtr<String> file_name_{};
 
-public:
+    mutable std::shared_mutex mutex_{};
     Vector<BufferObj *> outline_buffers_{};
 };
 

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -200,6 +200,7 @@ Pair<BlockOffset, BlockOffset> BlockEntry::GetVisibleRange(TxnTimeStamp begin_ts
 }
 
 bool BlockEntry::CheckVisible(BlockOffset block_offset, TxnTimeStamp check_ts) const {
+    std::shared_lock lock(rw_locker_);
     auto &block_version = this->block_version_;
     auto &deleted = block_version->deleted_;
     return deleted[block_offset] == 0 || deleted[block_offset] > check_ts;

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -171,7 +171,7 @@ public:
     inline void IncreaseRowCount(SizeT increased_row_count) { row_count_ += increased_row_count; }
 
 protected:
-    std::shared_mutex rw_locker_{};
+    mutable std::shared_mutex rw_locker_{};
     const SegmentEntry *segment_entry_{};
 
     BlockID block_id_{};

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -97,9 +97,6 @@ public:
                                                             BufferManager *buffer_mgr);
 
 public:
-    // Used in physical import
-    void FlushData(i64 checkpoint_row_count);
-
     nlohmann::json Serialize(TxnTimeStamp max_commit_ts);
 
     static UniquePtr<BlockEntry> Deserialize(const nlohmann::json &table_entry_json, SegmentEntry *table_entry, BufferManager *buffer_mgr);
@@ -118,8 +115,6 @@ protected:
     void CommitDelete(TransactionID txn_id, TxnTimeStamp commit_ts);
 
     void Flush(TxnTimeStamp checkpoint_ts);
-
-    void FlushVersion(BlockVersion &checkpoint_version);
 
     static SharedPtr<String> DetermineDir(const String &parent_dir, BlockID block_id);
 
@@ -169,6 +164,11 @@ public:
 public:
     // Setter
     inline void IncreaseRowCount(SizeT increased_row_count) { row_count_ += increased_row_count; }
+
+private:
+    void FlushData(i64 checkpoint_row_count);
+
+    void FlushVersion(BlockVersion &checkpoint_version);
 
 protected:
     mutable std::shared_mutex rw_locker_{};

--- a/src/storage/meta/entry/segment_column_index_entry.cpp
+++ b/src/storage/meta/entry/segment_column_index_entry.cpp
@@ -38,8 +38,8 @@ import plain_store;
 import catalog_delta_entry;
 import column_vector;
 import annivfflat_index_data;
-import segment_iter;
 import secondary_index_data;
+import catalog_iterator;
 
 namespace infinity {
 
@@ -148,7 +148,8 @@ Status SegmentColumnIndexEntry::CreateIndexPrepare(const IndexBase *index_base,
                     // TODO: How to select training data?
                     Vector<f32> segment_column_data;
                     segment_column_data.reserve(segment_entry->row_count() * dimension);
-                    for (const auto &block_entry : segment_entry->block_entries()) {
+                    auto iter = BlockEntryIter(segment_entry);
+                    for (auto *block_entry = iter.Next(); block_entry != nullptr; block_entry = iter.Next()) {
                         BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
 
                         ColumnVector column_vector = block_column_entry->GetColumnVector(buffer_mgr);
@@ -191,6 +192,7 @@ Status SegmentColumnIndexEntry::CreateIndexPrepare(const IndexBase *index_base,
                     OneColumnIterator<float> iter(segment_entry, buffer_mgr, column_id, begin_ts);
                     InsertHnswInner(iter);
                 } else {
+                    // Not check ts in uncommitted segment when compress segment
                     OneColumnIterator<float, false> iter(segment_entry, buffer_mgr, column_id, begin_ts);
                     InsertHnswInner(iter);
                 }

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -45,16 +45,22 @@ import catalog_iterator;
 
 namespace infinity {
 
-SegmentEntry::SegmentEntry(const TableEntry *table_entry, SharedPtr<String> segment_dir, SegmentID segment_id, SizeT row_capacity, SizeT column_count)
+SegmentEntry::SegmentEntry(const TableEntry *table_entry,
+                           SharedPtr<String> segment_dir,
+                           SegmentID segment_id,
+                           SizeT row_capacity,
+                           SizeT column_count,
+                           bool sealed)
     : BaseEntry(EntryType::kSegment), table_entry_(table_entry), segment_dir_(segment_dir), segment_id_(segment_id), row_capacity_(row_capacity),
-      column_count_(column_count) {}
+      column_count_(column_count), sealed_(sealed) {}
 
-SharedPtr<SegmentEntry> SegmentEntry::NewSegmentEntry(const TableEntry *table_entry, SegmentID segment_id, Txn *txn) {
+SharedPtr<SegmentEntry> SegmentEntry::NewSegmentEntry(const TableEntry *table_entry, SegmentID segment_id, Txn *txn, bool sealed) {
     SharedPtr<SegmentEntry> segment_entry = MakeShared<SegmentEntry>(table_entry,
                                                                      SegmentEntry::DetermineSegmentDir(*table_entry->TableEntryDir(), segment_id),
                                                                      segment_id,
                                                                      DEFAULT_SEGMENT_CAPACITY,
-                                                                     table_entry->ColumnCount());
+                                                                     table_entry->ColumnCount(),
+                                                                     sealed);
     auto operation = MakeUnique<AddSegmentEntryOp>(segment_entry.get());
     txn->AddCatalogDeltaOperation(std::move(operation));
     segment_entry->begin_ts_ = txn->BeginTS();
@@ -66,7 +72,7 @@ SharedPtr<SegmentEntry> SegmentEntry::NewReplaySegmentEntry(const TableEntry *ta
                                                             SegmentID segment_id,
                                                             const SharedPtr<String> &segment_dir,
                                                             TxnTimeStamp commit_ts) {
-    auto segment_entry = MakeShared<SegmentEntry>(table_entry, segment_dir, segment_id, DEFAULT_SEGMENT_CAPACITY, table_entry->ColumnCount());
+    auto segment_entry = MakeShared<SegmentEntry>(table_entry, segment_dir, segment_id, DEFAULT_SEGMENT_CAPACITY, table_entry->ColumnCount(), true);
     segment_entry->min_row_ts_ = commit_ts;
     return segment_entry;
 }
@@ -83,7 +89,7 @@ SharedPtr<SegmentEntry> SegmentEntry::NewReplayCatalogSegmentEntry(const TableEn
                                                                    TxnTimeStamp commit_ts,
                                                                    TxnTimeStamp begin_ts,
                                                                    TransactionID txn_id) {
-    auto segment_entry = MakeShared<SegmentEntry>(table_entry, segment_dir, segment_id, row_capacity, column_count);
+    auto segment_entry = MakeShared<SegmentEntry>(table_entry, segment_dir, segment_id, row_capacity, column_count, true);
     segment_entry->min_row_ts_ = min_row_ts;
     segment_entry->deprecate_ts_ = deprecate_ts;
     segment_entry->commit_ts_ = commit_ts;
@@ -94,16 +100,7 @@ SharedPtr<SegmentEntry> SegmentEntry::NewReplayCatalogSegmentEntry(const TableEn
     return segment_entry;
 }
 
-int SegmentEntry::Room() const {
-    std::shared_lock<std::shared_mutex> lck(rw_locker_);
-    return this->row_capacity_ - this->row_count_;
-}
-
-void SegmentEntry::FlushData() {
-    for (const auto &block_entry : this->block_entries_) {
-        block_entry->FlushData(block_entry->row_count());
-    }
-}
+int SegmentEntry::Room() const { return this->row_capacity_ - this->row_count(); }
 
 bool SegmentEntry::TrySetCompacting(CompactSegmentsTask *compact_task, TxnTimeStamp compacting_ts) {
     std::unique_lock lock(rw_locker_);
@@ -177,8 +174,10 @@ bool SegmentEntry::CheckAnyDelete(TxnTimeStamp check_ts) const {
     return first_delete_ts_ < check_ts;
 }
 
+// called by one thread
 BlockID SegmentEntry::GetNextBlockID() const { return block_entries_.size(); }
 
+// called by one thread
 Pair<SizeT, BlockOffset> SegmentEntry::GetWalInfo() const { return {block_entries_.size(), block_entries_.back()->row_count()}; }
 
 void SegmentEntry::AppendBlockEntry(UniquePtr<BlockEntry> block_entry) {
@@ -188,7 +187,7 @@ void SegmentEntry::AppendBlockEntry(UniquePtr<BlockEntry> block_entry) {
 }
 
 u64 SegmentEntry::AppendData(TransactionID txn_id, AppendState *append_state_ptr, BufferManager *buffer_mgr, Txn *txn) {
-    std::unique_lock<std::shared_mutex> lck(this->rw_locker_);
+    std::unique_lock<std::shared_mutex> lck(this->rw_locker_); // FIXME
     if (this->row_capacity_ - this->row_count_ <= 0)
         return 0;
     //    SizeT start_row = this->row_count_;
@@ -235,15 +234,18 @@ u64 SegmentEntry::AppendData(TransactionID txn_id, AppendState *append_state_ptr
 }
 
 void SegmentEntry::DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const HashMap<BlockID, Vector<BlockOffset>> &block_row_hashmap) {
-    std::unique_lock<std::shared_mutex> lck(this->rw_locker_);
-
     for (const auto &[block_id, delete_rows] : block_row_hashmap) {
-        try {
-            BlockEntry *block_entry = block_entries_.at(block_id).get();
-            block_entry->DeleteData(txn_id, commit_ts, delete_rows);
-        } catch (const std::out_of_range &e) {
-            UnrecoverableError(fmt::format("The segment doesn't contain the given block: {}.", block_id));
+        BlockEntry *block_entry = nullptr;
+        {
+            std::unique_lock<std::shared_mutex> lck(this->rw_locker_);
+            try {
+                block_entry = block_entries_.at(block_id).get();
+            } catch (const std::out_of_range &e) {
+                UnrecoverableError(fmt::format("The segment doesn't contain the given block: {}.", block_id));
+            }
         }
+
+        block_entry->DeleteData(txn_id, commit_ts, delete_rows);
     }
 }
 
@@ -254,27 +256,28 @@ void SegmentEntry::CommitAppend(TransactionID txn_id, TxnTimeStamp commit_ts, u1
         if (this->min_row_ts_ == UNCOMMIT_TS) {
             this->min_row_ts_ = commit_ts;
         }
-        this->deprecate_ts_ = std::max(this->deprecate_ts_, commit_ts);
         block_entry = this->block_entries_[block_id];
     }
     block_entry->CommitAppend(txn_id, commit_ts);
 }
 
 void SegmentEntry::CommitDelete(TransactionID txn_id, TxnTimeStamp commit_ts, const HashMap<u16, Vector<BlockOffset>> &block_row_hashmap) {
-    std::unique_lock<std::shared_mutex> lck(this->rw_locker_);
-
     for (const auto &[block_id, delete_rows] : block_row_hashmap) {
-        BlockEntry *block_entry = block_entries_.at(block_id).get();
-        if (delete_rows.size() > block_entry->row_capacity()) {
-            UnrecoverableError("Delete rows exceed block capacity");
-        }
-        if (block_entry == nullptr) {
-            UnrecoverableError(fmt::format("The segment doesn't contain the given block: {}.", block_id));
+        BlockEntry *block_entry = nullptr;
+        {
+            std::unique_lock<std::shared_mutex> lck(this->rw_locker_);
+            block_entry = block_entries_.at(block_id).get();
+            if (block_entry == nullptr) {
+                UnrecoverableError(fmt::format("The segment doesn't contain the given block: {}.", block_id));
+            }
+            if (delete_rows.size() > block_entry->row_capacity()) {
+                UnrecoverableError("Delete rows exceed block capacity");
+            }
+            DecreaseRemainRow(delete_rows.size());
+            this->first_delete_ts_ = std::min(this->first_delete_ts_, commit_ts);
         }
 
-        DecreaseRemainRow(delete_rows.size());
         block_entry->CommitDelete(txn_id, commit_ts);
-        this->first_delete_ts_ = std::min(this->first_delete_ts_, commit_ts);
     }
 }
 
@@ -292,12 +295,14 @@ BlockEntry *SegmentEntry::GetBlockEntryByID(BlockID block_id) const {
 nlohmann::json SegmentEntry::Serialize(TxnTimeStamp max_commit_ts, bool is_full_checkpoint) {
     nlohmann::json json_res;
 
+    // const field
+    json_res["segment_dir"] = *this->segment_dir_;
+    json_res["row_capacity"] = this->row_capacity_;
+    json_res["segment_id"] = this->segment_id_;
+    json_res["column_count"] = this->column_count_;
     {
         std::shared_lock<std::shared_mutex> lck(this->rw_locker_);
-        json_res["segment_dir"] = *this->segment_dir_;
-        json_res["row_capacity"] = this->row_capacity_;
-        json_res["segment_id"] = this->segment_id_;
-        json_res["column_count"] = this->column_count_;
+
         json_res["min_row_ts"] = this->min_row_ts_;
         json_res["max_row_ts"] = this->deprecate_ts_;
         json_res["deleted"] = this->deleted_;
@@ -320,8 +325,8 @@ SharedPtr<SegmentEntry> SegmentEntry::Deserialize(const nlohmann::json &segment_
                                                                      MakeShared<String>(segment_entry_json["segment_dir"]),
                                                                      segment_entry_json["segment_id"],
                                                                      segment_entry_json["row_capacity"],
-                                                                     segment_entry_json["column_count"]);
-
+                                                                     segment_entry_json["column_count"],
+                                                                     false); // FIXME: bug
     segment_entry->min_row_ts_ = segment_entry_json["min_row_ts"];
     segment_entry->deprecate_ts_ = segment_entry_json["max_row_ts"];
     segment_entry->deleted_ = segment_entry_json["deleted"];
@@ -346,14 +351,15 @@ SharedPtr<SegmentEntry> SegmentEntry::Deserialize(const nlohmann::json &segment_
 }
 
 void SegmentEntry::FlushDataToDisk(TxnTimeStamp max_commit_ts, bool is_full_checkpoint) {
-    std::shared_lock<std::shared_mutex> lck(this->rw_locker_);
     auto block_entry_iter = BlockEntryIter(this);
-    while (true) {
-        auto *block_entry = block_entry_iter.Next();
-        if (block_entry == nullptr) {
-            break;
-        }
+    for (auto *block_entry = block_entry_iter.Next(); block_entry != nullptr; block_entry = block_entry_iter.Next()) {
         block_entry->Flush(max_commit_ts);
+    }
+}
+
+void SegmentEntry::FlushNewData() {
+    for (const auto &block_entry : this->block_entries_) {
+        block_entry->FlushData(block_entry->row_count());
     }
 }
 

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -246,7 +246,7 @@ void TableEntry::Append(TransactionID txn_id, void *txn_store, BufferManager *bu
         }
         // Append data from app_state_ptr to the buffer in segment. If append all data, then set finish.
         u64 actual_appended = unsealed_segment_->AppendData(txn_id, append_state_ptr, buffer_mgr, txn);
-        LOG_TRACE(fmt::format("Segment {} is appended with {} rows", this->unsealed_segment_->segment_id_, actual_appended));
+        LOG_TRACE(fmt::format("Segment {} is appended with {} rows", this->unsealed_segment_->segment_id(), actual_appended));
     }
 }
 
@@ -384,19 +384,6 @@ SegmentEntry *TableEntry::GetSegmentByID(SegmentID segment_id, TxnTimeStamp ts) 
     }
 }
 
-const BlockEntry *TableEntry::GetBlockEntryByID(SegmentID seg_id, BlockID block_id, TxnTimeStamp ts) const {
-    SegmentEntry *segment_entry = GetSegmentByID(seg_id, ts);
-    if (segment_entry == nullptr) {
-        UnrecoverableError(fmt::format("Cannot find segment, segment id: {}", seg_id));
-    }
-
-    BlockEntry *block_entry = segment_entry->GetBlockEntryByID(block_id);
-    if (block_entry == nullptr) {
-        UnrecoverableError(fmt::format("Cannot find block, segment id: {}, block id: {}", seg_id, block_id));
-    }
-    return block_entry;
-}
-
 Tuple<SizeT, SizeT, Status> TableEntry::GetSegmentRowCountBySegmentID(u32 seg_id) {
     auto iter = this->segment_map_.find(seg_id);
     if (iter != this->segment_map_.end()) {
@@ -527,8 +514,8 @@ UniquePtr<TableEntry> TableEntry::Deserialize(const nlohmann::json &table_entry_
         u32 max_segment_id = 0;
         for (const auto &segment_json : table_entry_json["segments"]) {
             SharedPtr<SegmentEntry> segment_entry = SegmentEntry::Deserialize(segment_json, table_entry.get(), buffer_mgr);
-            table_entry->segment_map_.emplace(segment_entry->segment_id_, segment_entry);
-            max_segment_id = std::max(max_segment_id, segment_entry->segment_id_);
+            table_entry->segment_map_.emplace(segment_entry->segment_id(), segment_entry);
+            max_segment_id = std::max(max_segment_id, segment_entry->segment_id());
         }
         table_entry->unsealed_segment_ = table_entry->segment_map_[max_segment_id].get();
     }

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -167,7 +167,7 @@ private:
 
     HashMap<String, ColumnID> column_name2column_id_;
 
-    std::shared_mutex rw_locker_{};
+    mutable std::shared_mutex rw_locker_{};
 
     SharedPtr<String> table_entry_dir_{};
 

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -125,8 +125,6 @@ public:
 
     SegmentEntry *GetSegmentByID(SegmentID seg_id, TxnTimeStamp ts) const;
 
-    const BlockEntry *GetBlockEntryByID(SegmentID seg_id, BlockID block_id, TxnTimeStamp ts) const;
-
     inline const ColumnDef *GetColumnDefByID(ColumnID column_id) const { return columns_[column_id].get(); }
 
     inline SizeT ColumnCount() const { return columns_.size(); }
@@ -164,7 +162,7 @@ public:
 
     Vector<SharedPtr<ColumnDef>> &column_defs() { return columns_; }
 
-protected:
+private:
     TableMeta *table_meta_{};
 
     HashMap<String, ColumnID> column_name2column_id_;

--- a/src/storage/meta/iter/block_column_iter.cppm
+++ b/src/storage/meta/iter/block_column_iter.cppm
@@ -16,7 +16,7 @@ module;
 
 #include <utility>
 
-export module block_column_iter;
+export module catalog_iterator:block_column_iter;
 
 import stl;
 import catalog;

--- a/src/storage/meta/iter/block_column_iter.cppm
+++ b/src/storage/meta/iter/block_column_iter.cppm
@@ -29,8 +29,8 @@ export template <bool CheckTS = true>
 class BlockColumnIter {
 public:
     BlockColumnIter(BlockColumnEntry *entry, BufferManager *buffer_mgr, TxnTimeStamp iterate_ts)
-        : block_entry_(entry->GetBlockEntry()), column_vector_(entry->GetColumnVector(buffer_mgr)), ele_size_(entry->column_type()->Size()),
-          iterate_ts_(iterate_ts), offset_(0), read_end_(0) {}
+        : block_entry_(entry->GetBlockEntry()), column_vector_(MakeShared<ColumnVector>(entry->GetColumnVector(buffer_mgr))),
+          ele_size_(entry->column_type()->Size()), iterate_ts_(iterate_ts), offset_(0), read_end_(0) {}
     // TODO: Does `ColumnVector` implements the move constructor?
 
     Optional<Pair<const void *, BlockOffset>> Next() {
@@ -43,13 +43,13 @@ public:
             read_end_ = end;
             offset_ = begin;
         }
-        auto ret = column_vector_.data() + offset_ * ele_size_;
+        auto ret = column_vector_->data() + offset_ * ele_size_;
         return std::make_pair(ret, offset_++);
     }
 
 private:
     const BlockEntry *const block_entry_;
-    const ColumnVector column_vector_;
+    const SharedPtr<ColumnVector> column_vector_;
     const SizeT ele_size_;
     const TxnTimeStamp iterate_ts_;
 
@@ -61,20 +61,20 @@ export template <>
 class BlockColumnIter<false> {
 public:
     BlockColumnIter(BlockColumnEntry *entry, BufferManager *buffer_mgr, TxnTimeStamp)
-        : block_entry_(entry->GetBlockEntry()), column_vector_(entry->GetColumnVector(buffer_mgr)), ele_size_(entry->column_type()->Size()),
-          size_(block_entry_->row_count()), offset_(0) {}
+        : block_entry_(entry->GetBlockEntry()), column_vector_(MakeShared<ColumnVector>(entry->GetColumnVector(buffer_mgr))),
+          ele_size_(entry->column_type()->Size()), size_(block_entry_->row_count()), offset_(0) {}
 
     Optional<Pair<const void *, BlockOffset>> Next() {
         if (offset_ == size_) {
             return None;
         }
-        auto ret = column_vector_.data() + offset_ * ele_size_;
+        auto ret = column_vector_->data() + offset_ * ele_size_;
         return std::make_pair(ret, offset_++);
     }
 
 private:
     const BlockEntry *const block_entry_;
-    const ColumnVector column_vector_;
+    const SharedPtr<ColumnVector> column_vector_;
     const SizeT ele_size_;
     const BlockOffset size_;
 

--- a/src/storage/meta/iter/block_iter.cppm
+++ b/src/storage/meta/iter/block_iter.cppm
@@ -17,11 +17,12 @@ module;
 #include <utility>
 #include <vector>
 
-export module block_iter;
+export module catalog_iterator:block_iter;
+
+import :block_column_iter;
 
 import stl;
 import catalog;
-import block_column_iter;
 import buffer_manager;
 import infinity_exception;
 

--- a/src/storage/meta/iter/catalog_iterator.cppm
+++ b/src/storage/meta/iter/catalog_iterator.cppm
@@ -1,0 +1,21 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module catalog_iterator;
+
+export import :segment_iter;
+export import :block_iter;
+export import :block_column_iter;

--- a/src/storage/meta/iter/segment_iter.cpp
+++ b/src/storage/meta/iter/segment_iter.cpp
@@ -1,0 +1,35 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+module catalog_iterator;
+
+import stl;
+import catalog;
+
+namespace infinity {
+
+BlockEntry *BlockEntryIter::Next() {
+    std::shared_lock<std::shared_mutex> lock;
+    if (segment_->sealed()) {
+        lock = std::shared_lock(segment_->rw_locker_);
+    }
+    if (cur_block_idx_ >= segment_->block_entries_.size()) {
+        return nullptr;
+    }
+    return segment_->block_entries_[cur_block_idx_++].get();
+}
+
+} // namespace infinity

--- a/src/storage/meta/iter/segment_iter.cppm
+++ b/src/storage/meta/iter/segment_iter.cppm
@@ -45,6 +45,7 @@ public:
         }
         if (auto ret = block_iter_->Next(); ret) {
             auto &[vec, offset] = *ret;
+            // FIXME: segment_entry should store the block capacity
             return std::make_pair(std::move(vec), SegmentOffset(offset + block_idx_ * DEFAULT_BLOCK_CAPACITY));
         }
         block_idx_++;
@@ -54,7 +55,6 @@ public:
             block_iter_ = None;
             return None;
         }
-        // FIXME: segment_entry should store the block capacity
         block_iter_ = BlockIter<CheckTS>(block_entries[block_idx_].get(), buffer_mgr_, column_ids_, iterate_ts_);
         return Next();
     }

--- a/src/storage/meta/iter/segment_iter.cppm
+++ b/src/storage/meta/iter/segment_iter.cppm
@@ -16,26 +16,43 @@ module;
 
 #include <utility>
 
-export module segment_iter;
+export module catalog_iterator:segment_iter;
+
+import :block_iter;
 
 import stl;
 import catalog;
-import block_iter;
 import buffer_manager;
 import default_values;
+import infinity_exception;
 
 namespace infinity {
 
-export template <bool CheckTS = true>
+export class BlockEntryIter {
+public:
+    BlockEntryIter(const SegmentEntry *segment) : segment_(segment), cur_block_idx_(0) {}
+
+    BlockEntry *Next();
+
+private:
+    const SegmentEntry *const segment_;
+
+    BlockID cur_block_idx_;
+};
+
+export template <bool CheckTS>
 class SegmentIter {
 public:
     SegmentIter(const SegmentEntry *entry, BufferManager *buffer_mgr, Vector<ColumnID> &&column_ids, TxnTimeStamp iterate_ts)
-        : entry_(entry), buffer_mgr_(buffer_mgr), column_ids_(column_ids), iterate_ts_(iterate_ts), block_idx_(0) {
-        const auto &block_entries = entry->block_entries();
-        if (block_entries.empty()) {
+        : entry_(entry), buffer_mgr_(buffer_mgr), column_ids_(std::move(column_ids)), iterate_ts_(iterate_ts), block_entry_iter_(entry) {
+        auto *block_entry = block_entry_iter_.Next();
+        if (block_entry->block_id() != 0) {
+            UnrecoverableError("First block id is not 0");
+        }
+        if (block_entry == nullptr) {
             block_iter_ = None;
         } else {
-            block_iter_ = BlockIter<CheckTS>(block_entries[block_idx_].get(), buffer_mgr, column_ids_, iterate_ts_);
+            block_iter_ = BlockIter<CheckTS>(block_entry, buffer_mgr, column_ids_, iterate_ts_);
         }
     }
 
@@ -46,16 +63,18 @@ public:
         if (auto ret = block_iter_->Next(); ret) {
             auto &[vec, offset] = *ret;
             // FIXME: segment_entry should store the block capacity
-            return std::make_pair(std::move(vec), SegmentOffset(offset + block_idx_ * DEFAULT_BLOCK_CAPACITY));
+            return std::make_pair(std::move(vec), static_cast<SegmentOffset>(offset + block_idx_ * DEFAULT_BLOCK_CAPACITY));
         }
         block_idx_++;
-
-        const auto &block_entries = entry_->block_entries();
-        if (block_idx_ >= block_entries.size()) {
+        auto *block_entry = block_entry_iter_.Next();
+        if (block_entry == nullptr) {
             block_iter_ = None;
             return None;
         }
-        block_iter_ = BlockIter<CheckTS>(block_entries[block_idx_].get(), buffer_mgr_, column_ids_, iterate_ts_);
+        if (block_entry->block_id() != block_idx_) {
+            UnrecoverableError("Block id is not continuous");
+        }
+        block_iter_ = BlockIter<CheckTS>(block_entry, buffer_mgr_, column_ids_, iterate_ts_);
         return Next();
     }
 
@@ -65,7 +84,8 @@ private:
     const Vector<ColumnID> column_ids_;
     const TxnTimeStamp iterate_ts_;
 
-    BlockID block_idx_;
+    BlockEntryIter block_entry_iter_;
+    BlockID block_idx_ = 0;
     Optional<BlockIter<CheckTS>> block_iter_;
 };
 

--- a/src/storage/secondary_index/secondary_index_data.cpp
+++ b/src/storage/secondary_index/secondary_index_data.cpp
@@ -29,7 +29,7 @@ import infinity_exception;
 import column_vector;
 import third_party;
 import catalog;
-import segment_iter;
+import catalog_iterator;
 import buffer_manager;
 import secondary_index_pgm;
 import logger;

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -386,7 +386,7 @@ void AddSegmentEntryOp::SaveSate() {
     this->db_name_ = *this->segment_entry_->GetTableEntry()->GetDBName();
     this->table_name_ = *this->segment_entry_->GetTableEntry()->GetTableName();
     this->segment_id_ = this->segment_entry_->segment_id();
-    this->segment_dir_ = this->segment_entry_->segment_dir();
+    this->segment_dir_ = *this->segment_entry_->segment_dir();
     this->min_row_ts_ = this->segment_entry_->min_row_ts();
     this->max_row_ts_ = this->segment_entry_->max_row_ts();
     this->row_capacity_ = this->segment_entry_->row_capacity();

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -421,7 +421,7 @@ void AddColumnEntryOp::SaveSate() {
     this->segment_id_ = this->column_entry_->GetBlockEntry()->GetSegmentEntry()->segment_id();
     this->block_id_ = this->column_entry_->GetBlockEntry()->block_id();
     this->column_id_ = this->column_entry_->column_id();
-    this->next_outline_idx_ = this->column_entry_->outline_buffers_.size();
+    this->next_outline_idx_ = this->column_entry_->OutlineBufferCount();
     is_saved_sate_ = true;
 }
 

--- a/src/unit_test/storage/bg_task/compact_segments_task.cpp
+++ b/src/unit_test/storage/bg_task/compact_segments_task.cpp
@@ -70,7 +70,7 @@ protected:
                 }
                 block_entry->AppendBlock(column_vectors, 0, write_size, buffer_mgr);
                 segment_entry->AppendBlockEntry(std::move(block_entry));
-                block_entry = BlockEntry::NewBlockEntry(segment_entry.get(), segment_entry->block_entries().size(), 0, 1, txn);
+                block_entry = BlockEntry::NewBlockEntry(segment_entry.get(), segment_entry->GetNextBlockID(), 0, 1, txn);
             }
             auto txn_store = txn->GetTxnTableStore(table_entry);
             PhysicalImport::SaveSegmentData(txn_store, segment_entry);

--- a/src/unit_test/storage/wal/wal_replay.cpp
+++ b/src/unit_test/storage/wal/wal_replay.cpp
@@ -47,7 +47,7 @@ import default_values;
 import base_table_ref;
 
 class WalReplayTest : public BaseTest {
-    void SetUp() override {  system("rm -rf /tmp/infinity/log /tmp/infinity/data /tmp/infinity/wal"); }
+    void SetUp() override { system("rm -rf /tmp/infinity/log /tmp/infinity/data /tmp/infinity/wal"); }
 
     void TearDown() override {
         system("tree  /tmp/infinity");
@@ -616,9 +616,8 @@ TEST_F(WalReplayTest, WalReplayImport) {
             EXPECT_NE(table_entry, nullptr);
             auto segment_entry = table_entry->segment_map()[0].get();
             EXPECT_EQ(segment_entry->segment_id(), 0);
-            auto block_id = segment_entry->block_entries()[0]->block_id();
-            EXPECT_EQ(block_id, 0);
-            auto block_entry = segment_entry->block_entries()[0].get();
+            auto *block_entry = segment_entry->GetBlockEntryByID(0);
+            EXPECT_EQ(block_entry->block_id(), 0);
             EXPECT_EQ(block_entry->row_count(), 1);
 
             BlockColumnEntry *column0 = block_entry->GetColumnBlockEntry(0);

--- a/test/sql/dml/compact/test_compact_import_insert.slt
+++ b/test/sql/dml/compact/test_compact_import_insert.slt
@@ -1,0 +1,53 @@
+statement ok
+DROP TABLE IF EXISTS test_compact_import_delete;
+
+statement ok
+CREATE TABLE test_compact_import_delete (c1 INT, c2 EMBEDDING(int, 3));
+
+query I
+COPY test_compact_import_delete FROM '/tmp/infinity/test_data/embedding_int_dim3.csv' WITH (DELIMITER ',');
+----
+
+query I
+INSERT INTO test_compact_import_delete VALUES (13, [14,15,16]), (17, [18,19,20]);
+----
+
+query I
+COPY test_compact_import_delete FROM '/tmp/infinity/test_data/embedding_int_dim3.csv' WITH (DELIMITER ',');
+----
+
+query I
+INSERT INTO test_compact_import_delete VALUES (13, [14,15,16]), (17, [18,19,20]);
+----
+
+query II rowsort
+SELECT * FROM test_compact_import_delete;
+----
+1 2,3,4
+1 2,3,4
+13 14,15,16
+13 14,15,16
+17 18,19,20
+17 18,19,20
+5 6,7,8
+5 6,7,8
+9 10,11,12
+9 10,11,12
+
+query I
+COMPACT TABLE test_compact_import_delete;
+----
+
+query II rowsort
+SELECT * FROM test_compact_import_delete;
+----
+1 2,3,4
+1 2,3,4
+13 14,15,16
+13 14,15,16
+17 18,19,20
+17 18,19,20
+5 6,7,8
+5 6,7,8
+9 10,11,12
+9 10,11,12


### PR DESCRIPTION
### What problem does this PR solve?

1. Opt: use right value when pass iterator as parameter.
2. Add: catalog iterator
3. Refactor: remove `SegmentEntry::block_entries()` interface. Fix: encapsulate it in catalog iterator.
    The sealed segment do not add lock when iterate block_entries, unsealed segment add lock
4. Fix: make `BlockColumnEntry::outline_buffers_` private and add lock on it
5. Fix: unseal segment replay bug.

Issue link:
https://github.com/infiniflow/infinity/issues/533

### What is changed and how it works?

### Code changes

- [x] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

### Note for reviewer