### PR TITLE
Recycle log file

### DIFF
--- a/src/common/default_values.cppm
+++ b/src/common/default_values.cppm
@@ -93,7 +93,7 @@ export {
     constexpr SizeT DELTA_CHECKPOINT_INTERVAL_SEC = 5;         // 5 seconds
     constexpr SizeT DELTA_CHECKPOINT_INTERVAL_WAL_BYTES = 64 * 1024;
     constexpr std::string_view WAL_FILE_TEMP_FILE = "wal.log";
-    constexpr std::string_view WAL_FILE_PREFIX = "wal.log.";
+    constexpr std::string_view WAL_FILE_PREFIX = "wal.log";
     constexpr std::string_view CATALOG_FILE_DIR = "catalog";
 
     constexpr SizeT DEFAULT_CLEANUP_INTERVAL_SEC = 10;

--- a/src/common/default_values.cppm
+++ b/src/common/default_values.cppm
@@ -89,7 +89,7 @@ export {
     constexpr SizeT DEFAULT_OUTLINE_FILE_MAX_SIZE = 16 * 1024 * 1024;
 
     constexpr SizeT DEFAULT_WAL_FILE_SIZE_THRESHOLD = 8 * 1024;
-    constexpr SizeT FULL_CHECKPOINT_INTERVAL_SEC = 60;          // 60 seconds
+    constexpr SizeT FULL_CHECKPOINT_INTERVAL_SEC = 30;          // 30 seconds
     constexpr SizeT DELTA_CHECKPOINT_INTERVAL_SEC = 5;         // 5 seconds
     constexpr SizeT DELTA_CHECKPOINT_INTERVAL_WAL_BYTES = 64 * 1024;
     constexpr std::string_view WAL_FILE_TEMP_FILE = "wal.log";

--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -66,6 +66,8 @@ export namespace std {
     using std::errc;
 
     using std::stoi;
+    using std::stol;
+    using std::stoll;
     using std::strtol;
     using std::strtof;
     using std::strtod;

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -108,7 +108,8 @@ void FileWorker::CleanupFile() {
 
     String file_path = fmt::format("{}/{}", *file_dir_, *file_name_);
     if (!fs.Exists(file_path)) {
-        // UnrecoverableError(fmt::format("File {} not found.", file_path));
+        // this may happen the same reason as in "CleanupScanner::CleanupDir"
+        LOG_INFO(fmt::format("Cleanup: File {} not found.", file_path));
         return;
     }
     LOG_INFO(fmt::format("Cleanup file: {}", file_path));

--- a/src/storage/io/local_file_system.cpp
+++ b/src/storage/io/local_file_system.cpp
@@ -28,6 +28,7 @@ import file_system_type;
 import infinity_exception;
 import third_party;
 import logger;
+import status;
 
 module local_file_system;
 
@@ -236,7 +237,7 @@ void LocalFileSystem::DeleteEmptyDirectory(const String &path) {
     std::error_code error_code;
     Path p{path};
     if (!std::filesystem::exists(p, error_code)) {
-        UnrecoverableError(fmt::format("DeleteEmptyDirectory: {} is not exist", path));
+        RecoverableError(Status::DirNotFound(path));
     }
     std::filesystem::remove(p, error_code);
     if (error_code.value() != 0) {

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -42,6 +42,7 @@ import base_entry;
 
 import meta_entry_interface;
 import cleanup_scanner;
+import log_file;
 
 namespace infinity {
 
@@ -231,24 +232,25 @@ public:
     // Serialization and Deserialization
     nlohmann::json Serialize(TxnTimeStamp max_commit_ts, bool is_full_checkpoint);
 
-    UniquePtr<String> SaveFullCatalog(const String &catalog_dir, TxnTimeStamp max_commit_ts);
+    void SaveFullCatalog(TxnTimeStamp max_commit_ts, String &full_path);
 
-    bool SaveDeltaCatalog(const String &catalog_dir, TxnTimeStamp max_commit_ts);
+    bool SaveDeltaCatalog(TxnTimeStamp max_commit_ts, String &delta_path);
 
     void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size);
 
     static UniquePtr<Catalog> NewCatalog(SharedPtr<String> data_dir, bool create_default_db);
 
-    static UniquePtr<Catalog> LoadFromFiles(const Vector<String> &catalog_paths, BufferManager *buffer_mgr);
+    static UniquePtr<Catalog>
+    LoadFromFiles(const FullCatalogFileInfo &full_ckp_info, const Vector<DeltaCatalogFileInfo> &delta_ckp_infos, BufferManager *buffer_mgr);
 
 private:
     static UniquePtr<Catalog> Deserialize(const nlohmann::json &catalog_json, BufferManager *buffer_mgr);
 
-    static UniquePtr<CatalogDeltaEntry> LoadFromFileDelta(const String &catalog_path);
+    static UniquePtr<CatalogDeltaEntry> LoadFromFileDelta(const DeltaCatalogFileInfo &delta_ckp_info);
 
     void LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buffer_mgr);
 
-    static UniquePtr<Catalog> LoadFromFile(const String &catalog_path, BufferManager *buffer_mgr);
+    static UniquePtr<Catalog> LoadFromFile(const FullCatalogFileInfo &full_ckp_info, BufferManager *buffer_mgr);
 
 public:
     // Profile related methods

--- a/src/storage/meta/cleanup_scanner.cppm
+++ b/src/storage/meta/cleanup_scanner.cppm
@@ -36,6 +36,8 @@ public:
 
     TxnTimeStamp visible_ts() const { return visible_ts_; }
 
+    static void CleanupDir(const String &dir);
+
 private:
     Catalog *const catalog_;
     const TxnTimeStamp visible_ts_;

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -34,6 +34,7 @@ import segment_entry;
 import column_vector;
 import bitmask;
 import block_version;
+import cleanup_scanner;
 
 namespace infinity {
 
@@ -287,8 +288,7 @@ void BlockEntry::Cleanup() {
     }
     block_version_->Cleanup(this->VersionFilePath());
 
-    LocalFileSystem fs;
-    fs.DeleteEmptyDirectory(*block_dir_);
+    CleanupScanner::CleanupDir(*block_dir_);
 }
 
 // TODO: introduce BlockColumnMeta

--- a/src/storage/meta/entry/db_entry.cpp
+++ b/src/storage/meta/entry/db_entry.cpp
@@ -34,6 +34,7 @@ import catalog_delta_entry;
 import column_def;
 import local_file_system;
 import extra_ddl_info;
+import cleanup_scanner;
 
 namespace infinity {
 
@@ -272,8 +273,7 @@ void DBEntry::Cleanup() {
     table_meta_map_.Cleanup();
 
     LOG_INFO(fmt::format("Cleanup dir: {}", *db_entry_dir_));
-    LocalFileSystem fs;
-    fs.DeleteEmptyDirectory(*db_entry_dir_);
+    CleanupScanner::CleanupDir(*db_entry_dir_);
 }
 
 void DBEntry::MemIndexCommit() {

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -450,8 +450,7 @@ void SegmentEntry::Cleanup() {
     for (auto &block_entry : block_entries_) {
         block_entry->Cleanup();
     }
-    LocalFileSystem fs;
-    fs.DeleteEmptyDirectory(*segment_dir_);
+    CleanupScanner::CleanupDir(*segment_dir_);
 }
 
 void SegmentEntry::PickCleanup(CleanupScanner *scanner) {}

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -48,6 +48,7 @@ import local_file_system;
 import build_fast_rough_filter_task;
 import block_entry;
 import segment_index_entry;
+import cleanup_scanner;
 
 namespace infinity {
 
@@ -829,8 +830,7 @@ void TableEntry::Cleanup() {
     index_meta_map_.Cleanup();
 
     LOG_INFO(fmt::format("Cleanup dir: {}", *table_entry_dir_));
-    LocalFileSystem fs;
-    fs.DeleteEmptyDirectory(*table_entry_dir_);
+    CleanupScanner::CleanupDir(*table_entry_dir_);  
 }
 
 } // namespace infinity

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -398,8 +398,13 @@ void TableIndexEntry::Cleanup() {
     }
 
     LOG_INFO(fmt::format("Cleanup dir: {}", *index_dir_));
+
+    // FIXME(sys): delete full text index by whole directory tmply, should call CleanupScanner::CleanupDir
     LocalFileSystem fs;
-    fs.DeleteDirectory(*index_dir_); // FIXME(sys): delete full text index by whole directory tmply
+    if (!fs.Exists(*index_dir_)) {
+        return;
+    }
+    fs.DeleteDirectory(*index_dir_);
 }
 
 void TableIndexEntry::PickCleanup(CleanupScanner *scanner) {}

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -41,6 +41,7 @@ import status;
 import bg_task;
 import periodic_trigger_thread;
 import periodic_trigger;
+import log_file;
 
 namespace infinity {
 
@@ -52,7 +53,7 @@ void Storage::Init() {
 
     // Construct wal manager
     wal_mgr_ = MakeUnique<WalManager>(this,
-                                      Path(*config_ptr_->wal_dir()) / WAL_FILE_TEMP_FILE,
+                                      *config_ptr_->wal_dir(),
                                       config_ptr_->wal_size_threshold(),
                                       config_ptr_->delta_checkpoint_interval_wal_bytes(),
                                       config_ptr_->flush_at_commit());
@@ -139,12 +140,12 @@ void Storage::UnInit() {
     fmt::print("Shutdown storage successfully\n");
 }
 
-void Storage::AttachCatalog(const Vector<String> &catalog_files) {
-    LOG_INFO(fmt::format("Attach catalogs from {} files", catalog_files.size()));
-    for (const auto &catalog_file : catalog_files) {
-        LOG_TRACE(fmt::format("Catalog file: {}", catalog_file.c_str()));
+void Storage::AttachCatalog(const FullCatalogFileInfo &full_ckp_info, const Vector<DeltaCatalogFileInfo> &delta_ckp_infos) {
+    LOG_TRACE(fmt::format("Full catalog file: {}", full_ckp_info.path_));
+    for (const auto &delta_ckp_info : delta_ckp_infos) {
+        LOG_TRACE(fmt::format("Delta catalog file: {}", delta_ckp_info.path_));
     }
-    new_catalog_ = Catalog::LoadFromFiles(catalog_files, buffer_mgr_.get());
+    new_catalog_ = Catalog::LoadFromFiles(full_ckp_info, delta_ckp_infos, buffer_mgr_.get());
 }
 
 void Storage::InitNewCatalog() {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -105,7 +105,7 @@ void Storage::Init() {
             periodic_trigger_thread_->AddTrigger(
                 MakeUnique<CheckpointPeriodicTrigger>(std::chrono::seconds(full_checkpoint_interval_sec), bg_processor_.get(), true));
         } else {
-            LOG_WARN("Full checkpoint interval is not set, auto full checkpoint task will not be triggered");
+            LOG_WARN("Full checkpoint interval is not set, auto full checkpoint task will NOT be triggered");
         }
 
         i64 delta_checkpoint_interval_sec = config_ptr_->delta_checkpoint_interval_sec();
@@ -113,7 +113,7 @@ void Storage::Init() {
             periodic_trigger_thread_->AddTrigger(
                 MakeUnique<CheckpointPeriodicTrigger>(std::chrono::seconds(delta_checkpoint_interval_sec), bg_processor_.get(), false));
         } else {
-            LOG_WARN("Delta checkpoint interval is not set, auto delta checkpoint task will not be triggered");
+            LOG_WARN("Delta checkpoint interval is not set, auto delta checkpoint task will NOT be triggered");
         }
 
         periodic_trigger_thread_->Start();

--- a/src/storage/storage.cppm
+++ b/src/storage/storage.cppm
@@ -50,6 +50,8 @@ public:
 
     void InitNewCatalog();
 
+    const Config *config() const { return config_ptr_; }
+
 private:
     const Config *config_ptr_{};
     UniquePtr<Catalog> new_catalog_{};

--- a/src/storage/storage.cppm
+++ b/src/storage/storage.cppm
@@ -22,6 +22,7 @@ import buffer_manager;
 import wal_manager;
 import background_process;
 import periodic_trigger_thread;
+import log_file;
 
 export module storage;
 
@@ -45,7 +46,7 @@ public:
 
     void UnInit();
 
-    void AttachCatalog(const Vector<String> &catalog_files);
+    void AttachCatalog(const FullCatalogFileInfo &full_ckp_info, const Vector<DeltaCatalogFileInfo> &delta_ckp_infos);
 
     void InitNewCatalog();
 

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -474,10 +474,9 @@ void Txn::Checkpoint(const TxnTimeStamp max_commit_ts, bool is_full_checkpoint) 
 
 // Incremental checkpoint contains only the difference in status between the last checkpoint and this checkpoint (that is, "increment")
 void Txn::DeltaCheckpoint(const TxnTimeStamp max_commit_ts) {
-    String dir_name = *txn_mgr_->GetCatalog()->CatalogDir();
-    String delta_path = String(fmt::format("{}/CATALOG_DELTA_ENTRY.DELTA.{}", dir_name, max_commit_ts));
+    String delta_path;
     // only save the catalog delta entry
-    bool skip = catalog_->SaveDeltaCatalog(delta_path, max_commit_ts);
+    bool skip = catalog_->SaveDeltaCatalog(max_commit_ts, delta_path);
     if (skip) {
         return;
     }
@@ -485,18 +484,10 @@ void Txn::DeltaCheckpoint(const TxnTimeStamp max_commit_ts) {
 }
 
 void Txn::FullCheckpoint(const TxnTimeStamp max_commit_ts) {
-    String dir_name = *txn_mgr_->GetCatalog()->CatalogDir();
+    String full_path;
 
-    //    String delta_path = String(fmt::format("{}/META_CATALOG.{}.delta", dir_name, max_commit_ts));
-    //    String delta_tmp_path = String(fmt::format("{}/_META_CATALOG.{}.delta", dir_name, max_commit_ts));
-    //
-    //    String catalog_path = String(fmt::format("{}/META_CATALOG.{}.json", dir_name, max_commit_ts));
-    //    String catalog_tmp_path = String(fmt::format("{}/_META_CATALOG.{}.json", dir_name, max_commit_ts));
-
-    // Full Check point don't need increment checkpoint
-    // catalog_->SaveDeltaCatalog(delta_path, max_commit_ts, true);
-    UniquePtr<String> catalog_path_ptr = catalog_->SaveFullCatalog(dir_name, max_commit_ts);
-    wal_entry_->cmds_.push_back(MakeShared<WalCmdCheckpoint>(max_commit_ts, true, *catalog_path_ptr));
+    catalog_->SaveFullCatalog(max_commit_ts, full_path);
+    wal_entry_->cmds_.push_back(MakeShared<WalCmdCheckpoint>(max_commit_ts, true, full_path));
 }
 
 } // namespace infinity

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -478,7 +478,8 @@ void Txn::DeltaCheckpoint(const TxnTimeStamp max_commit_ts) {
     // only save the catalog delta entry
     bool skip = catalog_->SaveDeltaCatalog(max_commit_ts, delta_path);
     if (skip) {
-        return;
+        LOG_INFO("No delta catalog file is written");
+        // should not skip wal write.
     }
     wal_entry_->cmds_.push_back(MakeShared<WalCmdCheckpoint>(max_commit_ts, false, delta_path));
 }

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -741,7 +741,6 @@ UniquePtr<CatalogDeltaEntry> GlobalCatalogDeltaEntry::PickFlushEntry(TxnTimeStam
         UnrecoverableError(fmt::format("max_commit_ts {} != max_commit_ts_ {}", max_commit_ts, max_commit_ts_));
     }
 
-    TxnTimeStamp max_ts = 0;
     {
         std::unique_lock w_lock(mtx_);
 
@@ -754,7 +753,6 @@ UniquePtr<CatalogDeltaEntry> GlobalCatalogDeltaEntry::PickFlushEntry(TxnTimeStam
 
         flush_delta_entry->set_txn_ids(Vector<TransactionID>(txn_ids_.begin(), txn_ids_.end()));
 
-        std::swap(max_ts, max_commit_ts_);
         txn_ids_.clear();
         delta_ops_.clear();
     }

--- a/src/storage/wal/log_file.cpp
+++ b/src/storage/wal/log_file.cpp
@@ -1,0 +1,215 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <vector>
+
+module log_file;
+
+import stl;
+import local_file_system;
+import third_party;
+import infinity_exception;
+import logger;
+import default_values;
+
+namespace infinity {
+
+Optional<Pair<FullCatalogFileInfo, Vector<DeltaCatalogFileInfo>>> CatalogFile::ParseValidCheckpointFilenames(const String &catalog_dir,
+                                                                                                             TxnTimeStamp max_checkpoint_ts) {
+    auto [full_infos, delta_infos] = ParseCheckpointFilenames(catalog_dir);
+    std::sort(full_infos.begin(), full_infos.end(), [](const auto &lhs, const auto &rhs) { return lhs.max_commit_ts_ < rhs.max_commit_ts_; });
+    std::sort(delta_infos.begin(), delta_infos.end(), [](const auto &lhs, const auto &rhs) { return lhs.max_commit_ts_ < rhs.max_commit_ts_; });
+
+    while (!full_infos.empty() && full_infos.back().max_commit_ts_ > max_checkpoint_ts) {
+        LOG_WARN(fmt::format("Full catalog file {} is newer than the max checkpoint ts {}", full_infos.back().path_, max_checkpoint_ts));
+        full_infos.pop_back();
+    }
+    if (full_infos.empty()) {
+        return None;
+    }
+    if (full_infos.size() > 1) {
+        LOG_WARN(fmt::format("Multiple full catalog files found in the catalog directory: {}", catalog_dir));
+    }
+    FullCatalogFileInfo last_full_info = full_infos.back();
+
+    while (!delta_infos.empty() && delta_infos.back().max_commit_ts_ > max_checkpoint_ts) {
+        LOG_WARN(fmt::format("Delta catalog file {} is newer than the max checkpoint ts {}", delta_infos.back().path_, max_checkpoint_ts));
+        delta_infos.pop_back();
+    }
+    while (!delta_infos.empty() && delta_infos.front().max_commit_ts_ < last_full_info.max_commit_ts_) {
+        LOG_WARN(fmt::format("Delta catalog file {} is older than the full catalog file {}", delta_infos.front().path_, last_full_info.path_));
+        delta_infos.erase(delta_infos.begin());
+    }
+
+    auto res = Pair<FullCatalogFileInfo, Vector<DeltaCatalogFileInfo>>{last_full_info, std::move(delta_infos)};
+    return res;
+}
+
+String CatalogFile::FullCheckpoingFilename(TxnTimeStamp max_commit_ts) { return fmt::format("FULL.{}.json", max_commit_ts); }
+
+String CatalogFile::TempFullCheckpointFilename(TxnTimeStamp max_commit_ts) { return fmt::format("_FULL.{}.json", max_commit_ts); }
+
+String CatalogFile::DeltaCheckpointFilename(TxnTimeStamp max_commit_ts) { return fmt::format("DELTA.{}", max_commit_ts); }
+
+void CatalogFile::RecycleCatalogFile(TxnTimeStamp full_ckp_ts, const String &catalog_dir) {
+    auto [full_infos, delta_infos] = ParseCheckpointFilenames(catalog_dir);
+    bool found = false;
+    for (const auto &full_info : full_infos) {
+        if (full_info.max_commit_ts_ < full_ckp_ts) {
+            LocalFileSystem fs;
+            fs.DeleteFile(full_info.path_);
+            LOG_TRACE(fmt::format("WalManager::Checkpoint delete catalog file: {}", full_info.path_));
+        } else if (full_info.max_commit_ts_ == full_ckp_ts) {
+            found = true;
+        }
+    }
+    if (!found) {
+        UnrecoverableError(
+            fmt::format("Full catalog file {} not found in the catalog directory: {}", FullCheckpoingFilename(full_ckp_ts), catalog_dir));
+    }
+    for (const auto &delta_info : delta_infos) {
+        if (delta_info.max_commit_ts_ <= full_ckp_ts) {
+            LocalFileSystem fs;
+            fs.DeleteFile(delta_info.path_);
+            LOG_TRACE(fmt::format("WalManager::Checkpoint delete catalog file: {}", delta_info.path_));
+        }
+    }
+}
+
+Pair<Vector<FullCatalogFileInfo>, Vector<DeltaCatalogFileInfo>> CatalogFile::ParseCheckpointFilenames(const String &catalog_dir) {
+    LocalFileSystem fs;
+    const auto &entries = fs.ListDirectory(catalog_dir);
+    if (entries.empty()) {
+        return {Vector<FullCatalogFileInfo>{}, Vector<DeltaCatalogFileInfo>{}};
+    }
+
+    Vector<FullCatalogFileInfo> full_infos;
+    Vector<DeltaCatalogFileInfo> delta_infos;
+    for (const auto &entry : entries) {
+        if (!entry->is_regular_file()) {
+            LOG_WARN(fmt::format("Catalog file {} is not a regular file", entry->path().string()));
+            continue;
+        }
+        const auto &filename = entry->path().filename().string();
+        auto dot_pos = filename.rfind('.');
+        if (dot_pos == String::npos) {
+            LOG_WARN(fmt::format("Catalog file {} has wrong file name", entry->path().string()));
+            continue;
+        }
+        auto suffix = filename.substr(dot_pos + 1);
+        if (IsEqual(suffix, String("json"))) {
+            if (dot_pos == 0) {
+                LOG_WARN(fmt::format("Catalog file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            auto dot2_pos = filename.rfind('.', dot_pos - 1);
+            TxnTimeStamp checkpoint_ts;
+            try {
+                checkpoint_ts = std::stoll(filename.substr(dot2_pos + 1, dot_pos - dot2_pos - 1));
+            } catch (...) {
+                LOG_WARN(fmt::format("Catalog file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            auto file_prefix = filename.substr(0, dot2_pos);
+            if (!IsEqual(file_prefix, String("FULL"))) {
+                LOG_WARN(fmt::format("Catalog file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            full_infos.emplace_back(FullCatalogFileInfo{entry->path().string(), checkpoint_ts});
+        } else {
+            TxnTimeStamp checkpoint_ts;
+            try {
+                checkpoint_ts = std::stoll(filename.substr(dot_pos + 1));
+            } catch (...) {
+                LOG_WARN(fmt::format("Catalog file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            auto file_prefix = filename.substr(0, dot_pos);
+            if (!IsEqual(file_prefix, String("DELTA"))) {
+                LOG_WARN(fmt::format("Catalog file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            delta_infos.push_back({entry->path().string(), checkpoint_ts});
+        }
+    }
+    return {full_infos, delta_infos};
+}
+
+Pair<Optional<TempWalFileInfo>, Vector<WalFileInfo>> WalFile::ParseWalFilenames(const String &wal_dir) {
+    LocalFileSystem fs;
+    const auto &entries = fs.ListDirectory(wal_dir);
+    if (entries.empty()) {
+        return {TempWalFileInfo{}, Vector<WalFileInfo>{}};
+    }
+    Optional<TempWalFileInfo> cur_wal_info;
+    Vector<WalFileInfo> wal_infos;
+    for (const auto &entry : entries) {
+        if (!entry->is_regular_file()) {
+            LOG_WARN(fmt::format("Wal file {} is not a regular file", entry->path().string()));
+            continue;
+        }
+        const auto &filename = entry->path().filename().string();
+        if (IsEqual(filename, WalFile::TempWalFilename())) {
+            if (cur_wal_info.has_value()) {
+                UnrecoverableError(fmt::format("Multiple current wal files found in the wal directory: {}", wal_dir));
+            }
+            cur_wal_info = TempWalFileInfo{entry->path().string()};
+        } else {
+            auto dot_pos = filename.rfind('.');
+            if (dot_pos == String::npos) {
+                LOG_WARN(fmt::format("Wal file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            TxnTimeStamp checkpoint_ts;
+            try {
+                checkpoint_ts = std::stoll(filename.substr(dot_pos + 1));
+            } catch (...) {
+                LOG_WARN(fmt::format("Wal file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            auto file_prefix = filename.substr(0, dot_pos);
+            if (IsEqual(file_prefix, String("WAL"))) {
+                LOG_WARN(fmt::format("Wal file {} has wrong file name", entry->path().string()));
+                continue;
+            }
+            wal_infos.push_back({entry->path().string(), checkpoint_ts});
+        }
+    }
+    return {cur_wal_info, wal_infos};
+}
+
+String WalFile::WalFilename(TxnTimeStamp max_commit_ts) { return fmt::format("{}{}", String(WAL_FILE_PREFIX), max_commit_ts); }
+
+String WalFile::TempWalFilename() { return String(WAL_FILE_TEMP_FILE); }
+
+// /**
+//  * @brief Gc the old wal files.
+//  * Only delete the wal.log.* files. the wal.log file is current wal file.
+//  * Check if the wal.log.* files are too old.
+//  * if * is little than the max_commit_ts, we will delete it.
+//  */
+void WalFile::RecycleWalFile(TxnTimeStamp ckp_ts, const String &wal_dir) {
+    auto [cur_wal_info, wal_infos] = ParseWalFilenames(wal_dir);
+    for (const auto &wal_info : wal_infos) {
+        if (wal_info.max_commit_ts_ < ckp_ts) {
+            LocalFileSystem fs;
+            fs.DeleteFile(wal_info.path_);
+            LOG_TRACE(fmt::format("WalManager::Checkpoint delete wal file: {}", wal_info.path_));
+        }
+    }
+}
+
+} // namespace infinity

--- a/src/storage/wal/log_file.cppm
+++ b/src/storage/wal/log_file.cppm
@@ -55,13 +55,12 @@ public:
 
     static void RecycleCatalogFile(TxnTimeStamp full_ckp_ts, const String &catalog_dir);
 
-private:
     static Pair<Vector<FullCatalogFileInfo>, Vector<DeltaCatalogFileInfo>> ParseCheckpointFilenames(const String &catalog_dir);
 };
 
 export class WalFile {
 public:
-    static Pair<Optional<TempWalFileInfo>, Vector<WalFileInfo>> ParseWalFilenames(const String &wal_dir);
+    static Pair<TempWalFileInfo, Vector<WalFileInfo>> ParseWalFilenames(const String &wal_dir);
 
     static String WalFilename(TxnTimeStamp max_commit_ts);
 

--- a/src/storage/wal/log_file.cppm
+++ b/src/storage/wal/log_file.cppm
@@ -18,7 +18,6 @@ export module log_file;
 
 import stl;
 
-
 // responsible for parsing and generating filenames for catalog files and wal files
 
 namespace infinity {
@@ -60,7 +59,7 @@ public:
 
 export class WalFile {
 public:
-    static Pair<TempWalFileInfo, Vector<WalFileInfo>> ParseWalFilenames(const String &wal_dir);
+    static Pair<Optional<TempWalFileInfo>, Vector<WalFileInfo>> ParseWalFilenames(const String &wal_dir);
 
     static String WalFilename(TxnTimeStamp max_commit_ts);
 

--- a/src/storage/wal/log_file.cppm
+++ b/src/storage/wal/log_file.cppm
@@ -1,0 +1,73 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module log_file;
+
+import stl;
+
+
+// responsible for parsing and generating filenames for catalog files and wal files
+
+namespace infinity {
+
+export struct FullCatalogFileInfo {
+    String path_;
+    TxnTimeStamp max_commit_ts_;
+};
+
+export struct DeltaCatalogFileInfo {
+    String path_;
+    TxnTimeStamp max_commit_ts_;
+};
+
+export struct TempWalFileInfo {
+    String path_;
+};
+
+export struct WalFileInfo {
+    String path_;
+    TxnTimeStamp max_commit_ts_;
+};
+
+export class CatalogFile {
+public:
+    static Optional<Pair<FullCatalogFileInfo, Vector<DeltaCatalogFileInfo>>> ParseValidCheckpointFilenames(const String &catalog_dir,
+                                                                                                           TxnTimeStamp max_checkpoint_ts);
+
+    static String FullCheckpoingFilename(TxnTimeStamp max_commit_ts);
+
+    static String TempFullCheckpointFilename(TxnTimeStamp max_commit_ts);
+
+    static String DeltaCheckpointFilename(TxnTimeStamp max_commit_ts);
+
+    static void RecycleCatalogFile(TxnTimeStamp full_ckp_ts, const String &catalog_dir);
+
+private:
+    static Pair<Vector<FullCatalogFileInfo>, Vector<DeltaCatalogFileInfo>> ParseCheckpointFilenames(const String &catalog_dir);
+};
+
+export class WalFile {
+public:
+    static Pair<Optional<TempWalFileInfo>, Vector<WalFileInfo>> ParseWalFilenames(const String &wal_dir);
+
+    static String WalFilename(TxnTimeStamp max_commit_ts);
+
+    static String TempWalFilename();
+
+    static void RecycleWalFile(TxnTimeStamp ckp_ts, const String &wal_dir);
+};
+
+} // namespace infinity

--- a/src/storage/wal/wal_entry.cppm
+++ b/src/storage/wal/wal_entry.cppm
@@ -373,7 +373,7 @@ export struct WalEntryHeader {
     u32 checksum_{}; // crc32 of the entry, including the header and the
     // payload. User shall populate it before writing to wal.
     i64 txn_id_{};    // txn id of the entry
-    i64 commit_ts_{}; // commit timestamp of the txn
+    TxnTimeStamp commit_ts_{}; // commit timestamp of the txn
 };
 
 export struct WalEntry : WalEntryHeader {
@@ -392,11 +392,7 @@ export struct WalEntry : WalEntryHeader {
 
     Vector<SharedPtr<WalCmd>> cmds_{};
 
-    [[nodiscard]] Pair<i64, String> GetCheckpointInfo() const;
-
-    [[nodiscard]] bool IsCheckPoint() const;
-
-    [[nodiscard]] bool IsFullCheckPoint() const;
+    [[nodiscard]] bool IsCheckPoint(Vector<SharedPtr<WalEntry>> replay_entries, WalCmdCheckpoint *&checkpoint_cmd) const;
 
     [[nodiscard]] String ToString() const;
 };

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -49,14 +49,16 @@ import segment_entry;
 import block_entry;
 import table_index_meta;
 import table_index_entry;
+import log_file;
+import default_values;
 
 module wal_manager;
 
 namespace infinity {
 
-WalManager::WalManager(Storage *storage, String wal_path, u64 wal_size_threshold, u64 delta_checkpoint_interval_wal_bytes, FlushOption flush_option)
-    : cfg_wal_size_threshold_(wal_size_threshold), cfg_delta_checkpoint_interval_wal_bytes_(delta_checkpoint_interval_wal_bytes),
-      wal_path_(std::move(wal_path)), storage_(storage), running_(false), flush_option_(flush_option) {}
+WalManager::WalManager(Storage *storage, String wal_dir, u64 wal_size_threshold, u64 delta_checkpoint_interval_wal_bytes, FlushOption flush_option)
+    : cfg_wal_size_threshold_(wal_size_threshold), cfg_delta_checkpoint_interval_wal_bytes_(delta_checkpoint_interval_wal_bytes), wal_dir_(wal_dir),
+      wal_path_(wal_dir + "/" + WalFile::TempWalFilename()), storage_(storage), running_(false), flush_option_(flush_option) {}
 
 WalManager::~WalManager() {
     if (running_.load()) {
@@ -252,9 +254,10 @@ void WalManager::Checkpoint(bool is_full_checkpoint, TxnTimeStamp max_commit_ts,
 
         txn->Checkpoint(max_commit_ts, is_full_checkpoint);
 
-        // TODO: recycle delta checkpoint file
+        WalFile::RecycleWalFile(max_commit_ts, wal_dir_);
         if (is_full_checkpoint) {
-            RecycleWalFile(max_commit_ts);
+            const auto &catalog_dir = *storage_->catalog()->CatalogDir();
+            CatalogFile::RecycleCatalogFile(max_commit_ts, catalog_dir);
         }
         SetLastCkpWalSize(wal_size);
         txn_mgr->CommitTxn(txn);
@@ -295,10 +298,8 @@ void WalManager::SwapWalFile(const TxnTimeStamp max_commit_ts) {
         ofs_.close();
     }
 
-    Path old_file_path = Path(wal_path_);
-
-    String new_file_path = old_file_path.string() + '.' + std::to_string(max_commit_ts);
-    LOG_INFO(fmt::format("Wal Swap to new path: {}", new_file_path.c_str()));
+    String new_file_path = fmt::format("{}/{}", wal_dir_, WalFile::WalFilename(max_commit_ts));
+    LOG_INFO(fmt::format("Wal {} swap to new path: {}", wal_path_, new_file_path));
 
     // Rename the current wal file to a new one.
     LocalFileSystem fs;
@@ -358,36 +359,21 @@ i64 WalManager::ReplayWalFile() {
     }
 
     Vector<String> wal_list{};
-    for (const auto &entry : std::filesystem::directory_iterator(Path(wal_path_).parent_path())) {
-        if (entry.is_regular_file()) {
-            wal_list.push_back(entry.path().string());
+    {
+        auto [temp_wal_info, wal_infos] = WalFile::ParseWalFilenames(wal_dir_);
+        if (!wal_infos.empty()) {
+            std::sort(wal_infos.begin(), wal_infos.end(), [](const WalFileInfo &a, const WalFileInfo &b) {
+                return a.max_commit_ts_ > b.max_commit_ts_;
+            });
         }
+        if (temp_wal_info.has_value()) {
+            wal_list.push_back(temp_wal_info->path_);
+        }
+        for (const auto &wal_info : wal_infos) {
+            wal_list.push_back(wal_info.path_);
+        }
+        // e.g. wal_list = {wal.log , wal.log.100 , wal.log.50}
     }
-
-    // e.g. wal_list = {wal.log , wal.log.100 , wal.log.50}
-    std::sort(wal_list.begin(), wal_list.end(), [](const std::string &a, const std::string &b) {
-        auto get_lastNumber = [](const std::string &s) {
-            auto pos = s.find_last_of('.');
-            if (pos != std::string::npos) {
-                return std::stol(s.substr(pos + 1));
-            } else {
-                throw std::invalid_argument("No '.' found");
-            }
-        };
-        bool is_a_wal_log = (a.length() >= 7 && a.substr(a.length() - 7) == "wal.log");
-        bool is_b_wal_log = (b.length() >= 7 && b.substr(b.length() - 7) == "wal.log");
-
-        if (is_a_wal_log) {
-            return true;
-        } else if (is_b_wal_log) {
-            return false;
-        }
-
-        SizeT num_a = get_lastNumber(a);
-        SizeT num_b = get_lastNumber(b);
-
-        return num_a > num_b;
-    });
 
     LOG_INFO("Start Wal Replay");
     // log the wal files.
@@ -396,12 +382,11 @@ i64 WalManager::ReplayWalFile() {
     }
     LOG_INFO(fmt::format("List wal file size: {}", wal_list.size()));
 
-    i64 max_commit_ts = 0;
-    String catalog_path;
+    TxnTimeStamp max_commit_ts = 0;
     Vector<SharedPtr<WalEntry>> replay_entries;
-    Vector<String> checkpoint_catalog_paths;
+    String catalog_dir = "";
 
-    {
+    { // if no checkpoint, max_commit_ts is 0
         WalListIterator iterator(wal_list);
         // phase 1: find the max commit ts and catalog path
         LOG_INFO("Replay phase 1: find the max commit ts and catalog path");
@@ -415,28 +400,11 @@ i64 WalManager::ReplayWalFile() {
 
             replay_entries.push_back(wal_entry);
 
-            if (wal_entry->IsCheckPoint()) {
-
-                checkpoint_catalog_paths.push_back(wal_entry->GetCheckpointInfo().second);
-
-                if (wal_entry->IsFullCheckPoint()) {
-                    auto [current_max_commit_ts, current_catalog_path] = wal_entry->GetCheckpointInfo();
-                    if (current_max_commit_ts > max_commit_ts) {
-                        max_commit_ts = current_max_commit_ts;
-                        catalog_path = current_catalog_path;
-                    }
-                    LOG_TRACE(fmt::format("Find checkpoint max commit ts: {}", max_commit_ts));
-                    LOG_TRACE(fmt::format("Find catalog path: {}", catalog_path));
-                    break;
-                } else {
-                    // delta checkpoint
-                    auto [current_max_commit_ts, current_catalog_path] = wal_entry->GetCheckpointInfo();
-                    // if the current max commit ts is greater than the max commit ts, update the max commit ts and catalog path
-                    if (current_max_commit_ts > max_commit_ts) {
-                        max_commit_ts = current_max_commit_ts;
-                        catalog_path = current_catalog_path;
-                    }
-                }
+            WalCmdCheckpoint *checkpoint_cmd = nullptr;
+            if (wal_entry->IsCheckPoint(replay_entries, checkpoint_cmd)) {
+                max_commit_ts = checkpoint_cmd->max_commit_ts_;
+                catalog_dir = Path(checkpoint_cmd->catalog_path_).parent_path().string();
+                break;
             }
         }
         LOG_INFO(fmt::format("Find checkpoint max commit ts: {}", max_commit_ts));
@@ -461,11 +429,15 @@ i64 WalManager::ReplayWalFile() {
 
     // Note: Init a new catalog when not found any checkpoint wal entry
     // Indicates that the system has not done checkpoint in the previous.
-    if (checkpoint_catalog_paths.empty()) {
+    if (catalog_dir == "") { // no checkpoint found
         storage_->InitNewCatalog();
     } else {
-        std::reverse(checkpoint_catalog_paths.begin(), checkpoint_catalog_paths.end());
-        storage_->AttachCatalog(checkpoint_catalog_paths);
+        auto catalog_fileinfo = CatalogFile::ParseValidCheckpointFilenames(catalog_dir, max_commit_ts);
+        if (!catalog_fileinfo.has_value()) {
+            UnrecoverableError(fmt::format("Wal Replay: Parse catalog file failed, catalog_dir: {}", catalog_dir));
+        }
+        auto &[full_catalog_fileinfo, delta_catalog_fileinfos] = catalog_fileinfo.value();
+        storage_->AttachCatalog(full_catalog_fileinfo, delta_catalog_fileinfos);
     }
 
     // phase 3: replay the entries
@@ -473,23 +445,14 @@ i64 WalManager::ReplayWalFile() {
     std::reverse(replay_entries.begin(), replay_entries.end());
     TxnTimeStamp system_start_ts = 0;
     TransactionID last_txn_id = 0;
-    SizeT replay_count = 0;
-    for (; replay_count < replay_entries.size(); ++replay_count) {
-        if (replay_entries[replay_count]->commit_ts_ > max_commit_ts) {
-            break;
-        }
-    }
 
-    for (; replay_count < replay_entries.size(); ++replay_count) {
-        if (replay_entries[replay_count]->commit_ts_ <= max_commit_ts) {
+    for (SizeT replay_count = 0; replay_count < replay_entries.size(); ++replay_count) {
+        if (replay_entries[replay_count]->commit_ts_ < max_commit_ts) {
             UnrecoverableError("Wal Replay: Commit ts should be greater than max commit ts");
         }
         system_start_ts = replay_entries[replay_count]->commit_ts_;
         last_txn_id = replay_entries[replay_count]->txn_id_;
-        if (replay_entries[replay_count]->IsCheckPoint()) {
-            LOG_TRACE(fmt::format("\nSKIP checkpoint entry: {}", replay_entries[replay_count]->ToString()));
-            continue;
-        }
+
         ReplayWalEntry(*replay_entries[replay_count]);
         LOG_INFO(replay_entries[replay_count]->ToString());
     }
@@ -501,33 +464,7 @@ i64 WalManager::ReplayWalFile() {
     storage_->catalog()->InitDeltaEntry(max_commit_ts_);
     return system_start_ts;
 }
-/*****************************************************************************
- * GC WAL FILE
- *****************************************************************************/
 
-/**
- * @brief Gc the old wal files.
- * Only delete the wal.log.* files. the wal.log file is current wal file.
- * Check if the wal.log.* files are too old.
- * if * is little than the max_commit_ts, we will delete it.
- */
-void WalManager::RecycleWalFile(TxnTimeStamp full_ckp_ts) {
-    // Gc old wal files.
-    LOG_INFO("WalManager::Checkpoint begin to gc wal files");
-    LocalFileSystem fs;
-    if (fs.Exists(wal_path_)) {
-        for (const auto &entry : std::filesystem::directory_iterator(Path(wal_path_).parent_path())) {
-            if (entry.is_regular_file() && entry.path().string().find("wal.log.") != std::string::npos) {
-                auto suffix = entry.path().string().substr(entry.path().string().find_last_of('.') + 1);
-                if (std::stoll(suffix) < i64(full_ckp_ts)) {
-                    fs.DeleteFile(entry.path());
-                    LOG_TRACE(fmt::format("WalManager::Checkpoint delete wal file: {}", entry.path().string().c_str()));
-                }
-            }
-        }
-    }
-    LOG_INFO("WalManager::Checkpoint end to gc wal files");
-}
 void WalManager::ReplayWalEntry(const WalEntry &entry) {
     for (const auto &cmd : entry.cmds_) {
         LOG_TRACE(fmt::format("Replay wal cmd: {}, commit ts: {}", WalCmd::WalCommandTypeToString(cmd->GetType()).c_str(), entry.commit_ts_));
@@ -581,6 +518,7 @@ void WalManager::ReplayWalEntry(const WalEntry &entry) {
         }
     }
 }
+
 void WalManager::WalCmdCreateDatabaseReplay(const WalCmdCreateDatabase &cmd, TransactionID txn_id, TxnTimeStamp commit_ts) {
     Catalog *catalog = storage_->catalog();
     auto db_dir = MakeShared<String>(*catalog->DataDir() + "/" + cmd.db_dir_tail_);

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -27,6 +27,7 @@ namespace infinity {
 class Storage;
 class BGTaskProcessor;
 class TableEntry;
+class Txn;
 
 export class WalManager {
 public:
@@ -60,6 +61,10 @@ public:
 
     // Should only called in `Flush` thread
     i64 WalSize() const { return wal_size_; }
+
+private:
+    // Checkpoint Helper
+    void CheckpointInner(bool is_full_checkpoint, Txn *txn, TxnTimeStamp max_commit_ts, i64 wal_size);
 
 private:
     void SetLastCkpWalSize(i64 wal_size);

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -30,7 +30,7 @@ class TableEntry;
 
 export class WalManager {
 public:
-    WalManager(Storage *storage, String wal_path, u64 wal_size_threshold, u64 delta_checkpoint_interval_wal_bytes, FlushOption flush_option);
+    WalManager(Storage *storage, String wal_dir, u64 wal_size_threshold, u64 delta_checkpoint_interval_wal_bytes, FlushOption flush_option);
 
     ~WalManager();
 
@@ -57,8 +57,6 @@ public:
     i64 ReplayWalFile();
 
     void ReplayWalEntry(const WalEntry &entry);
-
-    void RecycleWalFile(TxnTimeStamp full_ckp_ts);
 
     // Should only called in `Flush` thread
     i64 WalSize() const { return wal_size_; }
@@ -90,7 +88,9 @@ public:
 private:
     // Concurrent writing WAL is disallowed. So put all WAL writing into a queue
     // and do serial writing.
+    String wal_dir_{};
     String wal_path_{};
+
     Storage *storage_{};
 
     // WalManager state

--- a/src/unit_test/storage/wal/recycle_log.cpp
+++ b/src/unit_test/storage/wal/recycle_log.cpp
@@ -1,0 +1,242 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "unit_test/base_test.h"
+
+import stl;
+import global_resource_usage;
+import storage;
+import infinity_context;
+import compilation_config;
+import txn_manager;
+import extra_ddl_info;
+import infinity_exception;
+import log_file;
+import config;
+import bg_task;
+import background_process;
+import local_file_system;
+import default_values;
+import status;
+import logger;
+
+using namespace infinity;
+
+class RecycleLogTest : public BaseTest {
+protected:
+    static std::shared_ptr<std::string> test_ckp_recycle_config() {
+        return std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_ckp_recycle.toml");
+    }
+
+    void SetUp() override { system("rm -rf /tmp/infinity"); }
+
+    void TearDown() override {}
+};
+
+TEST_F(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
+    {
+#ifdef INFINITY_DEBUG
+        infinity::GlobalResourceUsage::Init();
+#endif
+        std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
+        infinity::InfinityContext::instance().Init(config_path);
+
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        const Config *config = storage->config();
+        TxnManager *txn_mgr = storage->txn_manager();
+        BGTaskProcessor *bg_processor = storage->bg_processor();
+
+        const String &wal_dir = *config->wal_dir();
+        LocalFileSystem fs;
+        {
+            time_t start = time(nullptr);
+            while (true) {
+                time_t now = time(nullptr);
+                if (now - start > 20) {
+                    UnrecoverableError("Timeout");
+                }
+                // create and drop db to fill wal log
+                {
+                    auto *txn = txn_mgr->CreateTxn();
+                    txn->Begin();
+                    auto status = txn->DropDatabase("db1", ConflictType::kIgnore);
+                    ASSERT_TRUE(status.ok() || status.code() == ErrorCode::kIgnore);
+                    txn_mgr->CommitTxn(txn);
+                }
+                { // put create after drop to prevent the merge delta result is empty
+                    auto *txn = txn_mgr->CreateTxn();
+                    txn->Begin();
+                    auto status = txn->CreateDatabase("db1", ConflictType::kIgnore);
+                    ASSERT_TRUE(status.ok());
+                    txn_mgr->CommitTxn(txn);
+                }
+                { // loop until the wal directory has more than one wal
+                    auto [temp_wal_info, wal_infos] = WalFile::ParseWalFilenames(wal_dir);
+                    if (wal_infos.size() > 0) {
+                        break;
+                    }
+                }
+            }
+        }
+        {
+            auto *txn = txn_mgr->CreateTxn();
+            txn->Begin();
+            SharedPtr<ForceCheckpointTask> force_ckp_task = MakeShared<ForceCheckpointTask>(txn, false /*full_check_point*/);
+            bg_processor->Submit(force_ckp_task);
+            force_ckp_task->Wait();
+            txn_mgr->CommitTxn(txn);
+        }
+        {
+            // assert there is one log file
+            auto [temp_wal_file, wal_files] = WalFile::ParseWalFilenames(wal_dir);
+            ASSERT_TRUE(wal_files.empty());
+        }
+        infinity::InfinityContext::instance().UnInit();
+
+#ifdef INFINITY_DEBUG
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+        infinity::GlobalResourceUsage::UnInit();
+#endif
+    }
+    {
+#ifdef INFINITY_DEBUG
+        infinity::GlobalResourceUsage::Init(); // test replay
+#endif
+        std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
+        infinity::InfinityContext::instance().Init(config_path);
+
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+        {
+            auto *txn = txn_mgr->CreateTxn();
+            txn->Begin();
+            auto [db, status] = txn->GetDatabase("db1");
+            ASSERT_TRUE(status.ok());
+            txn_mgr->CommitTxn(txn);
+        }
+
+#ifdef INFINITY_DEBUG
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+        infinity::GlobalResourceUsage::UnInit();
+#endif
+    }
+}
+
+TEST_F(RecycleLogTest, recycle_wal_after_full_checkpoint) {
+    {
+#ifdef INFINITY_DEBUG
+        infinity::GlobalResourceUsage::Init();
+#endif
+        std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
+        infinity::InfinityContext::instance().Init(config_path);
+
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        const Config *config = storage->config();
+        TxnManager *txn_mgr = storage->txn_manager();
+        BGTaskProcessor *bg_processor = storage->bg_processor();
+
+        const String &wal_dir = *config->wal_dir();
+        const String &catalog_dir = *config->data_dir() + "/" + String(CATALOG_FILE_DIR);
+        LocalFileSystem fs;
+        for (int i = 0; i < 2; ++i) { // create 2 delta catalog file
+            time_t start = time(nullptr);
+            while (true) {
+                time_t now = time(nullptr);
+                if (now - start > 20) {
+                    UnrecoverableError("Timeout");
+                }
+                // create and drop db to fill wal log
+                {
+                    auto *txn = txn_mgr->CreateTxn();
+                    txn->Begin();
+                    auto status = txn->DropDatabase("db1", ConflictType::kIgnore);
+                    ASSERT_TRUE(status.ok() || status.code() == ErrorCode::kIgnore);
+                    txn_mgr->CommitTxn(txn);
+                }
+                { // put create after drop to prevent the merge delta result is empty
+                    auto *txn = txn_mgr->CreateTxn();
+                    txn->Begin();
+                    auto status = txn->CreateDatabase("db1", ConflictType::kIgnore);
+                    ASSERT_TRUE(status.ok());
+                    txn_mgr->CommitTxn(txn);
+                }
+                { // loop until the wal directory has more than one wal
+                    auto [temp_wal_info, wal_infos] = WalFile::ParseWalFilenames(wal_dir);
+                    if (wal_infos.size() > 0) {
+                        break;
+                    }
+                }
+            }
+            {
+                auto *txn = txn_mgr->CreateTxn();
+                txn->Begin();
+                SharedPtr<ForceCheckpointTask> force_ckp_task = MakeShared<ForceCheckpointTask>(txn, false /*full_check_point*/);
+                bg_processor->Submit(force_ckp_task);
+                force_ckp_task->Wait();
+                txn_mgr->CommitTxn(txn);
+            }
+        }
+        {
+            auto [full_catalog_infos, delta_catalog_infos] = CatalogFile::ParseCheckpointFilenames(catalog_dir);
+            ASSERT_EQ(full_catalog_infos.size(), 1ul); // initialize will write a full checkpoint
+            ASSERT_EQ(delta_catalog_infos.size(), 2ul);
+        }
+        {
+            auto *txn = txn_mgr->CreateTxn();
+            txn->Begin();
+            SharedPtr<ForceCheckpointTask> force_ckp_task = MakeShared<ForceCheckpointTask>(txn, true /*full_check_point*/);
+            bg_processor->Submit(force_ckp_task);
+            force_ckp_task->Wait();
+            txn_mgr->CommitTxn(txn);
+        }
+        {
+            // assert there is one full catalog file
+            auto [full_catalog_infos, delta_catalog_infos] = CatalogFile::ParseCheckpointFilenames(catalog_dir);
+            ASSERT_EQ(full_catalog_infos.size(), 1ul);
+            ASSERT_TRUE(delta_catalog_infos.empty());
+        }
+        infinity::InfinityContext::instance().UnInit();
+
+#ifdef INFINITY_DEBUG
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+        infinity::GlobalResourceUsage::UnInit();
+#endif
+    }
+    {
+#ifdef INFINITY_DEBUG
+        infinity::GlobalResourceUsage::Init(); // test replay
+#endif
+        std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
+        infinity::InfinityContext::instance().Init(config_path);
+
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+        {
+            auto *txn = txn_mgr->CreateTxn();
+            txn->Begin();
+            auto [db, status] = txn->GetDatabase("db1");
+            ASSERT_TRUE(status.ok());
+            txn_mgr->CommitTxn(txn);
+        }
+
+#ifdef INFINITY_DEBUG
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+        EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+        infinity::GlobalResourceUsage::UnInit();
+#endif
+    }
+}

--- a/src/unit_test/storage/wal/recycle_log.cpp
+++ b/src/unit_test/storage/wal/recycle_log.cpp
@@ -41,7 +41,7 @@ protected:
 
     void SetUp() override { system("rm -rf /tmp/infinity"); }
 
-    void TearDown() override {}
+    void TearDown() override { system("rm -rf /tmp/infinity"); }
 };
 
 TEST_F(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
@@ -81,7 +81,7 @@ TEST_F(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
                     ASSERT_TRUE(status.ok());
                     txn_mgr->CommitTxn(txn);
                 }
-                { // loop until the wal directory has more than one wal
+                { // loop until the wal directory has a non-temp wal
                     auto [temp_wal_info, wal_infos] = WalFile::ParseWalFilenames(wal_dir);
                     if (wal_infos.size() > 0) {
                         break;
@@ -126,6 +126,7 @@ TEST_F(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
             ASSERT_TRUE(status.ok());
             txn_mgr->CommitTxn(txn);
         }
+        infinity::InfinityContext::instance().UnInit();
 
 #ifdef INFINITY_DEBUG
         EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
@@ -173,7 +174,7 @@ TEST_F(RecycleLogTest, recycle_wal_after_full_checkpoint) {
                     ASSERT_TRUE(status.ok());
                     txn_mgr->CommitTxn(txn);
                 }
-                { // loop until the wal directory has more than one wal
+                { // loop until the wal directory has a non-temp wal
                     auto [temp_wal_info, wal_infos] = WalFile::ParseWalFilenames(wal_dir);
                     if (wal_infos.size() > 0) {
                         break;
@@ -232,6 +233,7 @@ TEST_F(RecycleLogTest, recycle_wal_after_full_checkpoint) {
             ASSERT_TRUE(status.ok());
             txn_mgr->CommitTxn(txn);
         }
+        infinity::InfinityContext::instance().UnInit();
 
 #ifdef INFINITY_DEBUG
         EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);

--- a/test/data/config/test_ckp_recycle.toml
+++ b/test/data/config/test_ckp_recycle.toml
@@ -1,0 +1,8 @@
+[general]
+version = "0.1.0"
+timezone = "utc-8"
+
+[wal]
+# make delta and full checkpoint manual to test recyle
+delta_checkpoint_interval_sec = 0
+full_checkpoint_interval_sec = 0

--- a/tools/generate_many_import_drop.py
+++ b/tools/generate_many_import_drop.py
@@ -8,7 +8,7 @@ import random
 def generate(generate_if_exists: bool, copy_dir: str):
     row_n = 100
     import_n = 100
-    loop_n = 100;
+    loop_n = 100
     table_name = "test_big_many_import_drop"
 
     csv_dir = "./test/data/csv"


### PR DESCRIPTION
### What problem does this PR solve?

1. Add: recycle log file after checkpoint. recycle wal log after both checkpoint and recycle delta checkpoint after full checkpoint.
2. Refactor: parse process of log filename.
3. Fix: cleanup bug after replay. #727.
 Cleanup may encounter not empty directory under such circumstance:
 3.1. Create table, add some block. Write delta catalog file.
 3.2. Drop table and write another delta catalog file.
 3.3. Replay delta catalog files. "add some block" ops will be pruned in replay stage. so not appears in catalog tree.
 3.4. When cleanup, the table directory is not empty. because block cannot be found in catalog.
 3.5. Solve: Cleanup will remove the whole directory.
6. Fix: force(manual) checkpoint will recycle log file now.
7. Fix: checkpoint should always write wal. (even if checkpoint file is empty)
8. Add: unit test for recycle.

TODO:
record all checkpoint file path in the last checkpoint file.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Test cases

