### PR TITLE
Fix: flushing index built on an empty table.

### DIFF
--- a/python/test/test_index.py
+++ b/python/test/test_index.py
@@ -165,7 +165,6 @@ class TestIndex:
             table_obj.create_index("my_index", index_info, None)
 
 
-    # @pytest.mark.skip(reason="Core dumped.")
     @pytest.mark.parametrize("column_name", [
         (1, False),
         (2.2, False),
@@ -347,7 +346,6 @@ class TestIndex:
         table_obj.import_data(os.getcwd() + TEST_DATA_DIR + file_format + "/pysdk_test." + file_format)
 
     # create index on all data are deleted table.
-    @pytest.mark.skip(reason="Core dumped")
     def test_create_index_on_deleted_table(self, get_infinity_db):
         db_obj = get_infinity_db
         db_obj.drop_table("test_create_index_on_deleted_table", if_exists=True)

--- a/src/storage/knn_index/ann_ivf/annivfflat_index_data.cppm
+++ b/src/storage/knn_index/ann_ivf/annivfflat_index_data.cppm
@@ -224,13 +224,15 @@ struct AnnIVFFlatIndexData {
         file_handler.Write(&dimension_, sizeof(dimension_));
         file_handler.Write(&partition_num_, sizeof(partition_num_));
         file_handler.Write(&data_num_, sizeof(data_num_));
-        file_handler.Write(centroids_.data(), sizeof(CentroidsDataType) * dimension_ * partition_num_);
-        u32 vector_element_num;
-        for (u32 i = 0; i < partition_num_; ++i) {
-            vector_element_num = ids_[i].size();
-            file_handler.Write(&vector_element_num, sizeof(vector_element_num));
-            file_handler.Write(ids_[i].data(), sizeof(u32) * vector_element_num);
-            file_handler.Write(vectors_[i].data(), sizeof(VectorDataType) * dimension_ * vector_element_num);
+        if (!centroids_.empty()) {
+            file_handler.Write(centroids_.data(), sizeof(CentroidsDataType) * dimension_ * partition_num_);
+            u32 vector_element_num;
+            for (u32 i = 0; i < partition_num_; ++i) {
+                vector_element_num = ids_[i].size();
+                file_handler.Write(&vector_element_num, sizeof(vector_element_num));
+                file_handler.Write(ids_[i].data(), sizeof(u32) * vector_element_num);
+                file_handler.Write(vectors_[i].data(), sizeof(VectorDataType) * dimension_ * vector_element_num);
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

The error appears when writing index built on empty tables to file. Now add `nullptr` check when flushing index.

Issue link:#759

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

