### PR TITLE
Fix: column vector type binding

### DIFF
--- a/python/test/test_update.py
+++ b/python/test/test_update.py
@@ -225,7 +225,6 @@ class TestUpdate:
 
     # update table with only one block
 
-    @pytest.mark.skip(reason="May cause core dumped.")
     def test_update_table_with_one_block(self):
         # connect
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
@@ -250,7 +249,6 @@ class TestUpdate:
         assert res.success
 
     # update table with multiple blocks, but only one segment
-    @pytest.mark.skip(reason="May cause core dumped.")
     def test_update_table_with_one_segment(self):
         # connect
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)

--- a/src/executor/expression/expression_state.cppm
+++ b/src/executor/expression/expression_state.cppm
@@ -62,7 +62,7 @@ private:
     String name_;
 
     // output blocks and each block have one output column;
-    SharedPtr<ColumnVector> column_vector_;
+    SharedPtr<ColumnVector> column_vector_{nullptr};
 };
 
 } // namespace infinity

--- a/src/executor/operator/physical_update.cpp
+++ b/src/executor/operator/physical_update.cpp
@@ -31,6 +31,7 @@ import data_block;
 import column_vector;
 import expression_evaluator;
 import expression_state;
+import expression_type;
 import base_expression;
 import logical_type;
 import internal_types;
@@ -67,8 +68,8 @@ bool PhysicalUpdate::Execute(QueryContext *query_context, OperatorState *operato
                 SizeT column_idx = update_columns_[expr_idx].first;
                 const SharedPtr<BaseExpression> &expr = update_columns_[expr_idx].second;
                 SharedPtr<ColumnVector> output_column = ColumnVector::Make(column_vectors[column_idx]->data_type());
-                output_column->Initialize(ColumnVectorType::kFlat);
                 SharedPtr<ExpressionState> expr_state = ExpressionState::CreateState(expr);
+                output_column->Initialize(expr_state->OutputColumnVector()->vector_type());
                 evaluator.Execute(expr, expr_state, output_column);
                 column_vectors[column_idx] = output_column;
             }

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -44,7 +44,7 @@ BufferObj *BufferManager::Allocate(UniquePtr<FileWorker> file_worker) {
     auto res = buffer_obj.get();
     std::unique_lock<std::shared_mutex> w_locker(rw_locker_);
     if (auto iter = buffer_map_.find(file_path); iter != buffer_map_.end()) {
-        UniquePtr<String> err_msg = MakeUnique<String>(fmt::format("BufferManager::Allocate: file %s already exists.", file_path.c_str()));
+        UniquePtr<String> err_msg = MakeUnique<String>(fmt::format("BufferManager::Allocate: file {} already exists.", file_path.c_str()));
         LOG_ERROR(*err_msg);
         UnrecoverableError(*err_msg);
     }

--- a/src/storage/column_vector/column_vector.cppm
+++ b/src/storage/column_vector/column_vector.cppm
@@ -195,8 +195,14 @@ private:
     static void CopyValue(ColumnVector &dst, const ColumnVector &src, SizeT from, SizeT count) {
         auto *src_ptr = (T *)(src.data_ptr_);
         T *dst_ptr = &((T *)(dst.data_ptr_))[dst.tail_index_];
-        for (SizeT idx = 0; idx < count; ++idx) {
-            dst_ptr[idx] = src_ptr[from + idx];
+        if (src.vector_type() == ColumnVectorType::kConstant && src.tail_index_ == 1) {
+            for (SizeT idx = 0; idx < count; ++idx) {
+                dst_ptr[idx] = src_ptr[from];
+            }
+        } else {
+            for (SizeT idx = 0; idx < count; ++idx) {
+                dst_ptr[idx] = src_ptr[from + idx];
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Expressions are bind to Flat type by default, which will build wrong column vector when update/select table with constant condition.
Fix column vector type binding, and modify `CopyValue` to allow constant copy.

Issue link:#596

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Other (please describe):
