### PR TITLE
avoid crash when insert unmatched column and value

### DIFF
--- a/src/planner/logical_planner.cpp
+++ b/src/planner/logical_planner.cpp
@@ -244,7 +244,10 @@ Status LogicalPlanner::BuildInsertValue(const InsertStatement *statement, Shared
         if (statement->columns_ != nullptr) {
             SizeT statement_column_count = statement->columns_->size();
             if (statement_column_count != value_list.size()) {
-                UnrecoverableError("INSERT: Target column count and input column count mismatch");
+                RecoverableError(Status::SyntaxError(fmt::format("INSERT: Target column count ({}) and "
+                                                                 "input value count mismatch ({})",
+                                                                 statement_column_count,
+                                                                 value_list.size())));
             }
 
             //        Value null_value = Value::MakeNullData();


### PR DESCRIPTION
### What problem does this PR solve?

Avoid crash when insert with unmatched number of target columns and values.

Issue link:#698

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):