### PR TITLE
Fix remove compile warnings

### DIFF
--- a/src/storage/invertedindex/indexer.cpp
+++ b/src/storage/invertedindex/indexer.cpp
@@ -15,6 +15,7 @@
 module;
 
 #include <filesystem>
+#include <unistd.h>
 
 module indexer;
 
@@ -38,7 +39,6 @@ import column_indexer;
 
 import logical_type;
 import internal_types;
-#include <unistd.h>
 
 namespace infinity {
 

--- a/src/storage/invertedindex/memory_indexer.cpp
+++ b/src/storage/invertedindex/memory_indexer.cpp
@@ -101,7 +101,7 @@ void MemoryIndexer::Insert(const ColumnVector &column_vector, u32 row_offset, u3
 void MemoryIndexer::Commit() {
     thread_pool_.push([this](int id) {
         Vector<SharedPtr<ColumnInverter>> inverters;
-        u64 seq_commit = this->ring_inverted_.GetMulti(inverters);
+        u64 seq_commit = this->ring_inverted_.GetBatch(inverters);
         SizeT num = inverters.size();
         for (SizeT i = 1; i < num; i++) {
             inverters[0]->Merge(*inverters[i]);

--- a/src/storage/invertedindex/ring.cppm
+++ b/src/storage/invertedindex/ring.cppm
@@ -1,9 +1,10 @@
 module;
 
+#include <cassert>
+
 export module ring;
 
 import stl;
-#include <cassert>
 
 namespace infinity {
 
@@ -50,7 +51,7 @@ public:
         return off_ceiling_ - off_ground_;
     }
 
-    u64 GetSigle(T &elem) {
+    u64 Get(T &elem) {
         std::unique_lock<std::mutex> lock(mutex_);
         if (off_ground_ == off_filled_) {
             cv_empty_.wait(lock, [this] { return off_ground_ < off_filled_; });
@@ -62,7 +63,7 @@ public:
         return seq;
     }
 
-    u64 GetMulti(Vector<T> &batch) {
+    u64 GetBatch(Vector<T> &batch) {
         std::unique_lock<std::mutex> lock(mutex_);
         if (off_ground_ == off_filled_) {
             cv_empty_.wait(lock, [this] { return off_ground_ < off_filled_; });


### PR DESCRIPTION
### What problem does this PR solve?

If #include isn't in global area, following warning will be issued:
'#include <filename>' attaches the declarations to the named module 'ring', which is not usually intended; consider moving that directive before the module declaration [-Winclude-angled-in-module-purview]

### Type of change

- [x] Refactoring

