### PR TITLE
1. Fix append, 2. Opt scheduler lock

### DIFF
--- a/python/test/test_insert.py
+++ b/python/test/test_insert.py
@@ -239,7 +239,6 @@ class TestInsert:
     # insert data into index created table
 
     # insert table with 10000 columns.
-    @pytest.mark.skip(reason="May cause core dumped.")
     def test_insert_table_with_10000_columns(self):
         # connect
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -203,7 +203,8 @@ u64 SegmentEntry::AppendData(TransactionID txn_id, AppendState *append_state_ptr
         while (to_append_rows > 0) {
             // Append to_append_rows into block
             if (block_entries_.empty() || block_entries_.back()->GetAvailableCapacity() <= 0) {
-                this->block_entries_.emplace_back(BlockEntry::NewBlockEntry(this, 0, 0, this->column_count_, txn));
+                BlockID new_block_id = this->block_entries_.size();
+                this->block_entries_.emplace_back(BlockEntry::NewBlockEntry(this, new_block_id, 0, this->column_count_, txn));
             }
             BlockEntry *last_block_entry = this->block_entries_.back().get();
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Not use correct block id.
Issue link: #598

2. In `TaskScheduler::WorkerLoop`. Execute all tasks from one dequeue at least once before dequeue new tasks.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Test cases
- [ ] Other (please describe):
