### PR TITLE
Fix: unimplemented type of KNN distance cause service crash.

### DIFF
--- a/python/test/test_knn.py
+++ b/python/test/test_knn.py
@@ -211,7 +211,6 @@ class TestKnn:
                                                    2).to_pl()
         print(res)
 
-    @pytest.mark.skip(reason="Core dumped.")
     @pytest.mark.parametrize("check_data", [{"file_name": "tmp_20240116.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     @pytest.mark.parametrize("embedding_data", [
@@ -219,14 +218,14 @@ class TestKnn:
         [1.0] * 4,
     ])
     @pytest.mark.parametrize("embedding_data_type", [
-        # FIXME "int",
-        "float",
+        # ("int", False),
+        ("float", True),
     ])
     @pytest.mark.parametrize("distance_type", [
-        "l2",
-        # FIXME "cosine",
-        "ip",
-        # FIXME "hamming",
+        ("l2", True),
+        ("cosine", False),
+        ("ip", True),
+        ("hamming", False),
     ])
     def test_various_distance_type(self, get_infinity_db, check_data, embedding_data, embedding_data_type,
                                    distance_type):
@@ -248,9 +247,14 @@ class TestKnn:
             copy_data("tmp_20240116.csv")
         test_csv_dir = "/tmp/infinity/test_data/tmp_20240116.csv"
         table_obj.import_data(test_csv_dir, None)
-        res = table_obj.output(["variant_id"]).knn("gender_vector", embedding_data, embedding_data_type, distance_type,
-                                                   2).to_pl()
-        print(res)
+        if distance_type[1] and embedding_data_type[1]:
+            res = table_obj.output(["variant_id"]).knn("gender_vector", embedding_data, embedding_data_type[0], distance_type[0],
+                                                    2).to_pl()
+            print(res)
+        else:
+            with pytest.raises(Exception, match="ERROR:3032*"):
+                res = table_obj.output(["variant_id"]).knn("gender_vector", embedding_data, embedding_data_type[0], distance_type[0],
+                                                        2).to_pl()
 
     @pytest.mark.parametrize("check_data", [{"file_name": "tmp_20240116.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)

--- a/src/executor/operator/physical_knn_scan.cpp
+++ b/src/executor/operator/physical_knn_scan.cpp
@@ -161,13 +161,13 @@ bool PhysicalKnnScan::Execute(QueryContext *query_context, OperatorState *operat
                     break;
                 }
                 default: {
-                    UnrecoverableError("Not implemented");
+                    RecoverableError(Status::NotSupport("Not implemented"));
                 }
             }
             break;
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
     }
     return true;
@@ -404,7 +404,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                             break;
                         }
                         default: {
-                            UnrecoverableError("Not implemented");
+                            RecoverableError(Status::NotSupport("Not implemented"));
                         }
                     }
                 };
@@ -507,7 +507,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                                 break;
                             }
                             default: {
-                                UnrecoverableError("Not implemented");
+                                RecoverableError(Status::NotSupport("Not implemented"));
                             }
                         }
                         break;
@@ -531,19 +531,19 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                                 break;
                             }
                             default: {
-                                UnrecoverableError("Not implemented");
+                                RecoverableError(Status::NotSupport("Not implemented"));
                             }
                         }
                         break;
                     }
                     default: {
-                        UnrecoverableError("Not implemented");
+                        RecoverableError(Status::NotSupport("Not implemented"));
                     }
                 }
                 break;
             }
             default: {
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
         }
         }

--- a/src/expression/cast_expression.cpp
+++ b/src/expression/cast_expression.cpp
@@ -37,7 +37,6 @@ SharedPtr<BaseExpression> CastExpression::AddCastToType(const SharedPtr<BaseExpr
         return MakeShared<CastExpression>(cast, source_expr_ptr, target_type);
     } else {
         RecoverableError(Status::NotSupportedTypeConversion(source_expr_ptr->Type().ToString(), target_type.ToString()));
-//        UnrecoverableError(fmt::format("Can't cast from: {} to {}", source_expr_ptr->Type().ToString(), target_type.ToString()));
     }
     return nullptr;
 }

