### PR TITLE
Fix show database, always show 'default' db fault

### DIFF
--- a/python/infinity/remote_thrift/client.py
+++ b/python/infinity/remote_thrift/client.py
@@ -109,6 +109,17 @@ class ThriftInfinityClient:
                                                       index_name=index_name,
                                                       drop_option=DropOption(conflict_type=conflict_type)))
 
+    def show_index(self, db_name: str, table_name: str, index_name: str):
+        return self.client.ShowIndex(ShowIndexRequest(session_id=self.session_id,
+                                                      db_name=db_name,
+                                                      table_name=table_name,
+                                                      index_name=index_name))
+
+    def list_indexes(self, db_name: str, table_name: str):
+        return self.client.ListIndex(ListIndexRequest(session_id=self.session_id,
+                                                      db_name=db_name,
+                                                      table_name=table_name))
+
     def insert(self, db_name: str, table_name: str, column_names: list[str], fields: list[Field]):
         return self.client.Insert(InsertRequest(session_id=self.session_id,
                                                 db_name=db_name,

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService-remote
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService-remote
@@ -39,6 +39,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('  UploadResponse UploadFileChunk(FileChunk request)')
     print('  ListDatabaseResponse ListDatabase(ListDatabaseRequest request)')
     print('  ListTableResponse ListTable(ListTableRequest request)')
+    print('  ListIndexResponse ListIndex(ListIndexRequest request)')
     print('  SelectResponse ShowVariable(ShowVariableRequest request)')
     print('  ShowTableResponse ShowTable(ShowTableRequest request)')
     print('  SelectResponse ShowColumns(ShowColumnsRequest request)')
@@ -217,6 +218,12 @@ elif cmd == 'ListTable':
         print('ListTable requires 1 args')
         sys.exit(1)
     pp.pprint(client.ListTable(eval(args[0]),))
+
+elif cmd == 'ListIndex':
+    if len(args) != 1:
+        print('ListIndex requires 1 args')
+        sys.exit(1)
+    pp.pprint(client.ListIndex(eval(args[0]),))
 
 elif cmd == 'ShowVariable':
     if len(args) != 1:

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService.py
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/InfinityService.py
@@ -134,6 +134,14 @@ class Iface(object):
         """
         pass
 
+    def ListIndex(self, request):
+        """
+        Parameters:
+         - request
+
+        """
+        pass
+
     def ShowVariable(self, request):
         """
         Parameters:
@@ -696,6 +704,38 @@ class Client(Iface):
             return result.success
         raise TApplicationException(TApplicationException.MISSING_RESULT, "ListTable failed: unknown result")
 
+    def ListIndex(self, request):
+        """
+        Parameters:
+         - request
+
+        """
+        self.send_ListIndex(request)
+        return self.recv_ListIndex()
+
+    def send_ListIndex(self, request):
+        self._oprot.writeMessageBegin('ListIndex', TMessageType.CALL, self._seqid)
+        args = ListIndex_args()
+        args.request = request
+        args.write(self._oprot)
+        self._oprot.writeMessageEnd()
+        self._oprot.trans.flush()
+
+    def recv_ListIndex(self):
+        iprot = self._iprot
+        (fname, mtype, rseqid) = iprot.readMessageBegin()
+        if mtype == TMessageType.EXCEPTION:
+            x = TApplicationException()
+            x.read(iprot)
+            iprot.readMessageEnd()
+            raise x
+        result = ListIndex_result()
+        result.read(iprot)
+        iprot.readMessageEnd()
+        if result.success is not None:
+            return result.success
+        raise TApplicationException(TApplicationException.MISSING_RESULT, "ListIndex failed: unknown result")
+
     def ShowVariable(self, request):
         """
         Parameters:
@@ -1036,6 +1076,7 @@ class Processor(Iface, TProcessor):
         self._processMap["UploadFileChunk"] = Processor.process_UploadFileChunk
         self._processMap["ListDatabase"] = Processor.process_ListDatabase
         self._processMap["ListTable"] = Processor.process_ListTable
+        self._processMap["ListIndex"] = Processor.process_ListIndex
         self._processMap["ShowVariable"] = Processor.process_ShowVariable
         self._processMap["ShowTable"] = Processor.process_ShowTable
         self._processMap["ShowColumns"] = Processor.process_ShowColumns
@@ -1409,6 +1450,29 @@ class Processor(Iface, TProcessor):
             msg_type = TMessageType.EXCEPTION
             result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
         oprot.writeMessageBegin("ListTable", msg_type, seqid)
+        result.write(oprot)
+        oprot.writeMessageEnd()
+        oprot.trans.flush()
+
+    def process_ListIndex(self, seqid, iprot, oprot):
+        args = ListIndex_args()
+        args.read(iprot)
+        iprot.readMessageEnd()
+        result = ListIndex_result()
+        try:
+            result.success = self._handler.ListIndex(args.request)
+            msg_type = TMessageType.REPLY
+        except TTransport.TTransportException:
+            raise
+        except TApplicationException as ex:
+            logging.exception('TApplication exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = ex
+        except Exception:
+            logging.exception('Unexpected exception in handler')
+            msg_type = TMessageType.EXCEPTION
+            result = TApplicationException(TApplicationException.INTERNAL_ERROR, 'Internal error')
+        oprot.writeMessageBegin("ListIndex", msg_type, seqid)
         result.write(oprot)
         oprot.writeMessageEnd()
         oprot.trans.flush()
@@ -3498,6 +3562,131 @@ class ListTable_result(object):
 all_structs.append(ListTable_result)
 ListTable_result.thrift_spec = (
     (0, TType.STRUCT, 'success', [ListTableResponse, None], None, ),  # 0
+)
+
+
+class ListIndex_args(object):
+    """
+    Attributes:
+     - request
+
+    """
+
+
+    def __init__(self, request=None,):
+        self.request = request
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.STRUCT:
+                    self.request = ListIndexRequest()
+                    self.request.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ListIndex_args')
+        if self.request is not None:
+            oprot.writeFieldBegin('request', TType.STRUCT, 1)
+            self.request.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(ListIndex_args)
+ListIndex_args.thrift_spec = (
+    None,  # 0
+    (1, TType.STRUCT, 'request', [ListIndexRequest, None], None, ),  # 1
+)
+
+
+class ListIndex_result(object):
+    """
+    Attributes:
+     - success
+
+    """
+
+
+    def __init__(self, success=None,):
+        self.success = success
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 0:
+                if ftype == TType.STRUCT:
+                    self.success = ListIndexResponse()
+                    self.success.read(iprot)
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ListIndex_result')
+        if self.success is not None:
+            oprot.writeFieldBegin('success', TType.STRUCT, 0)
+            self.success.write(oprot)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+all_structs.append(ListIndex_result)
+ListIndex_result.thrift_spec = (
+    (0, TType.STRUCT, 'success', [ListIndexResponse, None], None, ),  # 0
 )
 
 

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/infinity.thrift
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/infinity.thrift
@@ -275,6 +275,18 @@ struct ListTableResponse {
 3: list<string> table_names = [],
 }
 
+struct ListIndexRequest {
+1: string db_name,
+2: string table_name,
+3: i64 session_id,
+}
+
+struct ListIndexResponse {
+1: i64 error_code,
+2: string error_msg,
+3: list<string> index_names = [],
+}
+
 struct ShowDatabaseRequest {
 1: string db_name,
 2: i64 session_id,
@@ -355,10 +367,13 @@ struct ShowIndexRequest {
 }
 
 struct ShowIndexResponse {
-1: string db_name,
-2: string table_name,
-3: string index_name,
-4: string store_dir,
+1: i64 error_code,
+2: string error_msg,
+3: string db_name,
+4: string table_name,
+5: string index_name,
+6: string store_dir,
+7: string index_info,
 }
 
 struct GetDatabaseRequest {
@@ -518,6 +533,7 @@ UploadResponse UploadFileChunk(1:FileChunk request),
 
 ListDatabaseResponse ListDatabase(1:ListDatabaseRequest request),
 ListTableResponse ListTable(1:ListTableRequest request),
+ListIndexResponse ListIndex(1:ListIndexRequest request),
 
 SelectResponse ShowVariable(1:ShowVariableRequest request),
 ShowTableResponse ShowTable(1:ShowTableRequest request),

--- a/python/infinity/remote_thrift/infinity_thrift_rpc/ttypes.py
+++ b/python/infinity/remote_thrift/infinity_thrift_rpc/ttypes.py
@@ -3037,6 +3037,176 @@ class ListTableResponse(object):
         return not (self == other)
 
 
+class ListIndexRequest(object):
+    """
+    Attributes:
+     - db_name
+     - table_name
+     - session_id
+
+    """
+
+
+    def __init__(self, db_name=None, table_name=None, session_id=None,):
+        self.db_name = db_name
+        self.table_name = table_name
+        self.session_id = session_id
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.STRING:
+                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRING:
+                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.I64:
+                    self.session_id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ListIndexRequest')
+        if self.db_name is not None:
+            oprot.writeFieldBegin('db_name', TType.STRING, 1)
+            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeFieldEnd()
+        if self.table_name is not None:
+            oprot.writeFieldBegin('table_name', TType.STRING, 2)
+            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeFieldEnd()
+        if self.session_id is not None:
+            oprot.writeFieldBegin('session_id', TType.I64, 3)
+            oprot.writeI64(self.session_id)
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
+class ListIndexResponse(object):
+    """
+    Attributes:
+     - error_code
+     - error_msg
+     - index_names
+
+    """
+
+
+    def __init__(self, error_code=None, error_msg=None, index_names=[
+    ],):
+        self.error_code = error_code
+        self.error_msg = error_msg
+        if index_names is self.thrift_spec[3][4]:
+            index_names = [
+            ]
+        self.index_names = index_names
+
+    def read(self, iprot):
+        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
+            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
+            return
+        iprot.readStructBegin()
+        while True:
+            (fname, ftype, fid) = iprot.readFieldBegin()
+            if ftype == TType.STOP:
+                break
+            if fid == 1:
+                if ftype == TType.I64:
+                    self.error_code = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRING:
+                    self.error_msg = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.LIST:
+                    self.index_names = []
+                    (_etype143, _size140) = iprot.readListBegin()
+                    for _i144 in range(_size140):
+                        _elem145 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.index_names.append(_elem145)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
+            else:
+                iprot.skip(ftype)
+            iprot.readFieldEnd()
+        iprot.readStructEnd()
+
+    def write(self, oprot):
+        if oprot._fast_encode is not None and self.thrift_spec is not None:
+            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
+            return
+        oprot.writeStructBegin('ListIndexResponse')
+        if self.error_code is not None:
+            oprot.writeFieldBegin('error_code', TType.I64, 1)
+            oprot.writeI64(self.error_code)
+            oprot.writeFieldEnd()
+        if self.error_msg is not None:
+            oprot.writeFieldBegin('error_msg', TType.STRING, 2)
+            oprot.writeString(self.error_msg.encode('utf-8') if sys.version_info[0] == 2 else self.error_msg)
+            oprot.writeFieldEnd()
+        if self.index_names is not None:
+            oprot.writeFieldBegin('index_names', TType.LIST, 3)
+            oprot.writeListBegin(TType.STRING, len(self.index_names))
+            for iter146 in self.index_names:
+                oprot.writeString(iter146.encode('utf-8') if sys.version_info[0] == 2 else iter146)
+            oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        oprot.writeFieldStop()
+        oprot.writeStructEnd()
+
+    def validate(self):
+        return
+
+    def __repr__(self):
+        L = ['%s=%r' % (key, value)
+             for key, value in self.__dict__.items()]
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not (self == other)
+
+
 class ShowDatabaseRequest(object):
     """
     Attributes:
@@ -3618,11 +3788,11 @@ class IndexInfo(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.index_param_list = []
-                    (_etype143, _size140) = iprot.readListBegin()
-                    for _i144 in range(_size140):
-                        _elem145 = InitParameter()
-                        _elem145.read(iprot)
-                        self.index_param_list.append(_elem145)
+                    (_etype150, _size147) = iprot.readListBegin()
+                    for _i151 in range(_size147):
+                        _elem152 = InitParameter()
+                        _elem152.read(iprot)
+                        self.index_param_list.append(_elem152)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3647,8 +3817,8 @@ class IndexInfo(object):
         if self.index_param_list is not None:
             oprot.writeFieldBegin('index_param_list', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.index_param_list))
-            for iter146 in self.index_param_list:
-                iter146.write(oprot)
+            for iter153 in self.index_param_list:
+                iter153.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3721,11 +3891,11 @@ class CreateIndexRequest(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.index_info_list = []
-                    (_etype150, _size147) = iprot.readListBegin()
-                    for _i151 in range(_size147):
-                        _elem152 = IndexInfo()
-                        _elem152.read(iprot)
-                        self.index_info_list.append(_elem152)
+                    (_etype157, _size154) = iprot.readListBegin()
+                    for _i158 in range(_size154):
+                        _elem159 = IndexInfo()
+                        _elem159.read(iprot)
+                        self.index_info_list.append(_elem159)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3765,8 +3935,8 @@ class CreateIndexRequest(object):
         if self.index_info_list is not None:
             oprot.writeFieldBegin('index_info_list', TType.LIST, 5)
             oprot.writeListBegin(TType.STRUCT, len(self.index_info_list))
-            for iter153 in self.index_info_list:
-                iter153.write(oprot)
+            for iter160 in self.index_info_list:
+                iter160.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.session_id is not None:
@@ -3990,19 +4160,25 @@ class ShowIndexRequest(object):
 class ShowIndexResponse(object):
     """
     Attributes:
+     - error_code
+     - error_msg
      - db_name
      - table_name
      - index_name
      - store_dir
+     - index_info
 
     """
 
 
-    def __init__(self, db_name=None, table_name=None, index_name=None, store_dir=None,):
+    def __init__(self, error_code=None, error_msg=None, db_name=None, table_name=None, index_name=None, store_dir=None, index_info=None,):
+        self.error_code = error_code
+        self.error_msg = error_msg
         self.db_name = db_name
         self.table_name = table_name
         self.index_name = index_name
         self.store_dir = store_dir
+        self.index_info = index_info
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -4014,23 +4190,38 @@ class ShowIndexResponse(object):
             if ftype == TType.STOP:
                 break
             if fid == 1:
-                if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                if ftype == TType.I64:
+                    self.error_code = iprot.readI64()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.error_msg = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.index_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
+                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 5:
+                if ftype == TType.STRING:
+                    self.index_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRING:
                     self.store_dir = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.STRING:
+                    self.index_info = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4043,21 +4234,33 @@ class ShowIndexResponse(object):
             oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
             return
         oprot.writeStructBegin('ShowIndexResponse')
+        if self.error_code is not None:
+            oprot.writeFieldBegin('error_code', TType.I64, 1)
+            oprot.writeI64(self.error_code)
+            oprot.writeFieldEnd()
+        if self.error_msg is not None:
+            oprot.writeFieldBegin('error_msg', TType.STRING, 2)
+            oprot.writeString(self.error_msg.encode('utf-8') if sys.version_info[0] == 2 else self.error_msg)
+            oprot.writeFieldEnd()
         if self.db_name is not None:
-            oprot.writeFieldBegin('db_name', TType.STRING, 1)
+            oprot.writeFieldBegin('db_name', TType.STRING, 3)
             oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
             oprot.writeFieldEnd()
         if self.table_name is not None:
-            oprot.writeFieldBegin('table_name', TType.STRING, 2)
+            oprot.writeFieldBegin('table_name', TType.STRING, 4)
             oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
             oprot.writeFieldEnd()
         if self.index_name is not None:
-            oprot.writeFieldBegin('index_name', TType.STRING, 3)
+            oprot.writeFieldBegin('index_name', TType.STRING, 5)
             oprot.writeString(self.index_name.encode('utf-8') if sys.version_info[0] == 2 else self.index_name)
             oprot.writeFieldEnd()
         if self.store_dir is not None:
-            oprot.writeFieldBegin('store_dir', TType.STRING, 4)
+            oprot.writeFieldBegin('store_dir', TType.STRING, 6)
             oprot.writeString(self.store_dir.encode('utf-8') if sys.version_info[0] == 2 else self.store_dir)
+            oprot.writeFieldEnd()
+        if self.index_info is not None:
+            oprot.writeFieldBegin('index_info', TType.STRING, 7)
+            oprot.writeString(self.index_info.encode('utf-8') if sys.version_info[0] == 2 else self.index_info)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4350,11 +4553,11 @@ class CreateTableRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.column_defs = []
-                    (_etype157, _size154) = iprot.readListBegin()
-                    for _i158 in range(_size154):
-                        _elem159 = ColumnDef()
-                        _elem159.read(iprot)
-                        self.column_defs.append(_elem159)
+                    (_etype164, _size161) = iprot.readListBegin()
+                    for _i165 in range(_size161):
+                        _elem166 = ColumnDef()
+                        _elem166.read(iprot)
+                        self.column_defs.append(_elem166)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4390,8 +4593,8 @@ class CreateTableRequest(object):
         if self.column_defs is not None:
             oprot.writeFieldBegin('column_defs', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.column_defs))
-            for iter160 in self.column_defs:
-                iter160.write(oprot)
+            for iter167 in self.column_defs:
+                iter167.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.session_id is not None:
@@ -4560,21 +4763,21 @@ class InsertRequest(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.column_names = []
-                    (_etype164, _size161) = iprot.readListBegin()
-                    for _i165 in range(_size161):
-                        _elem166 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.column_names.append(_elem166)
+                    (_etype171, _size168) = iprot.readListBegin()
+                    for _i172 in range(_size168):
+                        _elem173 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.column_names.append(_elem173)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.fields = []
-                    (_etype170, _size167) = iprot.readListBegin()
-                    for _i171 in range(_size167):
-                        _elem172 = Field()
-                        _elem172.read(iprot)
-                        self.fields.append(_elem172)
+                    (_etype177, _size174) = iprot.readListBegin()
+                    for _i178 in range(_size174):
+                        _elem179 = Field()
+                        _elem179.read(iprot)
+                        self.fields.append(_elem179)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4604,15 +4807,15 @@ class InsertRequest(object):
         if self.column_names is not None:
             oprot.writeFieldBegin('column_names', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.column_names))
-            for iter173 in self.column_names:
-                oprot.writeString(iter173.encode('utf-8') if sys.version_info[0] == 2 else iter173)
+            for iter180 in self.column_names:
+                oprot.writeString(iter180.encode('utf-8') if sys.version_info[0] == 2 else iter180)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.fields is not None:
             oprot.writeFieldBegin('fields', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.fields))
-            for iter174 in self.fields:
-                iter174.write(oprot)
+            for iter181 in self.fields:
+                iter181.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.session_id is not None:
@@ -4956,11 +5159,11 @@ class ExplainRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.select_list = []
-                    (_etype178, _size175) = iprot.readListBegin()
-                    for _i179 in range(_size175):
-                        _elem180 = ParsedExpr()
-                        _elem180.read(iprot)
-                        self.select_list.append(_elem180)
+                    (_etype185, _size182) = iprot.readListBegin()
+                    for _i186 in range(_size182):
+                        _elem187 = ParsedExpr()
+                        _elem187.read(iprot)
+                        self.select_list.append(_elem187)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4979,11 +5182,11 @@ class ExplainRequest(object):
             elif fid == 7:
                 if ftype == TType.LIST:
                     self.group_by_list = []
-                    (_etype184, _size181) = iprot.readListBegin()
-                    for _i185 in range(_size181):
-                        _elem186 = ParsedExpr()
-                        _elem186.read(iprot)
-                        self.group_by_list.append(_elem186)
+                    (_etype191, _size188) = iprot.readListBegin()
+                    for _i192 in range(_size188):
+                        _elem193 = ParsedExpr()
+                        _elem193.read(iprot)
+                        self.group_by_list.append(_elem193)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5008,11 +5211,11 @@ class ExplainRequest(object):
             elif fid == 11:
                 if ftype == TType.LIST:
                     self.order_by_list = []
-                    (_etype190, _size187) = iprot.readListBegin()
-                    for _i191 in range(_size187):
-                        _elem192 = OrderByExpr()
-                        _elem192.read(iprot)
-                        self.order_by_list.append(_elem192)
+                    (_etype197, _size194) = iprot.readListBegin()
+                    for _i198 in range(_size194):
+                        _elem199 = OrderByExpr()
+                        _elem199.read(iprot)
+                        self.order_by_list.append(_elem199)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5046,8 +5249,8 @@ class ExplainRequest(object):
         if self.select_list is not None:
             oprot.writeFieldBegin('select_list', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.select_list))
