### PR TITLE
Support delete for ann_ivf_flat index

### DIFF
--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -192,6 +192,7 @@ export namespace std {
 
     using std::is_integral_v;
     using std::is_floating_point_v;
+    using std::common_type_t;
 
     using std::monostate;
     using std::function;

--- a/src/storage/knn_index/ann_ivf/ann_ivf_flat.cppm
+++ b/src/storage/knn_index/ann_ivf/ann_ivf_flat.cppm
@@ -61,8 +61,7 @@ public:
     static UniquePtr<AnnIVFFlatIndexData<DistType>>
     CreateIndex(u32 dimension, u32 train_count, const DistType *train_ptr, u32 vector_count, const DistType *vectors_ptr, u32 partition_num) {
         auto index_data = MakeUnique<AnnIVFFlatIndexData<DistType>>(metric, dimension, partition_num);
-        k_means_partition_only_centroids<f32>(metric, dimension, train_count, train_ptr, index_data->centroids_.data(), partition_num);
-        add_data_to_partition(dimension, vector_count, vectors_ptr, index_data.get());
+        index_data->BuildIndex(dimension, train_count, train_ptr, vector_count, vectors_ptr);
         return index_data;
     }
 

--- a/src/storage/knn_index/ann_ivf/ann_ivf_flat.cppm
+++ b/src/storage/knn_index/ann_ivf/ann_ivf_flat.cppm
@@ -144,11 +144,8 @@ public:
         }
     }
 
