### PR TITLE
Fix: bug of compact and cleanup

### DIFF
--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -130,17 +130,17 @@ CompactSegmentsTaskState CompactSegmentsTask::CompactSegments() {
         if (to_compact_segments.empty()) {
             return;
         }
+
+        auto new_segment = CompactSegmentsToOne(state.remapper_, to_compact_segments);
+        block_index->Insert(new_segment.get(), UNCOMMIT_TS, false);
         {
             String ss;
             ss += "Compacting segments: ";
             for (auto *segment : to_compact_segments) {
                 ss += std::to_string(segment->segment_id()) + " ";
             }
-            LOG_TRACE(fmt::format("Compacting segments: {}", ss));
+            LOG_INFO(fmt::format("Table {}, compacting segments: {}, into {}", *table_entry_->GetTableName(), ss, new_segment->segment_id()));
         }
-
-        auto new_segment = CompactSegmentsToOne(state.remapper_, to_compact_segments);
-        block_index->Insert(new_segment.get(), UNCOMMIT_TS, false);
         state.segment_data_.emplace_back(new_segment, std::move(to_compact_segments));
         state.old_segments_.insert(state.old_segments_.end(), to_compact_segments.begin(), to_compact_segments.end());
     };

--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -116,9 +116,9 @@ CompactSegmentsTask::CompactSegmentsTask(TableEntry *table_entry, Vector<Segment
 
 void CompactSegmentsTask::Execute() {
     auto state = CompactSegments();
-    CreateNewIndex(state.new_table_ref_.get());
     SaveSegmentsData(std::move(state.segment_data_));
     ApplyDeletes(state.remapper_, state.old_segments_);
+    CreateNewIndex(state.new_table_ref_.get());
 }
 
 // generate new_table_ref_ to compact

--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -43,6 +43,7 @@ import segment_entry;
 import table_index_entry;
 import table_index_meta;
 import block_entry;
+import compact_task_type;
 
 namespace infinity {
 

--- a/src/storage/bg_task/compact_segments_task.cppm
+++ b/src/storage/bg_task/compact_segments_task.cppm
@@ -24,6 +24,7 @@ import txn;
 import global_block_id;
 import base_table_ref;
 import internal_types;
+import compact_task_type;
 
 namespace infinity {
 
@@ -76,11 +77,6 @@ export struct CompactSegmentsTaskState {
     UniquePtr<BaseTableRef> new_table_ref_ = nullptr;
 };
 
-export enum class CompactSegmentsTaskType : i8 {
-    kCompactTable,
-    kCompactPickedSegments,
-};
-
 export class CompactSegmentsTask final : public BGTask {
 public:
     static SharedPtr<CompactSegmentsTask> MakeTaskWithPickedSegments(TableEntry *table_entry, Vector<SegmentEntry *> &&segments, Txn *txn);
@@ -121,7 +117,7 @@ private:
     SharedPtr<SegmentEntry> CompactSegmentsToOne(RowIDRemapper &remapper, const Vector<SegmentEntry *> &segments);
 
 private:
-    CompactSegmentsTaskType task_type_;
+    const CompactSegmentsTaskType task_type_;
     TableEntry *table_entry_;
     Vector<SegmentEntry *> segments_;
 

--- a/src/storage/bg_task/compact_task_type.cppm
+++ b/src/storage/bg_task/compact_task_type.cppm
@@ -1,0 +1,29 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module compact_task_type;
+
+import stl;
+
+namespace infinity {
+
+export enum class CompactSegmentsTaskType : i8 {
+    kCompactTable,
+    kCompactPickedSegments,
+    kInvalid,
+};
+
+}

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -73,26 +73,11 @@ BufferObj *BufferManager::Get(UniquePtr<FileWorker> file_worker) {
 }
 
 // return false if buffer_obj is not loaded
-bool BufferManager::Cleanup(const String &file_path) {
-    UniquePtr<BufferObj> buffer_obj = nullptr;
-    {
-        std::unique_lock w_lock(rw_locker_);
-        if (auto iter = buffer_map_.find(file_path); iter != buffer_map_.end()) {
-            buffer_obj = std::move(iter->second);
-            buffer_map_.erase(iter);
-        }
+void BufferManager::Cleanup(const String &file_path) {
+    std::unique_lock w_lock(rw_locker_);
+    if (auto iter = buffer_map_.find(file_path); iter != buffer_map_.end()) {
+        buffer_map_.erase(iter);
     }
-    if (buffer_obj.get() == nullptr) {
-        // FIXME: is it right?
-        LocalFileSystem fs;
-        if (!fs.Exists(file_path)) {
-            UnrecoverableError(fmt::format("File {} not found.", file_path));
-        }
-        fs.DeleteFile(file_path);
-        return false;
-    }
-    buffer_obj->Cleanup();
-    return true;
 }
 
 void BufferManager::RequestSpace(SizeT need_size, BufferObj *buffer_obj) {

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -35,7 +35,7 @@ public:
     // Get an existing BufferHandle from memory or disk.
     BufferObj *Get(UniquePtr<FileWorker> file_worker);
 
-    bool Cleanup(const String &file_path);
+    void Cleanup(const String &file_path);
 
     SharedPtr<String> BaseDir() const { return base_dir_; }
 

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -168,6 +168,7 @@ void BufferObj::Cleanup() {
         UnrecoverableError("Assert: buffer object status isn't freed.");
     }
     file_worker_->CleanupFile();
+    buffer_mgr_->Cleanup(this->GetFilename());
 }
 
 void BufferObj::CheckState() const {

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -56,8 +56,8 @@ void FileWorker::WriteToFile(bool to_spill) {
     u8 flags = FileFlags::WRITE_FLAG | FileFlags::CREATE_FLAG;
     file_handler_ = fs.OpenFile(write_path, flags, FileLockType::kWriteLock);
     if (to_spill) {
-        auto local_file_handle_ = static_cast<LocalFileHandler *>(file_handler_.get());
-        LOG_WARN(fmt::format("Open spill file: {}, fd: {}", write_path, local_file_handle_->fd_));
+        auto local_file_handle = static_cast<LocalFileHandler *>(file_handler_.get());
+        LOG_WARN(fmt::format("Open spill file: {}, fd: {}", write_path, local_file_handle->fd_));
     }
     bool prepare_success = false;
     DeferFn defer_fn([&]() {

--- a/src/storage/compaction/DBT_compaction_alg.cpp
+++ b/src/storage/compaction/DBT_compaction_alg.cpp
@@ -135,8 +135,8 @@ Optional<Pair<Vector<SegmentEntry *>, Txn *>> DBTCompactionAlg::DeleteInSegment(
 
 void DBTCompactionAlg::CommitCompact(const Vector<SegmentEntry *> &new_segments, TransactionID commit_txn_id) {
     std::unique_lock lock(mtx_);
-    if (status_ != DBTStatus::kRunning) {
-        UnrecoverableError("Commit compact when compaction not running");
+    if (status_ == DBTStatus::kEnable) {
+        UnrecoverableError("Wrong status of compaction alg");
     }
 
     for (auto &segment_layer : segment_layers_) {

--- a/src/storage/compaction/DBT_compaction_alg.cppm
+++ b/src/storage/compaction/DBT_compaction_alg.cppm
@@ -95,9 +95,11 @@ public:
 
     virtual void Disable() override;
 
+    virtual void AddSegmentNoCheck(SegmentEntry *new_segment) override;
+
 private:
     // return layer
-    int AddSegmentNoCheck(SegmentEntry *new_segment);
+    int AddSegmentNoCheckInner(SegmentEntry *new_segment);
 
     void AddSegmentToHigher(Vector<SegmentEntry *> &compact_segments, int layer, TransactionID txn_id);
 

--- a/src/storage/compaction/compaction_alg.cppm
+++ b/src/storage/compaction/compaction_alg.cppm
@@ -56,6 +56,9 @@ public:
 
     // Wait for all compaction to finish and disable auto compaction
     virtual void Disable() = 0;
+
+    // Used by replay, merely add the segment without checking
+    virtual void AddSegmentNoCheck(SegmentEntry *new_segment) = 0;
 };
 
 } // namespace infinity

--- a/src/storage/invertedindex/common/skiplist.cppm
+++ b/src/storage/invertedindex/common/skiplist.cppm
@@ -217,6 +217,8 @@ private:
 
     int RandomLevel() {
         int new_level = 1;
+        // Why not use (rand() & 1 == 0)
+        // 0.5 is the probability
         while (static_cast<double>(rand() / RAND_MAX) < 0.5 && new_level < MAX_LEVEL) {
             new_level++;
         }

--- a/src/storage/io/local_file_system.cpp
+++ b/src/storage/io/local_file_system.cpp
@@ -237,6 +237,20 @@ void LocalFileSystem::DeleteEmptyDirectory(const String &path) {
     Path p{path};
     u64 removed_count = std::filesystem::remove(p, error_code);
     if (error_code.value() != 0) {
+        // log all files in path
+        std::stringstream ss;
+        // recursively traverse the directory
+        std::function<void(const Path &)> list_dir = [&](const Path path) {
+            for (const auto &entry : std::filesystem::directory_iterator{path}) {
+                ss << entry.path().string() << " ";
+                if (entry.is_directory()) {
+                    list_dir(entry.path());
+                }
+            }
+        };
+        list_dir(p);
+
+        LOG_CRITICAL(fmt::format("ListDirectory: {} is not empty, files: {}", path, ss.str()));
         UnrecoverableError(fmt::format("Delete directory {} exception: {}", path, error_code.message()));
     }
 }

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -260,12 +260,6 @@ Status Catalog::CommitImport(TableEntry *table_entry, TxnTimeStamp commit_ts, Sh
 
 SegmentID Catalog::GetNextSegmentID(TableEntry *table_entry) { return table_entry->GetNextSegmentID(); }
 
-void Catalog::AddSegment(TableEntry *table_entry, SharedPtr<SegmentEntry> &segment_entry) {
-    table_entry->segment_map_.emplace(segment_entry->segment_id(), std::move(segment_entry));
-    // ATTENTION: focusing on the segment id
-    table_entry->next_segment_id_++;
-}
-
 SharedPtr<FunctionSet> Catalog::GetFunctionSetByName(Catalog *catalog, String function_name) {
     // Transfer the function to upper case.
     StringToLower(function_name);
@@ -487,7 +481,7 @@ void Catalog::LoadFromEntry(Catalog *catalog, const String &catalog_path, Buffer
                                                                                 begin_ts,
                                                                                 txn_id);
 
-                table_entry->segment_map_.insert({segment_id, std::move(segment_entry)});
+                table_entry->DeltaReplaySegment(std::move(segment_entry));
                 break;
             }
             case CatalogDeltaOpType::ADD_BLOCK_ENTRY: {

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -203,9 +203,6 @@ public:
 
     static SegmentID GetNextSegmentID(TableEntry *table_entry);
 
-    // This not add row count
-    static void AddSegment(TableEntry *table_entry, SharedPtr<SegmentEntry> &segment_entry);
-
 public:
     // Function related methods
     static SharedPtr<FunctionSet> GetFunctionSetByName(Catalog *catalog, String function_name);

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -69,9 +69,8 @@ TableEntry::TableEntry(bool is_delete,
     txn_id_ = txn_id;
 
     // SetCompactionAlg(nullptr);
-    SetCompactionAlg(MakeUnique<DBTCompactionAlg>(DBT_COMPACTION_M, DBT_COMPACTION_C, DBT_COMPACTION_S, DEFAULT_SEGMENT_CAPACITY));
-    Vector<SegmentEntry *> segments = this->PickCompactSegments();
-    compaction_alg_->Enable(segments);
+    this->SetCompactionAlg(MakeUnique<DBTCompactionAlg>(DBT_COMPACTION_M, DBT_COMPACTION_C, DBT_COMPACTION_S, DEFAULT_SEGMENT_CAPACITY));
+    compaction_alg_->Enable({});
 }
 
 SharedPtr<TableEntry> TableEntry::NewTableEntry(bool is_delete,
@@ -636,14 +635,27 @@ bool TableEntry::CheckDeleteConflict(const Vector<RowID> &delete_row_ids, Transa
     return SegmentEntry::CheckDeleteConflict(std::move(check_segments), txn_id);
 }
 
-Optional<Pair<Vector<SegmentEntry *>, Txn *>> TableEntry::AddSegment(SegmentEntry *new_segment, std::function<Txn *()> generate_txn) {
+void TableEntry::WalReplaySegment(SharedPtr<SegmentEntry> segment_entry) {
+    this->DeltaReplaySegment(std::move(segment_entry));
+    // ATTENTION: focusing on the segment id
+    next_segment_id_++;
+}
+
+void TableEntry::DeltaReplaySegment(SharedPtr<SegmentEntry> segment_entry) {
+    if (compaction_alg_.get() != nullptr) {
+        compaction_alg_->AddSegmentNoCheck(segment_entry.get());
+    }
+    segment_map_.emplace(segment_entry->segment_id(), std::move(segment_entry));
+}
+
+Optional<Pair<Vector<SegmentEntry *>, Txn *>> TableEntry::TryCompactAddSegment(SegmentEntry *new_segment, std::function<Txn *()> generate_txn) {
     if (compaction_alg_.get() == nullptr) {
         return None;
     }
     return compaction_alg_->AddSegment(new_segment, generate_txn);
 }
 
-Optional<Pair<Vector<SegmentEntry *>, Txn *>> TableEntry::DeleteInSegment(SegmentID segment_id, std::function<Txn *()> generate_txn) {
+Optional<Pair<Vector<SegmentEntry *>, Txn *>> TableEntry::TryCompactDeleteRow(SegmentID segment_id, std::function<Txn *()> generate_txn) {
     if (compaction_alg_.get() == nullptr) {
         return None;
     }

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -303,9 +303,22 @@ Status TableEntry::CommitCompact(TransactionID txn_id, TxnTimeStamp commit_ts, T
         }
     }
     {
+        {
+            String ss = "Commit compact: ";
+            for (const auto &[new_segment, old_segments] : compact_store.segment_data_) {
+                ss += "new segment: " + std::to_string(new_segment->segment_id_) + " old segment: ";
+                for (const auto *old_segment : old_segments) {
+                    ss += std::to_string(old_segment->segment_id_) + " ";
+                }
+            }
+            LOG_INFO(ss);
+        }
         std::unique_lock lock(this->rw_locker());
         for (const auto &[new_segment, old_segments] : compact_store.segment_data_) {
-            this->segment_map_.emplace(new_segment->segment_id_, new_segment);
+            auto [_, insert_ok] = this->segment_map_.emplace(new_segment->segment_id_, new_segment);
+            if (!insert_ok) {
+                UnrecoverableError(fmt::format("Insert new segment {} failed.", new_segment->segment_id()));
+            }
             for (const auto &old_segment : old_segments) {
                 old_segment->SetDeprecated(commit_ts);
             }

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -46,6 +46,7 @@ import default_values;
 import DBT_compaction_alg;
 import compact_segments_task;
 import local_file_system;
+import compact_task_type;
 
 namespace infinity {
 

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -174,6 +174,11 @@ public:
 
     bool CheckDeleteConflict(const Vector<RowID> &delete_row_ids, TransactionID txn_id);
 
+    // wal entry replay
+    void WalReplaySegment(SharedPtr<SegmentEntry> segment_entry);
+
+    void DeltaReplaySegment(SharedPtr<SegmentEntry> segment_entry);
+
 public:
     u64 GetColumnIdByName(const String &column_name) const;
 
@@ -206,9 +211,9 @@ public:
     // set nullptr to close auto compaction
     void SetCompactionAlg(UniquePtr<CompactionAlg> compaction_alg) { compaction_alg_ = std::move(compaction_alg); }
 
-    Optional<Pair<Vector<SegmentEntry *>, Txn *>> AddSegment(SegmentEntry *new_segment, std::function<Txn *()> generate_txn);
+    Optional<Pair<Vector<SegmentEntry *>, Txn *>> TryCompactAddSegment(SegmentEntry *new_segment, std::function<Txn *()> generate_txn);
 
-    Optional<Pair<Vector<SegmentEntry *>, Txn *>> DeleteInSegment(SegmentID segment_id, std::function<Txn *()> generate_txn);
+    Optional<Pair<Vector<SegmentEntry *>, Txn *>> TryCompactDeleteRow(SegmentID segment_id, std::function<Txn *()> generate_txn);
 
     Vector<SegmentEntry *> PickCompactSegments() const;
 

--- a/src/storage/meta/meta_map.cppm
+++ b/src/storage/meta/meta_map.cppm
@@ -110,7 +110,7 @@ Tuple<Meta *, Status, std::shared_lock<std::shared_mutex>> MetaMap<Meta>::GetExi
         LOG_TRACE(fmt::format("Ignore drop a non-exist meta: {}", name));
         return {nullptr, Status::OK(), std::move(r_lock)};
     }
-    auto err_msg = MakeUnique<String>(fmt::format("Attempt to drop non-exist entry {}", name));
+    auto err_msg = MakeUnique<String>(fmt::format("Not exist entry {}", name));
     LOG_ERROR(*err_msg);
     if constexpr (std::is_same_v<Meta, TableMeta>) {
         return {nullptr, Status(ErrorCode::kTableNotExist, std::move(err_msg)), std::move(r_lock)};

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -158,7 +158,9 @@ void TxnTableStore::PrepareCommit() {
         Catalog::CommitImport(table_entry_, txn_->CommitTS(), uncommitted);
     }
     // Attention: "compact" needs to be ahead of "delete"
-    Catalog::CommitCompact(table_entry_, txn_->TxnID(), txn_->CommitTS(), compact_state_);
+    if (!compact_state_.segment_data_.empty()) {
+        Catalog::CommitCompact(table_entry_, txn_->TxnID(), txn_->CommitTS(), compact_state_);
+    }
 
     Catalog::Delete(table_entry_, txn_->TxnID(), txn_->CommitTS(), delete_state_);
     Catalog::CommitCreateIndex(txn_indexes_store_);

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -179,7 +179,7 @@ void TxnTableStore::TryTriggerCompaction(BGTaskProcessor *bg_task_processor, Txn
 
     // FIXME OPT: trigger compaction one time for all segments
     for (const SharedPtr<SegmentEntry> &new_segment : uncommitted_segments_) {
-        auto ret = table_entry_->AddSegment(new_segment.get(), generate_txn);
+        auto ret = table_entry_->TryCompactAddSegment(new_segment.get(), generate_txn);
         if (!ret.has_value()) {
             continue;
         }
@@ -188,7 +188,7 @@ void TxnTableStore::TryTriggerCompaction(BGTaskProcessor *bg_task_processor, Txn
         bg_task_processor->Submit(compact_task);
     }
     for (const auto &[segment_id, delete_map] : delete_state_.rows_) {
-        auto ret = table_entry_->DeleteInSegment(segment_id, generate_txn);
+        auto ret = table_entry_->TryCompactDeleteRow(segment_id, generate_txn);
         if (!ret.has_value()) {
             continue;
         }

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -21,6 +21,7 @@ import stl;
 import data_access_state;
 import status;
 import internal_types;
+import compact_task_type;
 
 namespace infinity {
 
@@ -33,7 +34,6 @@ class DataBlock;
 class SegmentColumnIndexEntry;
 class BGTaskProcessor;
 class TxnManager;
-enum class CompactSegmentsTaskType;
 
 struct TxnSegmentIndexStore {
     HashMap<u32, SharedPtr<SegmentColumnIndexEntry>> index_entry_map_{};
@@ -56,7 +56,7 @@ public:
 export struct TxnCompactStore {
     Vector<Pair<SharedPtr<SegmentEntry>, Vector<SegmentEntry *>>> segment_data_;
 
-    CompactSegmentsTaskType task_type_;
+    CompactSegmentsTaskType task_type_ = CompactSegmentsTaskType::kInvalid;
 };
 
 export class TxnTableStore {

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -457,7 +457,7 @@ i64 WalManager::ReplayWalFile() {
                     }
                     LOG_TRACE(fmt::format("Find checkpoint max commit ts: {}", max_commit_ts));
                     LOG_TRACE(fmt::format("Find catalog path: {}", catalog_path));
-                    break;
+                    break; // why here break
                 } else {
                     // delta checkpoint
                     auto [current_max_commit_ts, current_catalog_path] = wal_entry->GetCheckpointInfo();
@@ -691,7 +691,7 @@ void WalManager::ReplaySegment(TableEntry *table_entry, const WalSegmentInfo &se
         segment_entry->AppendBlockEntry(std::move(block_entry));
     }
 
-    Catalog::AddSegment(table_entry, segment_entry);
+    table_entry->WalReplaySegment(segment_entry);
 }
 
 void WalManager::WalCmdImportReplay(const WalCmdImport &cmd, TransactionID txn_id, TxnTimeStamp commit_ts) {

--- a/test/sql/dql/knn/test_knn_hnsw_l2.slt
+++ b/test/sql/dql/knn/test_knn_hnsw_l2.slt
@@ -60,3 +60,5 @@ SELECT c1 FROM test_knn_hnsw_l2 SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l
 8
 8
 
+statement ok
+DROP TABLE test_knn_hnsw_l2;

--- a/test/sql/dql/knn/test_knn_hnsw_l2.slt
+++ b/test/sql/dql/knn/test_knn_hnsw_l2.slt
@@ -59,6 +59,3 @@ SELECT c1 FROM test_knn_hnsw_l2 SEARCH KNN(c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l
 8
 8
 8
-
-statement ok
-DROP TABLE test_knn_hnsw_l2;


### PR DESCRIPTION
### What problem does this PR solve?

* Add segment to `TableEntry::compaction_alg_` in replay process.
* Cleanup BufferObj entry in buffer_manager. (#670 )


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
