### PR TITLE
Add FullTextColumnLengthFileWorker for storage of column length info

### DIFF
--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -118,6 +118,7 @@ export namespace std {
     using std::reverse;
     using std::sort;
     using std::unique;
+    using std::reduce;
     using std::sqrt;
     using std::transform;
 

--- a/src/storage/buffer/file_worker/fulltext_file_worker.cppm
+++ b/src/storage/buffer/file_worker/fulltext_file_worker.cppm
@@ -1,0 +1,117 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module fulltext_file_worker;
+
+import stl;
+import index_file_worker;
+import file_worker;
+
+import index_base;
+import infinity_exception;
+import default_values;
+import column_def;
+import file_system;
+import logger;
+
+namespace infinity {
+
+export struct FullTextColumnLengthData {
+    f32 avg_length_{};
+    u32 row_count_{};
+    f32 total_length_{};        // sum of column_length
+    Vector<u32> column_length_; // column_length[i] is the length of the TermList of row with SegmentOffset i
+
+    void SaveIndexInner(FileHandler &file_handler) const {
+        file_handler.Write(&avg_length_, sizeof(avg_length_));
+        file_handler.Write(&row_count_, sizeof(row_count_));
+        file_handler.Write(&total_length_, sizeof(total_length_));
+        u32 column_length_size = column_length_.size();
+        file_handler.Write(&column_length_size, sizeof(column_length_size));
+        file_handler.Write(column_length_.data(), column_length_size * sizeof(u32));
+    }
+
+    void ReadIndexInner(FileHandler &file_handler) {
+        file_handler.Read(&avg_length_, sizeof(avg_length_));
+        file_handler.Read(&row_count_, sizeof(row_count_));
+        file_handler.Read(&total_length_, sizeof(total_length_));
+        u32 column_length_size = 0;
+        file_handler.Read(&column_length_size, sizeof(column_length_size));
+        column_length_.resize(column_length_size);
+        file_handler.Read(column_length_.data(), column_length_size * sizeof(u32));
+    }
+};
+
+export class FullTextColumnLengthFileWorker final : public IndexFileWorker {
+public:
+    explicit FullTextColumnLengthFileWorker(SharedPtr<String> file_dir,
+                                            SharedPtr<String> file_name,
+                                            const IndexBase *index_base,
+                                            const ColumnDef *column_def)
+        : IndexFileWorker(file_dir, file_name, index_base, column_def) {}
+
+    ~FullTextColumnLengthFileWorker() final {
+        if (data_ != nullptr) {
+            FreeInMemory();
+            data_ = nullptr;
+        }
+    }
+
+public:
+    void AllocateInMemory() final {
+        if (data_) [[unlikely]] {
+            UnrecoverableError("AllocateInMemory: Already allocated.");
+        } else {
+            data_ = static_cast<void *>(new FullTextColumnLengthData());
+        }
+    }
+
+    void FreeInMemory() final {
+        if (data_) [[likely]] {
+            auto len_data = static_cast<FullTextColumnLengthData *>(data_);
+            delete len_data;
+            data_ = nullptr;
+            LOG_TRACE("Finished FreeInMemory(), deleted data_ ptr.");
+        } else {
+            UnrecoverableError("FreeInMemory: Data is not allocated.");
+        }
+    }
+
+protected:
+    void WriteToFileImpl(bool &prepare_success) final {
+        if (data_) [[likely]] {
+            auto len_data = static_cast<FullTextColumnLengthData *>(data_);
+            len_data->SaveIndexInner(*file_handler_);
+            prepare_success = true;
+            LOG_TRACE("Finished WriteToFileImpl(bool &prepare_success).");
+        } else {
+            UnrecoverableError("WriteToFileImpl: data_ is nullptr");
+        }
+    }
+
+    void ReadFromFileImpl() final {
+        if (!data_) [[likely]] {
+            auto len_data = new FullTextColumnLengthData();
+            len_data->ReadIndexInner(*file_handler_);
+            data_ = static_cast<void *>(len_data);
+            LOG_TRACE("Finished ReadFromFileImpl().");
+        } else {
+            UnrecoverableError("ReadFromFileImpl: data_ is not nullptr");
+        }
+    }
+};
+
+} // namespace infinity

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cppm
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cppm
@@ -26,10 +26,6 @@ import column_def;
 
 namespace infinity {
 
-export struct CreateFullTextParam : public CreateIndexParam {
-    CreateFullTextParam(const IndexBase *index_base, const ColumnDef *column_def) : CreateIndexParam(index_base, column_def) {}
-};
-
 export struct CreateHnswLVQParam : public CreateIndexParam {
     const SizeT max_element_{};
 

--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -110,6 +110,12 @@ void ColumnInverter::Merge(Vector<SharedPtr<ColumnInverter>> &inverters) {
     }
 }
 
+void ColumnInverter::GetTermListLength(u32 *term_list_length_ptr) const {
+    for (const auto &[_, term_list] : terms_per_doc_) {
+        *(term_list_length_ptr++) = term_list->size();
+    }
+}
+
 struct TermRefRadix {
     u32 operator()(const u64 v) { return v >> 32; }
 };

--- a/src/storage/invertedindex/column_inverter.cppm
+++ b/src/storage/invertedindex/column_inverter.cppm
@@ -53,6 +53,8 @@ public:
 
     void GeneratePosting();
 
+    void GetTermListLength(u32 *term_list_length_ptr) const;
+
     struct PosInfo {
         u32 term_num_{0};
         u32 doc_id_{0};

--- a/src/storage/invertedindex/memory_indexer.cppm
+++ b/src/storage/invertedindex/memory_indexer.cppm
@@ -51,7 +51,7 @@ public:
     ~MemoryIndexer();
 
     // Insert is non-blocking. Caller must ensure there's no RowID gap between each call.
-    void Insert(SharedPtr<ColumnVector> column_vector, u32 row_offset, u32 row_count, bool offline = false);
+    void Insert(SharedPtr<ColumnVector> column_vector, u32 row_offset, u32 row_count, u32 *column_invert_length_ptr, bool offline = false);
 
     // Commit is non-blocking. There shall be a background thread which call this method regularly (for example, every 2 seconds).
     // Other threads can also call this method.

--- a/src/storage/invertedindex/search/bm25_ranker.cpp
+++ b/src/storage/invertedindex/search/bm25_ranker.cpp
@@ -27,9 +27,10 @@ constexpr float b = 0.75F;
 
 BM25Ranker::BM25Ranker(u64 total_df) : total_df_(std::max(total_df, 1UL)) {}
 
-void BM25Ranker::AddTermParam(u64 tf, u64 df, double avg_column_len, u64 column_len) {
+void BM25Ranker::AddTermParam(u64 tf, u64 df, double avg_column_len, u64 column_len, float weight) {
     float smooth_idf = std::log(1.0F + (total_df_ - df + 0.5F) / (df + 0.5F));
     float smooth_tf = (k1 + 1.0F) * tf / (tf + k1 * (1.0F - b + b * column_len / avg_column_len));
-    score_ += smooth_idf * smooth_tf;
+    score_ += smooth_idf * smooth_tf * weight;
 }
+
 } // namespace infinity

--- a/src/storage/invertedindex/search/bm25_ranker.cppm
+++ b/src/storage/invertedindex/search/bm25_ranker.cppm
@@ -24,7 +24,7 @@ public:
     BM25Ranker(u64 total_df);
     ~BM25Ranker() = default;
 
-    void AddTermParam(u64 tf, u64 df, double avg_column_len, u64 column_len);
+    void AddTermParam(u64 tf, u64 df, double avg_column_len, u64 column_len, float weight);
 
     float GetScore() { return score_; }
 

--- a/src/storage/invertedindex/search/column_length_io.cpp
+++ b/src/storage/invertedindex/search/column_length_io.cpp
@@ -89,6 +89,7 @@ void ColumnLengthReader::LoadColumnLength(u32 column_counter,
             UnrecoverableError("segment list mismatch between different fulltext indexes");
         }
     }
+    column_length_vector_.resize(column_counter_);
 }
 
 template void ColumnLengthReader::LoadColumnLength(u32 column_counter,

--- a/src/storage/invertedindex/search/column_length_io.cpp
+++ b/src/storage/invertedindex/search/column_length_io.cpp
@@ -1,0 +1,136 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <vector>
+module column_length_io;
+
+import stl;
+import index_defines;
+import internal_types;
+import status;
+import match_data;
+import create_index_info;
+import table_entry;
+import segment_index_entry;
+import third_party;
+import buffer_handle;
+import fulltext_file_worker;
+import infinity_exception;
+import logger;
+
+namespace infinity {
+
+template <typename ScorerColumnIndexMapType>
+void ColumnLengthReader::LoadColumnLength(u32 column_counter,
+                                          ScorerColumnIndexMapType &column_index_map,
+                                          TableEntry *table_entry,
+                                          TransactionID txn_id,
+                                          TxnTimeStamp begin_ts) {
+    column_counter_ = column_counter;
+    column_length_data_buffer_handles_.clear();
+    for (auto map_guard = table_entry->IndexMetaMap(); auto &[index_name, table_index_meta] : *map_guard) {
+        auto [table_index_entry, status] = table_index_meta->GetEntryNolock(txn_id, begin_ts);
+        if (!status.ok()) {
+            // Table index entry isn't found
+            RecoverableError(status);
+        }
+        const String column_name = table_index_entry->index_base()->column_name();
+        auto column_id = table_entry->GetColumnIdByName(column_name);
+        auto iter_column_index = column_index_map.find(column_id);
+        if (iter_column_index == column_index_map.end()) {
+            // unnecessary column
+            continue;
+        }
+        u32 column_index = iter_column_index->second;
+        // check index type
+        if (auto index_type = table_index_entry->index_base()->index_type_; index_type != IndexType::kFullText) {
+            // non-fulltext index
+            continue;
+        }
+        const HashMap<u32, SharedPtr<SegmentIndexEntry>> &index_by_segment = table_index_entry->index_by_segment();
+        for (auto &[segment_id, segment_index_entry] : index_by_segment) {
+            auto &buffer_handle_v = column_length_data_buffer_handles_[segment_id];
+            if (buffer_handle_v.empty()) {
+                buffer_handle_v.resize(column_counter);
+            }
+            if (buffer_handle_v[column_index].GetData() != nullptr) {
+                UnrecoverableError(fmt::format("Duplicate fulltext indexes for the same column {}", column_name));
+            }
+            buffer_handle_v[column_index] = segment_index_entry->GetIndex();
+        }
+    }
+    // check if all columns are loaded
+    for (const auto &[_, buffer_handle_v] : column_length_data_buffer_handles_) {
+        bool valid = true;
+        if (buffer_handle_v.size() != column_counter) {
+            valid = false;
+        } else {
+            for (const auto &buffer_handle : buffer_handle_v) {
+                if (buffer_handle.GetData() == nullptr) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            UnrecoverableError("segment list mismatch between different fulltext indexes");
+        }
+    }
+}
+
+template void ColumnLengthReader::LoadColumnLength(u32 column_counter,
+                                                   Scorer::ColumnIndexMapType &column_index_map,
+                                                   TableEntry *table_entry,
+                                                   TransactionID txn_id,
+                                                   TxnTimeStamp begin_ts);
+
+void ColumnLengthReader::UpdateAvgColumnLength(Vector<float> &avg_column_length) {
+    avg_column_length.clear();
+    avg_column_length.resize(column_counter_);
+    u32 total_row_count = 0;
+    for (const auto &[segment_id, buffer_handle_v] : column_length_data_buffer_handles_) {
+        u32 segment_row_cnt = -1;
+        for (u32 i = 0; i < column_counter_; ++i) {
+            auto &buffer_handle = buffer_handle_v[i];
+            auto &column_length_data = *static_cast<const FullTextColumnLengthData *>(buffer_handle.GetData());
+            if (segment_row_cnt == u32(-1)) {
+                segment_row_cnt = column_length_data.row_count_;
+                total_row_count += segment_row_cnt;
+            } else if (segment_row_cnt != column_length_data.row_count_) {
+                UnrecoverableError(fmt::format("Segment {} has different row count for different columns", segment_id));
+            }
+            avg_column_length[i] += column_length_data.total_length_;
+        }
+    }
+    for (auto &len : avg_column_length) {
+        len /= total_row_count;
+    }
+}
+
+u32 ColumnLengthReader::GetColumnLength(u32 scorer_column_idx, RowID doc_id) {
+    SegmentID segment_id = doc_id.segment_id_;
+    SegmentOffset segment_offset = doc_id.segment_offset_;
+    if (auto iter = column_length_data_buffer_handles_.find(segment_id); iter != column_length_data_buffer_handles_.end()) {
+        auto &buffer_handle = (iter->second)[scorer_column_idx];
+        auto &column_length_data = *static_cast<const FullTextColumnLengthData *>(buffer_handle.GetData());
+        return column_length_data.column_length_[segment_offset];
+    } else {
+        UnrecoverableError(fmt::format("Segment {} is not found in column length data", segment_id));
+        return -1;
+    }
+}
+
+} // namespace infinity

--- a/src/storage/invertedindex/search/column_length_io.cpp
+++ b/src/storage/invertedindex/search/column_length_io.cpp
@@ -120,17 +120,4 @@ void ColumnLengthReader::UpdateAvgColumnLength(Vector<float> &avg_column_length)
     }
 }
 
-u32 ColumnLengthReader::GetColumnLength(u32 scorer_column_idx, RowID doc_id) {
-    SegmentID segment_id = doc_id.segment_id_;
-    SegmentOffset segment_offset = doc_id.segment_offset_;
-    if (auto iter = column_length_data_buffer_handles_.find(segment_id); iter != column_length_data_buffer_handles_.end()) {
-        auto &buffer_handle = (iter->second)[scorer_column_idx];
-        auto &column_length_data = *static_cast<const FullTextColumnLengthData *>(buffer_handle.GetData());
-        return column_length_data.column_length_[segment_offset];
-    } else {
-        UnrecoverableError(fmt::format("Segment {} is not found in column length data", segment_id));
-        return -1;
-    }
-}
-
 } // namespace infinity

