### PR TITLE
Fix where clause only involve column expression of delete/update statements triggers core dump

### DIFF
--- a/src/planner/query_binder.cpp
+++ b/src/planner/query_binder.cpp
@@ -952,6 +952,9 @@ UniquePtr<BoundDeleteStatement> QueryBinder::BindDelete(const DeleteStatement &s
     auto where_binder = MakeShared<WhereBinder>(this->query_context_ptr_, bind_alias_proxy);
     if (statement.where_expr_ != nullptr) {
         SharedPtr<BaseExpression> where_expr = where_binder->Bind(*statement.where_expr_, this->bind_context_ptr_.get(), 0, true);
+        if(where_expr->Type().type() != LogicalType::kBoolean) {
+            RecoverableError(Status::InvalidFilterExpression(where_expr->Type().ToString()));
+        }
         bound_delete_statement->where_conditions_ = SplitExpressionByDelimiter(where_expr, ConjunctionType::kAnd);
     }
     return bound_delete_statement;
@@ -971,6 +974,9 @@ UniquePtr<BoundUpdateStatement> QueryBinder::BindUpdate(const UpdateStatement &s
     auto where_binder = MakeShared<WhereBinder>(this->query_context_ptr_, bind_alias_proxy);
     if (statement.where_expr_ != nullptr) {
         SharedPtr<BaseExpression> where_expr = where_binder->Bind(*statement.where_expr_, this->bind_context_ptr_.get(), 0, true);
+        if(where_expr->Type().type() != LogicalType::kBoolean) {
+            RecoverableError(Status::InvalidFilterExpression(where_expr->Type().ToString()));
+        }
         bound_update_statement->where_conditions_ = SplitExpressionByDelimiter(where_expr, ConjunctionType::kAnd);
     }
     if (statement.update_expr_array_ == nullptr) {


### PR DESCRIPTION
### What problem does this PR solve?

Fix where clause only involve column expression of delete/update statements triggers core dump

Issue link:#707

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