-            for iter193 in self.select_list:
-                iter193.write(oprot)
+            for iter200 in self.select_list:
+                iter200.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.search_expr is not None:
@@ -5061,8 +5264,8 @@ class ExplainRequest(object):
         if self.group_by_list is not None:
             oprot.writeFieldBegin('group_by_list', TType.LIST, 7)
             oprot.writeListBegin(TType.STRUCT, len(self.group_by_list))
-            for iter194 in self.group_by_list:
-                iter194.write(oprot)
+            for iter201 in self.group_by_list:
+                iter201.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.having_expr is not None:
@@ -5080,8 +5283,8 @@ class ExplainRequest(object):
         if self.order_by_list is not None:
             oprot.writeFieldBegin('order_by_list', TType.LIST, 11)
             oprot.writeListBegin(TType.STRUCT, len(self.order_by_list))
-            for iter195 in self.order_by_list:
-                iter195.write(oprot)
+            for iter202 in self.order_by_list:
+                iter202.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.explain_type is not None:
@@ -5153,22 +5356,22 @@ class ExplainResponse(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.column_defs = []
-                    (_etype199, _size196) = iprot.readListBegin()
-                    for _i200 in range(_size196):
-                        _elem201 = ColumnDef()
-                        _elem201.read(iprot)
-                        self.column_defs.append(_elem201)
+                    (_etype206, _size203) = iprot.readListBegin()
+                    for _i207 in range(_size203):
+                        _elem208 = ColumnDef()
+                        _elem208.read(iprot)
+                        self.column_defs.append(_elem208)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.column_fields = []
-                    (_etype205, _size202) = iprot.readListBegin()
-                    for _i206 in range(_size202):
-                        _elem207 = ColumnField()
-                        _elem207.read(iprot)
-                        self.column_fields.append(_elem207)
+                    (_etype212, _size209) = iprot.readListBegin()
+                    for _i213 in range(_size209):
+                        _elem214 = ColumnField()
+                        _elem214.read(iprot)
+                        self.column_fields.append(_elem214)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5193,15 +5396,15 @@ class ExplainResponse(object):
         if self.column_defs is not None:
             oprot.writeFieldBegin('column_defs', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.column_defs))
-            for iter208 in self.column_defs:
-                iter208.write(oprot)
+            for iter215 in self.column_defs:
+                iter215.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.column_fields is not None:
             oprot.writeFieldBegin('column_fields', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.column_fields))
-            for iter209 in self.column_fields:
-                iter209.write(oprot)
+            for iter216 in self.column_fields:
+                iter216.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -5292,11 +5495,11 @@ class SelectRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.select_list = []
-                    (_etype213, _size210) = iprot.readListBegin()
-                    for _i214 in range(_size210):
-                        _elem215 = ParsedExpr()
-                        _elem215.read(iprot)
-                        self.select_list.append(_elem215)
+                    (_etype220, _size217) = iprot.readListBegin()
+                    for _i221 in range(_size217):
+                        _elem222 = ParsedExpr()
+                        _elem222.read(iprot)
+                        self.select_list.append(_elem222)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5315,11 +5518,11 @@ class SelectRequest(object):
             elif fid == 7:
                 if ftype == TType.LIST:
                     self.group_by_list = []
-                    (_etype219, _size216) = iprot.readListBegin()
-                    for _i220 in range(_size216):
-                        _elem221 = ParsedExpr()
-                        _elem221.read(iprot)
-                        self.group_by_list.append(_elem221)
+                    (_etype226, _size223) = iprot.readListBegin()
+                    for _i227 in range(_size223):
+                        _elem228 = ParsedExpr()
+                        _elem228.read(iprot)
+                        self.group_by_list.append(_elem228)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5344,11 +5547,11 @@ class SelectRequest(object):
             elif fid == 11:
                 if ftype == TType.LIST:
                     self.order_by_list = []
-                    (_etype225, _size222) = iprot.readListBegin()
-                    for _i226 in range(_size222):
-                        _elem227 = OrderByExpr()
-                        _elem227.read(iprot)
-                        self.order_by_list.append(_elem227)
+                    (_etype232, _size229) = iprot.readListBegin()
+                    for _i233 in range(_size229):
+                        _elem234 = OrderByExpr()
+                        _elem234.read(iprot)
+                        self.order_by_list.append(_elem234)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5377,8 +5580,8 @@ class SelectRequest(object):
         if self.select_list is not None:
             oprot.writeFieldBegin('select_list', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.select_list))
-            for iter228 in self.select_list:
-                iter228.write(oprot)
+            for iter235 in self.select_list:
+                iter235.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.search_expr is not None:
@@ -5392,8 +5595,8 @@ class SelectRequest(object):
         if self.group_by_list is not None:
             oprot.writeFieldBegin('group_by_list', TType.LIST, 7)
             oprot.writeListBegin(TType.STRUCT, len(self.group_by_list))
-            for iter229 in self.group_by_list:
-                iter229.write(oprot)
+            for iter236 in self.group_by_list:
+                iter236.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.having_expr is not None:
@@ -5411,8 +5614,8 @@ class SelectRequest(object):
         if self.order_by_list is not None:
             oprot.writeFieldBegin('order_by_list', TType.LIST, 11)
             oprot.writeListBegin(TType.STRUCT, len(self.order_by_list))
-            for iter230 in self.order_by_list:
-                iter230.write(oprot)
+            for iter237 in self.order_by_list:
+                iter237.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -5480,22 +5683,22 @@ class SelectResponse(object):
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.column_defs = []
-                    (_etype234, _size231) = iprot.readListBegin()
-                    for _i235 in range(_size231):
-                        _elem236 = ColumnDef()
-                        _elem236.read(iprot)
-                        self.column_defs.append(_elem236)
+                    (_etype241, _size238) = iprot.readListBegin()
+                    for _i242 in range(_size238):
+                        _elem243 = ColumnDef()
+                        _elem243.read(iprot)
+                        self.column_defs.append(_elem243)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.column_fields = []
-                    (_etype240, _size237) = iprot.readListBegin()
-                    for _i241 in range(_size237):
-                        _elem242 = ColumnField()
-                        _elem242.read(iprot)
-                        self.column_fields.append(_elem242)
+                    (_etype247, _size244) = iprot.readListBegin()
+                    for _i248 in range(_size244):
+                        _elem249 = ColumnField()
+                        _elem249.read(iprot)
+                        self.column_fields.append(_elem249)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5520,15 +5723,15 @@ class SelectResponse(object):
         if self.column_defs is not None:
             oprot.writeFieldBegin('column_defs', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.column_defs))
-            for iter243 in self.column_defs:
-                iter243.write(oprot)
+            for iter250 in self.column_defs:
+                iter250.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.column_fields is not None:
             oprot.writeFieldBegin('column_fields', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.column_fields))
-            for iter244 in self.column_fields:
-                iter244.write(oprot)
+            for iter251 in self.column_fields:
+                iter251.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -5691,11 +5894,11 @@ class UpdateRequest(object):
             elif fid == 4:
                 if ftype == TType.LIST:
                     self.update_expr_array = []
-                    (_etype248, _size245) = iprot.readListBegin()
-                    for _i249 in range(_size245):
-                        _elem250 = UpdateExpr()
-                        _elem250.read(iprot)
-                        self.update_expr_array.append(_elem250)
+                    (_etype255, _size252) = iprot.readListBegin()
+                    for _i256 in range(_size252):
+                        _elem257 = UpdateExpr()
+                        _elem257.read(iprot)
+                        self.update_expr_array.append(_elem257)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5729,8 +5932,8 @@ class UpdateRequest(object):
         if self.update_expr_array is not None:
             oprot.writeFieldBegin('update_expr_array', TType.LIST, 4)
             oprot.writeListBegin(TType.STRUCT, len(self.update_expr_array))
-            for iter251 in self.update_expr_array:
-                iter251.write(oprot)
+            for iter258 in self.update_expr_array:
+                iter258.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.session_id is not None:
@@ -6118,6 +6321,21 @@ ListTableResponse.thrift_spec = (
     (3, TType.LIST, 'table_names', (TType.STRING, 'UTF8', False), [
     ], ),  # 3
 )
+all_structs.append(ListIndexRequest)
+ListIndexRequest.thrift_spec = (
+    None,  # 0
+    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
+    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
+    (3, TType.I64, 'session_id', None, None, ),  # 3
+)
+all_structs.append(ListIndexResponse)
+ListIndexResponse.thrift_spec = (
+    None,  # 0
+    (1, TType.I64, 'error_code', None, None, ),  # 1
+    (2, TType.STRING, 'error_msg', 'UTF8', None, ),  # 2
+    (3, TType.LIST, 'index_names', (TType.STRING, 'UTF8', False), [
+    ], ),  # 3
+)
 all_structs.append(ShowDatabaseRequest)
 ShowDatabaseRequest.thrift_spec = (
     None,  # 0
@@ -6206,10 +6424,13 @@ ShowIndexRequest.thrift_spec = (
 all_structs.append(ShowIndexResponse)
 ShowIndexResponse.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'index_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'store_dir', 'UTF8', None, ),  # 4
+    (1, TType.I64, 'error_code', None, None, ),  # 1
+    (2, TType.STRING, 'error_msg', 'UTF8', None, ),  # 2
+    (3, TType.STRING, 'db_name', 'UTF8', None, ),  # 3
+    (4, TType.STRING, 'table_name', 'UTF8', None, ),  # 4
+    (5, TType.STRING, 'index_name', 'UTF8', None, ),  # 5
+    (6, TType.STRING, 'store_dir', 'UTF8', None, ),  # 6
+    (7, TType.STRING, 'index_info', 'UTF8', None, ),  # 7
 )
 all_structs.append(GetDatabaseRequest)
 GetDatabaseRequest.thrift_spec = (

--- a/python/infinity/remote_thrift/table.py
+++ b/python/infinity/remote_thrift/table.py
@@ -91,6 +91,23 @@ class RemoteTable(Table, ABC):
         else:
             raise Exception(f"ERROR:{res.error_code}, {res.error_msg}")
 
+    def show_index(self, index_name: str):
+
+        check_valid_name(index_name, "Index")
+        res = self._conn.show_index(db_name=self._db_name, table_name=self._table_name, index_name=index_name)
+
+        if res.error_code == ErrorCode.OK:
+            return res
+        else:
+            raise Exception(f"ERROR:{res.error_code}, {res.error_msg}")
+
+    def list_indexes(self):
+        res = self._conn.list_indexes(db_name=self._db_name, table_name=self._table_name)
+        if res.error_code == ErrorCode.OK:
+            return res
+        else:
+            raise Exception(f"ERROR:{res.error_code}, {res.error_msg}")
+
     def insert(self, data: Union[INSERT_DATA, list[INSERT_DATA]]):
         # [{"c1": 1, "c2": 1.1}, {"c1": 2, "c2": 2.2}]
         db_name = self._db_name

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infinity_sdk"
-version = "0.1.0-dev10"
+version = "0.1.0-dev11"
 dependencies = [
     "sqlglot==11.7.1",
     "pydantic",

--- a/python/test/test_index.py
+++ b/python/test/test_index.py
@@ -232,7 +232,6 @@ class TestIndex:
                                                        index.InitParameter("metric", "l2")])], ConflictType.Error)
 
     # drop index then show index
