### PR TITLE
Add external sort merger

### DIFF
--- a/src/storage/invertedindex/common/external_sort_merger.cpp
+++ b/src/storage/invertedindex/common/external_sort_merger.cpp
@@ -1,0 +1,413 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+#include <cassert>
+#include <filesystem>
+#include <functional>
+#include <queue>
+#include <string.h>
+
+module external_sort_merger;
+
+import stl;
+
+namespace infinity {
+
+#define IASSERT(exp)                                                                                                                                 \
+    {                                                                                                                                                \
+        if (!(exp)) {                                                                                                                                \
+            assert(false);                                                                                                                           \
+        }                                                                                                                                            \
+    }
+
+template <typename KeyType, typename LenType>
+SortMerger<KeyType, LenType>::SortMerger(const char *filenm, u32 group_size, u32 bs, u32 output_num)
+    : filenm_(filenm), MAX_GROUP_SIZE_(group_size), BS_SIZE_(bs), PRE_BUF_SIZE_((u32)(1. * bs * 0.8 / (group_size + 1))),
+      RUN_BUF_SIZE_(PRE_BUF_SIZE_ * group_size), OUT_BUF_SIZE_(bs - RUN_BUF_SIZE_ - PRE_BUF_SIZE_), OUT_BUF_NUM_(output_num) {
+    pre_buf_ = run_buf_ = out_buf_ = nullptr;
+
+    pre_buf_size_ = pre_buf_num_ = count_ = 0;
+
+    micro_run_idx_ = new u32[MAX_GROUP_SIZE_];
+    micro_run_pos_ = new u32[MAX_GROUP_SIZE_];
+    num_micro_run_ = new u32[MAX_GROUP_SIZE_];
+    size_micro_run_ = new u32[MAX_GROUP_SIZE_];
+    num_run_ = new u32[MAX_GROUP_SIZE_];
+    size_run_ = new u32[MAX_GROUP_SIZE_];
+    size_loaded_run_ = new u32[MAX_GROUP_SIZE_];
+    run_addr_ = new u64[MAX_GROUP_SIZE_];
+    run_curr_addr_ = new u64[MAX_GROUP_SIZE_];
+
+    micro_buf_ = new char *[MAX_GROUP_SIZE_];
+    sub_out_buf_ = new char *[OUT_BUF_NUM_];
+
+    in_out_mtx_ = new std::mutex[OUT_BUF_NUM_];
+    in_out_con_ = new std::condition_variable[OUT_BUF_NUM_];
+
+    out_buf_size_ = new u32[OUT_BUF_NUM_];
+    out_buf_full_ = new bool[OUT_BUF_NUM_];
+}
+
+template <typename KeyType, typename LenType>
+SortMerger<KeyType, LenType>::~SortMerger() {
+    if (pre_buf_)
+        free(pre_buf_);
+
+    if (run_buf_)
+        free(run_buf_);
+
+    if (out_buf_)
+        free(out_buf_);
+
+    delete[] micro_run_idx_;
+    delete[] micro_run_pos_;
+    delete[] num_micro_run_;
+    delete[] size_micro_run_;
+    delete[] num_run_;
+    delete[] size_run_;
+    delete[] size_loaded_run_;
+    delete[] run_addr_;
+    delete[] run_curr_addr_;
+
+    delete[] micro_buf_;
+    delete[] sub_out_buf_;
+
+    delete[] in_out_mtx_;
+    delete[] in_out_con_;
+
+    delete[] out_buf_size_;
+    delete[] out_buf_full_;
+}
+
+template <typename KeyType, typename LenType>
+void SortMerger<KeyType, LenType>::NewBuffer() {
+    if (!pre_buf_)
+        pre_buf_ = (char *)malloc(PRE_BUF_SIZE_);
+
+    if (!run_buf_)
+        run_buf_ = (char *)malloc(RUN_BUF_SIZE_);
+
+    if (!out_buf_)
+        out_buf_ = (char *)malloc(OUT_BUF_SIZE_);
+}
+
+template <typename KeyType, typename LenType>
+void SortMerger<KeyType, LenType>::Init(DirectIO &io_stream) {
+    // initialize three buffers
+    NewBuffer();
+
+    // initiate output buffers
+    out_buf_size_[0] = 0;
+    sub_out_buf_[0] = out_buf_;
+    out_buf_full_[0] = false;
+    for (u32 i = 1; i < OUT_BUF_NUM_; ++i) {
+        sub_out_buf_[i] = sub_out_buf_[i - 1] + OUT_BUF_SIZE_ / OUT_BUF_NUM_;
+        out_buf_size_[i] = 0;
+        out_buf_full_[i] = false;
+    }
+    out_buf_in_idx_ = 0;
+    out_buf_out_idx_ = 0;
+
+    // initiate the microrun buffer
+    micro_buf_[0] = run_buf_;
+    for (u32 i = 1; i < MAX_GROUP_SIZE_; ++i)
+        micro_buf_[i] = micro_buf_[i - 1] + PRE_BUF_SIZE_;
+
+    //
+    group_size_ = 0;
+    u64 next_run_pos = 0;
+    for (u32 i = 0; i < MAX_GROUP_SIZE_ && (u64)io_stream.Tell() < FILE_LEN_; ++i, ++group_size_) {
+        // get the size of run
+        io_stream.Read((char *)(size_run_ + i), sizeof(u32));
+        // get the records number of a run
+        io_stream.Read((char *)(num_run_ + i), sizeof(u32));
+        io_stream.Read((char *)(&next_run_pos), sizeof(u64));
+
+        run_addr_[i] = io_stream.Tell(); // ftell(f);
+
+        // loading size of a microrun
+        u32 s = size_run_[i] > PRE_BUF_SIZE_ ? PRE_BUF_SIZE_ : size_run_[i];
+        size_t ret = io_stream.Read(micro_buf_[i], s);
+        size_micro_run_[i] = ret;
+        size_loaded_run_[i] = ret;
+        run_curr_addr_[i] = io_stream.Tell();
+
+        /// it is not needed for compression, validation will be made within IOStream in that case
+        // if a record can fit in microrun buffer
+        bool flag = false;
+        while (*(LenType *)(micro_buf_[i]) + sizeof(LenType) > s) {
+            size_micro_run_[i] = 0;
+            --count_;
+            // LOG_WARN("[Warning]: A record is too long, it will be ignored");
+
+            io_stream.Seek(*(LenType *)(micro_buf_[i]) + sizeof(LenType) - s, SEEK_CUR);
+
+            if (io_stream.Tell() - run_addr_[i] >= (u64)size_run_[i]) {
+                flag = true;
+                break;
+            }
+
+            s = (u32)((u64)size_run_[i] - (io_stream.Tell() - run_addr_[i]) > PRE_BUF_SIZE_ ? PRE_BUF_SIZE_
+                                                                                            : (u64)size_run_[i] - (io_stream.Tell() - run_addr_[i]));
+            size_micro_run_[i] = s;
+            io_stream.Read(micro_buf_[i], s);
+        }
+        if (flag)
+            continue;
+
+        merge_heap_.push(KeyAddr(micro_buf_[i], -1, i));
+        micro_run_idx_[i] = 1;
+        micro_run_pos_[i] = KeyAddr(micro_buf_[i], -1, i).LEN() + sizeof(LenType);
+        num_micro_run_[i] = 0;
+
+        // if size_run_[i]>PRE_BUF_SIZE_, it needs to the end of a run and turn to the next run
+        io_stream.Seek(next_run_pos);
+    }
+    // LOG_INFO << "Run number: " << group_size_;
+
+    // initialize predict heap and records number of every microrun
+    for (u32 i = 0; i < group_size_; ++i) {
+        u32 pos = 0;
+        u32 last_pos = -1;
+        assert(i < MAX_GROUP_SIZE_);
+        while (size_micro_run_[i]) {
+            LenType len = *(LenType *)(micro_buf_[i] + pos);
+            if (pos + sizeof(LenType) + len > size_micro_run_[i]) {
+                assert(last_pos != (u32)-1); // buffer too small that can't hold one record
+
+                len = *(LenType *)(micro_buf_[i] + last_pos) + sizeof(LenType);
+                char *tmp = (char *)malloc(len);
+                memcpy(tmp, micro_buf_[i] + last_pos, len);
+
+                pre_heap_.push(KeyAddr(tmp, run_addr_[i] + pos, i));
+                //
+                size_micro_run_[i] = pos;
+                break;
+            }
+
+            num_micro_run_[i]++;
+            last_pos = pos;
+            pos += sizeof(LenType) + len;
+        }
+    }
+}
+
+template <typename KeyType, typename LenType>
+void SortMerger<KeyType, LenType>::Predict(DirectIO &io_stream) {
+    while (pre_heap_.size() > 0) {
+        KeyAddr top = pre_heap_.top();
+        pre_heap_.pop();
+        u64 addr = top.ADDR();
+        u32 idx = top.IDX();
+        free(top.data);
+
+        std::unique_lock lock(pre_buf_mtx_);
+
+        while (pre_buf_size_ != 0)
+            pre_buf_con_.wait(lock);
+
+        assert(idx < MAX_GROUP_SIZE_);
+        // get loading size of a microrun
+        u32 s;
+        s = (u32)((u64)size_run_[idx] - (addr - run_addr_[idx]));
+
+        if (s == 0) {
+            continue;
+        }
+        s = s > PRE_BUF_SIZE_ ? PRE_BUF_SIZE_ : s;
+
+        // load microrun
+        io_stream.Seek(addr);
+        s = io_stream.Read(pre_buf_, s);
+        size_loaded_run_[idx] += s;
+        run_curr_addr_[idx] = io_stream.Tell();
+
+        u32 pos = 0;
+        u32 last_pos = -1;
+        pre_buf_num_ = 0;
+        while (1) {
+            LenType len = *(LenType *)(pre_buf_ + pos);
+            if (pos + sizeof(LenType) + len > s) {
+                // the last record of this microrun
+                IASSERT(last_pos != (u32)-1); // buffer too small that can't hold one record
+                len = *(LenType *)(pre_buf_ + last_pos) + sizeof(LenType);
+                char *tmp = (char *)malloc(len);
+                memcpy(tmp, pre_buf_ + last_pos, len);
+                pre_heap_.push(KeyAddr(tmp, addr + (u64)pos, idx));
+                break;
+            }
+
+            ++pre_buf_num_;
+            last_pos = pos;
+            pos += sizeof(LenType) + len;
+        }
+        pre_buf_size_ = pos;
+        pre_buf_con_.notify_one();
+    }
+    {
+        std::unique_lock lock(pre_buf_mtx_);
+        pre_buf_size_ = -1;
+        pre_buf_con_.notify_one();
+    }
+
+    // LOG_INFO("Predicting is over...");
+}
+
+template <typename KeyType, typename LenType>
+void SortMerger<KeyType, LenType>::Merge() {
+    while (merge_heap_.size() > 0) {
+        KeyAddr top = merge_heap_.top();
+        merge_heap_.pop();
+        u32 idx = top.IDX();
+
+        // output
+        while (1) {
+            assert(out_buf_in_idx_ < OUT_BUF_NUM_);
+            std::unique_lock lock(in_out_mtx_[out_buf_in_idx_]);
+            while (out_buf_full_[out_buf_in_idx_])
+                in_out_con_[out_buf_in_idx_].wait(lock);
+
+            // if buffer is full
+            if (top.LEN() + sizeof(LenType) + out_buf_size_[out_buf_in_idx_] > OUT_BUF_SIZE_ / OUT_BUF_NUM_) {
+                IASSERT(out_buf_size_[out_buf_in_idx_] != 0); // output buffer chanel is smaller than size of a record
+                out_buf_full_[out_buf_in_idx_] = true;
+                u32 tmp = out_buf_in_idx_;
+                ++out_buf_in_idx_;
+                out_buf_in_idx_ %= OUT_BUF_NUM_;
+                in_out_con_[tmp].notify_one();
+                continue;
+            }
+
+            assert(out_buf_in_idx_ < OUT_BUF_NUM_);
+            memcpy(sub_out_buf_[out_buf_in_idx_] + out_buf_size_[out_buf_in_idx_], top.data, top.LEN() + sizeof(LenType));
+            out_buf_size_[out_buf_in_idx_] += top.LEN() + sizeof(LenType);
+
+            break;
+        }
+
+        assert(idx < MAX_GROUP_SIZE_);
+        // reach the end of a microrun
+        if (micro_run_idx_[idx] == num_micro_run_[idx]) {
+            IASSERT(micro_run_pos_[idx] <= size_micro_run_[idx]);
+            std::unique_lock lock(pre_buf_mtx_);
+            while (pre_buf_size_ == 0)
+                pre_buf_con_.wait(lock);
+
+            if (pre_buf_size_ == (u32)-1)
+                continue;
+
+            assert(idx < MAX_GROUP_SIZE_);
+            memcpy(micro_buf_[idx], pre_buf_, pre_buf_size_);
+            size_micro_run_[idx] = pre_buf_size_;
+            num_micro_run_[idx] = pre_buf_num_;
+            micro_run_pos_[idx] = micro_run_idx_[idx] = pre_buf_num_ = pre_buf_size_ = 0;
+            pre_buf_con_.notify_one();
+        }
+
+        assert(idx < MAX_GROUP_SIZE_);
+        merge_heap_.push(KeyAddr(micro_buf_[idx] + micro_run_pos_[idx], -1, idx));
+        ++micro_run_idx_[idx];
+        micro_run_pos_[idx] += KeyAddr(micro_buf_[idx] + micro_run_pos_[idx], -1, idx).LEN() + sizeof(LenType);
+    }
+    {
+        assert(out_buf_in_idx_ < OUT_BUF_NUM_);
+        std::unique_lock lock(in_out_mtx_[out_buf_in_idx_]);
+        if (!out_buf_full_[out_buf_in_idx_] && out_buf_size_[out_buf_in_idx_] > 0) {
+            out_buf_full_[out_buf_in_idx_] = true;
+            in_out_con_[out_buf_in_idx_].notify_one();
+        }
+    }
+}
+
+template <typename KeyType, typename LenType>
+void SortMerger<KeyType, LenType>::Output(FILE *f, u32 idx) {
+    DirectIO io_stream(f, "w");
+
+    while (count_ > 0) {
+        // wait its turn to output
+        std::unique_lock out_lock(out_out_mtx_);
+        while (out_buf_out_idx_ != idx)
+            out_out_con_.wait(out_lock);
+
+        if (count_ == 0) {
+            ++out_buf_out_idx_;
+            out_buf_out_idx_ %= OUT_BUF_NUM_;
+            out_out_con_.notify_all();
+            break;
+        }
+
+        assert(idx < OUT_BUF_NUM_);
+        std::unique_lock in_lock(in_out_mtx_[idx]);
+        while (!out_buf_full_[idx])
+            in_out_con_[idx].wait(in_lock);
+
+        IASSERT(out_buf_size_[idx] != 0);
+        assert(idx < OUT_BUF_NUM_);
+        for (u32 pos = 0; pos < out_buf_size_[idx]; --count_, pos += *(LenType *)(sub_out_buf_[idx] + pos) + sizeof(LenType))
+            ;
+
+        IASSERT(out_buf_size_[idx] <= OUT_BUF_SIZE_ / OUT_BUF_NUM_);
+        io_stream.Write(sub_out_buf_[idx], out_buf_size_[idx]);
+        out_buf_full_[idx] = false;
+        out_buf_size_[idx] = 0;
+        ++out_buf_out_idx_;
+        out_buf_out_idx_ %= OUT_BUF_NUM_;
+
+        out_out_con_.notify_all();
+        in_out_con_[idx].notify_one();
+    }
+}
+
+template <typename KeyType, typename LenType>
+void SortMerger<KeyType, LenType>::Run() {
+    FILE *f = fopen(filenm_.c_str(), "r");
+
+    DirectIO io_stream(f);
+    FILE_LEN_ = io_stream.Length();
+
+    io_stream.Read((char *)(&count_), sizeof(u64));
+
+    Init(io_stream);
+
+    Thread predict_thread(std::bind(&self_t::Predict, this, io_stream));
+    Thread merge_thread(std::bind(&self_t::Merge, this));
+
+    FILE *out_f = fopen((filenm_ + ".out").c_str(), "w+");
+    IASSERT(out_f);
+    IASSERT(fwrite(&count_, sizeof(u64), 1, out_f) == 1);
+
+    Thread *out_thread[OUT_BUF_NUM_];
+    for (u32 i = 0; i < OUT_BUF_NUM_; ++i)
+        out_thread[i] = new Thread(std::bind(&self_t::Output, this, out_f, i));
+
+    predict_thread.join();
+    merge_thread.join();
+    for (u32 i = 0; i < OUT_BUF_NUM_; ++i) {
+        out_thread[i]->join();
+        delete out_thread[i];
+    }
+
+    fclose(f);
+    fclose(out_f);
+
+    if (std::filesystem::exists(filenm_))
+        std::filesystem::remove(filenm_);
+    if (std::filesystem::exists(filenm_ + ".out"))
+        std::filesystem::rename(filenm_ + ".out", filenm_);
+}
+
+template class SortMerger<u32, u8>;
+
+} // namespace infinity

