### PR TITLE
[Fix bug] Deny the connect request after shutdown the server

### DIFF
--- a/src/network/db_server.cppm
+++ b/src/network/db_server.cppm
@@ -38,7 +38,7 @@ private:
 
     void StartConnection(SharedPtr<Connection> &connection);
 
-    atomic_bool initialized{false};
+    bool initialized_{false};
     atomic_u64 running_connection_count_{0};
     boost::asio::io_service io_service_{};
     UniquePtr<boost::asio::ip::tcp::acceptor> acceptor_ptr_{};


### PR DESCRIPTION
### What problem does this PR solve?

When we use pg_client to connect infinity, due to the pg_clients haven't disconnected with infinity. The infinity server can't be shutdown. At this moment, infinity server can still be connected with pg_client. Correct behavior should be infinity server should deny the access in this moment, since infinity server is in stopping status.

Be aware, this PR is only fix the PG client connection. For thrift server part, we haven't fixed it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