-    @pytest.mark.skip(reason="Not support for showing index yet.")
     def test_drop_index_show_index(self, get_infinity_db):
         # connect
         db_obj = get_infinity_db
@@ -245,6 +244,13 @@ class TestIndex:
                                                       index.IndexType.IVFFlat,
                                                       [index.InitParameter("centroids_count", "128"),
                                                        index.InitParameter("metric", "l2")])], ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
+        res = table_obj.show_index("my_index")
+        assert res.error_code == ErrorCode.OK
+
+        res = table_obj.list_indexes()
+        assert res.error_code == ErrorCode.OK
 
         table_obj.drop_index("my_index")
 

--- a/src/main/infinity.cpp
+++ b/src/main/infinity.cpp
@@ -390,6 +390,22 @@ Infinity::DropIndex(const String &db_name, const String &table_name, const Strin
     return result;
 }
 
+QueryResult Infinity::ShowIndex(const String &db_name, const String &table_name, const String &index_name) {
+    UniquePtr<QueryContext> query_context_ptr = MakeUnique<QueryContext>(session_.get());
+    query_context_ptr->Init(InfinityContext::instance().config(),
+                            InfinityContext::instance().task_scheduler(),
+                            InfinityContext::instance().storage(),
+                            InfinityContext::instance().resource_manager(),
+                            InfinityContext::instance().session_manager());
+    UniquePtr<ShowStatement> show_statement = MakeUnique<ShowStatement>();
+    show_statement->schema_name_ = db_name;
+    show_statement->table_name_ = table_name;
+    show_statement->index_name_ = index_name;
+    show_statement->show_type_ = ShowStmtType::kIndex;
+    QueryResult result = query_context_ptr->QueryStatement(show_statement.get());
+    return result;
+}
+
 QueryResult Infinity::Insert(const String &db_name, const String &table_name, Vector<String> *columns, Vector<Vector<ParsedExpr *> *> *values) {
     UniquePtr<QueryContext> query_context_ptr = MakeUnique<QueryContext>(session_.get());
     query_context_ptr->Init(InfinityContext::instance().config(),

--- a/src/main/infinity.cppm
+++ b/src/main/infinity.cppm
@@ -103,6 +103,8 @@ public:
 
     QueryResult DropIndex(const String &db_name, const String &table_name, const String &index_name, const DropIndexOptions &drop_index_option);
 
+    QueryResult ShowIndex(const String &db_name, const String &table_name, const String &index_name);
+
     QueryResult Insert(const String &db_name, const String &table_name, Vector<String> *columns, Vector<Vector<ParsedExpr *> *> *values);
 
     QueryResult Import(const String &db_name, const String &table_name, const String &path, ImportOptions import_options);

--- a/src/network/infinity_thrift/InfinityService.cpp
+++ b/src/network/infinity_thrift/InfinityService.cpp
@@ -2793,6 +2793,193 @@ uint32_t InfinityService_ListTable_presult::read(::apache::thrift::protocol::TPr
 }
 
 
+InfinityService_ListIndex_args::~InfinityService_ListIndex_args() noexcept {
+}
+
+
+uint32_t InfinityService_ListIndex_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->request.read(iprot);
+          this->__isset.request = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t InfinityService_ListIndex_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("InfinityService_ListIndex_args");
+
+  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += this->request.write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_ListIndex_pargs::~InfinityService_ListIndex_pargs() noexcept {
+}
+
+
+uint32_t InfinityService_ListIndex_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("InfinityService_ListIndex_pargs");
+
+  xfer += oprot->writeFieldBegin("request", ::apache::thrift::protocol::T_STRUCT, 1);
+  xfer += (*(this->request)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_ListIndex_result::~InfinityService_ListIndex_result() noexcept {
+}
+
+
+uint32_t InfinityService_ListIndex_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->success.read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t InfinityService_ListIndex_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+
+  uint32_t xfer = 0;
+
+  xfer += oprot->writeStructBegin("InfinityService_ListIndex_result");
+
+  if (this->__isset.success) {
+    xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_STRUCT, 0);
+    xfer += this->success.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+
+InfinityService_ListIndex_presult::~InfinityService_ListIndex_presult() noexcept {
+}
+
+
+uint32_t InfinityService_ListIndex_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += (*(this->success)).read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+
 InfinityService_ShowVariable_args::~InfinityService_ShowVariable_args() noexcept {
 }
 
@@ -5531,6 +5718,64 @@ void InfinityServiceClient::recv_ListTable(ListTableResponse& _return)
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ListTable failed: unknown result");
 }
 
+void InfinityServiceClient::ListIndex(ListIndexResponse& _return, const ListIndexRequest& request)
+{
+  send_ListIndex(request);
+  recv_ListIndex(_return);
+}
+
+void InfinityServiceClient::send_ListIndex(const ListIndexRequest& request)
+{
+  int32_t cseqid = 0;
+  oprot_->writeMessageBegin("ListIndex", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  InfinityService_ListIndex_pargs args;
+  args.request = &request;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->writeEnd();
+  oprot_->getTransport()->flush();
+}
+
+void InfinityServiceClient::recv_ListIndex(ListIndexResponse& _return)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  iprot_->readMessageBegin(fname, mtype, rseqid);
+  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+    ::apache::thrift::TApplicationException x;
+    x.read(iprot_);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw x;
+  }
+  if (mtype != ::apache::thrift::protocol::T_REPLY) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+  }
+  if (fname.compare("ListIndex") != 0) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+  }
+  InfinityService_ListIndex_presult result;
+  result.success = &_return;
+  result.read(iprot_);
+  iprot_->readMessageEnd();
+  iprot_->getTransport()->readEnd();
+
+  if (result.__isset.success) {
+    // _return pointer has now been filled
+    return;
+  }
+  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ListIndex failed: unknown result");
+}
+
 void InfinityServiceClient::ShowVariable(SelectResponse& _return, const ShowVariableRequest& request)
 {
   send_ShowVariable(request);
@@ -6937,6 +7182,60 @@ void InfinityServiceProcessor::process_ListTable(int32_t seqid, ::apache::thrift
 
   if (this->eventHandler_.get() != nullptr) {
     this->eventHandler_->postWrite(ctx, "InfinityService.ListTable", bytes);
+  }
+}
+
+void InfinityServiceProcessor::process_ListIndex(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext)
+{
+  void* ctx = nullptr;
+  if (this->eventHandler_.get() != nullptr) {
+    ctx = this->eventHandler_->getContext("InfinityService.ListIndex", callContext);
+  }
+  ::apache::thrift::TProcessorContextFreer freer(this->eventHandler_.get(), ctx, "InfinityService.ListIndex");
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->preRead(ctx, "InfinityService.ListIndex");
+  }
+
+  InfinityService_ListIndex_args args;
+  args.read(iprot);
+  iprot->readMessageEnd();
+  uint32_t bytes = iprot->getTransport()->readEnd();
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->postRead(ctx, "InfinityService.ListIndex", bytes);
+  }
+
+  InfinityService_ListIndex_result result;
+  try {
+    iface_->ListIndex(result.success, args.request);
+    result.__isset.success = true;
+  } catch (const std::exception& e) {
+    if (this->eventHandler_.get() != nullptr) {
+      this->eventHandler_->handlerError(ctx, "InfinityService.ListIndex");
+    }
+
+    ::apache::thrift::TApplicationException x(e.what());
+    oprot->writeMessageBegin("ListIndex", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    x.write(oprot);
+    oprot->writeMessageEnd();
+    oprot->getTransport()->writeEnd();
+    oprot->getTransport()->flush();
+    return;
+  }
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->preWrite(ctx, "InfinityService.ListIndex");
+  }
+
+  oprot->writeMessageBegin("ListIndex", ::apache::thrift::protocol::T_REPLY, seqid);
+  result.write(oprot);
+  oprot->writeMessageEnd();
+  bytes = oprot->getTransport()->writeEnd();
+  oprot->getTransport()->flush();
+
+  if (this->eventHandler_.get() != nullptr) {
+    this->eventHandler_->postWrite(ctx, "InfinityService.ListIndex", bytes);
   }
 }
 
@@ -8737,6 +9036,90 @@ void InfinityServiceConcurrentClient::recv_ListTable(ListTableResponse& _return,
       }
       // in a bad state, don't commit
       throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ListTable failed: unknown result");
+    }
+    // seqid != rseqid
+    this->sync_->updatePending(fname, mtype, rseqid);
+
+    // this will temporarily unlock the readMutex, and let other clients get work done
+    this->sync_->waitForWork(seqid);
+  } // end while(true)
+}
+
+void InfinityServiceConcurrentClient::ListIndex(ListIndexResponse& _return, const ListIndexRequest& request)
+{
+  int32_t seqid = send_ListIndex(request);
+  recv_ListIndex(_return, seqid);
+}
+
+int32_t InfinityServiceConcurrentClient::send_ListIndex(const ListIndexRequest& request)
+{
+  int32_t cseqid = this->sync_->generateSeqId();
+  ::apache::thrift::async::TConcurrentSendSentry sentry(this->sync_.get());
+  oprot_->writeMessageBegin("ListIndex", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  InfinityService_ListIndex_pargs args;
+  args.request = &request;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->writeEnd();
+  oprot_->getTransport()->flush();
+
+  sentry.commit();
+  return cseqid;
+}
+
+void InfinityServiceConcurrentClient::recv_ListIndex(ListIndexResponse& _return, const int32_t seqid)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  // the read mutex gets dropped and reacquired as part of waitForWork()
+  // The destructor of this sentry wakes up other clients
+  ::apache::thrift::async::TConcurrentRecvSentry sentry(this->sync_.get(), seqid);
+
+  while(true) {
+    if(!this->sync_->getPending(fname, mtype, rseqid)) {
+      iprot_->readMessageBegin(fname, mtype, rseqid);
+    }
+    if(seqid == rseqid) {
+      if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+        ::apache::thrift::TApplicationException x;
+        x.read(iprot_);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+        sentry.commit();
+        throw x;
+      }
+      if (mtype != ::apache::thrift::protocol::T_REPLY) {
+        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+      }
+      if (fname.compare("ListIndex") != 0) {
+        iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+        iprot_->readMessageEnd();
+        iprot_->getTransport()->readEnd();
+
+        // in a bad state, don't commit
+        using ::apache::thrift::protocol::TProtocolException;
+        throw TProtocolException(TProtocolException::INVALID_DATA);
+      }
+      InfinityService_ListIndex_presult result;
+      result.success = &_return;
+      result.read(iprot_);
+      iprot_->readMessageEnd();
+      iprot_->getTransport()->readEnd();
+
+      if (result.__isset.success) {
+        // _return pointer has now been filled
+        sentry.commit();
+        return;
+      }
+      // in a bad state, don't commit
+      throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "ListIndex failed: unknown result");
     }
     // seqid != rseqid
     this->sync_->updatePending(fname, mtype, rseqid);

--- a/src/network/infinity_thrift/InfinityService.h
+++ b/src/network/infinity_thrift/InfinityService.h
@@ -37,6 +37,7 @@ class InfinityServiceIf {
   virtual void UploadFileChunk(UploadResponse& _return, const FileChunk& request) = 0;
   virtual void ListDatabase(ListDatabaseResponse& _return, const ListDatabaseRequest& request) = 0;
   virtual void ListTable(ListTableResponse& _return, const ListTableRequest& request) = 0;
+  virtual void ListIndex(ListIndexResponse& _return, const ListIndexRequest& request) = 0;
   virtual void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) = 0;
   virtual void ShowTable(ShowTableResponse& _return, const ShowTableRequest& request) = 0;
   virtual void ShowColumns(SelectResponse& _return, const ShowColumnsRequest& request) = 0;