--- a/src/storage/invertedindex/common/external_sort_merger.cppm
+++ b/src/storage/invertedindex/common/external_sort_merger.cppm
@@ -1,0 +1,201 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <filesystem>
+#include <queue>
+
+export module external_sort_merger;
+
+import stl;
+
+namespace infinity {
+
+export struct DirectIO {
+    DirectIO(FILE *fd, const String &mode = "r") : fd_(fd), length_(0) {
+        if (mode.compare("r") == 0) {
+            fseek(fd_, 0, SEEK_END);
+            length_ = ftell(fd_);
+            fseek(fd_, 0, SEEK_SET);
+        }
+    }
+
+    SizeT Write(char *const data, SizeT length) { return fwrite(data, length, 1, fd_); }
+
+    SizeT Read(char *data, SizeT length) { return fread(data, 1, length, fd_); }
+
+    SizeT Tell() { return ftell(fd_); }
+
+    void Seek(SizeT pos, int origin = SEEK_SET) { fseek(fd_, pos, origin); }
+
+    SizeT Length() { return length_; }
+
+    FILE *fd_;
+
+    SizeT length_;
+};
+
+export template <typename KeyType, typename LenType>
+class SortMerger {
+    typedef SortMerger<KeyType, LenType> self_t;
+
+    struct KeyAddr;
+    String filenm_;
+    const u32 MAX_GROUP_SIZE_; //!< max group size
+    const u32 BS_SIZE_;        //!< in fact it equals to memory size
+    u32 PRE_BUF_SIZE_;         //!< max predict buffer size
+    u32 RUN_BUF_SIZE_;         //!< max run buffer size
+    u32 OUT_BUF_SIZE_;         //!< max size of output buffer
+    const u32 OUT_BUF_NUM_;    //!< output threads number
+
+    std::priority_queue<struct KeyAddr> pre_heap_;   //!< predict heap
+    std::priority_queue<struct KeyAddr> merge_heap_; //!< merge heap
+
+    u32 *micro_run_idx_{nullptr};   //!< the access index of each microruns
+    u32 *micro_run_pos_{nullptr};   //!< the access position within each microruns
+    u32 *num_micro_run_{nullptr};   //!< the records number of each microruns
+    u32 *size_micro_run_{nullptr};  //!< the size of entire microrun
+    u32 *num_run_{nullptr};         //!< records number of each runs
+    u32 *size_run_{nullptr};        //!< size of each entire runs
+    u32 *size_loaded_run_{nullptr}; //!< size of data that have been read within each entire runs
+    u64 *run_addr_{nullptr};        //!< start file address of each runs
+    u64 *run_curr_addr_{nullptr};   //!< current file address of each runs
+
+    char **micro_buf_{nullptr};   //!< address of every microrun channel buffer
+    char **sub_out_buf_{nullptr}; //!< addresses of each output buffer
+
+    char *pre_buf_{nullptr}; //!< predict buffer
+    char *run_buf_{nullptr}; //!< entire run buffer
+    char *out_buf_{nullptr}; //!< the entire output buffer
+
+    std::mutex pre_buf_mtx_; //!< mutex and condition for predict buffer accessed by merge and predict thread
+    std::condition_variable pre_buf_con_;
+
+    std::mutex *in_out_mtx_{nullptr};              //!< mutex and condition for output buffers accessed by output threads and merge threads
+    std::condition_variable *in_out_con_{nullptr}; //!<
+
+    std::mutex out_out_mtx_; //!< mutex and condition to ensure the seqence of file writing of all the output threads
+    std::condition_variable out_out_con_;
+
+    u32 pre_buf_size_; //!< the current size of microrun that has been loaded onto prediect buffer
+    u32 pre_buf_num_;  //!< the current records number of microrun that has been loaded onto prediect buffer
+    // u32 pre_idx_;//!< the index of microrun channel right in the predict buffer
+    u32 out_buf_in_idx_;          //!< used by merge to get the current available output buffer
+    u32 out_buf_out_idx_;         //!< used by output threads to get the index of the turn of outputting
+    u32 *out_buf_size_{nullptr};  //!< data size of each output buffer
+    bool *out_buf_full_{nullptr}; //!< a flag to ensure if the output buffer is full or not
+
+    u64 count_;      //!< records number
+    u32 group_size_; //!< the real run number that can get from the input file.
+
+    u64 FILE_LEN_;
+
+    struct KeyAddr {
+        char *data{nullptr};
+        u64 addr;
+        u32 idx;
+
+        KeyAddr(char *p, u64 ad, u32 i) {
+            data = p;
+            addr = ad;
+            idx = i;
+        }
+
+        KeyAddr() {
+            data = nullptr;
+            addr = -1;
+            idx = -1;
+        }
+
+        KeyType &KEY() { return *(KeyType *)(data + sizeof(LenType)); }
+        KeyType KEY() const { return *(KeyType *)(data + sizeof(LenType)); }
+        LenType LEN() const { return *(LenType *)data; }
+        u64 &ADDR() { return addr; }
+        u64 ADDR() const { return addr; }
+        u32 IDX() const { return idx; }
+        u32 &IDX() { return idx; }
+
+        int Compare(const KeyAddr &p) const {
+            if (KEY() == p.KEY())
+                return 0;
+
+            if (KEY() > p.KEY())
+                return 1;
+            if (KEY() < p.KEY())
+                return -1;
+
+            LenType len1 = LEN() / sizeof(KeyType);
+            LenType len2 = p.LEN() / sizeof(KeyType);
+
+            for (LenType i = 1; i < len1 && i < len2; ++i) {
+                if (((KeyType *)(data + sizeof(LenType)))[i] > ((KeyType *)(p.data + sizeof(LenType)))[i])
+                    return 1;
+                if (((KeyType *)(data + sizeof(LenType)))[i] < ((KeyType *)(p.data + sizeof(LenType)))[i])
+                    return -1;
+            }
+
+            if (len1 == len2)
+                return 0;
+
+            if (len1 > len2)
+                return 1;
+            return -1;
+        }
+
+        bool operator==(const KeyAddr &other) const { return Compare(other) == 0; }
+
+        bool operator>(const KeyAddr &other) const { return Compare(other) < 0; }
+
+        bool operator<(const KeyAddr &other) const { return Compare(other) > 0; }
+    };
+
+    void NewBuffer();
+
+    void Init(DirectIO &io_stream);
+
+    void Predict(DirectIO &io_stream);
+
+    void Merge();
+
+    void Output(FILE *f, u32 idx);
+
+public:
+    SortMerger(const char *filenm, u32 group_size = 4, u32 bs = 100000000, u32 output_num = 2);
+
+    ~SortMerger();
+
+    void SetParams(u32 max_record_len) {
+        if (max_record_len > PRE_BUF_SIZE_) {
+            PRE_BUF_SIZE_ = max_record_len;
+            RUN_BUF_SIZE_ = PRE_BUF_SIZE_ * MAX_GROUP_SIZE_;
+            // OUT_BUF_SIZE_ = BS_SIZE_ - RUN_BUF_SIZE_ - PRE_BUF_SIZE_; ///we do not change OUT_BUF_SIZE_
+        }
+    }
+
+    void SetParams(u32 max_record_len, u32 min_buff_size_required) {
+        if (max_record_len > PRE_BUF_SIZE_)
+            PRE_BUF_SIZE_ = max_record_len;
+        if (RUN_BUF_SIZE_ < min_buff_size_required)
+            RUN_BUF_SIZE_ = min_buff_size_required;
+        if (RUN_BUF_SIZE_ < PRE_BUF_SIZE_ * MAX_GROUP_SIZE_)
+            RUN_BUF_SIZE_ = PRE_BUF_SIZE_ * MAX_GROUP_SIZE_;
+        if (OUT_BUF_SIZE_ < min_buff_size_required)
+            OUT_BUF_SIZE_ = min_buff_size_required;
+    }
+
+    void Run();
+};
+
+} // namespace infinity

