### PR TITLE
Add offline index building based on external sort

### DIFF
--- a/src/storage/invertedindex/column_inverter.cppm
+++ b/src/storage/invertedindex/column_inverter.cppm
@@ -14,6 +14,8 @@
 
 module;
 
+#include <cstdio>
+
 export module column_inverter;
 
 import stl;
@@ -62,6 +64,8 @@ public:
             return term_pos_ < rhs.term_pos_;
         }
     };
+
+    void SpillSortResults(FILE *spill_file, u64 &tuple_count);
 
 private:
     using TermBuffer = Vector<char, PoolAllocator<char>>;

--- a/src/storage/invertedindex/memory_indexer.cppm
+++ b/src/storage/invertedindex/memory_indexer.cppm
@@ -14,18 +14,14 @@
 
 module;
 
+#include <cstdio>
+
 export module memory_indexer;
 import stl;
 import memory_pool;
-import segment_posting;
-import index_segment_reader;
-import posting_iterator;
 import index_defines;
 import index_config;
-import index_segment_reader;
 import posting_writer;
-import data_block;
-
 import column_vector;
 import analyzer;
 import column_inverter;
@@ -85,6 +81,12 @@ public:
 private:
     void SetAnalyzer();
 
+    void OfflineDump();
+
+    void FinalSpillFile();
+
+    void PrepareSpillFile();
+
 private:
     friend class ColumnIndexer;
 
@@ -105,5 +107,10 @@ private:
 
     std::condition_variable cv_;
     std::mutex mutex_;
+
+    u32 num_runs_{0};                  // For offline index building
+    FILE *spill_file_handle_{nullptr}; // Temp file for offline external merge sort
+    String spill_full_path_;           // Path of spill file
+    u64 tuple_count_{0};               // Number of tuples for external merge sort
 };
 } // namespace infinity


### PR DESCRIPTION
### What problem does this PR solve?

Offline index building will be built based on external sort. When scan the columnar data of each segment, the index building logic is:
1. For every commit, the column inverter will sort the buffered data at first. (Under parallel building, the data will be merged at first). The merge/sort steps are the same with real time/near real time indexing. After sorting, the results will be spilled to a temporary file, no postings are generated.
2. After the segment data has been finished scanning, the external merge sort will be triggered based on the spilled temporary file.
3. According to the final sorted data file, build the posting data and dump to the segment index.

TODO: Just interfaces provided, need to be integrated

Issue link:#633

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring
