### PR TITLE
Fix link thrift error

### DIFF
--- a/client/cpp/CMakeLists.txt
+++ b/client/cpp/CMakeLists.txt
@@ -31,5 +31,5 @@ target_link_libraries(
 
 target_include_directories(infinity_client_test PUBLIC "${CMAKE_SOURCE_DIR}/src/network/infinity_thrift")
 target_include_directories(infinity_client_test PUBLIC "${CMAKE_SOURCE_DIR}/client/cpp")
-#target_link_libraries(infinity_client_test PUBLIC "${CMAKE_BINARY_DIR}/client/cpp")
+target_link_directories(infinity_client_test PUBLIC "${CMAKE_BINARY_DIR}/lib")
 


### PR DESCRIPTION
### What problem does this PR solve?

Release building is blocked by linking with libthrift.

Issue link:#[Link the issue here]

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

