### PR TITLE
fix data race in PhysicalFilter

### DIFF
--- a/src/executor/expression/expression_selector.cpp
+++ b/src/executor/expression/expression_selector.cpp
@@ -32,7 +32,6 @@ import data_type;
 
 import infinity_exception;
 
-
 namespace infinity {
 
 SizeT ExpressionSelector::Select(const SharedPtr<BaseExpression> &expr,
@@ -48,8 +47,8 @@ SizeT ExpressionSelector::Select(const SharedPtr<BaseExpression> &expr,
 
     Select(expr, state, count, input_select, output_true_select, output_false_select);
 
-    output_data_block->UnInit();
     // Shrink the input data block into output data block
+    // this Init function will throw if output_data_block is already initialized before
     output_data_block->Init(input_data_block, output_true_select);
     return output_true_select->Size();
 }

--- a/src/executor/operator/physical_filter.cppm
+++ b/src/executor/operator/physical_filter.cppm
@@ -24,8 +24,6 @@ import physical_operator;
 import physical_operator_type;
 import base_expression;
 import data_table;
-import expression_evaluator;
-import expression_selector;
 import load_meta;
 import infinity_exception;
 import internal_types;
@@ -54,9 +52,6 @@ public:
 
 private:
     SharedPtr<BaseExpression> condition_;
-
-    ExpressionEvaluator executor_;
-    ExpressionSelector selector_;
 
     SharedPtr<DataTable> input_table_{};
 };

--- a/src/executor/operator/physical_index_scan.cpp
+++ b/src/executor/operator/physical_index_scan.cpp
@@ -22,22 +22,12 @@ module physical_index_scan;
 import query_context;
 import operator_state;
 import default_values;
-import base_expression;
-import expression_type;
-import value_expression;
-import column_expression;
-import cast_expression;
-import function_expression;
-import expression_evaluator;
-import expression_state;
-import column_vector;
+import buffer_handle;
 import infinity_exception;
 import logger;
 import third_party;
 import txn;
 import data_block;
-import default_values;
-import buffer_handle;
 import secondary_index_scan_execute_expression;
 import logical_type;
 import segment_column_index_entry;
@@ -465,7 +455,6 @@ public:
         // delete_filter: return false if the row is deleted
         std::visit(Overload{[&](const Bitmask &bitmask) {
                                 u32 output_block_row_id = 0;
-                                u32 output_block_idx = 0;
                                 DataBlock *output_block_ptr = output_data_blocks.back().get();
                                 // TODO: 64 bit in a loop?
                                 const u32 segment_row_count = SegmentRowCount();
@@ -495,8 +484,7 @@ public:
                             },
                             [&](const Vector<u32> &selected_rows) {
                                 u32 output_block_row_id = 0;
-                                u32 output_block_idx = 0;
-                                DataBlock *output_block_ptr = output_data_blocks[output_block_idx++].get();
+                                DataBlock *output_block_ptr = output_data_blocks.back().get();
                                 for (u32 segment_offset : selected_rows) {
                                     if (!delete_filter(segment_offset)) {
                                         // deleted


### PR DESCRIPTION
### What problem does this PR solve?

data race may occur when multiple PhysicalFilter jobs are running at the same time

### What is changed and how it works?

every job should have a local ExpressionSelector instance which contains a pointer to the input data

### Code changes

- [ ] Has Code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (knn performance test)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer