### PR TITLE
avoid crash when insert unmatch column names

### DIFF
--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -610,7 +610,7 @@ UniquePtr<TableEntry> TableEntry::Deserialize(const nlohmann::json &table_entry_
 u64 TableEntry::GetColumnIdByName(const String &column_name) const {
     auto it = column_name2column_id_.find(column_name);
     if (it == column_name2column_id_.end()) {
-        UnrecoverableError(fmt::format("No column name: {}", column_name));
+        RecoverableError(Status::SyntaxError(fmt::format("No column name: {}", column_name)));
     }
     return it->second;
 }

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -610,7 +610,7 @@ UniquePtr<TableEntry> TableEntry::Deserialize(const nlohmann::json &table_entry_
 u64 TableEntry::GetColumnIdByName(const String &column_name) const {
     auto it = column_name2column_id_.find(column_name);
     if (it == column_name2column_id_.end()) {
-        RecoverableError(Status::SyntaxError(fmt::format("No column name: {}", column_name)));
+        RecoverableError(Status::ColumnNotExist(column_name));
     }
     return it->second;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Avoid crash when insert unmatch column names with table column names.

Issue link:#688

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
