### PR TITLE
Fix: type check in python sdk

### DIFF
--- a/python/infinity/remote_thrift/db.py
+++ b/python/infinity/remote_thrift/db.py
@@ -115,9 +115,10 @@ class RemoteDatabase(Database, ABC):
         # {"c1":'int, primary key',"c2":'vector,1024,float32'}
         # db_obj.create_table("my_table", {"c1": "int, primary key", "c2": "vector,1024,float32"}, None)
         # to column_defs
-        check_valid_name(table_name)
+        check_valid_name(table_name, "Table")
         column_defs = []
         for index, (column_name, column_info) in enumerate(columns_definition.items()):
+            check_valid_name(column_name, "Column")
             column_big_info = [item.strip() for item in column_info.split(",")]
             if column_big_info[0] == "vector":
                 get_embedding_info(
@@ -136,7 +137,7 @@ class RemoteDatabase(Database, ABC):
             raise Exception(res.error_msg)
 
     def drop_table(self, table_name, if_exists=True):
-        check_valid_name(table_name)
+        check_valid_name(table_name, "Table")
         return self._conn.drop_table(db_name=self._db_name, table_name=table_name, if_exists=if_exists)
 
     def list_tables(self):
@@ -147,7 +148,7 @@ class RemoteDatabase(Database, ABC):
             raise Exception(res.error_msg)
 
     def describe_table(self, table_name):
-        check_valid_name(table_name)
+        check_valid_name(table_name, "Table")
         res = self._conn.describe_table(
             db_name=self._db_name, table_name=table_name)
         if res.success is True:
@@ -156,7 +157,7 @@ class RemoteDatabase(Database, ABC):
             raise Exception(res.error_msg)
 
     def get_table(self, table_name):
-        check_valid_name(table_name)
+        check_valid_name(table_name, "Table")
         res = self._conn.get_table(
             db_name=self._db_name, table_name=table_name)
         if res.success is True:

--- a/python/infinity/remote_thrift/infinity.py
+++ b/python/infinity/remote_thrift/infinity.py
@@ -33,7 +33,7 @@ class RemoteThriftInfinityConnection(InfinityConnection, ABC):
             self.disconnect()
 
     def create_database(self, db_name: str, options=None):
-        check_valid_name(db_name)
+        check_valid_name(db_name, "DB")
         res = self._client.create_database(db_name=db_name)
         if res.success is True:
             return RemoteDatabase(self._client, db_name)
@@ -48,7 +48,7 @@ class RemoteThriftInfinityConnection(InfinityConnection, ABC):
             raise Exception(res.error_msg)
 
     def describe_database(self, db_name: str):
-        check_valid_name(db_name)
+        check_valid_name(db_name, "DB")
         res = self._client.describe_database(db_name=db_name)
         if res.success is True:
             return res
@@ -56,7 +56,7 @@ class RemoteThriftInfinityConnection(InfinityConnection, ABC):
             raise Exception(res.error_msg)
 
     def drop_database(self, db_name: str, options=None):
-        check_valid_name(db_name)
+        check_valid_name(db_name, "DB")
         res = self._client.drop_database(db_name=db_name)
         if res.success is True:
             return res
@@ -64,7 +64,7 @@ class RemoteThriftInfinityConnection(InfinityConnection, ABC):
             raise Exception(res.error_msg)
 
     def get_database(self, db_name: str):
-        check_valid_name(db_name)
+        check_valid_name(db_name, "DB")
         res = self._client.get_database(db_name)
         if res.success is True:
             return RemoteDatabase(self._client, db_name)

--- a/python/infinity/remote_thrift/table.py
+++ b/python/infinity/remote_thrift/table.py
@@ -36,7 +36,7 @@ class RemoteTable(Table, ABC):
         self.query_builder = InfinityThriftQueryBuilder(table=self)
 
     def create_index(self, index_name: str, index_infos: list[IndexInfo], options=None):
-        check_valid_name(index_name)
+        check_valid_name(index_name, "Index")
         index_name = index_name.strip()
 
         index_info_list_to_use: list[ttypes.IndexInfo] = []
@@ -61,7 +61,7 @@ class RemoteTable(Table, ABC):
             raise Exception(res.error_msg)
 
     def drop_index(self, index_name: str):
-        check_valid_name(index_name)
+        check_valid_name(index_name, "Index")
         res = self._conn.drop_index(db_name=self._db_name, table_name=self._table_name,
                                     index_name=index_name)
         if res.success:

--- a/python/infinity/remote_thrift/utils.py
+++ b/python/infinity/remote_thrift/utils.py
@@ -124,18 +124,18 @@ def traverse_conditions(cons) -> ttypes.ParsedExpr:
 identifier_limit = 65536
 
 
-def check_valid_name(name):
+def check_valid_name(name, name_type: str = "Table"):
     if not isinstance(name, str):
-        raise ValueError(f"Table name must be a string, got {type(name)}")
+        raise ValueError(f"{name_type} name must be a string, got {type(name)}")
     if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
         raise ValueError(
-            f"Table name '{name}' is not valid. It should start with a letter and can contain only letters, numbers and underscores")
+            f"{name_type} name '{name}' is not valid. It should start with a letter and can contain only letters, numbers and underscores")
     if len(name) > identifier_limit:
-        raise ValueError(f"Table name '{name}' is not of appropriate length")
+        raise ValueError(f"{name_type} name '{name}' is not of appropriate length")
     if name is None:
         raise ValueError(f"invalid name: {name}")
     if name.isspace():
-        raise ValueError(f"Table name cannot be composed of whitespace characters only")
+        raise ValueError(f"{name_type} name cannot be composed of whitespace characters only")
     if name == '':
         raise ValueError(f"invalid name: {name}")
     if name == ' ':

--- a/python/test/test_create_table.py
+++ b/python/test/test_create_table.py
@@ -52,7 +52,7 @@ class TestCreateTable:
 
     def test_create_table_with_invalid_column_name(self):
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
-        with pytest.raises(Exception, match=r".*Empty column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -60,7 +60,7 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -68,7 +68,7 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -76,7 +76,7 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -84,7 +84,7 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -92,7 +92,7 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -100,7 +100,7 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
@@ -108,10 +108,30 @@ class TestCreateTable:
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
 
-        with pytest.raises(Exception, match=r".*invalid column name"):
+        with pytest.raises(Exception):
             db_obj = infinity_obj.get_database("default")
             db_obj.drop_table("test_create_invalid_column_name", True)
             table_obj = db_obj.create_table("test_create_invalid_column_name", {
                 "1.1": "vector,128,float"}, None)
             assert table_obj
             db_obj.drop_table("test_create_invalid_column_name")
+
+    @pytest.mark.parametrize("column_name", common_values.invalid_name_array)
+    def test_create_table_with_invalid_column_name_python(self, column_name):
+        """
+        target: create with invalid column name
+        methods: create table with invalid column name
+        expect: all operations throw exception on python side
+        """
+        infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
+        db_obj = infinity_obj.get_database("default")
+        db_obj.drop_table("my_table")
+
+        try:
+            tb = db_obj.create_table("my_table", {column_name: "int"}, None)
+        except Exception as e:
+            print(e)
+
+        # disconnect
+        res = infinity_obj.disconnect()
+        assert res.success

--- a/python/test/test_table.py
+++ b/python/test/test_table.py
@@ -572,22 +572,3 @@ class TestTable:
         res = infinity_obj.disconnect()
         assert res.success
 
-    @pytest.mark.parametrize("column_name", common_values.invalid_name_array)
-    def test_create_with_invalid_column_name(self, column_name):
-        """
-        target: create with invalid column name
-        methods: create table with invalid column name
-        expect: all operations throw exception on python side
-        """
-        infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
-        db_obj = infinity_obj.get_database("default")
-        db_obj.drop_table("my_table")
-
-        try:
-            tb = db_obj.create_table("my_table", {column_name: "int"}, None)
-        except Exception as e:
-            print(e)
-
-        # disconnect
-        res = infinity_obj.disconnect()
-        assert res.success

--- a/python/test/test_table.py
+++ b/python/test/test_table.py
@@ -571,3 +571,23 @@ class TestTable:
         # disconnect
         res = infinity_obj.disconnect()
         assert res.success
+
+    @pytest.mark.parametrize("column_name", common_values.invalid_name_array)
+    def test_create_with_invalid_column_name(self, column_name):
+        """
+        target: create with invalid column name
+        methods: create table with invalid column name
+        expect: all operations throw exception on python side
+        """
+        infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
+        db_obj = infinity_obj.get_database("default")
+        db_obj.drop_table("my_table")
+
+        try:
+            tb = db_obj.create_table("my_table", {column_name: "int"}, None)
+        except Exception as e:
+            print(e)
+
+        # disconnect
+        res = infinity_obj.disconnect()
+        assert res.success


### PR DESCRIPTION
### What problem does this PR solve?

The type of column name is not checked in python side, which will cause error when disconnect db.
Add type check and correspond test case.

Issue link:#505

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Test cases
- [ ] Other (please describe):
