### PR TITLE
Fix: add lock when query txn_map.

### DIFF
--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -162,6 +162,7 @@ void TxnManager::RollBackTxn(Txn *txn) {
 }
 
 TxnTimeStamp TxnManager::GetMinUncommitTs() {
+    std::shared_lock r_locker(rw_locker_);
     while (!ts_queue_.empty()) {
         TxnTimeStamp front_ts = ts_queue_.front();
         if (txn_map_.find(front_ts) != txn_map_.end()) {


### PR DESCRIPTION
### What problem does this PR solve?

`TxnManager::GetMinUncommitTs` needs to add read lock when query min uncommitted ts in txn_map.

Issue link:#665

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
