### PR TITLE
Remove unused variable to avoid warning

### DIFF
--- a/src/storage/invertedindex/search/and_iterator.cpp
+++ b/src/storage/invertedindex/search/and_iterator.cpp
@@ -39,7 +39,6 @@ void AndIterator::DoSeek(docid_t doc_id) {
     docid_t current = doc_id;
     do {
         docid_t tmp_id = INVALID_DOCID;
-        bool ret = (*current_iter)->Seek(current);
         tmp_id = doc_id_;
         if (tmp_id == INVALID_DOCID) {
             current = tmp_id;


### PR DESCRIPTION
### What problem does this PR solve?

Remove unused variable in src/storage/invertedindex/search/and_iterator.cpp to avoid warning.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
