### PR TITLE
Fix: service can't crash down when error occurs in building index

### DIFF
--- a/python/test/test_index.py
+++ b/python/test/test_index.py
@@ -18,6 +18,7 @@ import infinity.index as index
 import pandas
 import pytest
 from common import common_values
+from utils import copy_data
 from infinity.common import ConflictType
 from infinity.errors import ErrorCode
 
@@ -398,10 +399,7 @@ class TestIndex:
         assert not res.is_empty()
         print(res)
 
-    @pytest.mark.parametrize("check_data", [{"file_name": "enwiki_9.csv", "data_dir": common_values.TEST_TMP_DIR,}],
-                             indirect=True,
-                             )
-    @pytest.mark.xfail(reason="ERROR:7011, Unexpected error: Invalid analyzer")
+    @pytest.mark.parametrize("check_data", [{"file_name": "enwiki_9.csv", "data_dir": common_values.TEST_TMP_DIR,}], indirect=True)
     def test_fulltext_match_with_invalid_analyzer(self, get_infinity_db, check_data):
         db_obj = get_infinity_db
         db_obj.drop_table("test_with_fulltext_match", ConflictType.Ignore)
@@ -418,7 +416,8 @@ class TestIndex:
         if not check_data:
             copy_data("enwiki_9.csv")
         test_csv_dir = common_values.TEST_TMP_DIR + "enwiki_9.csv"
-        table_obj.import_data(test_csv_dir, {"delimiter": "\t"})
+        with pytest.raises(Exception, match="ERROR:7011, Unexpected error: Invalid analyzer"):
+            table_obj.import_data(test_csv_dir, {"delimiter": "\t"})
         res = table_obj.output(["*"]).to_pl()
         print(res)
 

--- a/python/test/test_index.py
+++ b/python/test/test_index.py
@@ -17,6 +17,7 @@ import time
 import infinity.index as index
 import pandas
 import pytest
+from common import common_values
 from infinity.common import ConflictType
 from infinity.errors import ErrorCode
 

--- a/python/test/test_knn.py
+++ b/python/test/test_knn.py
@@ -321,7 +321,7 @@ class TestKnn:
     @pytest.mark.parametrize("index_distance_type", ["l2", "ip"])
     @pytest.mark.parametrize("knn_distance_type", ["l2", "ip"])
     def test_with_index_before(self, get_infinity_db, check_data, index_column_name, knn_column_name,
-                        index_distance_type, knn_distance_type):
+                               index_distance_type, knn_distance_type):
         db_obj = get_infinity_db
         db_obj.drop_table("test_with_index", ConflictType.Ignore)
         table_obj = db_obj.create_table("test_with_index", {
@@ -374,8 +374,8 @@ class TestKnn:
     @pytest.mark.parametrize("index_distance_type", ["l2", "ip"])
     @pytest.mark.parametrize("knn_distance_type", ["l2", "ip"])
     def test_with_index_after(self, get_infinity_db, check_data,
-                        index_column_name, knn_column_name,
-                        index_distance_type, knn_distance_type):
+                              index_column_name, knn_column_name,
+                              index_distance_type, knn_distance_type):
         db_obj = get_infinity_db
         db_obj.drop_table("test_with_index", ConflictType.Ignore)
         table_obj = db_obj.create_table("test_with_index", {

--- a/src/bin/infinity_main.cpp
+++ b/src/bin/infinity_main.cpp
@@ -46,10 +46,11 @@ bool server_running = false;
 infinity::Thread shutdown_thread;
 
 void ShutdownServer() {
-
-    std::unique_lock<std::mutex> lock(server_mutex);
-    server_running = true;
-    server_cv.wait(lock, [&] { return !server_running; });
+    {
+        std::unique_lock<std::mutex> lock(server_mutex);
+        server_running = true;
+        server_cv.wait(lock, [&] { return !server_running; });
+    }
 
     //            threaded_thrift_server.Shutdown();
     //            threaded_thrift_thread.join();

--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -44,7 +44,7 @@ static u32 Align(u32 unaligned) {
 ColumnInverter::ColumnInverter(const String &analyzer, MemoryPool *memory_pool, PostingWriterProvider posting_writer_provider)
     : analyzer_(AnalyzerPool::instance().Get(analyzer)), posting_writer_provider_(posting_writer_provider) {
     if (analyzer_.get() == nullptr) {
-        UnrecoverableError(fmt::format("Invalid analyzer: {}", analyzer));
+        RecoverableError(Status::UnexpectedError(fmt::format("Invalid analyzer: {}", analyzer)));
     }
 }
 

--- a/src/storage/invertedindex/memory_indexer.cpp
+++ b/src/storage/invertedindex/memory_indexer.cpp
@@ -95,7 +95,6 @@ void MemoryIndexer::Insert(SharedPtr<ColumnVector> column_vector,
     u32 doc_count(0);
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        inflight_tasks_++;
         seq_inserted = seq_inserted_++;
         doc_count = doc_count_;
         doc_count_ += row_count;
@@ -108,8 +107,8 @@ void MemoryIndexer::Insert(SharedPtr<ColumnVector> column_vector,
     auto task = MakeShared<BatchInvertTask>(seq_inserted, column_vector, row_offset, row_count, doc_count);
     PostingWriterProvider provider = [this](const String &term) -> SharedPtr<PostingWriter> { return GetOrAddPosting(term); };
     if (offline) {
-        auto func = [this, task, provider, length_handler = std::move(update_length_job)](int id) {
-            auto inverter = MakeShared<ColumnInverter>(this->analyzer_, &this->byte_slice_pool_, provider);
+        auto inverter = MakeShared<ColumnInverter>(this->analyzer_, &this->byte_slice_pool_, provider);
+        auto func = [this, task, provider, length_handler = std::move(update_length_job), inverter](int id) {
             inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
             inverter->GetTermListLength(length_handler->GetColumnLengthArray());
             length_handler->DumpToFile();
@@ -118,14 +117,18 @@ void MemoryIndexer::Insert(SharedPtr<ColumnVector> column_vector,
         };
         thread_pool_.push(std::move(func));
     } else {
-        auto func = [this, task, provider, length_handler = std::move(update_length_job)](int id) {
-            auto inverter = MakeShared<ColumnInverter>(this->analyzer_, &this->byte_slice_pool_, provider);
+        auto inverter = MakeShared<ColumnInverter>(this->analyzer_, &this->byte_slice_pool_, provider);
+        auto func = [this, task, provider, length_handler = std::move(update_length_job), inverter](int id) {
             inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
             inverter->GetTermListLength(length_handler->GetColumnLengthArray());
             length_handler->DumpToFile();
             this->ring_inverted_.Put(task->task_seq_, inverter);
         };
         thread_pool_.push(std::move(func));
+    }
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        inflight_tasks_++;
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

The service can't crash down when error occurs in building index. It mainly because the  `UnrecoverableError`  is raised in thread which will not be caught. And Fix the dead lock when shutdown service.

Issue link:#914

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