--- a/src/function/cast/bitmap_cast.cppm
+++ b/src/function/cast/bitmap_cast.cppm
@@ -51,7 +51,7 @@ struct BitmapTryCastToVarlen {
 
 template <>
 inline bool BitmapTryCastToVarlen::Run(const BitmapT &source, VarcharT &target, const SharedPtr<ColumnVector> &vector_ptr) {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
     return false;
 }
 

--- a/src/function/cast/embedding_cast.cppm
+++ b/src/function/cast/embedding_cast.cppm
@@ -54,7 +54,6 @@ export inline BoundCastFunc BindEmbeddingCast(const DataType &source, const Data
     auto target_info = static_cast<const EmbeddingInfo *>(target.type_info().get());
     if (source_info->Dimension() != target_info->Dimension()) {
         RecoverableError(Status::DataTypeMismatch(source.ToString(), target.ToString()));
-        //        UnrecoverableError(fmt::format("Can't cast from Embedding type to {}", target.ToString()));
     }
     switch (source_info->Type()) {
         case EmbeddingDataType::kElemInt8: {

--- a/src/function/cast/uuid_cast.cppm
+++ b/src/function/cast/uuid_cast.cppm
@@ -26,6 +26,7 @@ import logical_type;
 import infinity_exception;
 import third_party;
 import internal_types;
+import status;
 
 namespace infinity {
 
@@ -54,7 +55,7 @@ struct UuidTryCastToVarlen {
 
 template <>
 inline bool UuidTryCastToVarlen::Run(const UuidT &, VarcharT &, ColumnVector*) {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
 //    target.length_ = UuidT::LENGTH;
 //    std::memcpy(target.prefix, source.body, VarcharT::PREFIX_LENGTH);
 //    Assert<UnrecoverableException>(vector_ptr->buffer_->buffer_type_ == VectorBufferType::kHeap,

--- a/src/function/table/knn_scan_data.cpp
+++ b/src/function/table/knn_scan_data.cpp
@@ -18,7 +18,6 @@ module knn_scan_data;
 
 import stl;
 
-
 import infinity_exception;
 import third_party;
 import knn_flat_ip;
@@ -41,6 +40,7 @@ import base_expression;
 import expression_state;
 import internal_types;
 import data_type;
+import status;
 
 namespace infinity {
 
@@ -56,14 +56,14 @@ KnnDistance1<f32>::KnnDistance1(KnnDistanceType dist_type) {
             break;
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport(fmt::format("KnnDistanceType: {} is not support.", (i32)dist_type)));
         }
     }
 }
 
 // --------------------------------------------
 
-KnnScanFunctionData::KnnScanFunctionData(KnnScanSharedData* shared_data, u32 current_parallel_idx)
+KnnScanFunctionData::KnnScanFunctionData(KnnScanSharedData *shared_data, u32 current_parallel_idx)
     : knn_scan_shared_data_(shared_data), task_id_(current_parallel_idx) {
     switch (knn_scan_shared_data_->elem_type_) {
         case EmbeddingDataType::kElemFloat: {
@@ -71,7 +71,7 @@ KnnScanFunctionData::KnnScanFunctionData(KnnScanSharedData* shared_data, u32 cur
             break;
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport(fmt::format("EmbeddingDataType: {} is not support.", knn_scan_shared_data_->elem_type_)));
         }
     }
 }
@@ -103,7 +103,7 @@ void KnnScanFunctionData::Init() {
     if (knn_scan_shared_data_->filter_expression_) {
         filter_state_ = ExpressionState::CreateState(knn_scan_shared_data_->filter_expression_);
         db_for_filter_ = MakeUnique<DataBlock>();
-        db_for_filter_->Init(*(knn_scan_shared_data_->table_ref_->column_types_));                         // default capacity
+        db_for_filter_->Init(*(knn_scan_shared_data_->table_ref_->column_types_));                // default capacity
         bool_column_ = ColumnVector::Make(MakeShared<infinity::DataType>(LogicalType::kBoolean)); // default capacity
     }
 }

--- a/src/function/table/merge_knn_data.cpp
+++ b/src/function/table/merge_knn_data.cpp
@@ -21,6 +21,7 @@ import base_table_ref;
 import infinity_exception;
 import merge_knn;
 import knn_result_handler;
+import status;
 
 module merge_knn_data;
 
@@ -41,7 +42,7 @@ MergeKnnFunctionData::MergeKnnFunctionData(i64 query_count,
             break;
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
     }
 }

--- a/src/storage/column_vector/column_vector.cpp
+++ b/src/storage/column_vector/column_vector.cpp
@@ -265,10 +265,10 @@ void ColumnVector::Initialize(const ColumnVector &other, const Selection &input_
                 break;
             }
             case kNull: {
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
             case kMissing: {
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
             case kInvalid: {
                 UnrecoverableError("Invalid data type");
@@ -405,13 +405,13 @@ void ColumnVector::Initialize(ColumnVectorType vector_type, const ColumnVector &
                 CopyFrom<MixedT>(other.buffer_.get(), this->buffer_.get(), start_idx, 0, end_idx - start_idx);
                 break;
 #endif
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
             case kNull: {
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
             case kMissing: {
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
             case kInvalid: {
                 UnrecoverableError("Invalid data type");
@@ -562,13 +562,13 @@ void ColumnVector::CopyRow(const ColumnVector &other, SizeT dst_idx, SizeT src_i
             break;
         }
         case kNull: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kMissing: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kInvalid: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
     }
 }
@@ -600,7 +600,7 @@ String ColumnVector::ToString(SizeT row_index) const {
             return std::to_string(((BigIntT *)data_ptr_)[row_index]);
         }
         case kHugeInt: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kFloat: {
             return std::to_string(((FloatT *)data_ptr_)[row_index]);
@@ -609,7 +609,7 @@ String ColumnVector::ToString(SizeT row_index) const {
             return std::to_string(((DoubleT *)data_ptr_)[row_index]);
         }
         case kDecimal: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kVarchar: {
             VarcharT &varchar_ref = ((VarcharT *)data_ptr_)[row_index];
@@ -642,44 +642,44 @@ String ColumnVector::ToString(SizeT row_index) const {
             return ((TimestampT *)data_ptr_)[row_index].ToString();
         }
         case kInterval: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kArray: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kTuple: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kPoint: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kLine: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kLineSeg: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         case kBox: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
             //        case kPath: {
             //        }
             //        case kPolygon: {
             //        }
         case kCircle: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
             //        case kBitmap: {
             //        }
         case kUuid: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
             //        case kBlob: {
             //        }
         case kEmbedding: {
-            //            UnrecoverableError("Not implemented");
+            //            RecoverableError(Status::NotSupport("Not implemented"));
             if (data_type_->type_info()->type() != TypeInfoType::kEmbedding) {
-                UnrecoverableError("Not implemented");
+                RecoverableError(Status::NotSupport("Not implemented"));
             }
             EmbeddingInfo *embedding_info = static_cast<EmbeddingInfo *>(data_type_->type_info().get());
             EmbeddingT embedding_element(nullptr, false);
@@ -692,7 +692,7 @@ String ColumnVector::ToString(SizeT row_index) const {
             return (((RowID *)data_ptr_)[row_index]).ToString();
         }
         case kMixed: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
         default: {
             UnrecoverableError("Attempt to access an unaccepted type");
@@ -1248,7 +1248,7 @@ void ColumnVector::AppendByStringView(std::string_view sv, char delimiter) {
             SizeT dst_off = index * data_type_->Size();
             switch (embedding_info->Type()) {
                 case kElemBit: {
-                    UnrecoverableError("Not implemented");
+                    RecoverableError(Status::NotSupport("Not implemented"));
                     break;
                 }
                 case kElemInt8: {
@@ -1296,7 +1296,7 @@ void ColumnVector::AppendByStringView(std::string_view sv, char delimiter) {
             break;
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
     }
 }

--- a/src/storage/column_vector/operator/binary_operator.cppm
+++ b/src/storage/column_vector/operator/binary_operator.cppm
@@ -28,6 +28,7 @@ import bitmask;
 import bitmask_buffer;
 import third_party;
 import internal_types;
+import status;
 
 namespace infinity {
 
@@ -887,7 +888,7 @@ private:
                                                 SizeT,
                                                 void *,
                                                 bool) {
-        UnrecoverableError("Not implemented.");
+        RecoverableError(Status::NotSupport("Not implemented"));
     }
 
     template <typename LeftType, typename RightType, typename ResultType, typename Operator>
@@ -1045,7 +1046,7 @@ private:
                                                     SizeT,
                                                     void *,
                                                     bool) {
-        UnrecoverableError("Not implemented.");
+        RecoverableError(Status::NotSupport("Not implemented"));
     }
 
     template <typename LeftType, typename RightType, typename ResultType, typename Operator>
@@ -1055,7 +1056,7 @@ private:
                                                 SizeT,
                                                 void *,
                                                 bool) {
-        UnrecoverableError("Not implemented.");
+        RecoverableError(Status::NotSupport("Not implemented"));
     }
 
     template <typename LeftType, typename RightType, typename ResultType, typename Operator>
@@ -1065,7 +1066,7 @@ private:
                                                     SizeT,
                                                     void *,
                                                     bool) {
-        UnrecoverableError("Not implemented.");
+        RecoverableError(Status::NotSupport("Not implemented"));
     }
 
     template <typename LeftType, typename RightType, typename ResultType, typename Operator>
@@ -1075,7 +1076,7 @@ private:
                                                          SizeT,
                                                          void *,
                                                          bool) {
-        UnrecoverableError("Not implemented.");
+        RecoverableError(Status::NotSupport("Not implemented"));
     }
 };
 

--- a/src/storage/definition/index_base.cpp
+++ b/src/storage/definition/index_base.cpp
@@ -26,6 +26,7 @@ import index_hnsw;
 import index_full_text;
 import index_secondary;
 import third_party;
+import status;
 
 import infinity_exception;
 import create_index_info;
@@ -135,7 +136,7 @@ SharedPtr<IndexBase> IndexBase::ReadAdv(char *&ptr, int32_t maxbytes) {
             UnrecoverableError("Error index method while reading");
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
     }
     if (ptr_end < ptr) {
@@ -212,7 +213,7 @@ SharedPtr<IndexBase> IndexBase::Deserialize(const nlohmann::json &index_def_json
             UnrecoverableError("Error index method while deserializing");
         }
         default: {
-            UnrecoverableError("Not implemented");
+            RecoverableError(Status::NotSupport("Not implemented"));
         }
     }
     return res;

--- a/src/storage/definition/index_full_text.cpp
+++ b/src/storage/definition/index_full_text.cpp
@@ -100,7 +100,7 @@ nlohmann::json IndexFullText::Serialize() const {
 }
 
 SharedPtr<IndexFullText> IndexFullText::Deserialize(const nlohmann::json &) {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
     return nullptr;
 }
 

--- a/src/storage/definition/index_ivfflat.cpp
+++ b/src/storage/definition/index_ivfflat.cpp
@@ -73,7 +73,7 @@ void IndexIVFFlat::WriteAdv(char *&ptr) const {
 }
 
 SharedPtr<IndexBase> IndexIVFFlat::ReadAdv(char *&, int32_t) {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
     return nullptr;
 }
 
@@ -91,7 +91,7 @@ nlohmann::json IndexIVFFlat::Serialize() const {
 }
 
 SharedPtr<IndexIVFFlat> IndexIVFFlat::Deserialize(const nlohmann::json &) {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
     return nullptr;
 }
 

--- a/src/storage/knn_index/ann_ivf/annivfflat_index_data.cppm
+++ b/src/storage/knn_index/ann_ivf/annivfflat_index_data.cppm
@@ -25,6 +25,7 @@ import kmeans_partition;
 import infinity_exception;
 import logger;
 import third_party;
+import status;
 
 namespace infinity {
 
@@ -61,9 +62,9 @@ struct AnnIVFFlatIndexData {
         }
         if (metric_ != MetricType::kMerticL2 && metric_ != MetricType::kMerticInnerProduct) {
             if (metric_ != MetricType::kInvalid) {
-                UnrecoverableError("Metric type not implemented");
+                RecoverableError(Status::NotSupport("Metric type not implemented"));
             } else {
-                UnrecoverableError("Metric type not supported");
+                RecoverableError(Status::NotSupport("Metric type not supported"));
             }
             return;
         }
@@ -100,9 +101,9 @@ struct AnnIVFFlatIndexData {
         }
         if (metric_ != MetricType::kMerticL2 && metric_ != MetricType::kMerticInnerProduct) {
             if (metric_ != MetricType::kInvalid) {
-                UnrecoverableError("Metric type not implemented");
+                RecoverableError(Status::NotSupport("Metric type not implemented"));
             } else {
-                UnrecoverableError("Metric type not supported");
+                RecoverableError(Status::NotSupport("Metric type not supported"));
             }
             return;
         }

--- a/src/storage/meta/entry/fulltext_index_entry.cpp
+++ b/src/storage/meta/entry/fulltext_index_entry.cpp
@@ -25,6 +25,7 @@ import index_base;
 import index_full_text;
 import logger;
 import catalog_delta_entry;
+import status;
 
 namespace infinity {
 
@@ -91,7 +92,7 @@ void FulltextIndexEntry::Cleanup() {
 }
 
 SharedPtr<String> FulltextIndexEntry::DetermineIndexDir(const String &, const String &) {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
     return nullptr;
 }
 

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -382,7 +382,7 @@ Status SegmentIndexEntry::CreateIndexDo(const IndexBase *index_base, const Colum
                                     break;
                                 }
                                 default: {
-                                    UnrecoverableError("Not implemented");
+                                    RecoverableError(Status::NotSupport("Not implemented"));
                                 }
                             }
                             break;
@@ -406,19 +406,19 @@ Status SegmentIndexEntry::CreateIndexDo(const IndexBase *index_base, const Colum
                                     break;
                                 }
                                 default: {
-                                    UnrecoverableError("Not implemented");
+                                    RecoverableError(Status::NotSupport("Not implemented"));
                                 }
                             }
                             break;
                         }
                         default: {
-                            UnrecoverableError("Not implemented");
+                            RecoverableError(Status::NotSupport("Not implemented"));
                         }
                     }
                     break;
                 }
                 default: {
-                    UnrecoverableError("Not implemented");
+                    RecoverableError(Status::NotSupport("Not implemented"));
                 }
             }
             break;
@@ -430,7 +430,7 @@ Status SegmentIndexEntry::CreateIndexDo(const IndexBase *index_base, const Colum
     return Status::OK();
 }
 
-void SegmentIndexEntry::UpdateIndex(TxnTimeStamp, FaissIndexPtr *, BufferManager *) { UnrecoverableError("Not implemented"); }
+void SegmentIndexEntry::UpdateIndex(TxnTimeStamp, FaissIndexPtr *, BufferManager *) { RecoverableError(Status::NotSupport("Not implemented")); }
 
 bool SegmentIndexEntry::Flush(TxnTimeStamp checkpoint_ts) {
     if (table_index_entry_->index_base()->index_type_ == IndexType::kFullText) {

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -248,7 +248,7 @@ TableIndexEntry::CreateIndexPrepare(TableEntry *table_entry, BlockIndex *block_i
 Status TableIndexEntry::CreateIndexDo(const TableEntry *table_entry, HashMap<SegmentID, atomic_u64> &create_index_idxes) {
     if (this->index_base_->column_names_.size() != 1) {
         // TODO
-        UnrecoverableError("Not implemented");
+        RecoverableError(Status::NotSupport("Not implemented"));
     }
     const String &column_name = this->index_base_->column_name();
     const auto *column_def = table_entry->GetColumnDefByName(column_name);

--- a/src/storage/meta/table_index_meta.cpp
+++ b/src/storage/meta/table_index_meta.cpp
@@ -127,7 +127,7 @@ TableIndexMeta::GetTableIndexInfo(std::shared_lock<std::shared_mutex> &&r_lock, 
 }
 
 SharedPtr<String> TableIndexMeta::ToString() {
-    UnrecoverableError("Not implemented");
+    RecoverableError(Status::NotSupport("Not implemented"));
     return nullptr;
 }
 

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -359,33 +359,27 @@ Tuple<SharedPtr<TableInfo>, Status> Txn::GetTableInfo(const String &db_name, con
 }
 
 Status Txn::CreateCollection(const String &, const String &, ConflictType, BaseEntry *&) {
-    UnrecoverableError("Not Implemented");
-    return {ErrorCode::kNotSupported, "Not Implemented"};
+    return {ErrorCode::kNotSupported, "Not Implemented Txn Operation: CreateCollection"};
 }
 
 Status Txn::GetCollectionByName(const String &, const String &, BaseEntry *&) {
-    UnrecoverableError("Not Implemented");
-    return {ErrorCode::kNotSupported, "Not Implemented"};
+    return {ErrorCode::kNotSupported, "Not Implemented Txn Operation: GetCollectionByName"};
 }
 
 Status Txn::CreateView(const String &, const String &, ConflictType, BaseEntry *&) {
-    UnrecoverableError("Not Implemented");
-    return {ErrorCode::kNotSupported, "Not Implemented"};
+    return {ErrorCode::kNotSupported, "Not Implemented Txn Operation: CreateView"};
 }
 
 Status Txn::DropViewByName(const String &, const String &, ConflictType, BaseEntry *&) {
-    UnrecoverableError("Not Implemented");
-    return {ErrorCode::kNotSupported, "Not Implemented"};
+    return {ErrorCode::kNotSupported, "Not Implemented Txn Operation: DropViewByName"};
 }
 
 Status Txn::GetViewByName(const String &, const String &, BaseEntry *&) {
-    UnrecoverableError("Not Implemented");
-    return {ErrorCode::kNotSupported, "Not Implemented"};
+    return {ErrorCode::kNotSupported, "Not Implemented Txn Operation: GetViewByName"};
 }
 
 Status Txn::GetViews(const String &, Vector<ViewDetail> &output_view_array) {
-    UnrecoverableError("Not Implemented");
-    return {ErrorCode::kNotSupported, "Not Implemented"};
+    return {ErrorCode::kNotSupported, "Not Implemented Txn Operation: GetViews"};
 }
 
 void Txn::Begin() {

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -587,7 +587,7 @@ void WalManager::ReplayWalEntry(const WalEntry &entry) {
                 WalCmdDropTableReplay(*dynamic_cast<const WalCmdDropTable *>(cmd.get()), entry.txn_id_, entry.commit_ts_);
                 break;
             case WalCommandType::ALTER_INFO:
-                UnrecoverableError("WalCmdAlterInfo Replay Not implemented");
+                RecoverableError(Status::NotSupport("WalCmdAlterInfo Replay Not implemented"));
                 break;
             case WalCommandType::CREATE_INDEX:
                 WalCmdCreateIndexReplay(*dynamic_cast<const WalCmdCreateIndex *>(cmd.get()), entry.txn_id_, entry.commit_ts_);


### PR DESCRIPTION
### What problem does this PR solve?

When using cosine distance as KNN distance which is not supported yet, the service crash down.
Now replace all not implemented exceptions into `RecoverableError` to avoid service crashes.

Issue link:#775

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