--- a/src/storage/invertedindex/search/column_length_io.cppm
+++ b/src/storage/invertedindex/search/column_length_io.cppm
@@ -19,15 +19,32 @@ export module column_length_io;
 import stl;
 import index_defines;
 import internal_types;
+import table_entry;
+import buffer_handle;
 
 namespace infinity {
+
 export class ColumnLengthWriter {};
 
 export class ColumnLengthReader {
+    u32 column_counter_{};
+    // all available data in the table
+    Map<SegmentID, Vector<BufferHandle>> column_length_data_buffer_handles_;
+
 public:
     ColumnLengthReader() = default;
     ~ColumnLengthReader() = default;
 
-    u32 GetColumnLength(u64 column_id, RowID doc_id) { return 0; }
+    template <typename ScorerColumnIndexMapType>
+    void LoadColumnLength(u32 column_counter,
+                          ScorerColumnIndexMapType &column_index_map,
+                          TableEntry *table_entry,
+                          TransactionID txn_id,
+                          TxnTimeStamp begin_ts);
+
+    void UpdateAvgColumnLength(Vector<float> &avg_column_length);
+
+    u32 GetColumnLength(u32 scorer_column_idx, RowID doc_id);
 };
+
 } // namespace infinity

--- a/src/storage/invertedindex/search/column_length_io.cppm
+++ b/src/storage/invertedindex/search/column_length_io.cppm
@@ -21,15 +21,19 @@ import index_defines;
 import internal_types;
 import table_entry;
 import buffer_handle;
