### PR TITLE
Fix: invalid data type for knn query crash down the service

### DIFF
--- a/python/infinity/remote_thrift/query_builder.py
+++ b/python/infinity/remote_thrift/query_builder.py
@@ -74,6 +74,13 @@ class InfinityThriftQueryBuilder(ABC):
 
         column_expr = ColumnExpr(column_name=[vector_column_name], star=False)
 
+        # type casting
+        if (embedding_data_type == 'tinyint' or
+            embedding_data_type == 'smallint' or
+            embedding_data_type == 'int' or
+            embedding_data_type == 'bigint'):
+            embedding_data = [int(x) for x in embedding_data]
+
         if isinstance(embedding_data, list):
             embedding_data = embedding_data
         if isinstance(embedding_data, np.ndarray):

--- a/python/test/test_knn.py
+++ b/python/test/test_knn.py
@@ -183,8 +183,8 @@ class TestKnn:
         [1.0] * 4,
     ])
     @pytest.mark.parametrize("embedding_data_type", [
-        # FIXME "int",
-        "float",
+        ("int", False),
+        ("float", True),
         pytest.param(1, marks=pytest.mark.xfail(reason="Invalid embedding 1.0 type")),
         pytest.param(2.2, marks=pytest.mark.xfail(reason="Invalid embedding 1.0 type")),
         pytest.param("#@!$!@", marks=pytest.mark.xfail(reason="Invalid embedding 1.0 type")),
@@ -208,9 +208,14 @@ class TestKnn:
             copy_data("tmp_20240116.csv")
         test_csv_dir = "/tmp/infinity/test_data/tmp_20240116.csv"
         table_obj.import_data(test_csv_dir, None)
-        res = table_obj.output(["variant_id"]).knn("gender_vector", embedding_data, embedding_data_type, "ip",
-                                                   2).to_pl()
-        print(res)
+        if embedding_data_type[1]:
+            res = table_obj.output(["variant_id"]).knn("gender_vector", embedding_data, embedding_data_type[0], "ip",
+                                                        2).to_pl()
+            print(res)
+        else:
+            with pytest.raises(Exception, match="ERROR:3032*"):
+                res = table_obj.output(["variant_id"]).knn("gender_vector", embedding_data, embedding_data_type[0], "ip",
+                                                        2).to_pl()
 
     @pytest.mark.parametrize("check_data", [{"file_name": "tmp_20240116.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)

--- a/src/function/table/knn_scan_data.cpp
+++ b/src/function/table/knn_scan_data.cpp
@@ -71,7 +71,7 @@ KnnScanFunctionData::KnnScanFunctionData(KnnScanSharedData *shared_data, u32 cur
             break;
         }
         default: {
-            RecoverableError(Status::NotSupport(fmt::format("EmbeddingDataType: {} is not support.", knn_scan_shared_data_->elem_type_)));
+            RecoverableError(Status::NotSupport(fmt::format("EmbeddingDataType: {} is not support.", EmbeddingType::EmbeddingDataType2String(knn_scan_shared_data_->elem_type_))));
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

When using invalid data type in knn query, python sdk throw unexpected exceptions.

Issue link:#774

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [x] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
