### PR TITLE
Fix: error of show_database

### DIFF
--- a/python/test/test_database.py
+++ b/python/test/test_database.py
@@ -14,8 +14,9 @@
 
 import threading
 import infinity
-from common import common_values
 import pytest
+from common import common_values
+from infinity.common import ConflictType
 from infinity.errors import ErrorCode
 from utils import trace_expected_exceptions
 
@@ -536,15 +537,15 @@ class TestDatabase:
         res = infinity_obj.disconnect()
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.skip(reason="Attempt to access an invalid index of column vector")
     def test_show_database(self):
         # create db
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
+        infinity_obj.drop_database("test_show_database", ConflictType.Ignore)
         infinity_obj.create_database("test_show_database")
 
-        infinity_obj.show_database("test_show_database")
+        res = infinity_obj.show_database("test_show_database")
+        assert res.database_name=="test_show_database"
 
-        infinity_obj.drop_database("test_show_database")
         # disconnect
         res = infinity_obj.disconnect()
         assert res.error_code == ErrorCode.OK

--- a/python/test/test_database.py
+++ b/python/test/test_database.py
@@ -546,6 +546,7 @@ class TestDatabase:
         res = infinity_obj.show_database("test_show_database")
         assert res.database_name=="test_show_database"
 
+        infinity_obj.drop_database("test_show_database", ConflictType.Ignore)
         # disconnect
         res = infinity_obj.disconnect()
         assert res.error_code == ErrorCode.OK

--- a/src/network/thrift_server.cpp
+++ b/src/network/thrift_server.cpp
@@ -880,12 +880,12 @@ public:
             }
 
             {
-                Value value = data_block->GetValue(1, 2);
+                Value value = data_block->GetValue(1, 1);
                 response.store_dir = value.GetVarchar();
             }
 
             {
-                Value value = data_block->GetValue(1, 3);
+                Value value = data_block->GetValue(1, 2);
                 response.table_count = value.value_.big_int;
             }
 

--- a/src/planner/logical_planner.cpp
+++ b/src/planner/logical_planner.cpp
@@ -1067,7 +1067,7 @@ Status LogicalPlanner::BuildShowDatabase(const ShowStatement *statement, SharedP
     String object_name;
     SharedPtr<LogicalNode> logical_show = MakeShared<LogicalShow>(bind_context_ptr->GetNewLogicalNodeId(),
                                                                   ShowType::kShowDatabase,
-                                                                  query_context_ptr_->schema_name(),
+                                                                  statement->schema_name_,
                                                                   object_name,
                                                                   bind_context_ptr->GenerateTableIndex());
     this->logical_plan_ = logical_show;


### PR DESCRIPTION
### What problem does this PR solve?

The service crashes when executing `ShowDatabase()` through thrift server.

Issue link:#829

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