+import third_party;
 
 namespace infinity {
 
 export class ColumnLengthWriter {};
 
 export class ColumnLengthReader {
+    struct Hash {
+        inline SegmentID operator()(const SegmentID &val) const { return val; }
+    };
     u32 column_counter_{};
     // all available data in the table
-    Map<SegmentID, Vector<BufferHandle>> column_length_data_buffer_handles_;
+    FlatHashMap<SegmentID, Vector<BufferHandle>, Hash> column_length_data_buffer_handles_;
 
 public:
     ColumnLengthReader() = default;

--- a/src/storage/invertedindex/search/column_length_io.cppm
+++ b/src/storage/invertedindex/search/column_length_io.cppm
@@ -19,6 +19,7 @@ export module column_length_io;
 import stl;
 import index_defines;
 import internal_types;
+import default_values;
 import table_entry;
 import buffer_handle;
 import fulltext_file_worker;
@@ -36,6 +37,8 @@ export class ColumnLengthReader {
     u32 column_counter_{};
     // all available data in the table
     FlatHashMap<SegmentID, Vector<BufferHandle>, Hash> column_length_data_buffer_handles_;
+    mutable Vector<const u32 *> column_length_vector_;
+    mutable SegmentID segment_id_now = INVALID_SEGMENT_ID;
 
 public:
     ColumnLengthReader() = default;
@@ -50,17 +53,21 @@ public:
 
     void UpdateAvgColumnLength(Vector<float> &avg_column_length);
 
-    inline u32 GetColumnLength(u32 scorer_column_idx, RowID doc_id) {
-        SegmentID segment_id = doc_id.segment_id_;
-        SegmentOffset segment_offset = doc_id.segment_offset_;
-        if (auto iter = column_length_data_buffer_handles_.find(segment_id); iter != column_length_data_buffer_handles_.end()) {
-            auto &buffer_handle = (iter->second)[scorer_column_idx];
-            auto &column_length_data = *static_cast<const FullTextColumnLengthData *>(buffer_handle.GetData());
-            return column_length_data.column_length_[segment_offset];
-        } else {
-            UnrecoverableError(fmt::format("Segment {} is not found in column length data", segment_id));
-            return -1;
+    inline u32 GetColumnLength(u32 scorer_column_idx, RowID doc_id) const {
+        if (SegmentID segment_id = doc_id.segment_id_; segment_id != segment_id_now) [[unlikely]] {
+            segment_id_now = segment_id;
+            if (auto iter = column_length_data_buffer_handles_.find(segment_id); iter != column_length_data_buffer_handles_.end()) [[likely]] {
+                const Vector<BufferHandle> &buffer_handles = iter->second;
+                for (u32 i = 0; i < column_counter_; ++i) {
+                    const auto *column_length_data = static_cast<const FullTextColumnLengthData *>(buffer_handles[i].GetData());
+                    column_length_vector_[i] = column_length_data->column_length_.data();
+                }
+            } else {
+                UnrecoverableError(fmt::format("Segment {} is not found in column length data", segment_id));
+                return -1;
+            }
         }
+        return column_length_vector_[scorer_column_idx][doc_id.segment_offset_];
     }
 };
 

--- a/src/storage/invertedindex/search/match_data.cpp
+++ b/src/storage/invertedindex/search/match_data.cpp
@@ -35,19 +35,6 @@ u32 Scorer::GetOrSetColumnIndex(u64 column_id) {
         return column_index_map_[column_id];
 }
 
-void Scorer::InitRanker(const Map<u64, double> &weight_map) {
-    for (auto it : weight_map) {
-        u32 column_index = GetOrSetColumnIndex(it.first);
-        column_weights_.resize(column_index + 1);
-        column_weights_[column_index] = it.second;
-        column_ids_.resize(column_index + 1);
-        column_ids_[column_index] = it.first;
-    }
-    for (u32 i = 0; i < column_counter_; ++i) {
-        avg_column_length_[i] = GetAvgColumnLength(column_ids_[i]);
-    }
-}
-
 double Scorer::GetAvgColumnLength(u64 column_id) {
     double length = 0.0F;
     //  TODO
@@ -69,11 +56,10 @@ float Scorer::Score(RowID doc_id) {
         TermColumnMatchData &column_match_data = match_data_.term_columns_[i];
         for (u32 j = 0; j < column_iters.size(); j++) {
             if (column_iters[j]->GetTermMatchData(column_match_data, doc_id)) {
-                ranker.AddTermParam(column_match_data.tf_, column_iters[j]->GetDF(), avg_column_length_[i], column_len);
+                ranker.AddTermParam(column_match_data.tf_, column_iters[j]->GetDF(), avg_column_length_[i], column_len, column_iters[j]->GetWeight());
             }
         }
-        auto s = ranker.GetScore();
-        score += column_weights_[i] * s;
+        score += ranker.GetScore();
     }
     return score;
 }

--- a/src/storage/invertedindex/search/match_data.cppm
+++ b/src/storage/invertedindex/search/match_data.cppm
@@ -21,6 +21,7 @@ import third_party;
 import index_defines;
 import column_length_io;
 import internal_types;
+import table_entry;
 
 namespace infinity {
 export struct TermColumnMatchData {
@@ -44,12 +45,12 @@ public:
 
     void AddDocIterator(TermDocIterator *iter, u64 column_id);
 
+    void LoadColumnLength(TableEntry *table_entry, TransactionID txn_id, TxnTimeStamp begin_ts);
+
     float Score(RowID doc_id);
 
 private:
     u32 GetOrSetColumnIndex(u64 column_id);
-
-    double GetAvgColumnLength(u64 column_id);
 
     struct Hash {
         inline u64 operator()(const u64 &val) const { return val; }
@@ -60,9 +61,12 @@ private:
     FlatHashMap<u64, u32, Hash> column_index_map_;
     Vector<u64> column_ids_;
     Vector<Vector<TermDocIterator *>> iterators_;
-    Vector<double> avg_column_length_;
+    Vector<float> avg_column_length_;
     UniquePtr<ColumnLengthReader> column_length_reader_;
     MatchData match_data_;
+
+public:
+    using ColumnIndexMapType = decltype(column_index_map_);
 };
 
 } // namespace infinity

--- a/src/storage/invertedindex/search/match_data.cppm
+++ b/src/storage/invertedindex/search/match_data.cppm
@@ -42,8 +42,6 @@ public:
 
     ~Scorer() = default;
 
-    void InitRanker(const Map<u64, double> &weight_map);
-
     void AddDocIterator(TermDocIterator *iter, u64 column_id);
 
     float Score(RowID doc_id);
@@ -62,7 +60,6 @@ private:
     FlatHashMap<u64, u32, Hash> column_index_map_;
     Vector<u64> column_ids_;
     Vector<Vector<TermDocIterator *>> iterators_;
-    Vector<double> column_weights_;
     Vector<double> avg_column_length_;
     UniquePtr<ColumnLengthReader> column_length_reader_;
     MatchData match_data_;

--- a/src/storage/invertedindex/search/query_builder.cpp
+++ b/src/storage/invertedindex/search/query_builder.cpp
@@ -82,7 +82,7 @@ UniquePtr<DocIterator> QueryBuilder::CreateSearch(QueryContext &context) {
     // Optimize the query tree.
     context.query_tree_ = QueryNode::GetOptimizedQueryTree(std::move(context.query_tree_));
     // Create the iterator from the query tree.
-    return context.query_tree_->CreateSearch(table_entry_, index_reader_, scorer_);
+    return context.query_tree_->CreateSearch(table_entry_, index_reader_, scorer_.get());
 }
 
 } // namespace infinity

--- a/src/storage/invertedindex/search/query_node.h
+++ b/src/storage/invertedindex/search/query_node.h
@@ -76,8 +76,7 @@ struct QueryNode {
     // recursively multiply and push down the weight to the leaf term nodes
     virtual void PushDownWeight(float factor = 1.0f) = 0;
     // create the iterator from the query tree, need to be called after optimization
-    virtual std::unique_ptr<DocIterator>
-    CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, std::unique_ptr<Scorer> &scorer) const = 0;
+    virtual std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, Scorer *scorer) const = 0;
     // print the query tree, for debugging
     virtual void PrintTree(std::ostream &os, const std::string &prefix = "", bool is_final = true) const = 0;
 };
@@ -90,7 +89,7 @@ struct TermQueryNode final : public QueryNode {
     TermQueryNode() : QueryNode(QueryNodeType::TERM) {}
 
     void PushDownWeight(float factor) final { MultiplyWeight(factor); }
-    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, std::unique_ptr<Scorer> &scorer) const final;
+    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, Scorer *scorer) const final;
     void PrintTree(std::ostream &os, const std::string &prefix, bool is_final) const final;
 };
 
