### PR TITLE
Fix: error embedding column vector parameter

### DIFF
--- a/python/test/test_insert.py
+++ b/python/test/test_insert.py
@@ -475,9 +475,8 @@ class TestInsert:
         res = infinity_obj.disconnect()
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.skip(reason="When use type = varchar type-example = list, core dumped.")
     @pytest.mark.parametrize('column_types', ["varchar"])
-    @pytest.mark.parametrize('column_types_example', [[1, 2, 3]])
+    @pytest.mark.parametrize('column_types_example', [[1, 2, 3], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
     def test_various_insert_types(self, column_types, column_types_example):
         # connect
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)

--- a/src/function/cast/column_vector_cast.cppm
+++ b/src/function/cast/column_vector_cast.cppm
@@ -134,7 +134,7 @@ struct TryCastValueToVarlenWithType {
     template <typename SourceValueType, typename TargetValueType>
     inline static void Execute(const SourceValueType &input, TargetValueType &result, Bitmask *nulls_ptr, SizeT idx, void *state_ptr) {
         auto *cast_data_ptr = (ColumnVectorCastData *)(state_ptr);
-        //        LOG_TRACE("{}, {}", cast_data_ptr->source_type_.ToString(), cast_data_ptr->target_type_.ToString());
+        // LOG_INFO(fmt::format("{}, {}", cast_data_ptr->source_type_.ToString(), cast_data_ptr->target_type_.ToString()));
         if (Operator::template Run<SourceValueType, TargetValueType>(input,
                                                                      cast_data_ptr->source_type_,
                                                                      result,

--- a/src/parser/type/complex/embedding_type.h
+++ b/src/parser/type/complex/embedding_type.h
@@ -215,8 +215,8 @@ public:
     inline void Reset() {
         if (ptr && new_allocated_) {
             delete[] ptr;
-            ptr = nullptr;
         }
+        ptr = nullptr;
     }
 
     inline void SetNull() { ptr = nullptr; }

--- a/src/storage/column_vector/operator/unary_operator.cppm
+++ b/src/storage/column_vector/operator/unary_operator.cppm
@@ -89,6 +89,10 @@ public:
                         BooleanT result_value;
                         Operator::template Execute(input->buffer_->GetCompactBit(0), result_value, result_null.get(), 0, state_ptr);
                         result->buffer_->SetCompactBit(0, result_value);
+                    } else if constexpr (std::is_same_v<InputType, EmbeddingT>) {
+                        EmbeddingT embedding_input(input->data(), false);
+                        Operator::template Execute<InputType, ResultType>(embedding_input, result_ptr[0], result_null.get(), 0, state_ptr);
+                        embedding_input.Reset();
                     } else {
                         Operator::template Execute<InputType, ResultType>(input_ptr[0], result_ptr[0], result_null.get(), 0, state_ptr);
                     }


### PR DESCRIPTION
### What problem does this PR solve?

When a column vector deals with embedding types, it actually copies the internal data to member `data_ptr_`, that means the content of `data_ptr_` in `ColumnVector` is equal to `ptr` in `EmbeddingType`. But in embedding type cast to varchar, `data_ptr_` is passed as a whole `EmbeddingType`, which will result in data errors.

Issue link:#642

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
