### PR TITLE
Fix cast integer type to boolean type issue crash in update set expression

### DIFF
--- a/src/function/cast/integer_cast.cppm
+++ b/src/function/cast/integer_cast.cppm
@@ -27,6 +27,7 @@ import column_vector;
 import vector_buffer;
 import internal_types;
 import data_type;
+import status;
 
 namespace infinity {
 
@@ -67,7 +68,7 @@ inline BoundCastFunc BindIntegerCast(const DataType &source, const DataType &tar
             return BoundCastFunc(&ColumnVectorCast::TryCastColumnVectorToVarlen<SourceType, VarcharT, IntegerTryCastToVarlen>);
         }
         default: {
-            UnrecoverableError(fmt::format("Attempt to cast from {} to {}", source.ToString(), target.ToString()));
+            RecoverableError(Status::NotSupport(fmt::format("Attempt to cast from {} to {}", source.ToString(), target.ToString())));
         }
     }
     return BoundCastFunc(nullptr);

--- a/src/unit_test/function/cast/integer_cast/bigint_cast.cpp
+++ b/src/unit_test/function/cast/integer_cast/bigint_cast.cpp
@@ -420,6 +420,6 @@ TEST_F(BigIntCastTest, bigint_cast1) {
     {
         DataType source(LogicalType::kBigInt);
         DataType target(LogicalType::kTimestamp);
-        EXPECT_THROW(BindIntegerCast<IntegerT>(source, target), UnrecoverableException);
+        EXPECT_THROW(BindIntegerCast<IntegerT>(source, target), RecoverableException);
     }
 }

--- a/src/unit_test/function/cast/integer_cast/hugeint_cast.cpp
+++ b/src/unit_test/function/cast/integer_cast/hugeint_cast.cpp
@@ -234,6 +234,6 @@ TEST_F(HugeIntCastTest, hugeint_cast1) {
     {
         DataType source(LogicalType::kBigInt);
         DataType target(LogicalType::kTimestamp);
-        EXPECT_THROW(BindIntegerCast<IntegerT>(source, target), UnrecoverableException);
+        EXPECT_THROW(BindIntegerCast<IntegerT>(source, target), RecoverableException);
     }
 }

--- a/src/unit_test/function/cast/integer_cast/integer_cast.cpp
+++ b/src/unit_test/function/cast/integer_cast/integer_cast.cpp
@@ -409,6 +409,6 @@ TEST_F(IntegerCastTest, integer_cast1) {
     {
         DataType source(LogicalType::kInteger);
         DataType target(LogicalType::kTimestamp);
-        EXPECT_THROW(BindIntegerCast<IntegerT>(source, target), UnrecoverableException);
+        EXPECT_THROW(BindIntegerCast<IntegerT>(source, target), RecoverableException);
     }
 }

--- a/src/unit_test/function/cast/integer_cast/small_integer_cast.cpp
+++ b/src/unit_test/function/cast/integer_cast/small_integer_cast.cpp
@@ -396,6 +396,6 @@ TEST_F(SmallIntegerCastTest, small_integer_cast1) {
     {
         DataType source(LogicalType::kSmallInt);
         DataType target(LogicalType::kTimestamp);
-        EXPECT_THROW(BindIntegerCast<SmallIntT>(source, target), UnrecoverableException);
+        EXPECT_THROW(BindIntegerCast<SmallIntT>(source, target), RecoverableException);
     }
 }

--- a/src/unit_test/function/cast/integer_cast/tiny_integer_cast.cpp
+++ b/src/unit_test/function/cast/integer_cast/tiny_integer_cast.cpp
@@ -389,6 +389,6 @@ TEST_F(TinyIntegerCastTest, tiny_integer_cast1) {
     {
         DataType source(LogicalType::kTinyInt);
         DataType target(LogicalType::kTimestamp);
-        EXPECT_THROW(BindIntegerCast<SmallIntT>(source, target), UnrecoverableException);
+        EXPECT_THROW(BindIntegerCast<SmallIntT>(source, target), RecoverableException);
     }
 }

--- a/test/sql/dml/update.slt
+++ b/test/sql/dml/update.slt
@@ -58,3 +58,9 @@ SELECT * FROM products;
 
 statement ok
 DROP TABLE products;
+
+statement ok
+CREATE TABLE T2 (c1 boolean, c2 boolean);
+
+statement ok
+UPDATE t2 SET c1 = 1 WHERE c2 = true;

--- a/test/sql/dml/update.slt
+++ b/test/sql/dml/update.slt
@@ -62,5 +62,5 @@ DROP TABLE products;
 statement ok
 CREATE TABLE T2 (c1 boolean, c2 boolean);
 
-statement ok
+statement error
 UPDATE t2 SET c1 = 1 WHERE c2 = true;


### PR DESCRIPTION
### What problem does this PR solve?

> create table t2 (c1 boolean, c2 boolean);
> update t2 set c1 = 1 where c2 = true; # will raise unrecoverable error.

Issue link:#534

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