@@ -119,6 +120,9 @@ class InfinityServiceNull : virtual public InfinityServiceIf {
     return;
   }
   void ListTable(ListTableResponse& /* _return */, const ListTableRequest& /* request */) override {
+    return;
+  }
+  void ListIndex(ListIndexResponse& /* _return */, const ListIndexRequest& /* request */) override {
     return;
   }
   void ShowVariable(SelectResponse& /* _return */, const ShowVariableRequest& /* request */) override {
@@ -1701,6 +1705,110 @@ class InfinityService_ListTable_presult {
 
 };
 
+typedef struct _InfinityService_ListIndex_args__isset {
+  _InfinityService_ListIndex_args__isset() : request(false) {}
+  bool request :1;
+} _InfinityService_ListIndex_args__isset;
+
+class InfinityService_ListIndex_args {
+ public:
+
+  InfinityService_ListIndex_args(const InfinityService_ListIndex_args&);
+  InfinityService_ListIndex_args& operator=(const InfinityService_ListIndex_args&);
+  InfinityService_ListIndex_args() noexcept {
+  }
+
+  virtual ~InfinityService_ListIndex_args() noexcept;
+  ListIndexRequest request;
+
+  _InfinityService_ListIndex_args__isset __isset;
+
+  void __set_request(const ListIndexRequest& val);
+
+  bool operator == (const InfinityService_ListIndex_args & rhs) const
+  {
+    if (!(request == rhs.request))
+      return false;
+    return true;
+  }
+  bool operator != (const InfinityService_ListIndex_args &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const InfinityService_ListIndex_args & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class InfinityService_ListIndex_pargs {
+ public:
+
+
+  virtual ~InfinityService_ListIndex_pargs() noexcept;
+  const ListIndexRequest* request;
+
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _InfinityService_ListIndex_result__isset {
+  _InfinityService_ListIndex_result__isset() : success(false) {}
+  bool success :1;
+} _InfinityService_ListIndex_result__isset;
+
+class InfinityService_ListIndex_result {
+ public:
+
+  InfinityService_ListIndex_result(const InfinityService_ListIndex_result&);
+  InfinityService_ListIndex_result& operator=(const InfinityService_ListIndex_result&);
+  InfinityService_ListIndex_result() noexcept {
+  }
+
+  virtual ~InfinityService_ListIndex_result() noexcept;
+  ListIndexResponse success;
+
+  _InfinityService_ListIndex_result__isset __isset;
+
+  void __set_success(const ListIndexResponse& val);
+
+  bool operator == (const InfinityService_ListIndex_result & rhs) const
+  {
+    if (!(success == rhs.success))
+      return false;
+    return true;
+  }
+  bool operator != (const InfinityService_ListIndex_result &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const InfinityService_ListIndex_result & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _InfinityService_ListIndex_presult__isset {
+  _InfinityService_ListIndex_presult__isset() : success(false) {}
+  bool success :1;
+} _InfinityService_ListIndex_presult__isset;
+
+class InfinityService_ListIndex_presult {
+ public:
+
+
+  virtual ~InfinityService_ListIndex_presult() noexcept;
+  ListIndexResponse* success;
+
+  _InfinityService_ListIndex_presult__isset __isset;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+
+};
+
 typedef struct _InfinityService_ShowVariable_args__isset {
   _InfinityService_ShowVariable_args__isset() : request(false) {}
   bool request :1;
@@ -2811,6 +2919,9 @@ class InfinityServiceClient : virtual public InfinityServiceIf {
   void ListTable(ListTableResponse& _return, const ListTableRequest& request) override;
   void send_ListTable(const ListTableRequest& request);
   void recv_ListTable(ListTableResponse& _return);
+  void ListIndex(ListIndexResponse& _return, const ListIndexRequest& request) override;
+  void send_ListIndex(const ListIndexRequest& request);
+  void recv_ListIndex(ListIndexResponse& _return);
   void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override;
   void send_ShowVariable(const ShowVariableRequest& request);
   void recv_ShowVariable(SelectResponse& _return);
@@ -2871,6 +2982,7 @@ class InfinityServiceProcessor : public ::apache::thrift::TDispatchProcessor {
   void process_UploadFileChunk(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ListDatabase(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ListTable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
+  void process_ListIndex(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ShowVariable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ShowTable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_ShowColumns(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
@@ -2899,6 +3011,7 @@ class InfinityServiceProcessor : public ::apache::thrift::TDispatchProcessor {
     processMap_["UploadFileChunk"] = &InfinityServiceProcessor::process_UploadFileChunk;
     processMap_["ListDatabase"] = &InfinityServiceProcessor::process_ListDatabase;
     processMap_["ListTable"] = &InfinityServiceProcessor::process_ListTable;
+    processMap_["ListIndex"] = &InfinityServiceProcessor::process_ListIndex;
     processMap_["ShowVariable"] = &InfinityServiceProcessor::process_ShowVariable;
     processMap_["ShowTable"] = &InfinityServiceProcessor::process_ShowTable;
     processMap_["ShowColumns"] = &InfinityServiceProcessor::process_ShowColumns;
@@ -3087,6 +3200,16 @@ class InfinityServiceMultiface : virtual public InfinityServiceIf {
     return;
   }
 
+  void ListIndex(ListIndexResponse& _return, const ListIndexRequest& request) override {
+    size_t sz = ifaces_.size();
+    size_t i = 0;
+    for (; i < (sz - 1); ++i) {
+      ifaces_[i]->ListIndex(_return, request);
+    }
+    ifaces_[i]->ListIndex(_return, request);
+    return;
+  }
+
   void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override {
     size_t sz = ifaces_.size();
     size_t i = 0;
@@ -3264,6 +3387,9 @@ class InfinityServiceConcurrentClient : virtual public InfinityServiceIf {
   void ListTable(ListTableResponse& _return, const ListTableRequest& request) override;
   int32_t send_ListTable(const ListTableRequest& request);
   void recv_ListTable(ListTableResponse& _return, const int32_t seqid);
+  void ListIndex(ListIndexResponse& _return, const ListIndexRequest& request) override;
+  int32_t send_ListIndex(const ListIndexRequest& request);
+  void recv_ListIndex(ListIndexResponse& _return, const int32_t seqid);
   void ShowVariable(SelectResponse& _return, const ShowVariableRequest& request) override;
   int32_t send_ShowVariable(const ShowVariableRequest& request);
   void recv_ShowVariable(SelectResponse& _return, const int32_t seqid);

--- a/src/network/infinity_thrift/infinity_types.cpp
+++ b/src/network/infinity_thrift/infinity_types.cpp
@@ -5177,6 +5177,290 @@ void ListTableResponse::printTo(std::ostream& out) const {
 }
 
 
+ListIndexRequest::~ListIndexRequest() noexcept {
+}
+
+
+void ListIndexRequest::__set_db_name(const std::string& val) {
+  this->db_name = val;
+}
+
+void ListIndexRequest::__set_table_name(const std::string& val) {
+  this->table_name = val;
+}
+
+void ListIndexRequest::__set_session_id(const int64_t val) {
+  this->session_id = val;
+}
+std::ostream& operator<<(std::ostream& out, const ListIndexRequest& obj)
+{
+  obj.printTo(out);
+  return out;
+}
+
+
+uint32_t ListIndexRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->db_name);
+          this->__isset.db_name = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->table_name);
+          this->__isset.table_name = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->session_id);
+          this->__isset.session_id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t ListIndexRequest::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("ListIndexRequest");
+
+  xfer += oprot->writeFieldBegin("db_name", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeString(this->db_name);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("table_name", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeString(this->table_name);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("session_id", ::apache::thrift::protocol::T_I64, 3);
+  xfer += oprot->writeI64(this->session_id);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(ListIndexRequest &a, ListIndexRequest &b) {
+  using ::std::swap;
+  swap(a.db_name, b.db_name);
+  swap(a.table_name, b.table_name);
+  swap(a.session_id, b.session_id);
+  swap(a.__isset, b.__isset);
+}
+
+ListIndexRequest::ListIndexRequest(const ListIndexRequest& other196) {
+  db_name = other196.db_name;
+  table_name = other196.table_name;
+  session_id = other196.session_id;
+  __isset = other196.__isset;
+}
+ListIndexRequest& ListIndexRequest::operator=(const ListIndexRequest& other197) {
+  db_name = other197.db_name;
+  table_name = other197.table_name;
+  session_id = other197.session_id;
+  __isset = other197.__isset;
+  return *this;
+}
+void ListIndexRequest::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "ListIndexRequest(";
+  out << "db_name=" << to_string(db_name);
+  out << ", " << "table_name=" << to_string(table_name);
+  out << ", " << "session_id=" << to_string(session_id);
+  out << ")";
+}
+
+
+ListIndexResponse::~ListIndexResponse() noexcept {
+}
+
+
+void ListIndexResponse::__set_error_code(const int64_t val) {
+  this->error_code = val;
+}
+
+void ListIndexResponse::__set_error_msg(const std::string& val) {
+  this->error_msg = val;
+}
+
+void ListIndexResponse::__set_index_names(const std::vector<std::string> & val) {
+  this->index_names = val;
+}
+std::ostream& operator<<(std::ostream& out, const ListIndexResponse& obj)
+{
+  obj.printTo(out);
+  return out;
+}
+
+
+uint32_t ListIndexResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  ::apache::thrift::protocol::TInputRecursionTracker tracker(*iprot);
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->error_code);
+          this->__isset.error_code = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->error_msg);
+          this->__isset.error_msg = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->index_names.clear();
+            uint32_t _size198;
+            ::apache::thrift::protocol::TType _etype201;
+            xfer += iprot->readListBegin(_etype201, _size198);
+            this->index_names.resize(_size198);
+            uint32_t _i202;
+            for (_i202 = 0; _i202 < _size198; ++_i202)
+            {
+              xfer += iprot->readString(this->index_names[_i202]);
+            }
+            xfer += iprot->readListEnd();
+          }
+          this->__isset.index_names = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t ListIndexResponse::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
+  xfer += oprot->writeStructBegin("ListIndexResponse");
+
+  xfer += oprot->writeFieldBegin("error_code", ::apache::thrift::protocol::T_I64, 1);
+  xfer += oprot->writeI64(this->error_code);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("error_msg", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeString(this->error_msg);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("index_names", ::apache::thrift::protocol::T_LIST, 3);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->index_names.size()));
+    std::vector<std::string> ::const_iterator _iter203;
+    for (_iter203 = this->index_names.begin(); _iter203 != this->index_names.end(); ++_iter203)
+    {
+      xfer += oprot->writeString((*_iter203));
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+void swap(ListIndexResponse &a, ListIndexResponse &b) {
+  using ::std::swap;
+  swap(a.error_code, b.error_code);
+  swap(a.error_msg, b.error_msg);
+  swap(a.index_names, b.index_names);
+  swap(a.__isset, b.__isset);
+}
+
+ListIndexResponse::ListIndexResponse(const ListIndexResponse& other204) {
+  error_code = other204.error_code;
+  error_msg = other204.error_msg;
+  index_names = other204.index_names;
+  __isset = other204.__isset;
+}
+ListIndexResponse& ListIndexResponse::operator=(const ListIndexResponse& other205) {
+  error_code = other205.error_code;
+  error_msg = other205.error_msg;
+  index_names = other205.index_names;
+  __isset = other205.__isset;
+  return *this;
+}
+void ListIndexResponse::printTo(std::ostream& out) const {
+  using ::apache::thrift::to_string;
+  out << "ListIndexResponse(";
+  out << "error_code=" << to_string(error_code);
+  out << ", " << "error_msg=" << to_string(error_msg);
+  out << ", " << "index_names=" << to_string(index_names);
+  out << ")";
+}
+
+
 ShowDatabaseRequest::~ShowDatabaseRequest() noexcept {
 }
 
@@ -5269,15 +5553,15 @@ void swap(ShowDatabaseRequest &a, ShowDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowDatabaseRequest::ShowDatabaseRequest(const ShowDatabaseRequest& other196) {
-  db_name = other196.db_name;
-  session_id = other196.session_id;
-  __isset = other196.__isset;
+ShowDatabaseRequest::ShowDatabaseRequest(const ShowDatabaseRequest& other206) {
+  db_name = other206.db_name;
+  session_id = other206.session_id;
+  __isset = other206.__isset;
 }
-ShowDatabaseRequest& ShowDatabaseRequest::operator=(const ShowDatabaseRequest& other197) {
-  db_name = other197.db_name;
-  session_id = other197.session_id;
-  __isset = other197.__isset;
+ShowDatabaseRequest& ShowDatabaseRequest::operator=(const ShowDatabaseRequest& other207) {
+  db_name = other207.db_name;
+  session_id = other207.session_id;
+  __isset = other207.__isset;
   return *this;
 }
 void ShowDatabaseRequest::printTo(std::ostream& out) const {
@@ -5432,21 +5716,21 @@ void swap(ShowDatabaseResponse &a, ShowDatabaseResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowDatabaseResponse::ShowDatabaseResponse(const ShowDatabaseResponse& other198) {
-  error_code = other198.error_code;
-  error_msg = other198.error_msg;
-  database_name = other198.database_name;
-  store_dir = other198.store_dir;
-  table_count = other198.table_count;
-  __isset = other198.__isset;
+ShowDatabaseResponse::ShowDatabaseResponse(const ShowDatabaseResponse& other208) {
+  error_code = other208.error_code;
+  error_msg = other208.error_msg;
+  database_name = other208.database_name;
+  store_dir = other208.store_dir;
+  table_count = other208.table_count;
+  __isset = other208.__isset;
 }
-ShowDatabaseResponse& ShowDatabaseResponse::operator=(const ShowDatabaseResponse& other199) {
-  error_code = other199.error_code;
-  error_msg = other199.error_msg;
-  database_name = other199.database_name;
-  store_dir = other199.store_dir;
-  table_count = other199.table_count;
-  __isset = other199.__isset;
+ShowDatabaseResponse& ShowDatabaseResponse::operator=(const ShowDatabaseResponse& other209) {
+  error_code = other209.error_code;
+  error_msg = other209.error_msg;
+  database_name = other209.database_name;
+  store_dir = other209.store_dir;
+  table_count = other209.table_count;
+  __isset = other209.__isset;
   return *this;
 }
 void ShowDatabaseResponse::printTo(std::ostream& out) const {
@@ -5570,17 +5854,17 @@ void swap(ShowTableRequest &a, ShowTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowTableRequest::ShowTableRequest(const ShowTableRequest& other200) {
-  db_name = other200.db_name;
-  table_name = other200.table_name;
-  session_id = other200.session_id;
-  __isset = other200.__isset;
+ShowTableRequest::ShowTableRequest(const ShowTableRequest& other210) {
+  db_name = other210.db_name;
+  table_name = other210.table_name;
+  session_id = other210.session_id;
+  __isset = other210.__isset;
 }
-ShowTableRequest& ShowTableRequest::operator=(const ShowTableRequest& other201) {
-  db_name = other201.db_name;
-  table_name = other201.table_name;
-  session_id = other201.session_id;
-  __isset = other201.__isset;
+ShowTableRequest& ShowTableRequest::operator=(const ShowTableRequest& other211) {
+  db_name = other211.db_name;
+  table_name = other211.table_name;
+  session_id = other211.session_id;
+  __isset = other211.__isset;
   return *this;
 }
 void ShowTableRequest::printTo(std::ostream& out) const {
@@ -5787,27 +6071,27 @@ void swap(ShowTableResponse &a, ShowTableResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowTableResponse::ShowTableResponse(const ShowTableResponse& other202) {
-  error_code = other202.error_code;
-  error_msg = other202.error_msg;
-  database_name = other202.database_name;
-  table_name = other202.table_name;
-  store_dir = other202.store_dir;
-  column_count = other202.column_count;
-  segment_count = other202.segment_count;
-  row_count = other202.row_count;
-  __isset = other202.__isset;
+ShowTableResponse::ShowTableResponse(const ShowTableResponse& other212) {
+  error_code = other212.error_code;
+  error_msg = other212.error_msg;
+  database_name = other212.database_name;
+  table_name = other212.table_name;
+  store_dir = other212.store_dir;
+  column_count = other212.column_count;
+  segment_count = other212.segment_count;
+  row_count = other212.row_count;
+  __isset = other212.__isset;
 }
-ShowTableResponse& ShowTableResponse::operator=(const ShowTableResponse& other203) {
-  error_code = other203.error_code;
-  error_msg = other203.error_msg;
-  database_name = other203.database_name;
-  table_name = other203.table_name;
-  store_dir = other203.store_dir;
-  column_count = other203.column_count;
-  segment_count = other203.segment_count;
-  row_count = other203.row_count;
-  __isset = other203.__isset;
+ShowTableResponse& ShowTableResponse::operator=(const ShowTableResponse& other213) {
+  error_code = other213.error_code;
+  error_msg = other213.error_msg;
+  database_name = other213.database_name;
+  table_name = other213.table_name;
+  store_dir = other213.store_dir;
+  column_count = other213.column_count;
+  segment_count = other213.segment_count;
+  row_count = other213.row_count;
+  __isset = other213.__isset;
   return *this;
 }
 void ShowTableResponse::printTo(std::ostream& out) const {
@@ -5934,17 +6218,17 @@ void swap(ShowColumnsRequest &a, ShowColumnsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowColumnsRequest::ShowColumnsRequest(const ShowColumnsRequest& other204) {
-  db_name = other204.db_name;
-  table_name = other204.table_name;
-  session_id = other204.session_id;
-  __isset = other204.__isset;
+ShowColumnsRequest::ShowColumnsRequest(const ShowColumnsRequest& other214) {
+  db_name = other214.db_name;
+  table_name = other214.table_name;
+  session_id = other214.session_id;
+  __isset = other214.__isset;
 }
-ShowColumnsRequest& ShowColumnsRequest::operator=(const ShowColumnsRequest& other205) {
-  db_name = other205.db_name;
-  table_name = other205.table_name;
-  session_id = other205.session_id;
-  __isset = other205.__isset;
+ShowColumnsRequest& ShowColumnsRequest::operator=(const ShowColumnsRequest& other215) {
+  db_name = other215.db_name;
+  table_name = other215.table_name;
+  session_id = other215.session_id;
+  __isset = other215.__isset;
   return *this;
 }
 void ShowColumnsRequest::printTo(std::ostream& out) const {
@@ -6066,17 +6350,17 @@ void swap(GetTableRequest &a, GetTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTableRequest::GetTableRequest(const GetTableRequest& other206) {
-  db_name = other206.db_name;
-  table_name = other206.table_name;
-  session_id = other206.session_id;
-  __isset = other206.__isset;
+GetTableRequest::GetTableRequest(const GetTableRequest& other216) {
+  db_name = other216.db_name;
+  table_name = other216.table_name;
+  session_id = other216.session_id;
+  __isset = other216.__isset;
 }
-GetTableRequest& GetTableRequest::operator=(const GetTableRequest& other207) {
-  db_name = other207.db_name;
-  table_name = other207.table_name;
-  session_id = other207.session_id;
-  __isset = other207.__isset;
+GetTableRequest& GetTableRequest::operator=(const GetTableRequest& other217) {
+  db_name = other217.db_name;
+  table_name = other217.table_name;
+  session_id = other217.session_id;
+  __isset = other217.__isset;
   return *this;
 }
 void GetTableRequest::printTo(std::ostream& out) const {
@@ -6142,9 +6426,9 @@ uint32_t IndexInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast208;
-          xfer += iprot->readI32(ecast208);
-          this->index_type = static_cast<IndexType::type>(ecast208);
+          int32_t ecast218;
+          xfer += iprot->readI32(ecast218);
+          this->index_type = static_cast<IndexType::type>(ecast218);
           this->__isset.index_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -6154,14 +6438,14 @@ uint32_t IndexInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->index_param_list.clear();
-            uint32_t _size209;
-            ::apache::thrift::protocol::TType _etype212;
-            xfer += iprot->readListBegin(_etype212, _size209);
-            this->index_param_list.resize(_size209);
-            uint32_t _i213;
-            for (_i213 = 0; _i213 < _size209; ++_i213)
+            uint32_t _size219;
+            ::apache::thrift::protocol::TType _etype222;
+            xfer += iprot->readListBegin(_etype222, _size219);
+            this->index_param_list.resize(_size219);
+            uint32_t _i223;
+            for (_i223 = 0; _i223 < _size219; ++_i223)
             {
-              xfer += this->index_param_list[_i213].read(iprot);
+              xfer += this->index_param_list[_i223].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6198,10 +6482,10 @@ uint32_t IndexInfo::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("index_param_list", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->index_param_list.size()));
-    std::vector<InitParameter> ::const_iterator _iter214;
-    for (_iter214 = this->index_param_list.begin(); _iter214 != this->index_param_list.end(); ++_iter214)
+    std::vector<InitParameter> ::const_iterator _iter224;
+    for (_iter224 = this->index_param_list.begin(); _iter224 != this->index_param_list.end(); ++_iter224)
     {
-      xfer += (*_iter214).write(oprot);
+      xfer += (*_iter224).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -6220,17 +6504,17 @@ void swap(IndexInfo &a, IndexInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-IndexInfo::IndexInfo(const IndexInfo& other215) {
-  column_name = other215.column_name;
-  index_type = other215.index_type;
-  index_param_list = other215.index_param_list;
-  __isset = other215.__isset;
+IndexInfo::IndexInfo(const IndexInfo& other225) {
+  column_name = other225.column_name;
+  index_type = other225.index_type;
+  index_param_list = other225.index_param_list;
+  __isset = other225.__isset;
 }
-IndexInfo& IndexInfo::operator=(const IndexInfo& other216) {
-  column_name = other216.column_name;
-  index_type = other216.index_type;
-  index_param_list = other216.index_param_list;
-  __isset = other216.__isset;
+IndexInfo& IndexInfo::operator=(const IndexInfo& other226) {
+  column_name = other226.column_name;
+  index_type = other226.index_type;
+  index_param_list = other226.index_param_list;
+  __isset = other226.__isset;
   return *this;
 }
 void IndexInfo::printTo(std::ostream& out) const {
@@ -6326,14 +6610,14 @@ uint32_t CreateIndexRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->index_info_list.clear();
-            uint32_t _size217;
-            ::apache::thrift::protocol::TType _etype220;
-            xfer += iprot->readListBegin(_etype220, _size217);
-            this->index_info_list.resize(_size217);
-            uint32_t _i221;
-            for (_i221 = 0; _i221 < _size217; ++_i221)
+            uint32_t _size227;
+            ::apache::thrift::protocol::TType _etype230;
+            xfer += iprot->readListBegin(_etype230, _size227);
+            this->index_info_list.resize(_size227);
+            uint32_t _i231;
+            for (_i231 = 0; _i231 < _size227; ++_i231)
             {
-              xfer += this->index_info_list[_i221].read(iprot);
+              xfer += this->index_info_list[_i231].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6390,10 +6674,10 @@ uint32_t CreateIndexRequest::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("index_info_list", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->index_info_list.size()));
-    std::vector<IndexInfo> ::const_iterator _iter222;
-    for (_iter222 = this->index_info_list.begin(); _iter222 != this->index_info_list.end(); ++_iter222)
+    std::vector<IndexInfo> ::const_iterator _iter232;
+    for (_iter232 = this->index_info_list.begin(); _iter232 != this->index_info_list.end(); ++_iter232)
     {
-      xfer += (*_iter222).write(oprot);
+      xfer += (*_iter232).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -6423,23 +6707,23 @@ void swap(CreateIndexRequest &a, CreateIndexRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateIndexRequest::CreateIndexRequest(const CreateIndexRequest& other223) {
-  db_name = other223.db_name;
-  table_name = other223.table_name;
-  index_name = other223.index_name;
-  index_info_list = other223.index_info_list;
-  session_id = other223.session_id;
-  create_option = other223.create_option;
-  __isset = other223.__isset;
+CreateIndexRequest::CreateIndexRequest(const CreateIndexRequest& other233) {
+  db_name = other233.db_name;
+  table_name = other233.table_name;
+  index_name = other233.index_name;
+  index_info_list = other233.index_info_list;
+  session_id = other233.session_id;
+  create_option = other233.create_option;
+  __isset = other233.__isset;
 }
-CreateIndexRequest& CreateIndexRequest::operator=(const CreateIndexRequest& other224) {
-  db_name = other224.db_name;
-  table_name = other224.table_name;
-  index_name = other224.index_name;
-  index_info_list = other224.index_info_list;
-  session_id = other224.session_id;
-  create_option = other224.create_option;
-  __isset = other224.__isset;
+CreateIndexRequest& CreateIndexRequest::operator=(const CreateIndexRequest& other234) {
+  db_name = other234.db_name;
+  table_name = other234.table_name;
+  index_name = other234.index_name;
+  index_info_list = other234.index_info_list;
+  session_id = other234.session_id;
+  create_option = other234.create_option;
+  __isset = other234.__isset;
   return *this;
 }
 void CreateIndexRequest::printTo(std::ostream& out) const {
@@ -6598,21 +6882,21 @@ void swap(DropIndexRequest &a, DropIndexRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropIndexRequest::DropIndexRequest(const DropIndexRequest& other225) {
-  db_name = other225.db_name;
-  table_name = other225.table_name;
-  index_name = other225.index_name;
-  session_id = other225.session_id;
-  drop_option = other225.drop_option;
-  __isset = other225.__isset;
+DropIndexRequest::DropIndexRequest(const DropIndexRequest& other235) {
+  db_name = other235.db_name;
+  table_name = other235.table_name;
+  index_name = other235.index_name;
+  session_id = other235.session_id;
+  drop_option = other235.drop_option;
+  __isset = other235.__isset;
 }
-DropIndexRequest& DropIndexRequest::operator=(const DropIndexRequest& other226) {
-  db_name = other226.db_name;
-  table_name = other226.table_name;
-  index_name = other226.index_name;
-  session_id = other226.session_id;
-  drop_option = other226.drop_option;
-  __isset = other226.__isset;
+DropIndexRequest& DropIndexRequest::operator=(const DropIndexRequest& other236) {
+  db_name = other236.db_name;
+  table_name = other236.table_name;
+  index_name = other236.index_name;
+  session_id = other236.session_id;
+  drop_option = other236.drop_option;
+  __isset = other236.__isset;
   return *this;
 }
 void DropIndexRequest::printTo(std::ostream& out) const {
@@ -6753,19 +7037,19 @@ void swap(ShowIndexRequest &a, ShowIndexRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowIndexRequest::ShowIndexRequest(const ShowIndexRequest& other227) {
-  db_name = other227.db_name;
-  table_name = other227.table_name;
-  index_name = other227.index_name;
-  session_id = other227.session_id;
-  __isset = other227.__isset;
+ShowIndexRequest::ShowIndexRequest(const ShowIndexRequest& other237) {
+  db_name = other237.db_name;
+  table_name = other237.table_name;
+  index_name = other237.index_name;
+  session_id = other237.session_id;
+  __isset = other237.__isset;
 }
-ShowIndexRequest& ShowIndexRequest::operator=(const ShowIndexRequest& other228) {
-  db_name = other228.db_name;
-  table_name = other228.table_name;
-  index_name = other228.index_name;
-  session_id = other228.session_id;
-  __isset = other228.__isset;
+ShowIndexRequest& ShowIndexRequest::operator=(const ShowIndexRequest& other238) {
+  db_name = other238.db_name;
+  table_name = other238.table_name;
+  index_name = other238.index_name;
+  session_id = other238.session_id;
+  __isset = other238.__isset;
   return *this;
 }
 void ShowIndexRequest::printTo(std::ostream& out) const {
@@ -6783,6 +7067,14 @@ ShowIndexResponse::~ShowIndexResponse() noexcept {
 }
 
 
+void ShowIndexResponse::__set_error_code(const int64_t val) {
+  this->error_code = val;
+}
+
+void ShowIndexResponse::__set_error_msg(const std::string& val) {
+  this->error_msg = val;
+}
+
 void ShowIndexResponse::__set_db_name(const std::string& val) {
   this->db_name = val;
 }
@@ -6797,6 +7089,10 @@ void ShowIndexResponse::__set_index_name(const std::string& val) {
 
 void ShowIndexResponse::__set_store_dir(const std::string& val) {
   this->store_dir = val;
+}
+
+void ShowIndexResponse::__set_index_info(const std::string& val) {
+  this->index_info = val;
 }
 std::ostream& operator<<(std::ostream& out, const ShowIndexResponse& obj)
 {
@@ -6827,6 +7123,22 @@ uint32_t ShowIndexResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
     switch (fid)
     {
       case 1:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->error_code);
+          this->__isset.error_code = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->error_msg);
+          this->__isset.error_msg = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
         if (ftype == ::apache::thrift::protocol::T_STRING) {
           xfer += iprot->readString(this->db_name);
           this->__isset.db_name = true;
@@ -6834,7 +7146,7 @@ uint32_t ShowIndexResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
-      case 2:
+      case 4:
         if (ftype == ::apache::thrift::protocol::T_STRING) {
           xfer += iprot->readString(this->table_name);
           this->__isset.table_name = true;
@@ -6842,7 +7154,7 @@ uint32_t ShowIndexResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
-      case 3:
+      case 5:
         if (ftype == ::apache::thrift::protocol::T_STRING) {
           xfer += iprot->readString(this->index_name);
           this->__isset.index_name = true;
@@ -6850,10 +7162,18 @@ uint32_t ShowIndexResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
-      case 4:
+      case 6:
         if (ftype == ::apache::thrift::protocol::T_STRING) {
           xfer += iprot->readString(this->store_dir);
           this->__isset.store_dir = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->index_info);
+          this->__isset.index_info = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -6875,20 +7195,32 @@ uint32_t ShowIndexResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   ::apache::thrift::protocol::TOutputRecursionTracker tracker(*oprot);
   xfer += oprot->writeStructBegin("ShowIndexResponse");
 
-  xfer += oprot->writeFieldBegin("db_name", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeFieldBegin("error_code", ::apache::thrift::protocol::T_I64, 1);
+  xfer += oprot->writeI64(this->error_code);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("error_msg", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeString(this->error_msg);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("db_name", ::apache::thrift::protocol::T_STRING, 3);
   xfer += oprot->writeString(this->db_name);
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("table_name", ::apache::thrift::protocol::T_STRING, 2);
+  xfer += oprot->writeFieldBegin("table_name", ::apache::thrift::protocol::T_STRING, 4);
   xfer += oprot->writeString(this->table_name);
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("index_name", ::apache::thrift::protocol::T_STRING, 3);
+  xfer += oprot->writeFieldBegin("index_name", ::apache::thrift::protocol::T_STRING, 5);
   xfer += oprot->writeString(this->index_name);
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("store_dir", ::apache::thrift::protocol::T_STRING, 4);
+  xfer += oprot->writeFieldBegin("store_dir", ::apache::thrift::protocol::T_STRING, 6);
   xfer += oprot->writeString(this->store_dir);
+  xfer += oprot->writeFieldEnd();
+
+  xfer += oprot->writeFieldBegin("index_info", ::apache::thrift::protocol::T_STRING, 7);
+  xfer += oprot->writeString(this->index_info);
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldStop();
@@ -6898,35 +7230,47 @@ uint32_t ShowIndexResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
 
 void swap(ShowIndexResponse &a, ShowIndexResponse &b) {
   using ::std::swap;
+  swap(a.error_code, b.error_code);
+  swap(a.error_msg, b.error_msg);
   swap(a.db_name, b.db_name);
   swap(a.table_name, b.table_name);
   swap(a.index_name, b.index_name);
   swap(a.store_dir, b.store_dir);
+  swap(a.index_info, b.index_info);
   swap(a.__isset, b.__isset);
 }
 
-ShowIndexResponse::ShowIndexResponse(const ShowIndexResponse& other229) {
-  db_name = other229.db_name;
-  table_name = other229.table_name;
-  index_name = other229.index_name;
-  store_dir = other229.store_dir;
-  __isset = other229.__isset;
+ShowIndexResponse::ShowIndexResponse(const ShowIndexResponse& other239) {
+  error_code = other239.error_code;
+  error_msg = other239.error_msg;
+  db_name = other239.db_name;
+  table_name = other239.table_name;
+  index_name = other239.index_name;
+  store_dir = other239.store_dir;
+  index_info = other239.index_info;
+  __isset = other239.__isset;
 }
-ShowIndexResponse& ShowIndexResponse::operator=(const ShowIndexResponse& other230) {
-  db_name = other230.db_name;
-  table_name = other230.table_name;
-  index_name = other230.index_name;
-  store_dir = other230.store_dir;
-  __isset = other230.__isset;
+ShowIndexResponse& ShowIndexResponse::operator=(const ShowIndexResponse& other240) {
+  error_code = other240.error_code;
+  error_msg = other240.error_msg;
+  db_name = other240.db_name;
+  table_name = other240.table_name;
+  index_name = other240.index_name;
+  store_dir = other240.store_dir;
+  index_info = other240.index_info;
+  __isset = other240.__isset;
   return *this;
 }
 void ShowIndexResponse::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "ShowIndexResponse(";
-  out << "db_name=" << to_string(db_name);
+  out << "error_code=" << to_string(error_code);
+  out << ", " << "error_msg=" << to_string(error_msg);
+  out << ", " << "db_name=" << to_string(db_name);
   out << ", " << "table_name=" << to_string(table_name);
   out << ", " << "index_name=" << to_string(index_name);
   out << ", " << "store_dir=" << to_string(store_dir);
+  out << ", " << "index_info=" << to_string(index_info);
   out << ")";
 }
 
@@ -7023,15 +7367,15 @@ void swap(GetDatabaseRequest &a, GetDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetDatabaseRequest::GetDatabaseRequest(const GetDatabaseRequest& other231) {
-  db_name = other231.db_name;
-  session_id = other231.session_id;
-  __isset = other231.__isset;
+GetDatabaseRequest::GetDatabaseRequest(const GetDatabaseRequest& other241) {
+  db_name = other241.db_name;
+  session_id = other241.session_id;
+  __isset = other241.__isset;
 }
-GetDatabaseRequest& GetDatabaseRequest::operator=(const GetDatabaseRequest& other232) {
-  db_name = other232.db_name;
-  session_id = other232.session_id;
-  __isset = other232.__isset;
+GetDatabaseRequest& GetDatabaseRequest::operator=(const GetDatabaseRequest& other242) {
+  db_name = other242.db_name;
+  session_id = other242.session_id;
+  __isset = other242.__isset;
   return *this;
 }
 void GetDatabaseRequest::printTo(std::ostream& out) const {
@@ -7152,17 +7496,17 @@ void swap(CreateDatabaseRequest &a, CreateDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateDatabaseRequest::CreateDatabaseRequest(const CreateDatabaseRequest& other233) {
-  db_name = other233.db_name;
-  session_id = other233.session_id;
-  create_option = other233.create_option;
-  __isset = other233.__isset;
+CreateDatabaseRequest::CreateDatabaseRequest(const CreateDatabaseRequest& other243) {
+  db_name = other243.db_name;
+  session_id = other243.session_id;
+  create_option = other243.create_option;
+  __isset = other243.__isset;
 }
-CreateDatabaseRequest& CreateDatabaseRequest::operator=(const CreateDatabaseRequest& other234) {
-  db_name = other234.db_name;
-  session_id = other234.session_id;
-  create_option = other234.create_option;
-  __isset = other234.__isset;
+CreateDatabaseRequest& CreateDatabaseRequest::operator=(const CreateDatabaseRequest& other244) {
+  db_name = other244.db_name;
+  session_id = other244.session_id;
+  create_option = other244.create_option;
+  __isset = other244.__isset;
   return *this;
 }
 void CreateDatabaseRequest::printTo(std::ostream& out) const {
@@ -7284,17 +7628,17 @@ void swap(DropDatabaseRequest &a, DropDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropDatabaseRequest::DropDatabaseRequest(const DropDatabaseRequest& other235) {
-  db_name = other235.db_name;
-  session_id = other235.session_id;
-  drop_option = other235.drop_option;
-  __isset = other235.__isset;
+DropDatabaseRequest::DropDatabaseRequest(const DropDatabaseRequest& other245) {
+  db_name = other245.db_name;
+  session_id = other245.session_id;
+  drop_option = other245.drop_option;
+  __isset = other245.__isset;
 }
-DropDatabaseRequest& DropDatabaseRequest::operator=(const DropDatabaseRequest& other236) {
-  db_name = other236.db_name;
-  session_id = other236.session_id;
-  drop_option = other236.drop_option;
-  __isset = other236.__isset;
+DropDatabaseRequest& DropDatabaseRequest::operator=(const DropDatabaseRequest& other246) {
+  db_name = other246.db_name;
+  session_id = other246.session_id;
+  drop_option = other246.drop_option;
+  __isset = other246.__isset;
   return *this;
 }
 void DropDatabaseRequest::printTo(std::ostream& out) const {
@@ -7378,14 +7722,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_defs.clear();
-            uint32_t _size237;
-            ::apache::thrift::protocol::TType _etype240;
-            xfer += iprot->readListBegin(_etype240, _size237);
-            this->column_defs.resize(_size237);
-            uint32_t _i241;
-            for (_i241 = 0; _i241 < _size237; ++_i241)
+            uint32_t _size247;
+            ::apache::thrift::protocol::TType _etype250;
+            xfer += iprot->readListBegin(_etype250, _size247);
+            this->column_defs.resize(_size247);
+            uint32_t _i251;
+            for (_i251 = 0; _i251 < _size247; ++_i251)
             {
-              xfer += this->column_defs[_i241].read(iprot);
+              xfer += this->column_defs[_i251].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7438,10 +7782,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("column_defs", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_defs.size()));
-    std::vector<ColumnDef> ::const_iterator _iter242;
-    for (_iter242 = this->column_defs.begin(); _iter242 != this->column_defs.end(); ++_iter242)
+    std::vector<ColumnDef> ::const_iterator _iter252;
+    for (_iter252 = this->column_defs.begin(); _iter252 != this->column_defs.end(); ++_iter252)
     {
-      xfer += (*_iter242).write(oprot);
+      xfer += (*_iter252).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7470,21 +7814,21 @@ void swap(CreateTableRequest &a, CreateTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateTableRequest::CreateTableRequest(const CreateTableRequest& other243) {
-  db_name = other243.db_name;
-  table_name = other243.table_name;
-  column_defs = other243.column_defs;
-  session_id = other243.session_id;
-  create_option = other243.create_option;
-  __isset = other243.__isset;
+CreateTableRequest::CreateTableRequest(const CreateTableRequest& other253) {
+  db_name = other253.db_name;
+  table_name = other253.table_name;
+  column_defs = other253.column_defs;
+  session_id = other253.session_id;
+  create_option = other253.create_option;
+  __isset = other253.__isset;
 }
-CreateTableRequest& CreateTableRequest::operator=(const CreateTableRequest& other244) {
-  db_name = other244.db_name;
-  table_name = other244.table_name;
-  column_defs = other244.column_defs;
-  session_id = other244.session_id;
-  create_option = other244.create_option;
-  __isset = other244.__isset;
+CreateTableRequest& CreateTableRequest::operator=(const CreateTableRequest& other254) {
+  db_name = other254.db_name;
+  table_name = other254.table_name;
+  column_defs = other254.column_defs;
+  session_id = other254.session_id;
+  create_option = other254.create_option;
+  __isset = other254.__isset;
   return *this;
 }
 void CreateTableRequest::printTo(std::ostream& out) const {
@@ -7625,19 +7969,19 @@ void swap(DropTableRequest &a, DropTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DropTableRequest::DropTableRequest(const DropTableRequest& other245) {
-  db_name = other245.db_name;
-  table_name = other245.table_name;
-  session_id = other245.session_id;
-  drop_option = other245.drop_option;
-  __isset = other245.__isset;
+DropTableRequest::DropTableRequest(const DropTableRequest& other255) {
+  db_name = other255.db_name;
+  table_name = other255.table_name;
+  session_id = other255.session_id;
+  drop_option = other255.drop_option;
+  __isset = other255.__isset;
 }
-DropTableRequest& DropTableRequest::operator=(const DropTableRequest& other246) {
-  db_name = other246.db_name;
-  table_name = other246.table_name;
-  session_id = other246.session_id;
-  drop_option = other246.drop_option;
-  __isset = other246.__isset;
+DropTableRequest& DropTableRequest::operator=(const DropTableRequest& other256) {
+  db_name = other256.db_name;
+  table_name = other256.table_name;
+  session_id = other256.session_id;
+  drop_option = other256.drop_option;
+  __isset = other256.__isset;
   return *this;
 }
 void DropTableRequest::printTo(std::ostream& out) const {
@@ -7722,14 +8066,14 @@ uint32_t InsertRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_names.clear();
-            uint32_t _size247;
-            ::apache::thrift::protocol::TType _etype250;
-            xfer += iprot->readListBegin(_etype250, _size247);
-            this->column_names.resize(_size247);
-            uint32_t _i251;
-            for (_i251 = 0; _i251 < _size247; ++_i251)
+            uint32_t _size257;
+            ::apache::thrift::protocol::TType _etype260;
+            xfer += iprot->readListBegin(_etype260, _size257);
+            this->column_names.resize(_size257);
+            uint32_t _i261;
+            for (_i261 = 0; _i261 < _size257; ++_i261)
             {
-              xfer += iprot->readString(this->column_names[_i251]);
+              xfer += iprot->readString(this->column_names[_i261]);
             }
             xfer += iprot->readListEnd();
           }
@@ -7742,14 +8086,14 @@ uint32_t InsertRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fields.clear();
-            uint32_t _size252;
-            ::apache::thrift::protocol::TType _etype255;
-            xfer += iprot->readListBegin(_etype255, _size252);
-            this->fields.resize(_size252);
-            uint32_t _i256;
-            for (_i256 = 0; _i256 < _size252; ++_i256)
+            uint32_t _size262;
+            ::apache::thrift::protocol::TType _etype265;
+            xfer += iprot->readListBegin(_etype265, _size262);
+            this->fields.resize(_size262);
+            uint32_t _i266;
+            for (_i266 = 0; _i266 < _size262; ++_i266)
             {
-              xfer += this->fields[_i256].read(iprot);
+              xfer += this->fields[_i266].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7794,10 +8138,10 @@ uint32_t InsertRequest::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("column_names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->column_names.size()));
-    std::vector<std::string> ::const_iterator _iter257;
-    for (_iter257 = this->column_names.begin(); _iter257 != this->column_names.end(); ++_iter257)
+    std::vector<std::string> ::const_iterator _iter267;
+    for (_iter267 = this->column_names.begin(); _iter267 != this->column_names.end(); ++_iter267)
     {
-      xfer += oprot->writeString((*_iter257));
+      xfer += oprot->writeString((*_iter267));
     }
     xfer += oprot->writeListEnd();
   }
@@ -7806,10 +8150,10 @@ uint32_t InsertRequest::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("fields", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fields.size()));
-    std::vector<Field> ::const_iterator _iter258;
-    for (_iter258 = this->fields.begin(); _iter258 != this->fields.end(); ++_iter258)
+    std::vector<Field> ::const_iterator _iter268;
+    for (_iter268 = this->fields.begin(); _iter268 != this->fields.end(); ++_iter268)
     {
-      xfer += (*_iter258).write(oprot);
+      xfer += (*_iter268).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7834,21 +8178,21 @@ void swap(InsertRequest &a, InsertRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-InsertRequest::InsertRequest(const InsertRequest& other259) {
-  db_name = other259.db_name;
-  table_name = other259.table_name;
-  column_names = other259.column_names;
-  fields = other259.fields;
-  session_id = other259.session_id;
-  __isset = other259.__isset;
+InsertRequest::InsertRequest(const InsertRequest& other269) {
+  db_name = other269.db_name;
+  table_name = other269.table_name;
+  column_names = other269.column_names;
+  fields = other269.fields;
+  session_id = other269.session_id;
+  __isset = other269.__isset;
 }
-InsertRequest& InsertRequest::operator=(const InsertRequest& other260) {
-  db_name = other260.db_name;
-  table_name = other260.table_name;
-  column_names = other260.column_names;
-  fields = other260.fields;
-  session_id = other260.session_id;
-  __isset = other260.__isset;
+InsertRequest& InsertRequest::operator=(const InsertRequest& other270) {
+  db_name = other270.db_name;
+  table_name = other270.table_name;
+  column_names = other270.column_names;
+  fields = other270.fields;
+  session_id = other270.session_id;
+  __isset = other270.__isset;
   return *this;
 }
 void InsertRequest::printTo(std::ostream& out) const {
@@ -8023,23 +8367,23 @@ void swap(ImportRequest &a, ImportRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ImportRequest::ImportRequest(const ImportRequest& other261) {
-  db_name = other261.db_name;
-  table_name = other261.table_name;
-  file_name = other261.file_name;
-  file_content = other261.file_content;
-  import_option = other261.import_option;
-  session_id = other261.session_id;
-  __isset = other261.__isset;
+ImportRequest::ImportRequest(const ImportRequest& other271) {
+  db_name = other271.db_name;
+  table_name = other271.table_name;
+  file_name = other271.file_name;
+  file_content = other271.file_content;
+  import_option = other271.import_option;
+  session_id = other271.session_id;
+  __isset = other271.__isset;
 }
-ImportRequest& ImportRequest::operator=(const ImportRequest& other262) {
-  db_name = other262.db_name;
-  table_name = other262.table_name;
-  file_name = other262.file_name;
-  file_content = other262.file_content;
-  import_option = other262.import_option;
-  session_id = other262.session_id;
-  __isset = other262.__isset;
+ImportRequest& ImportRequest::operator=(const ImportRequest& other272) {
+  db_name = other272.db_name;
+  table_name = other272.table_name;
+  file_name = other272.file_name;
+  file_content = other272.file_content;
+  import_option = other272.import_option;
+  session_id = other272.session_id;
+  __isset = other272.__isset;
   return *this;
 }
 void ImportRequest::printTo(std::ostream& out) const {
@@ -8249,27 +8593,27 @@ void swap(FileChunk &a, FileChunk &b) {
   swap(a.__isset, b.__isset);
 }
 
-FileChunk::FileChunk(const FileChunk& other263) {
-  db_name = other263.db_name;
-  table_name = other263.table_name;
-  file_name = other263.file_name;
-  data = other263.data;
-  index = other263.index;
-  is_last = other263.is_last;
-  session_id = other263.session_id;
-  total_size = other263.total_size;
-  __isset = other263.__isset;
+FileChunk::FileChunk(const FileChunk& other273) {
+  db_name = other273.db_name;
+  table_name = other273.table_name;
+  file_name = other273.file_name;
+  data = other273.data;
+  index = other273.index;
+  is_last = other273.is_last;
+  session_id = other273.session_id;
+  total_size = other273.total_size;
+  __isset = other273.__isset;
 }
-FileChunk& FileChunk::operator=(const FileChunk& other264) {
-  db_name = other264.db_name;
-  table_name = other264.table_name;
-  file_name = other264.file_name;
-  data = other264.data;
-  index = other264.index;
-  is_last = other264.is_last;
-  session_id = other264.session_id;
-  total_size = other264.total_size;
-  __isset = other264.__isset;
+FileChunk& FileChunk::operator=(const FileChunk& other274) {
+  db_name = other274.db_name;
+  table_name = other274.table_name;
+  file_name = other274.file_name;
+  data = other274.data;
+  index = other274.index;
+  is_last = other274.is_last;
+  session_id = other274.session_id;
+  total_size = other274.total_size;
+  __isset = other274.__isset;
   return *this;
 }
 void FileChunk::printTo(std::ostream& out) const {
@@ -8401,14 +8745,14 @@ uint32_t ExplainRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->select_list.clear();
-            uint32_t _size265;
-            ::apache::thrift::protocol::TType _etype268;
-            xfer += iprot->readListBegin(_etype268, _size265);
-            this->select_list.resize(_size265);
-            uint32_t _i269;
-            for (_i269 = 0; _i269 < _size265; ++_i269)
+            uint32_t _size275;
+            ::apache::thrift::protocol::TType _etype278;
+            xfer += iprot->readListBegin(_etype278, _size275);
+            this->select_list.resize(_size275);
+            uint32_t _i279;
+            for (_i279 = 0; _i279 < _size275; ++_i279)
             {
-              xfer += this->select_list[_i269].read(iprot);
+              xfer += this->select_list[_i279].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -8437,14 +8781,14 @@ uint32_t ExplainRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_by_list.clear();
-            uint32_t _size270;
-            ::apache::thrift::protocol::TType _etype273;
-            xfer += iprot->readListBegin(_etype273, _size270);
-            this->group_by_list.resize(_size270);
-            uint32_t _i274;
-            for (_i274 = 0; _i274 < _size270; ++_i274)
+            uint32_t _size280;
+            ::apache::thrift::protocol::TType _etype283;
+            xfer += iprot->readListBegin(_etype283, _size280);
+            this->group_by_list.resize(_size280);
+            uint32_t _i284;
+            for (_i284 = 0; _i284 < _size280; ++_i284)
             {
-              xfer += this->group_by_list[_i274].read(iprot);
+              xfer += this->group_by_list[_i284].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -8481,14 +8825,14 @@ uint32_t ExplainRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->order_by_list.clear();
-            uint32_t _size275;
-            ::apache::thrift::protocol::TType _etype278;
-            xfer += iprot->readListBegin(_etype278, _size275);
-            this->order_by_list.resize(_size275);
-            uint32_t _i279;
-            for (_i279 = 0; _i279 < _size275; ++_i279)
+            uint32_t _size285;
+            ::apache::thrift::protocol::TType _etype288;
+            xfer += iprot->readListBegin(_etype288, _size285);
+            this->order_by_list.resize(_size285);
+            uint32_t _i289;
+            for (_i289 = 0; _i289 < _size285; ++_i289)
             {
-              xfer += this->order_by_list[_i279].read(iprot);
+              xfer += this->order_by_list[_i289].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -8499,9 +8843,9 @@ uint32_t ExplainRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 12:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast280;
-          xfer += iprot->readI32(ecast280);
-          this->explain_type = static_cast<ExplainType::type>(ecast280);
+          int32_t ecast290;
+          xfer += iprot->readI32(ecast290);
+          this->explain_type = static_cast<ExplainType::type>(ecast290);
           this->__isset.explain_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -8539,10 +8883,10 @@ uint32_t ExplainRequest::write(::apache::thrift::protocol::TProtocol* oprot) con
   xfer += oprot->writeFieldBegin("select_list", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->select_list.size()));
-    std::vector<ParsedExpr> ::const_iterator _iter281;
-    for (_iter281 = this->select_list.begin(); _iter281 != this->select_list.end(); ++_iter281)
+    std::vector<ParsedExpr> ::const_iterator _iter291;
+    for (_iter291 = this->select_list.begin(); _iter291 != this->select_list.end(); ++_iter291)
     {
-      xfer += (*_iter281).write(oprot);
+      xfer += (*_iter291).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -8562,10 +8906,10 @@ uint32_t ExplainRequest::write(::apache::thrift::protocol::TProtocol* oprot) con
     xfer += oprot->writeFieldBegin("group_by_list", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->group_by_list.size()));
-      std::vector<ParsedExpr> ::const_iterator _iter282;
-      for (_iter282 = this->group_by_list.begin(); _iter282 != this->group_by_list.end(); ++_iter282)
+      std::vector<ParsedExpr> ::const_iterator _iter292;
+      for (_iter292 = this->group_by_list.begin(); _iter292 != this->group_by_list.end(); ++_iter292)
       {
-        xfer += (*_iter282).write(oprot);
+        xfer += (*_iter292).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -8590,10 +8934,10 @@ uint32_t ExplainRequest::write(::apache::thrift::protocol::TProtocol* oprot) con
     xfer += oprot->writeFieldBegin("order_by_list", ::apache::thrift::protocol::T_LIST, 11);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->order_by_list.size()));
-      std::vector<OrderByExpr> ::const_iterator _iter283;
-      for (_iter283 = this->order_by_list.begin(); _iter283 != this->order_by_list.end(); ++_iter283)
+      std::vector<OrderByExpr> ::const_iterator _iter293;
+      for (_iter293 = this->order_by_list.begin(); _iter293 != this->order_by_list.end(); ++_iter293)
       {
-        xfer += (*_iter283).write(oprot);
+        xfer += (*_iter293).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -8625,35 +8969,35 @@ void swap(ExplainRequest &a, ExplainRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ExplainRequest::ExplainRequest(const ExplainRequest& other284) {
-  session_id = other284.session_id;
-  db_name = other284.db_name;
-  table_name = other284.table_name;
-  select_list = other284.select_list;
-  search_expr = other284.search_expr;
-  where_expr = other284.where_expr;
-  group_by_list = other284.group_by_list;
-  having_expr = other284.having_expr;
-  limit_expr = other284.limit_expr;
-  offset_expr = other284.offset_expr;
-  order_by_list = other284.order_by_list;
-  explain_type = other284.explain_type;
-  __isset = other284.__isset;
+ExplainRequest::ExplainRequest(const ExplainRequest& other294) {
+  session_id = other294.session_id;
+  db_name = other294.db_name;
+  table_name = other294.table_name;
+  select_list = other294.select_list;
+  search_expr = other294.search_expr;
+  where_expr = other294.where_expr;
+  group_by_list = other294.group_by_list;
+  having_expr = other294.having_expr;
+  limit_expr = other294.limit_expr;
+  offset_expr = other294.offset_expr;
+  order_by_list = other294.order_by_list;
+  explain_type = other294.explain_type;
+  __isset = other294.__isset;
 }
-ExplainRequest& ExplainRequest::operator=(const ExplainRequest& other285) {
-  session_id = other285.session_id;
-  db_name = other285.db_name;
-  table_name = other285.table_name;
-  select_list = other285.select_list;
-  search_expr = other285.search_expr;
-  where_expr = other285.where_expr;
-  group_by_list = other285.group_by_list;
-  having_expr = other285.having_expr;
-  limit_expr = other285.limit_expr;
-  offset_expr = other285.offset_expr;
-  order_by_list = other285.order_by_list;
-  explain_type = other285.explain_type;
-  __isset = other285.__isset;
+ExplainRequest& ExplainRequest::operator=(const ExplainRequest& other295) {
+  session_id = other295.session_id;
+  db_name = other295.db_name;
+  table_name = other295.table_name;
+  select_list = other295.select_list;
+  search_expr = other295.search_expr;
+  where_expr = other295.where_expr;
+  group_by_list = other295.group_by_list;
+  having_expr = other295.having_expr;
+  limit_expr = other295.limit_expr;
+  offset_expr = other295.offset_expr;
+  order_by_list = other295.order_by_list;
+  explain_type = other295.explain_type;
+  __isset = other295.__isset;
   return *this;
 }
 void ExplainRequest::printTo(std::ostream& out) const {
@@ -8742,14 +9086,14 @@ uint32_t ExplainResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_defs.clear();
-            uint32_t _size286;
-            ::apache::thrift::protocol::TType _etype289;
-            xfer += iprot->readListBegin(_etype289, _size286);
-            this->column_defs.resize(_size286);
-            uint32_t _i290;
-            for (_i290 = 0; _i290 < _size286; ++_i290)
+            uint32_t _size296;
+            ::apache::thrift::protocol::TType _etype299;
+            xfer += iprot->readListBegin(_etype299, _size296);
+            this->column_defs.resize(_size296);
+            uint32_t _i300;
+            for (_i300 = 0; _i300 < _size296; ++_i300)
             {
-              xfer += this->column_defs[_i290].read(iprot);
+              xfer += this->column_defs[_i300].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -8762,14 +9106,14 @@ uint32_t ExplainResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_fields.clear();
-            uint32_t _size291;
-            ::apache::thrift::protocol::TType _etype294;
-            xfer += iprot->readListBegin(_etype294, _size291);
-            this->column_fields.resize(_size291);
-            uint32_t _i295;
-            for (_i295 = 0; _i295 < _size291; ++_i295)
+            uint32_t _size301;
+            ::apache::thrift::protocol::TType _etype304;
+            xfer += iprot->readListBegin(_etype304, _size301);
+            this->column_fields.resize(_size301);
+            uint32_t _i305;
+            for (_i305 = 0; _i305 < _size301; ++_i305)
             {
-              xfer += this->column_fields[_i295].read(iprot);
+              xfer += this->column_fields[_i305].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -8806,10 +9150,10 @@ uint32_t ExplainResponse::write(::apache::thrift::protocol::TProtocol* oprot) co
   xfer += oprot->writeFieldBegin("column_defs", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_defs.size()));
-    std::vector<ColumnDef> ::const_iterator _iter296;
-    for (_iter296 = this->column_defs.begin(); _iter296 != this->column_defs.end(); ++_iter296)
+    std::vector<ColumnDef> ::const_iterator _iter306;
+    for (_iter306 = this->column_defs.begin(); _iter306 != this->column_defs.end(); ++_iter306)
     {
-      xfer += (*_iter296).write(oprot);
+      xfer += (*_iter306).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -8818,10 +9162,10 @@ uint32_t ExplainResponse::write(::apache::thrift::protocol::TProtocol* oprot) co
   xfer += oprot->writeFieldBegin("column_fields", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_fields.size()));
-    std::vector<ColumnField> ::const_iterator _iter297;
-    for (_iter297 = this->column_fields.begin(); _iter297 != this->column_fields.end(); ++_iter297)
+    std::vector<ColumnField> ::const_iterator _iter307;
+    for (_iter307 = this->column_fields.begin(); _iter307 != this->column_fields.end(); ++_iter307)
     {
-      xfer += (*_iter297).write(oprot);
+      xfer += (*_iter307).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -8841,19 +9185,19 @@ void swap(ExplainResponse &a, ExplainResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ExplainResponse::ExplainResponse(const ExplainResponse& other298) {
-  error_code = other298.error_code;
-  error_msg = other298.error_msg;
-  column_defs = other298.column_defs;
-  column_fields = other298.column_fields;
-  __isset = other298.__isset;
+ExplainResponse::ExplainResponse(const ExplainResponse& other308) {
+  error_code = other308.error_code;
+  error_msg = other308.error_msg;
+  column_defs = other308.column_defs;
+  column_fields = other308.column_fields;
+  __isset = other308.__isset;
 }
-ExplainResponse& ExplainResponse::operator=(const ExplainResponse& other299) {
-  error_code = other299.error_code;
-  error_msg = other299.error_msg;
-  column_defs = other299.column_defs;
-  column_fields = other299.column_fields;
-  __isset = other299.__isset;
+ExplainResponse& ExplainResponse::operator=(const ExplainResponse& other309) {
+  error_code = other309.error_code;
+  error_msg = other309.error_msg;
+  column_defs = other309.column_defs;
+  column_fields = other309.column_fields;
+  __isset = other309.__isset;
   return *this;
 }
 void ExplainResponse::printTo(std::ostream& out) const {
@@ -8977,14 +9321,14 @@ uint32_t SelectRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->select_list.clear();
-            uint32_t _size300;
-            ::apache::thrift::protocol::TType _etype303;
-            xfer += iprot->readListBegin(_etype303, _size300);
-            this->select_list.resize(_size300);
-            uint32_t _i304;
-            for (_i304 = 0; _i304 < _size300; ++_i304)
+            uint32_t _size310;
+            ::apache::thrift::protocol::TType _etype313;
+            xfer += iprot->readListBegin(_etype313, _size310);
+            this->select_list.resize(_size310);
+            uint32_t _i314;
+            for (_i314 = 0; _i314 < _size310; ++_i314)
             {
-              xfer += this->select_list[_i304].read(iprot);
+              xfer += this->select_list[_i314].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -9013,14 +9357,14 @@ uint32_t SelectRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_by_list.clear();
-            uint32_t _size305;
-            ::apache::thrift::protocol::TType _etype308;
-            xfer += iprot->readListBegin(_etype308, _size305);
-            this->group_by_list.resize(_size305);
-            uint32_t _i309;
-            for (_i309 = 0; _i309 < _size305; ++_i309)
+            uint32_t _size315;
+            ::apache::thrift::protocol::TType _etype318;
+            xfer += iprot->readListBegin(_etype318, _size315);
+            this->group_by_list.resize(_size315);
+            uint32_t _i319;
+            for (_i319 = 0; _i319 < _size315; ++_i319)
             {
-              xfer += this->group_by_list[_i309].read(iprot);
+              xfer += this->group_by_list[_i319].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -9057,14 +9401,14 @@ uint32_t SelectRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->order_by_list.clear();
-            uint32_t _size310;
-            ::apache::thrift::protocol::TType _etype313;
-            xfer += iprot->readListBegin(_etype313, _size310);
-            this->order_by_list.resize(_size310);
-            uint32_t _i314;
-            for (_i314 = 0; _i314 < _size310; ++_i314)
+            uint32_t _size320;
+            ::apache::thrift::protocol::TType _etype323;
+            xfer += iprot->readListBegin(_etype323, _size320);
+            this->order_by_list.resize(_size320);
+            uint32_t _i324;
+            for (_i324 = 0; _i324 < _size320; ++_i324)
             {
-              xfer += this->order_by_list[_i314].read(iprot);
+              xfer += this->order_by_list[_i324].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -9105,10 +9449,10 @@ uint32_t SelectRequest::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("select_list", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->select_list.size()));
-    std::vector<ParsedExpr> ::const_iterator _iter315;
-    for (_iter315 = this->select_list.begin(); _iter315 != this->select_list.end(); ++_iter315)
+    std::vector<ParsedExpr> ::const_iterator _iter325;
+    for (_iter325 = this->select_list.begin(); _iter325 != this->select_list.end(); ++_iter325)
     {
-      xfer += (*_iter315).write(oprot);
+      xfer += (*_iter325).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -9128,10 +9472,10 @@ uint32_t SelectRequest::write(::apache::thrift::protocol::TProtocol* oprot) cons
     xfer += oprot->writeFieldBegin("group_by_list", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->group_by_list.size()));
-      std::vector<ParsedExpr> ::const_iterator _iter316;
-      for (_iter316 = this->group_by_list.begin(); _iter316 != this->group_by_list.end(); ++_iter316)
+      std::vector<ParsedExpr> ::const_iterator _iter326;
+      for (_iter326 = this->group_by_list.begin(); _iter326 != this->group_by_list.end(); ++_iter326)
       {
-        xfer += (*_iter316).write(oprot);
+        xfer += (*_iter326).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -9156,10 +9500,10 @@ uint32_t SelectRequest::write(::apache::thrift::protocol::TProtocol* oprot) cons
     xfer += oprot->writeFieldBegin("order_by_list", ::apache::thrift::protocol::T_LIST, 11);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->order_by_list.size()));
-      std::vector<OrderByExpr> ::const_iterator _iter317;
-      for (_iter317 = this->order_by_list.begin(); _iter317 != this->order_by_list.end(); ++_iter317)
+      std::vector<OrderByExpr> ::const_iterator _iter327;
+      for (_iter327 = this->order_by_list.begin(); _iter327 != this->order_by_list.end(); ++_iter327)
       {
-        xfer += (*_iter317).write(oprot);
+        xfer += (*_iter327).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -9186,33 +9530,33 @@ void swap(SelectRequest &a, SelectRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-SelectRequest::SelectRequest(const SelectRequest& other318) {
-  session_id = other318.session_id;
-  db_name = other318.db_name;
-  table_name = other318.table_name;
-  select_list = other318.select_list;
-  search_expr = other318.search_expr;
-  where_expr = other318.where_expr;
-  group_by_list = other318.group_by_list;
-  having_expr = other318.having_expr;
-  limit_expr = other318.limit_expr;
-  offset_expr = other318.offset_expr;
-  order_by_list = other318.order_by_list;
-  __isset = other318.__isset;
+SelectRequest::SelectRequest(const SelectRequest& other328) {
+  session_id = other328.session_id;
+  db_name = other328.db_name;
+  table_name = other328.table_name;
+  select_list = other328.select_list;
+  search_expr = other328.search_expr;
+  where_expr = other328.where_expr;
+  group_by_list = other328.group_by_list;
+  having_expr = other328.having_expr;
+  limit_expr = other328.limit_expr;
+  offset_expr = other328.offset_expr;
+  order_by_list = other328.order_by_list;
+  __isset = other328.__isset;
 }
-SelectRequest& SelectRequest::operator=(const SelectRequest& other319) {
-  session_id = other319.session_id;
-  db_name = other319.db_name;
-  table_name = other319.table_name;
-  select_list = other319.select_list;
-  search_expr = other319.search_expr;
-  where_expr = other319.where_expr;
-  group_by_list = other319.group_by_list;
-  having_expr = other319.having_expr;
-  limit_expr = other319.limit_expr;
-  offset_expr = other319.offset_expr;
-  order_by_list = other319.order_by_list;
-  __isset = other319.__isset;
+SelectRequest& SelectRequest::operator=(const SelectRequest& other329) {
+  session_id = other329.session_id;
+  db_name = other329.db_name;
+  table_name = other329.table_name;
+  select_list = other329.select_list;
+  search_expr = other329.search_expr;
+  where_expr = other329.where_expr;
+  group_by_list = other329.group_by_list;
+  having_expr = other329.having_expr;
+  limit_expr = other329.limit_expr;
+  offset_expr = other329.offset_expr;
+  order_by_list = other329.order_by_list;
+  __isset = other329.__isset;
   return *this;
 }
 void SelectRequest::printTo(std::ostream& out) const {
@@ -9300,14 +9644,14 @@ uint32_t SelectResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_defs.clear();
-            uint32_t _size320;
-            ::apache::thrift::protocol::TType _etype323;
-            xfer += iprot->readListBegin(_etype323, _size320);
-            this->column_defs.resize(_size320);
-            uint32_t _i324;
-            for (_i324 = 0; _i324 < _size320; ++_i324)
+            uint32_t _size330;
+            ::apache::thrift::protocol::TType _etype333;
+            xfer += iprot->readListBegin(_etype333, _size330);
+            this->column_defs.resize(_size330);
+            uint32_t _i334;
+            for (_i334 = 0; _i334 < _size330; ++_i334)
             {
-              xfer += this->column_defs[_i324].read(iprot);
+              xfer += this->column_defs[_i334].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -9320,14 +9664,14 @@ uint32_t SelectResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_fields.clear();
-            uint32_t _size325;
-            ::apache::thrift::protocol::TType _etype328;
-            xfer += iprot->readListBegin(_etype328, _size325);
-            this->column_fields.resize(_size325);
-            uint32_t _i329;
-            for (_i329 = 0; _i329 < _size325; ++_i329)
+            uint32_t _size335;
+            ::apache::thrift::protocol::TType _etype338;
+            xfer += iprot->readListBegin(_etype338, _size335);
+            this->column_fields.resize(_size335);
+            uint32_t _i339;
+            for (_i339 = 0; _i339 < _size335; ++_i339)
             {
-              xfer += this->column_fields[_i329].read(iprot);
+              xfer += this->column_fields[_i339].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -9364,10 +9708,10 @@ uint32_t SelectResponse::write(::apache::thrift::protocol::TProtocol* oprot) con
   xfer += oprot->writeFieldBegin("column_defs", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_defs.size()));
-    std::vector<ColumnDef> ::const_iterator _iter330;
-    for (_iter330 = this->column_defs.begin(); _iter330 != this->column_defs.end(); ++_iter330)
+    std::vector<ColumnDef> ::const_iterator _iter340;
+    for (_iter340 = this->column_defs.begin(); _iter340 != this->column_defs.end(); ++_iter340)
     {
-      xfer += (*_iter330).write(oprot);
+      xfer += (*_iter340).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -9376,10 +9720,10 @@ uint32_t SelectResponse::write(::apache::thrift::protocol::TProtocol* oprot) con
   xfer += oprot->writeFieldBegin("column_fields", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->column_fields.size()));
-    std::vector<ColumnField> ::const_iterator _iter331;
-    for (_iter331 = this->column_fields.begin(); _iter331 != this->column_fields.end(); ++_iter331)
+    std::vector<ColumnField> ::const_iterator _iter341;
+    for (_iter341 = this->column_fields.begin(); _iter341 != this->column_fields.end(); ++_iter341)
     {
-      xfer += (*_iter331).write(oprot);
+      xfer += (*_iter341).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -9399,19 +9743,19 @@ void swap(SelectResponse &a, SelectResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-SelectResponse::SelectResponse(const SelectResponse& other332) {
-  error_code = other332.error_code;
-  error_msg = other332.error_msg;
-  column_defs = other332.column_defs;
-  column_fields = other332.column_fields;
-  __isset = other332.__isset;
+SelectResponse::SelectResponse(const SelectResponse& other342) {
+  error_code = other342.error_code;
+  error_msg = other342.error_msg;
+  column_defs = other342.column_defs;
+  column_fields = other342.column_fields;
+  __isset = other342.__isset;
 }
-SelectResponse& SelectResponse::operator=(const SelectResponse& other333) {
-  error_code = other333.error_code;
-  error_msg = other333.error_msg;
-  column_defs = other333.column_defs;
-  column_fields = other333.column_fields;
-  __isset = other333.__isset;
+SelectResponse& SelectResponse::operator=(const SelectResponse& other343) {
+  error_code = other343.error_code;
+  error_msg = other343.error_msg;
+  column_defs = other343.column_defs;
+  column_fields = other343.column_fields;
+  __isset = other343.__isset;
   return *this;
 }
 void SelectResponse::printTo(std::ostream& out) const {
@@ -9551,19 +9895,19 @@ void swap(DeleteRequest &a, DeleteRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-DeleteRequest::DeleteRequest(const DeleteRequest& other334) {
-  db_name = other334.db_name;
-  table_name = other334.table_name;
-  where_expr = other334.where_expr;
-  session_id = other334.session_id;
-  __isset = other334.__isset;
+DeleteRequest::DeleteRequest(const DeleteRequest& other344) {
+  db_name = other344.db_name;
+  table_name = other344.table_name;
+  where_expr = other344.where_expr;
+  session_id = other344.session_id;
+  __isset = other344.__isset;
 }
-DeleteRequest& DeleteRequest::operator=(const DeleteRequest& other335) {
-  db_name = other335.db_name;
-  table_name = other335.table_name;
-  where_expr = other335.where_expr;
-  session_id = other335.session_id;
-  __isset = other335.__isset;
+DeleteRequest& DeleteRequest::operator=(const DeleteRequest& other345) {
+  db_name = other345.db_name;
+  table_name = other345.table_name;
+  where_expr = other345.where_expr;
+  session_id = other345.session_id;
+  __isset = other345.__isset;
   return *this;
 }
 void DeleteRequest::printTo(std::ostream& out) const {
@@ -9656,14 +10000,14 @@ uint32_t UpdateRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->update_expr_array.clear();
-            uint32_t _size336;
-            ::apache::thrift::protocol::TType _etype339;
-            xfer += iprot->readListBegin(_etype339, _size336);
-            this->update_expr_array.resize(_size336);
-            uint32_t _i340;
-            for (_i340 = 0; _i340 < _size336; ++_i340)
+            uint32_t _size346;
+            ::apache::thrift::protocol::TType _etype349;
+            xfer += iprot->readListBegin(_etype349, _size346);
+            this->update_expr_array.resize(_size346);
+            uint32_t _i350;
+            for (_i350 = 0; _i350 < _size346; ++_i350)
             {
-              xfer += this->update_expr_array[_i340].read(iprot);
+              xfer += this->update_expr_array[_i350].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -9712,10 +10056,10 @@ uint32_t UpdateRequest::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("update_expr_array", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->update_expr_array.size()));
-    std::vector<UpdateExpr> ::const_iterator _iter341;
-    for (_iter341 = this->update_expr_array.begin(); _iter341 != this->update_expr_array.end(); ++_iter341)
+    std::vector<UpdateExpr> ::const_iterator _iter351;
+    for (_iter351 = this->update_expr_array.begin(); _iter351 != this->update_expr_array.end(); ++_iter351)
     {
-      xfer += (*_iter341).write(oprot);
+      xfer += (*_iter351).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -9740,21 +10084,21 @@ void swap(UpdateRequest &a, UpdateRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-UpdateRequest::UpdateRequest(const UpdateRequest& other342) {
-  db_name = other342.db_name;
-  table_name = other342.table_name;
-  where_expr = other342.where_expr;
-  update_expr_array = other342.update_expr_array;
-  session_id = other342.session_id;
-  __isset = other342.__isset;
+UpdateRequest::UpdateRequest(const UpdateRequest& other352) {
+  db_name = other352.db_name;
+  table_name = other352.table_name;
+  where_expr = other352.where_expr;
+  update_expr_array = other352.update_expr_array;
+  session_id = other352.session_id;
+  __isset = other352.__isset;
 }
-UpdateRequest& UpdateRequest::operator=(const UpdateRequest& other343) {
-  db_name = other343.db_name;
-  table_name = other343.table_name;
-  where_expr = other343.where_expr;
-  update_expr_array = other343.update_expr_array;
-  session_id = other343.session_id;
-  __isset = other343.__isset;
+UpdateRequest& UpdateRequest::operator=(const UpdateRequest& other353) {
+  db_name = other353.db_name;
+  table_name = other353.table_name;
+  where_expr = other353.where_expr;
+  update_expr_array = other353.update_expr_array;
+  session_id = other353.session_id;
+  __isset = other353.__isset;
   return *this;
 }
 void UpdateRequest::printTo(std::ostream& out) const {
@@ -9861,15 +10205,15 @@ void swap(ShowVariableRequest &a, ShowVariableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowVariableRequest::ShowVariableRequest(const ShowVariableRequest& other344) {
-  session_id = other344.session_id;
-  variable_name = other344.variable_name;
-  __isset = other344.__isset;
+ShowVariableRequest::ShowVariableRequest(const ShowVariableRequest& other354) {
+  session_id = other354.session_id;
+  variable_name = other354.variable_name;
+  __isset = other354.__isset;
 }
-ShowVariableRequest& ShowVariableRequest::operator=(const ShowVariableRequest& other345) {
-  session_id = other345.session_id;
-  variable_name = other345.variable_name;
-  __isset = other345.__isset;
+ShowVariableRequest& ShowVariableRequest::operator=(const ShowVariableRequest& other355) {
+  session_id = other355.session_id;
+  variable_name = other355.variable_name;
+  __isset = other355.__isset;
   return *this;
 }
 void ShowVariableRequest::printTo(std::ostream& out) const {
@@ -9973,15 +10317,15 @@ void swap(ShowTablesRequest &a, ShowTablesRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowTablesRequest::ShowTablesRequest(const ShowTablesRequest& other346) {
-  session_id = other346.session_id;
-  db_name = other346.db_name;
-  __isset = other346.__isset;
+ShowTablesRequest::ShowTablesRequest(const ShowTablesRequest& other356) {
+  session_id = other356.session_id;
+  db_name = other356.db_name;
+  __isset = other356.__isset;
 }
-ShowTablesRequest& ShowTablesRequest::operator=(const ShowTablesRequest& other347) {
-  session_id = other347.session_id;
-  db_name = other347.db_name;
-  __isset = other347.__isset;
+ShowTablesRequest& ShowTablesRequest::operator=(const ShowTablesRequest& other357) {
+  session_id = other357.session_id;
+  db_name = other357.db_name;
+  __isset = other357.__isset;
   return *this;
 }
 void ShowTablesRequest::printTo(std::ostream& out) const {

--- a/src/network/infinity_thrift/infinity_types.h
+++ b/src/network/infinity_thrift/infinity_types.h
@@ -273,6 +273,10 @@ class ListTableRequest;
 
 class ListTableResponse;
 
+class ListIndexRequest;
+
+class ListIndexResponse;
+
 class ShowDatabaseRequest;
 
 class ShowDatabaseResponse;
@@ -2194,6 +2198,120 @@ void swap(ListTableResponse &a, ListTableResponse &b);
 
 std::ostream& operator<<(std::ostream& out, const ListTableResponse& obj);
 
+typedef struct _ListIndexRequest__isset {
+  _ListIndexRequest__isset() : db_name(false), table_name(false), session_id(false) {}
+  bool db_name :1;
+  bool table_name :1;
+  bool session_id :1;
+} _ListIndexRequest__isset;
+
+class ListIndexRequest : public virtual ::apache::thrift::TBase {
+ public:
+
+  ListIndexRequest(const ListIndexRequest&);
+  ListIndexRequest& operator=(const ListIndexRequest&);
+  ListIndexRequest() noexcept
+                   : db_name(),
+                     table_name(),
+                     session_id(0) {
+  }
+
+  virtual ~ListIndexRequest() noexcept;
+  std::string db_name;
+  std::string table_name;
+  int64_t session_id;
+
+  _ListIndexRequest__isset __isset;
+
+  void __set_db_name(const std::string& val);
+
+  void __set_table_name(const std::string& val);
+
+  void __set_session_id(const int64_t val);
+
+  bool operator == (const ListIndexRequest & rhs) const
+  {
+    if (!(db_name == rhs.db_name))
+      return false;
+    if (!(table_name == rhs.table_name))
+      return false;
+    if (!(session_id == rhs.session_id))
+      return false;
+    return true;
+  }
+  bool operator != (const ListIndexRequest &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const ListIndexRequest & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot) override;
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const override;
+
+  virtual void printTo(std::ostream& out) const;
+};
+
+void swap(ListIndexRequest &a, ListIndexRequest &b);
+
+std::ostream& operator<<(std::ostream& out, const ListIndexRequest& obj);
+
+typedef struct _ListIndexResponse__isset {
+  _ListIndexResponse__isset() : error_code(false), error_msg(false), index_names(true) {}
+  bool error_code :1;
+  bool error_msg :1;
+  bool index_names :1;
+} _ListIndexResponse__isset;
+
+class ListIndexResponse : public virtual ::apache::thrift::TBase {
+ public:
+
+  ListIndexResponse(const ListIndexResponse&);
+  ListIndexResponse& operator=(const ListIndexResponse&);
+  ListIndexResponse() noexcept
+                    : error_code(0),
+                      error_msg() {
+
+  }
+
+  virtual ~ListIndexResponse() noexcept;
+  int64_t error_code;
+  std::string error_msg;
+  std::vector<std::string>  index_names;
+
+  _ListIndexResponse__isset __isset;
+
+  void __set_error_code(const int64_t val);
+
+  void __set_error_msg(const std::string& val);
+
+  void __set_index_names(const std::vector<std::string> & val);
+
+  bool operator == (const ListIndexResponse & rhs) const
+  {
+    if (!(error_code == rhs.error_code))
+      return false;
+    if (!(error_msg == rhs.error_msg))
+      return false;
+    if (!(index_names == rhs.index_names))
+      return false;
+    return true;
+  }
+  bool operator != (const ListIndexResponse &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const ListIndexResponse & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot) override;
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const override;
+
+  virtual void printTo(std::ostream& out) const;
+};
+
+void swap(ListIndexResponse &a, ListIndexResponse &b);
+
+std::ostream& operator<<(std::ostream& out, const ListIndexResponse& obj);
+
 typedef struct _ShowDatabaseRequest__isset {
   _ShowDatabaseRequest__isset() : db_name(false), session_id(false) {}
   bool db_name :1;
@@ -2851,11 +2969,14 @@ void swap(ShowIndexRequest &a, ShowIndexRequest &b);
 std::ostream& operator<<(std::ostream& out, const ShowIndexRequest& obj);
 
 typedef struct _ShowIndexResponse__isset {
-  _ShowIndexResponse__isset() : db_name(false), table_name(false), index_name(false), store_dir(false) {}
+  _ShowIndexResponse__isset() : error_code(false), error_msg(false), db_name(false), table_name(false), index_name(false), store_dir(false), index_info(false) {}
+  bool error_code :1;
+  bool error_msg :1;
   bool db_name :1;
   bool table_name :1;
   bool index_name :1;
   bool store_dir :1;
+  bool index_info :1;
 } _ShowIndexResponse__isset;
 
 class ShowIndexResponse : public virtual ::apache::thrift::TBase {
@@ -2864,19 +2985,29 @@ class ShowIndexResponse : public virtual ::apache::thrift::TBase {
   ShowIndexResponse(const ShowIndexResponse&);
   ShowIndexResponse& operator=(const ShowIndexResponse&);
   ShowIndexResponse() noexcept
-                    : db_name(),
+                    : error_code(0),
+                      error_msg(),
+                      db_name(),
                       table_name(),
                       index_name(),
-                      store_dir() {
+                      store_dir(),
+                      index_info() {
   }
 
   virtual ~ShowIndexResponse() noexcept;
+  int64_t error_code;
+  std::string error_msg;
   std::string db_name;
   std::string table_name;
   std::string index_name;
   std::string store_dir;
+  std::string index_info;
 
   _ShowIndexResponse__isset __isset;
+
+  void __set_error_code(const int64_t val);
+
+  void __set_error_msg(const std::string& val);
 
   void __set_db_name(const std::string& val);
 
@@ -2886,8 +3017,14 @@ class ShowIndexResponse : public virtual ::apache::thrift::TBase {
 
   void __set_store_dir(const std::string& val);
 
+  void __set_index_info(const std::string& val);
+
   bool operator == (const ShowIndexResponse & rhs) const
   {
+    if (!(error_code == rhs.error_code))
+      return false;
+    if (!(error_msg == rhs.error_msg))
+      return false;
     if (!(db_name == rhs.db_name))
       return false;
     if (!(table_name == rhs.table_name))
@@ -2895,6 +3032,8 @@ class ShowIndexResponse : public virtual ::apache::thrift::TBase {
     if (!(index_name == rhs.index_name))
       return false;
     if (!(store_dir == rhs.store_dir))
+      return false;
+    if (!(index_info == rhs.index_info))
       return false;
     return true;
   }

--- a/src/planner/logical_planner.cpp
+++ b/src/planner/logical_planner.cpp
@@ -1067,7 +1067,7 @@ Status LogicalPlanner::BuildShowDatabase(const ShowStatement *statement, SharedP
     String object_name;
     SharedPtr<LogicalNode> logical_show = MakeShared<LogicalShow>(bind_context_ptr->GetNewLogicalNodeId(),
                                                                   ShowType::kShowDatabase,
-                                                                  query_context_ptr_->schema_name(),
+                                                                  statement->schema_name_,
                                                                   object_name,
                                                                   bind_context_ptr->GenerateTableIndex());
     this->logical_plan_ = logical_show;


### PR DESCRIPTION
### What problem does this PR solve?

1. 
Before the patch.
```

infiniflow=> show database db2;
       name        |                  value                   
-------------------+------------------------------------------
 database_name     | default
 storage_directory | /tmp/infinity/data/xwYBP0Xf57_db_default
 table_count       | 0


```

After the patch.
```

infiniflow=> show database db2;
       name        |                value                 
-------------------+--------------------------------------
 database_name     | db2
 storage_directory | /tmp/infinity/data/5eVKS3M82y_db_db2
 table_count       | 0
(3 rows)

```

This PR will also affect HTTP API.

2. Introduce new interfaces: show index and list indexes.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)