@@ -119,22 +118,22 @@ struct MultiQueryNode : public QueryNode {
 struct NotQueryNode final : public MultiQueryNode {
     NotQueryNode() : MultiQueryNode(QueryNodeType::NOT) {}
     std::unique_ptr<QueryNode> InnerGetNewOptimizedQueryTree() final;
-    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, std::unique_ptr<Scorer> &scorer) const final;
+    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, Scorer *scorer) const final;
 };
 struct AndQueryNode final : public MultiQueryNode {
     AndQueryNode() : MultiQueryNode(QueryNodeType::AND) {}
     std::unique_ptr<QueryNode> InnerGetNewOptimizedQueryTree() final;
-    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, std::unique_ptr<Scorer> &scorer) const final;
+    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, Scorer *scorer) const final;
 };
 struct AndNotQueryNode final : public MultiQueryNode {
     AndNotQueryNode() : MultiQueryNode(QueryNodeType::AND_NOT) {}
     std::unique_ptr<QueryNode> InnerGetNewOptimizedQueryTree() final;
-    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, std::unique_ptr<Scorer> &scorer) const final;
+    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, Scorer *scorer) const final;
 };
 struct OrQueryNode final : public MultiQueryNode {
     OrQueryNode() : MultiQueryNode(QueryNodeType::OR) {}
     std::unique_ptr<QueryNode> InnerGetNewOptimizedQueryTree() final;
-    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, std::unique_ptr<Scorer> &scorer) const final;
+    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *table_entry, IndexReader &index_reader, Scorer *scorer) const final;
 };
 
 // unimplemented

