### PR TITLE
Add flush option, but it is not used right now.

### DIFF
--- a/conf/infinity_conf.toml
+++ b/conf/infinity_conf.toml
@@ -61,5 +61,10 @@ delta_checkpoint_interval_sec     = 60
 delta_checkpoint_interval_wal_bytes = 1000000000
 wal_file_size_threshold            = "1GB"
 
+# flush_at_once: write and flush log each commit
+# only_write: write log, OS control when to flush the log, default
+# flush_per_second: logs are written after each commit and flushed to disk per second.
+flush_at_commit                   = "only_write"
+
 [resource]
 dictionary_dir                = "/var/infinity/resource"

--- a/src/executor/operator/physical_show.cpp
+++ b/src/executor/operator/physical_show.cpp
@@ -350,8 +350,7 @@ void PhysicalShow::ExecuteShowDatabase(QueryContext *query_context, ShowOperator
 
     // Prepare the output data block
     UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
-    Vector<SharedPtr<DataType>>
-        column_types{varchar_type, varchar_type};
+    Vector<SharedPtr<DataType>> column_types{varchar_type, varchar_type};
 
     output_block_ptr->Init(column_types);
 
@@ -428,8 +427,7 @@ void PhysicalShow::ExecuteShowTable(QueryContext *query_context, ShowOperatorSta
 
     // Prepare the output data block
     UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
-    Vector<SharedPtr<DataType>>
-        column_types{varchar_type, varchar_type};
+    Vector<SharedPtr<DataType>> column_types{varchar_type, varchar_type};
 
     output_block_ptr->Init(column_types);
 
@@ -551,8 +549,7 @@ void PhysicalShow::ExecuteShowIndex(QueryContext *query_context, ShowOperatorSta
 
     // Prepare the output data block
     UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
-    Vector<SharedPtr<DataType>>
-        column_types{varchar_type, varchar_type};
+    Vector<SharedPtr<DataType>> column_types{varchar_type, varchar_type};
 
     output_block_ptr->Init(column_types);
 
@@ -2101,6 +2098,31 @@ void PhysicalShow::ExecuteShowVar(QueryContext *query_context, ShowOperatorState
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[0]);
             break;
+        }
+        case SysVar::kLogFlushPolicy: {
+            switch (query_context->global_config()->flush_at_commit()) {
+                case FlushOption::kFlushAtOnce: {
+                    Value value = Value::MakeVarchar("Write and flush log at each commit");
+                    ValueExpression value_expr(value);
+                    value_expr.AppendToChunk(output_block_ptr->column_vectors[0]);
+                    break;
+                }
+                case FlushOption::kOnlyWrite: {
+                    Value value = Value::MakeVarchar("Only write log at each commit");
+                    ValueExpression value_expr(value);
+                    value_expr.AppendToChunk(output_block_ptr->column_vectors[0]);
+                    break;
+                }
+                case FlushOption::kFlushPerSecond: {
+                    Value value = Value::MakeVarchar("Write log at each commit and commit log per second");
+                    ValueExpression value_expr(value);
+                    value_expr.AppendToChunk(output_block_ptr->column_vectors[0]);
+                    break;
+                }
+                default: {
+                    UnrecoverableError("Invalid log flush policy: {}");
+                }
+            }
         }
         default: {
             RecoverableError(Status::NoSysVar(object_name_));

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -29,6 +29,7 @@ import logger;
 import local_file_system;
 import utility;
 import status;
+import options;
 
 namespace infinity {
 
@@ -164,13 +165,14 @@ Status Config::Init(const SharedPtr<String> &config_path) {
     SharedPtr<String> default_temp_dir = MakeShared<String>("/tmp/infinity/temp");
 
     // Default wal config
-    u64 wal_size_threshold = DEFAULT_WAL_FILE_SIZE_THRESHOLD;
+    u64 default_wal_size_threshold = DEFAULT_WAL_FILE_SIZE_THRESHOLD;
     // Attention: this phase full checkpoint interval is used for testing,
     //            it should be set to a larger value in production environment.
     u64 full_checkpoint_interval_sec = FULL_CHECKPOINT_INTERVAL_SEC;
     u64 delta_checkpoint_interval_sec = DELTA_CHECKPOINT_INTERVAL_SEC;
     u64 delta_checkpoint_interval_wal_bytes = DELTA_CHECKPOINT_INTERVAL_WAL_BYTES;
     SharedPtr<String> default_wal_dir = MakeShared<String>("/tmp/infinity/wal");
+    FlushOption default_flush_at_commit = FlushOption::kOnlyWrite;
 
     // Default resource config
     String default_resource_dict_path = String("/tmp/infinity/resource");
@@ -245,10 +247,11 @@ Status Config::Init(const SharedPtr<String> &config_path) {
         // Wal
         {
             system_option_.wal_dir = MakeShared<String>(*default_wal_dir);
-            system_option_.wal_size_threshold_ = wal_size_threshold;
+            system_option_.wal_size_threshold_ = default_wal_size_threshold;
             system_option_.full_checkpoint_interval_sec_ = full_checkpoint_interval_sec;
             system_option_.delta_checkpoint_interval_sec_ = delta_checkpoint_interval_sec;
             system_option_.delta_checkpoint_interval_wal_bytes_ = delta_checkpoint_interval_wal_bytes;
+            system_option_.flush_at_commit_ = default_flush_at_commit;
         }
 
         // Resource
@@ -445,6 +448,17 @@ Status Config::Init(const SharedPtr<String> &config_path) {
             if (!status.ok()) {
                 return status;
             }
+            String flush_log_str = wal_config["flush_at_commit"].value_or("only_write");
+            system_option_.flush_at_commit_ = default_flush_at_commit;
+            if (IsEqual(flush_log_str, "flush_at_once")) {
+                system_option_.flush_at_commit_ = FlushOption::kFlushAtOnce;
+            }
+            if (IsEqual(flush_log_str, "only_write")) {
+                system_option_.flush_at_commit_ = default_flush_at_commit;
+            }
+            if (IsEqual(flush_log_str, "flush_per_second")) {
+                system_option_.flush_at_commit_ = FlushOption::kFlushPerSecond;
+            }
         }
 
         // Resource
@@ -508,6 +522,23 @@ void Config::PrintAll() const {
     fmt::print(" - wal_size_threshold: {}\n", Utility::FormatByteSize(system_option_.wal_size_threshold_));
     fmt::print(" - wal_dir: {}\n", system_option_.wal_dir->c_str());
 
+    String flush_str;
+    switch (system_option_.flush_at_commit_) {
+        case FlushOption::kFlushAtOnce: {
+            flush_str = "FlushAtOnce";
+            break;
+        }
+        case FlushOption::kOnlyWrite: {
+            flush_str = "OnlyWrite";
+            break;
+        }
+        case FlushOption::kFlushPerSecond: {
+            flush_str = "FlushPerSecond";
+            break;
+        }
+    }
+    fmt::print(" - flush_at_commit: {}\n", flush_str);
+
     // Resource
     fmt::print(" - dictionary_dir: {}\n", system_option_.resource_dict_path_.c_str());
 }
@@ -527,6 +558,7 @@ void SystemVariables::InitVariablesMap() {
     map_["http_api_port"] = SysVar::kHttpAPIPort;
     map_["data_url"] = SysVar::kDataURL;
     map_["time_zone"] = SysVar::kTimezone;
+    map_["flush_at_commit"] = SysVar::kLogFlushPolicy;
 }
 
 HashMap<String, SysVar> SystemVariables::map_;

--- a/src/main/config.cppm
+++ b/src/main/config.cppm
@@ -110,6 +110,8 @@ public:
 
     [[nodiscard]] inline u64 wal_size_threshold() const { return system_option_.wal_size_threshold_; }
 
+    [[nodiscard]] inline FlushOption flush_at_commit() const { return system_option_.flush_at_commit_; }
+
     // Resource
     [[nodiscard]] inline String resource_dict_path() const { return system_option_.resource_dict_path_; }
 
@@ -144,6 +146,7 @@ export enum class SysVar {
     kHttpAPIPort,
     kDataURL,
     kTimezone,
+    kLogFlushPolicy,
     kInvalid,
 };
 

--- a/src/main/options.cppm
+++ b/src/main/options.cppm
@@ -21,6 +21,12 @@ import third_party;
 
 namespace infinity {
 
+export enum class FlushOption {
+    kFlushAtOnce,
+    kOnlyWrite,
+    kFlushPerSecond,
+};
+
 export struct SessionOptions {
     inline bool enable_profiling() const { return enable_profiling_; }
     inline u64 profile_history_capacity() const { return profile_history_capacity_; }
@@ -80,6 +86,7 @@ export struct SystemOptions {
     u64 full_checkpoint_txn_interval_{};
     u64 delta_checkpoint_interval_sec_{};
     u64 delta_checkpoint_interval_wal_bytes_{};
+    FlushOption flush_at_commit_{FlushOption::kOnlyWrite}; // 0: flush_at_once, 1: only_write, 2: flush_per_second
 
     // Resource
     String resource_dict_path_{};

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -59,7 +59,8 @@ void Storage::Init() {
                                       config_ptr_->wal_size_threshold(),
                                       config_ptr_->full_checkpoint_interval_sec(),
                                       config_ptr_->delta_checkpoint_interval_sec(),
-                                      config_ptr_->delta_checkpoint_interval_wal_bytes());
+                                      config_ptr_->delta_checkpoint_interval_wal_bytes(),
+                                      config_ptr_->flush_at_commit());
 
     // Must init catalog before txn manager.
     // Replay wal file wrap init catalog

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -19,6 +19,7 @@ export module wal_manager;
 import stl;
 import bg_task;
 import wal_entry;
+import options;
 
 namespace infinity {
 
@@ -33,7 +34,8 @@ public:
                u64 wal_size_threshold,
                u64 full_checkpoint_interval_sec,
                u64 delta_checkpoint_interval_sec,
-               u64 delta_checkpoint_interval_wal_bytes);
+               u64 delta_checkpoint_interval_wal_bytes,
+               FlushOption flush_option);
 
     ~WalManager();
 
@@ -123,7 +125,7 @@ private:
     i64 last_delta_ckp_wal_size_{};
     i64 last_full_ckp_time_{};
     i64 last_delta_ckp_time_{};
-
+    FlushOption flush_option_{FlushOption::kOnlyWrite};
 
     Vector<String> wal_list_{};
 };


### PR DESCRIPTION
### What problem does this PR solve?

Currently, the log flush policy is fixed to Flush at once. This PR is to add a config which can be used to change the flush policy. Be aware, this PR only introduce the config, but setting the parameter won't change the flush behavior right now.

In the future, another PR is need to activate this function.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)

