### PR TITLE
Fix: invalid top-n value in knn which cause core dumped.

### DIFF
--- a/python/test/test_knn.py
+++ b/python/test/test_knn.py
@@ -255,10 +255,10 @@ class TestKnn:
     @pytest.mark.parametrize("check_data", [{"file_name": "tmp_20240116.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     @pytest.mark.parametrize("topn", [
-        2,
-        10,
-        # FIXME 0, ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000009bf0 at pc 0x5bdb2772d2a4 bp 0x7d8ea9efc9d0 sp 0x7d8ea9efc9c8
-        # FIXME -1, exceeds maximum supported size of 0x10000000000
+        (2, True),
+        (10, True),
+        (0, False),
+        (-1, False),
         pytest.param("word", marks=pytest.mark.skip(reason="struct.error: required argument is not an integer")),
         pytest.param({}, marks=pytest.mark.skip(reason="struct.error: required argument is not an integer")),
         pytest.param((), marks=pytest.mark.skip(reason="struct.error: required argument is not an integer")),
@@ -283,5 +283,9 @@ class TestKnn:
             copy_data("tmp_20240116.csv")
         test_csv_dir = "/tmp/infinity/test_data/tmp_20240116.csv"
         table_obj.import_data(test_csv_dir, None)
-        res = table_obj.output(["variant_id"]).knn("gender_vector", [1] * 4, "float", "pl", topn).to_pl()
-        print(res)
+        if topn[1]:
+            res = table_obj.output(["variant_id"]).knn("gender_vector", [1] * 4, "float", "pl", topn[0]).to_pl()
+            print(res)
+        else:
+            with pytest.raises(Exception, match="ERROR:3014*"):
+                res = table_obj.output(["variant_id"]).knn("gender_vector", [1] * 4, "float", "pl", topn[0]).to_pl()

--- a/src/network/thrift_server.cpp
+++ b/src/network/thrift_server.cpp
@@ -406,6 +406,7 @@ public:
                         knn_expr = nullptr;
                     }
 
+                    delete search_expr;
                     ProcessStatus(response, knn_expr_status);
                     return;
                 }
@@ -1165,6 +1166,13 @@ private:
         }
 
         knn_expr->topn_ = expr.topn;
+        if (knn_expr->topn_ <= 0) {
+            delete knn_expr;
+            knn_expr = nullptr;
+            String topn = std::to_string(expr.topn);
+            return {nullptr, Status::InvalidParameterValue("topn", topn, "topn should be greater than 0")};
+        }
+
         knn_expr->opt_params_ = new Vector<InitParameter *>();
         for (auto &param : expr.opt_params) {
             auto init_parameter = new InitParameter();

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -454,6 +454,10 @@ SharedPtr<BaseExpression> ExpressionBinder::BuildKnnExpr(const KnnExpr &parsed_k
     if (parsed_knn_expr.column_expr_->type_ != ParsedExprType::kColumn) {
         UnrecoverableError("Knn expression expect a column expression");
     }
+    if (parsed_knn_expr.topn_ <= 0) {
+        String topn = std::to_string(parsed_knn_expr.topn_);
+        RecoverableError(Status::InvalidParameterValue("topn", topn, "topn should be greater than 0"));
+    }
     auto expr_ptr = BuildColExpr((ColumnExpr &)*parsed_knn_expr.column_expr_, bind_context_ptr, depth, false);
     TypeInfo *type_info = expr_ptr->Type().type_info().get();
     if (type_info == nullptr or type_info->type() != TypeInfoType::kEmbedding) {


### PR DESCRIPTION
### What problem does this PR solve?

Add range check for TOP-N in KNN, now if non-positive number is passed, throw a `RecoverableError`.

Issue link:#776

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
