### PR TITLE
avoid crash when condition is star expression.

### DIFF
--- a/src/planner/column_identifier.cpp
+++ b/src/planner/column_identifier.cpp
@@ -18,6 +18,7 @@ import stl;
 
 import column_expr;
 import infinity_exception;
+import status;
 import third_party;
 import query_context;
 
@@ -27,7 +28,7 @@ namespace infinity {
 
 ColumnIdentifier ColumnIdentifier::MakeColumnIdentifier(QueryContext *, const ColumnExpr &expr) {
     if (expr.star_) {
-        UnrecoverableError("Star expression should be unfolded before.");
+        RecoverableError(Status::SyntaxError("Star expression should be unfolded before."));
     }
 
     SharedPtr<String> db_name_ptr = nullptr;
@@ -37,7 +38,7 @@ ColumnIdentifier ColumnIdentifier::MakeColumnIdentifier(QueryContext *, const Co
 
     i64 name_count = expr.names_.size();
     if (name_count > 4 || name_count <= 0) {
-        UnrecoverableError("Star expression should be unfolded before.");
+        RecoverableError(Status::SyntaxError("Star expression should be unfolded before."));
     }
     --name_count;
     column_name_ptr = MakeShared<String>(expr.names_[name_count]);


### PR DESCRIPTION
### What problem does this PR solve?

Avoid crash when condition is star expression, such as `select * from t1 where (*);`.

Issue link:#[#682]

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