--- a/src/storage/invertedindex/search/term_doc_iterator.cpp
+++ b/src/storage/invertedindex/search/term_doc_iterator.cpp
@@ -26,7 +26,7 @@ import doc_iterator;
 import internal_types;
 
 namespace infinity {
-TermDocIterator::TermDocIterator(PostingIterator *iter, u64 column_id) : column_id_(column_id), iter_(iter) {}
+TermDocIterator::TermDocIterator(PostingIterator *iter, u64 column_id, float weight) : column_id_(column_id), iter_(iter), weight_(weight) {}
 
 TermDocIterator::~TermDocIterator() {}
 

--- a/src/storage/invertedindex/search/term_doc_iterator.cppm
+++ b/src/storage/invertedindex/search/term_doc_iterator.cppm
@@ -29,7 +29,7 @@ import internal_types;
 namespace infinity {
 export class TermDocIterator : public DocIterator {
 public:
-    TermDocIterator(PostingIterator *iter, u64 column_id);
+    TermDocIterator(PostingIterator *iter, u64 column_id, float weight);
 
     virtual ~TermDocIterator();
 
@@ -48,8 +48,11 @@ public:
         return false;
     }
 
+    float GetWeight() const { return weight_; }
+
 private:
     u64 column_id_;
     PostingIterator *iter_ = nullptr;
+    float weight_;
 };
 } // namespace infinity

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -51,6 +51,7 @@ import segment_iter;
 import annivfflat_index_file_worker;
 import hnsw_file_worker;
 import secondary_index_file_worker;
