### PR TITLE
Fix memory consumption during offline index building 

### DIFF
--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -18,7 +18,6 @@ module;
 #include <cassert>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <vector>
 module column_inverter;
 import stl;

--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -18,6 +18,7 @@ module;
 #include <cassert>
 #include <cstdio>
 #include <cstring>
+#include <iostream>
 #include <vector>
 module column_inverter;
 import stl;
@@ -42,12 +43,13 @@ static u32 Align(u32 unaligned) {
 }
 
 ColumnInverter::ColumnInverter(const String &analyzer, MemoryPool *memory_pool, PostingWriterProvider posting_writer_provider)
-    : analyzer_(AnalyzerPool::instance().Get(analyzer)), alloc_(memory_pool), terms_(alloc_), positions_(alloc_), term_refs_(alloc_),
-      posting_writer_provider_(posting_writer_provider) {
+    : analyzer_(AnalyzerPool::instance().Get(analyzer)), posting_writer_provider_(posting_writer_provider) {
     if (analyzer_.get() == nullptr) {
         UnrecoverableError(fmt::format("Invalid analyzer: {}", analyzer));
     }
 }
+
+ColumnInverter::~ColumnInverter() = default;
 
 bool ColumnInverter::CompareTermRef::operator()(const u32 lhs, const u32 rhs) const { return std::strcmp(GetTerm(lhs), GetTerm(rhs)) < 0; }
 

--- a/src/storage/invertedindex/column_inverter.cppm
+++ b/src/storage/invertedindex/column_inverter.cppm
@@ -38,6 +38,7 @@ public:
     ColumnInverter(const ColumnInverter &&) = delete;
     ColumnInverter &operator=(const ColumnInverter &) = delete;
     ColumnInverter &operator=(const ColumnInverter &&) = delete;
+    ~ColumnInverter();
 
     void InvertColumn(SharedPtr<ColumnVector> column_vector, u32 row_offset, u32 row_count, u32 begin_doc_id);
 
@@ -74,9 +75,9 @@ public:
     void SpillSortResults(FILE *spill_file, u64 &tuple_count);
 
 private:
-    using TermBuffer = Vector<char, PoolAllocator<char>>;
-    using PosInfoVec = Vector<PosInfo, PoolAllocator<PosInfo>>;
-    using U32Vec = Vector<u32, PoolAllocator<u32>>;
+    using TermBuffer = Vector<char>;
+    using PosInfoVec = Vector<PosInfo>;
+    using U32Vec = Vector<u32>;
 
     struct CompareTermRef {
         const char *const term_buffer_;
@@ -109,7 +110,6 @@ private:
     void MergePrepare();
 
     UniquePtr<Analyzer> analyzer_{nullptr};
-    PoolAllocator<char> alloc_;
     u32 begin_doc_id_{0};
     TermBuffer terms_;
     PosInfoVec positions_;

--- a/src/storage/invertedindex/memory_indexer.cpp
+++ b/src/storage/invertedindex/memory_indexer.cpp
@@ -28,7 +28,6 @@ module;
 #include <filesystem>
 #include <string.h>
 #include <unistd.h>
-
 module memory_indexer;
 
 import stl;
@@ -290,6 +289,14 @@ void MemoryIndexer::OfflineDump() {
 
     for (u64 i = 0; i < count; ++i) {
         fread(&record_length, sizeof(u16), 1, f);
+        if (record_length >= MAX_TUPLE_LENGTH) {
+            // rubbish tuple, abandoned
+            char *buffer = new char[record_length];
+            fread(buffer, record_length, 1, f);
+            // TermTuple tuple(buffer, record_length);
+            delete[] buffer;
+            continue;
+        }
         fread(buf, record_length, 1, f);
         TermTuple tuple(buf, record_length);
         if (tuple.term_ != last_term) {

--- a/src/storage/invertedindex/ring.cppm
+++ b/src/storage/invertedindex/ring.cppm
@@ -83,7 +83,9 @@ public:
     void Iterate(std::function<void(T &)> func) {
         std::unique_lock<std::mutex> lock(mutex_);
         for (u64 off = off_ground_; off < off_filled_; off++) {
-            func(ring_buf_[off & cap_mask_]);
+            T &obj = ring_buf_[off & cap_mask_];
+            func(obj);
+            obj = T();
         }
         off_ground_ = off_filled_;
     }


### PR DESCRIPTION
### What problem does this PR solve?

Memory is not recycled during offline index building
Outlier token will be abandoned(length >= 1024) which will lead to buffer overflow

Issue link:#889
Issue link:#890

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