-    void Search(const AnnIVFFlatIndexData<DistType> *base_ivf, u32 segment_id, u32 n_probes, Bitmask &bitmask) {
-        if (bitmask.IsAllTrue()) {
-            Search(base_ivf, segment_id, n_probes);
-            return;
-        }
+    template <typename Filter>
+    void Search(const AnnIVFFlatIndexData<DistType> *base_ivf, u32 segment_id, u32 n_probes, Filter &filter) {
         // check metric type
         if (base_ivf->metric_ != metric) {
             UnrecoverableError("Metric type is invalid");
@@ -176,7 +173,7 @@ public:
                 const DistType *y_j = base_ivf->vectors_[selected_centroid].data();
                 for (u32 j = 0; j < contain_nums; j++, y_j += this->dimension_) {
                     auto segment_offset = base_ivf->ids_[selected_centroid][j];
-                    if (bitmask.IsTrue(segment_offset)) {
+                    if (filter(segment_offset)) {
                         DistType distance = Distance(x_i, y_j, this->dimension_);
                         result_handler_->AddResult(i, distance, RowID(segment_id, segment_offset));
                     }
@@ -202,7 +199,7 @@ public:
                     const DistType *y_j = base_ivf->vectors_[selected_centroid].data();
                     for (u32 j = 0; j < contain_nums; j++, y_j += this->dimension_) {
                         auto segment_offset = base_ivf->ids_[selected_centroid][j];
-                        if (bitmask.IsTrue(segment_offset)) {
+                        if (filter(segment_offset)) {
                             DistType distance = Distance(x_i, y_j, this->dimension_);
                             result_handler_->AddResult(i, distance, RowID(segment_id, segment_offset));
                         }

--- a/src/storage/meta/entry/segment_column_index_entry.cpp
+++ b/src/storage/meta/entry/segment_column_index_entry.cpp
@@ -147,26 +147,21 @@ Status SegmentColumnIndexEntry::CreateIndexPrepare(const IndexBase *index_base,
             }
             TypeInfo *type_info = column_def->type()->type_info().get();
             auto embedding_info = static_cast<EmbeddingInfo *>(type_info);
-            SizeT dimension = embedding_info->Dimension();
+            u32 dimension = embedding_info->Dimension();
+            u32 actual_row_count = segment_entry->actual_row_count();
             BufferHandle buffer_handle = GetIndex();
             switch (embedding_info->Type()) {
                 case kElemFloat: {
                     auto annivfflat_index = reinterpret_cast<AnnIVFFlatIndexData<f32> *>(buffer_handle.GetDataMut());
                     // TODO: How to select training data?
-                    Vector<f32> segment_column_data;
-                    segment_column_data.reserve(segment_entry->row_count() * dimension);
-                    auto iter = BlockEntryIter(segment_entry);
-                    for (auto *block_entry = iter.Next(); block_entry != nullptr; block_entry = iter.Next()) {
-                        BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
-
-                        ColumnVector column_vector = block_column_entry->GetColumnVector(buffer_mgr);
-                        auto *data_ptr = reinterpret_cast<float *>(column_vector.data());
-                        SizeT block_row_cnt = block_entry->row_count();
-                        segment_column_data.insert(segment_column_data.end(), data_ptr, data_ptr + block_row_cnt * dimension);
+                    if (check_ts) {
+                        OneColumnIterator<float> iter(segment_entry, buffer_mgr, column_id, begin_ts);
+                        annivfflat_index->BuildIndex(iter, dimension, actual_row_count);
+                    } else {
+                        // Not check ts in uncommitted segment when compact segment
+                        OneColumnIterator<float, false> iter(segment_entry, buffer_mgr, column_id, begin_ts);
+                        annivfflat_index->BuildIndex(iter, dimension, actual_row_count);
                     }
-                    SizeT total_row_cnt = segment_column_data.size() / dimension;
-                    annivfflat_index->train_centroids(dimension, total_row_cnt, segment_column_data.data());
-                    annivfflat_index->insert_data(dimension, total_row_cnt, segment_column_data.data());
                     break;
                 }
                 default: {
@@ -199,7 +194,7 @@ Status SegmentColumnIndexEntry::CreateIndexPrepare(const IndexBase *index_base,
                     OneColumnIterator<float> iter(segment_entry, buffer_mgr, column_id, begin_ts);
                     InsertHnswInner(iter);
                 } else {
-                    // Not check ts in uncommitted segment when compress segment
+                    // Not check ts in uncommitted segment when compact segment
                     OneColumnIterator<float, false> iter(segment_entry, buffer_mgr, column_id, begin_ts);
                     InsertHnswInner(iter);
                 }

--- a/src/unit_test/storage/knnindex/ann_ivf/ann_ivf_flat_l2.cpp
+++ b/src/unit_test/storage/knnindex/ann_ivf/ann_ivf_flat_l2.cpp
@@ -16,7 +16,7 @@
 
 import infinity_exception;
 import stl;
-
+import knn_filter;
 import ann_ivf_flat;
 import bitmask;
 import knn_expr;
@@ -30,8 +30,8 @@ TEST_F(AnnIVFFlatL2Test, test1) {
     i64 dimension = 4;
     i64 top_k = 4;
     i64 base_embedding_count = 4;
-    UniquePtr < f32[] > base_embedding = MakeUnique<f32[]>(dimension * base_embedding_count);
-    UniquePtr < f32[] > query_embedding = MakeUnique<f32[]>(dimension);
+    UniquePtr<f32[]> base_embedding = MakeUnique<f32[]>(dimension * base_embedding_count);
+    UniquePtr<f32[]> query_embedding = MakeUnique<f32[]>(dimension);
 
     {
         base_embedding[0] = 0.1;
@@ -95,12 +95,13 @@ TEST_F(AnnIVFFlatL2Test, test1) {
     EXPECT_FLOAT_EQ(id_array[3].segment_offset_, 3);
 
     {
-        AnnIVFFlatL2 <f32> ann_distance_m(query_embedding.get(), 1, top_k, dimension, EmbeddingDataType::kElemFloat);
+        AnnIVFFlatL2<f32> ann_distance_m(query_embedding.get(), 1, top_k, dimension, EmbeddingDataType::kElemFloat);
         auto p_bitmask = Bitmask::Make(64);
+        BitmaskFilter<SegmentOffset> filter(*p_bitmask);
         p_bitmask->SetFalse(1);
         {
             ann_distance_m.Begin();
-            ann_distance_m.Search(ann_ivf_l2_index.get(), 0, 1, *p_bitmask);
+            ann_distance_m.Search(ann_ivf_l2_index.get(), 0, 1, filter);
             ann_distance_m.End();
             f32 *distance_array_m = ann_distance_m.GetDistanceByIdx(0);
             RowID *id_array_m = ann_distance_m.GetIDByIdx(0);
@@ -120,7 +121,7 @@ TEST_F(AnnIVFFlatL2Test, test1) {
         p_bitmask->SetFalse(0);
         {
             ann_distance_m.ReInitialize();
-            ann_distance_m.Search(ann_ivf_l2_index.get(), 0, 1, *p_bitmask);
+            ann_distance_m.Search(ann_ivf_l2_index.get(), 0, 1, filter);
             ann_distance_m.End();
             f32 *distance_array_m = ann_distance_m.GetDistanceByIdx(0);
             RowID *id_array_m = ann_distance_m.GetIDByIdx(0);
@@ -137,7 +138,7 @@ TEST_F(AnnIVFFlatL2Test, test1) {
         p_bitmask->SetFalse(2);
         {
             ann_distance_m.ReInitialize();
-            ann_distance_m.Search(ann_ivf_l2_index.get(), 0, 1, *p_bitmask);
+            ann_distance_m.Search(ann_ivf_l2_index.get(), 0, 1, filter);
             ann_distance_m.End();
             f32 *distance_array_m = ann_distance_m.GetDistanceByIdx(0);
             RowID *id_array_m = ann_distance_m.GetIDByIdx(0);

--- a/test/sql/dml/delete/test_delete_with_annivfflat.slt
+++ b/test/sql/dml/delete/test_delete_with_annivfflat.slt
@@ -1,0 +1,71 @@
+statement ok
+DROP TABLE IF EXISTS test_delete_with_annivfflat;
+
+statement ok
+CREATE TABLE test_delete_with_annivfflat (c1 INT, c2 EMBEDDING(FLOAT, 4));
+
+# 2, dist: 0.22
+# 4, dist: 0.1
+# 6, dist: 0.06
+# 8, dist: 0.02
+query I
+COPY test_delete_with_annivfflat FROM '/tmp/infinity/test_data/embedding_float_dim4.csv' WITH (DELIMITER ',');
+----
+
+query I
+COPY test_delete_with_annivfflat FROM '/tmp/infinity/test_data/embedding_float_dim4.csv' WITH (DELIMITER ',');
+----
+
+statement ok
+DELETE FROM test_delete_with_annivfflat WHERE c1 = 8;
+
+query I
+SELECT c1 FROM test_delete_with_annivfflat SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3);
+----
+6
+6
+4
+
+statement ok
+CREATE INDEX idx1 ON test_delete_with_annivfflat (c2) USING IVFFlat WITH (centroids_count = 1, metric = l2);
+
+query I
+SELECT c1 FROM test_delete_with_annivfflat SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3);
+----
+6
+6
+4
+
+statement ok
+DELETE FROM test_delete_with_annivfflat WHERE c1 = 6;
+
+query I
+SELECT c1 FROM test_delete_with_annivfflat SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3);
+----
+4
+4
+2
+
+query I
+COPY test_delete_with_annivfflat FROM '/tmp/infinity/test_data/embedding_float_dim4.csv' WITH (DELIMITER ',');
+----
+
+query I
+SELECT c1 FROM test_delete_with_annivfflat SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3);
+----
+8
+6
+4
+
+statement ok
+DELETE FROM test_delete_with_annivfflat WHERE c1 = 8;
+
+query I
+SELECT c1 FROM test_delete_with_annivfflat SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3);
+----
+6
+4
+4
+
+statement ok
+DROP TABLE test_delete_with_annivfflat;


### PR DESCRIPTION
### What problem does this PR solve?

Now ann_ivf_flat index will be built without deleted rows.
Now knn_scan will exclude deleted rows for ann_ivf_flat index.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