+import fulltext_file_worker;
 import fulltext_index_entry;
 import index_full_text;
 import index_defines;
@@ -274,17 +275,28 @@ Status SegmentIndexEntry::CreateIndexPrepare(const IndexBase *index_base,
                                                         table_index_entry_->GetFulltextBufferPool(),
                                                         table_index_entry_->GetFulltextThreadPool());
             u64 column_id = column_def->id();
+            Vector<u32> column_length(segment_entry->row_count());
+            u32 *column_length_ptr = column_length.data();
             auto block_entry_iter = BlockEntryIter(segment_entry);
             for (const auto *block_entry = block_entry_iter.Next(); block_entry != nullptr; block_entry = block_entry_iter.Next()) {
                 BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
                 SharedPtr<ColumnVector> column_vector = MakeShared<ColumnVector>(block_column_entry->GetColumnVector(buffer_mgr));
-                memory_indexer_->Insert(column_vector, 0, block_entry->row_count());
+                memory_indexer_->Insert(column_vector, 0, block_entry->row_count(), column_length_ptr);
+                column_length_ptr += block_entry->row_count();
             }
             memory_indexer_->Commit();
             memory_indexer_->Dump();
+            {
+                // after dump, all build threads should be finished.
+                BufferHandle column_length_handle = GetIndex();
+                auto &fulltext_column_length = *static_cast<FullTextColumnLengthData *>(column_length_handle.GetDataMut());
+                fulltext_column_length.row_count_ = column_length.size();
+                fulltext_column_length.total_length_ = std::reduce(column_length.begin(), column_length.end(), f32{0});
+                fulltext_column_length.avg_length_ = fulltext_column_length.total_length_ / fulltext_column_length.row_count_;
+                fulltext_column_length.column_length_ = std::move(column_length);
+            }
             ft_base_names_.push_back(base_name);
             ft_base_rowids_.push_back(base_row_id.ToUint64());
