### PR TITLE
Remove fake txn of mem index recovery

### DIFF
--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -929,12 +929,12 @@ void Catalog::MemIndexCommitLoop() {
     }
 }
 
-void Catalog::MemIndexRecover(Txn *faked_txn) {
+void Catalog::MemIndexRecover(BufferManager* buffer_manager) {
     auto db_meta_map_guard = db_meta_map_.GetMetaMap();
     for (auto &[_, db_meta] : *db_meta_map_guard) {
         auto [db_entry, status] = db_meta->GetEntryNolock(0UL, MAX_TIMESTAMP);
         if (status.ok()) {
-            db_entry->MemIndexRecover(faked_txn);
+            db_entry->MemIndexRecover(buffer_manager);
         }
     }
 }

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -297,7 +297,7 @@ private: // TODO: remove this
     void MemIndexCommitLoop();
 
 public:
-    void MemIndexRecover(Txn *faked_txn);
+    void MemIndexRecover(BufferManager* buffer_manager);
 
     void PickCleanup(CleanupScanner *scanner);
 

--- a/src/storage/meta/entry/db_entry.cpp
+++ b/src/storage/meta/entry/db_entry.cpp
@@ -286,12 +286,12 @@ void DBEntry::MemIndexCommit() {
     }
 }
 
-void DBEntry::MemIndexRecover(Txn *faked_txn) {
+void DBEntry::MemIndexRecover(BufferManager* buffer_manager) {
     auto table_meta_map_guard = table_meta_map_.GetMetaMap();
     for (auto &[_, table_meta] : *table_meta_map_guard) {
         auto [table_entry, status] = table_meta->GetEntryNolock(0UL, MAX_TIMESTAMP);
         if (status.ok()) {
-            table_entry->MemIndexRecover(faked_txn);
+            table_entry->MemIndexRecover(buffer_manager);
         }
     }
 }

--- a/src/storage/meta/entry/db_entry.cppm
+++ b/src/storage/meta/entry/db_entry.cppm
@@ -139,6 +139,6 @@ public:
     void Cleanup() override;
 
     void MemIndexCommit();
-    void MemIndexRecover(Txn *faked_txn);
+    void MemIndexRecover(BufferManager* buffer_manager);
 };
 } // namespace infinity

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -86,7 +86,7 @@ public:
     inline TxnTimeStamp max_ts() const { return max_ts_; }
 
     // MemIndexInsert is non-blocking. Caller must ensure there's no RowID gap between each call.
-    void MemIndexInsert(Txn *txn, SharedPtr<BlockEntry> block_entry, u32 row_offset, u32 row_count);
+    void MemIndexInsert(SharedPtr<BlockEntry> block_entry, u32 row_offset, u32 row_count, TxnTimeStamp commit_ts, BufferManager* buffer_manager);
 
     // User shall invoke this reguarly to populate recently inserted rows into the fulltext index. Noop for other types of index.
     void MemIndexCommit();

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -158,7 +158,7 @@ public:
     void MemIndexCommit();
 
     // Invoked once at init stage to recovery memory index.
-    void MemIndexRecover(Txn *faked_txn);
+    void MemIndexRecover(BufferManager* buffer_manager);
 
 public:
     // Getter

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -80,8 +80,7 @@ void Storage::Init() {
     // start WalManager after TxnManager since it depends on TxnManager.
     wal_mgr_->Start();
 
-    Txn *faked_txn = txn_mgr_->CreateTxn();
-    new_catalog_->MemIndexRecover(faked_txn);
+    new_catalog_->MemIndexRecover(buffer_mgr_.get());
 
     bg_processor_->Start();
 


### PR DESCRIPTION
### What problem does this PR solve?

Currently, when storage init, segment data will be read to recreate the mem index and a faked txn is created. 

This faked txn will be commit several times, and will not begin at. This TXN is also managed by txn_manager.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