--- a/src/unit_test/storage/invertedindex/common/external_sort.cpp
+++ b/src/unit_test/storage/invertedindex/common/external_sort.cpp
@@ -1,0 +1,111 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "unit_test/base_test.h"
+#include <cassert>
+#include <filesystem>
+#include <iostream>
+
+import stl;
+import third_party;
+import external_sort_merger;
+
+using namespace infinity;
+
+template <class T>
+Vector<char> RandStr(T key) {
+    u32 len = rand() % 100 + sizeof(T);
+    while (len == sizeof(T))
+        len = rand() % 100 + sizeof(T);
+
+    Vector<char> str;
+    str.reserve(len);
+    for (u32 i = 0; i < len; ++i)
+        str.push_back('a' + rand() % 26);
+
+    *(T *)str.data() = key;
+    return str;
+}
+
+class ExternalSortTest : public BaseTest {
+public:
+    ExternalSortTest() {}
+    ~ExternalSortTest() {}
+    void SetUp() override {}
+    void TearDown() override {}
+
+protected:
+    template <class KeyType, class LenType>
+    void CheckMerger(const u64 SIZE, u32 bs = 100000000) {
+        std::filesystem::remove("./tt");
+
+        Vector<char> str;
+        FILE *f = fopen("./tt", "w+");
+        fwrite(&SIZE, sizeof(u64), 1, f);
+
+        u32 run_num = rand() % 300;
+        while (run_num < 100 || SIZE % run_num != 0)
+            run_num = rand() % 300;
+
+        // run_num = 800;
+        for (u32 i = 0; i < run_num; ++i) {
+            u64 pos = ftell(f);
+            fseek(f, 2 * sizeof(u32) + sizeof(u64), SEEK_CUR);
+            u32 s = 0;
+            for (u32 j = 0; j < SIZE / run_num; ++j) {
+                str = RandStr<KeyType>(i * SIZE / run_num + j);
+                LenType len = str.size();
+                fwrite(&len, sizeof(LenType), 1, f);
+                fwrite(str.data(), len, 1, f);
+                s += len + sizeof(LenType);
+
+                // cout<<"\rAdd data: "<<(double)(i*SIZE/run_num+j)/SIZE*100.<<"%"<<std::Flush;
+            }
+            u64 next_run_pos = ftell(f);
+            fseek(f, pos, SEEK_SET);
+            fwrite(&s, sizeof(u32), 1, f);
+            s = SIZE / run_num;
+            fwrite(&s, sizeof(u32), 1, f);
+            fwrite(&next_run_pos, sizeof(u64), 1, f);
+            fseek(f, 0, SEEK_END);
+        }
+        fclose(f);
+
+        SortMerger<KeyType, LenType> merger("./tt", run_num, bs, 2);
+        merger.Run();
+
+        f = fopen("./tt", "r");
+        u64 count = 0;
+        fread(&count, sizeof(u64), 1, f);
+        EXPECT_EQ(count, SIZE);
+        for (u32 i = 0; i < count; ++i) {
+            LenType len = 0;
+            fread(&len, sizeof(LenType), 1, f);
+            char *buf = new char[len];
+            fread(buf, len, 1, f);
+            EXPECT_EQ(*(KeyType *)buf, i);
+            if (*(KeyType *)buf != i) {
+                std::cout << "\nERROR: " << *(KeyType *)buf << ":" << i << std::endl;
+                break;
+            }
+            delete[] buf;
+        }
+        std::filesystem::remove("./tt");
+    }
+};
+
+TEST_F(ExternalSortTest, test1) {
+    CheckMerger<u32, u8>(1000, 100000);
+    CheckMerger<u32, u8>(10000, 1000000);
+}


### PR DESCRIPTION
### What problem does this PR solve?

External sort merger is used during offline inverted index building

TODO: It's a general external sort merger, for the requirements for offline index building, it's needed to be adapted for string sorting.

Issue link:#633

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