-
             auto duration = Clock::now().time_since_epoch();
             u64 ts = ChronoCast<NanoSeconds>(duration).count();
             table_index_entry_->UpdateFulltextSegmentTs(ts);
@@ -465,7 +477,7 @@ UniquePtr<CreateIndexParam> SegmentIndexEntry::GetCreateIndexParam(const IndexBa
             return MakeUnique<CreateHnswParam>(index_base, column_def, max_element);
         }
         case IndexType::kFullText: {
-            return MakeUnique<CreateFullTextParam>(index_base, column_def);
+            return MakeUnique<CreateIndexParam>(index_base, column_def);
         }
         case IndexType::kSecondary: {
             u32 part_capacity = DEFAULT_BLOCK_CAPACITY;

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -37,6 +37,7 @@ import index_file_worker;
 import annivfflat_index_file_worker;
 import hnsw_file_worker;
 import secondary_index_file_worker;
+import fulltext_file_worker;
 import embedding_info;
 
 namespace infinity {
@@ -291,10 +292,6 @@ Vector<UniquePtr<IndexFileWorker>> TableIndexEntry::CreateFileWorker(CreateIndex
     // reference file_worker will be invalidated when vector_file_worker is resized
     const auto *index_base = param->index_base_;
     const auto *column_def = param->column_def_;
-    if (index_base->index_type_ == IndexType::kFullText) {
-        // fulltext doesn't use BufferManager
-        return vector_file_worker;
-    }
 
     auto file_name = MakeShared<String>(IndexFileName(segment_id));
     vector_file_worker.resize(1);
@@ -324,7 +321,7 @@ Vector<UniquePtr<IndexFileWorker>> TableIndexEntry::CreateFileWorker(CreateIndex
             break;
         }
         case IndexType::kFullText: {
-            // fulltext doesn't use BufferManager
+            file_worker = MakeUnique<FullTextColumnLengthFileWorker>(this->index_dir(), file_name, index_base, column_def);
             break;
         }
         case IndexType::kSecondary: {
@@ -372,7 +369,7 @@ UniquePtr<CreateIndexParam> TableIndexEntry::GetCreateIndexParam(const IndexBase
             return MakeUnique<CreateHnswParam>(index_base, column_def, max_element);
         }
         case IndexType::kFullText: {
-            return MakeUnique<CreateFullTextParam>(index_base, column_def);
+            return MakeUnique<CreateIndexParam>(index_base, column_def);
         }
         case IndexType::kSecondary: {
             u32 part_capacity = DEFAULT_BLOCK_CAPACITY;

--- a/src/unit_test/storage/invertedindex/memory_indexer.cpp
+++ b/src/unit_test/storage/invertedindex/memory_indexer.cpp
@@ -74,15 +74,16 @@ TEST_F(MemoryIndexerTest, Insert) {
     }
     Vector<ExpectedPosting> expected_postings = {{"fst", {0, 1, 2}, {4, 2, 2}}, {"automaton", {0, 3}, {2, 5}}, {"transducer", {0, 4}, {1, 4}}};
 
+    Array<u32, 5> column_invert_length = {};
     MemoryIndexer
         indexer1("/tmp/infinity/fulltext_tbl1_col1", "chunk1", RowID(0U, 0U), flag_, "standard", byte_slice_pool_, buffer_pool_, thread_pool_);
-    indexer1.Insert(column, 0, 1);
-    indexer1.Insert(column, 1, 3);
+    indexer1.Insert(column, 0, 1, column_invert_length.data());
+    indexer1.Insert(column, 1, 3, column_invert_length.data() + 1);
     indexer1.Dump();
 
     MemoryIndexer
         indexer2("/tmp/infinity/fulltext_tbl1_col1", "chunk2", RowID(0U, 4U), flag_, "standard", byte_slice_pool_, buffer_pool_, thread_pool_);
-    indexer2.Insert(column, 4, 1);
+    indexer2.Insert(column, 4, 1, column_invert_length.data() + 4);
     while (indexer2.GetInflightTasks() > 0) {
         sleep(1);
         indexer2.CommitSync();
@@ -129,11 +130,12 @@ TEST_F(MemoryIndexerTest, test2) {
     }
     Vector<ExpectedPosting> expected_postings = {{"fst", {0, 1, 2}, {4, 2, 2}}, {"automaton", {0, 3}, {2, 5}}, {"transducer", {0, 4}, {1, 4}}};
 
+    Array<u32, 5> column_invert_length = {};
     MemoryIndexer
         indexer1("/tmp/infinity/fulltext_tbl1_col1", "chunk1", RowID(0U, 0U), flag_, "standard", byte_slice_pool_, buffer_pool_, thread_pool_);
-    indexer1.Insert(column, 0, 2, true);
-    indexer1.Insert(column, 2, 2, true);
-    indexer1.Insert(column, 4, 1, true);
+    indexer1.Insert(column, 0, 2, column_invert_length.data(), true);
+    indexer1.Insert(column, 2, 2, column_invert_length.data() + 2, true);
+    indexer1.Insert(column, 4, 1, column_invert_length.data() + 4, true);
     indexer1.Dump(true);
 
     ColumnIndexReader reader;

--- a/src/unit_test/storage/invertedindex/search/query_builder.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_builder.cpp
@@ -57,7 +57,7 @@ struct MockQueryNode : public QueryNode {
     MockQueryNode(Vector<RowID> doc_ids) : QueryNode(QueryNodeType::TERM), doc_ids_(std::move(doc_ids)) {}
 
     void PushDownWeight(float factor) final { MultiplyWeight(factor); }
-    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *, IndexReader &, std::unique_ptr<Scorer> &) const final {
+    std::unique_ptr<DocIterator> CreateSearch(const TableEntry *, IndexReader &, Scorer *) const final {
         return MakeUnique<MockVectorDocIterator>(std::move(doc_ids_));
     }
     void PrintTree(std::ostream &os, const std::string &prefix, bool is_final) const final {


### PR DESCRIPTION
### What problem does this PR solve?

1. Add FullTextColumnLengthFileWorker for storage of column length info
2. fix QueryNode, scorer and column_weights
nodes under "not" will not be added to scorer
add weight info to TermDocIterator
remove column_weights from MatchData

Issue link:#641

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
