### PR TITLE
Fix recycle wal file unit test.

### DIFF
--- a/src/storage/wal/log_file.cppm
+++ b/src/storage/wal/log_file.cppm
@@ -52,7 +52,8 @@ public:
 
     static String DeltaCheckpointFilename(TxnTimeStamp max_commit_ts);
 
-    static void RecycleCatalogFile(TxnTimeStamp full_ckp_ts, const String &catalog_dir);
+    // max_commit_ts is the largest commit ts before the latest full checkpoint
+    static void RecycleCatalogFile(TxnTimeStamp max_commit_ts, const String &catalog_dir);
 
     static Pair<Vector<FullCatalogFileInfo>, Vector<DeltaCatalogFileInfo>> ParseCheckpointFilenames(const String &catalog_dir);
 };
@@ -65,7 +66,8 @@ public:
 
     static String TempWalFilename();
 
-    static void RecycleWalFile(TxnTimeStamp ckp_ts, const String &wal_dir);
+    // max_commit_ts is the largest commit ts before the latest checkpoint
+    static void RecycleWalFile(TxnTimeStamp max_commit_ts, const String &wal_dir);
 };
 
 } // namespace infinity

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -43,7 +43,7 @@ public:
 
     // Session request to persist an entry. Assuming txn_id of the entry has
     // been initialized.
-    void PutEntry(WalEntry* entry, Txn* txn);
+    void PutEntry(WalEntry *entry, Txn *txn);
 
     // Flush is scheduled regularly. It collects a batch of transactions, sync
     // wal and do parallel committing. Each sync cost ~1s. Each checkpoint cost
@@ -72,7 +72,6 @@ private:
     // Checkpoint Helper
     void CheckpointInner(bool is_full_checkpoint, Txn *txn, TxnTimeStamp max_commit_ts, i64 wal_size);
 
-private:
     void SetLastCkpWalSize(i64 wal_size);
     i64 GetLastCkpWalSize();
 
@@ -124,6 +123,8 @@ private:
     Atomic<bool> checkpoint_in_progress_{false};
 
     // Only Checkpoint thread access following members
+    TxnTimeStamp last_ckp_ts_{};
+    TxnTimeStamp last_full_ckp_ts_{};
 };
 
 } // namespace infinity

--- a/src/unit_test/storage/wal/recycle_log.cpp
+++ b/src/unit_test/storage/wal/recycle_log.cpp
@@ -101,6 +101,7 @@ TEST_F(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
         {
             // assert there is one log file
             auto [temp_wal_file, wal_files] = WalFile::ParseWalFilenames(wal_dir);
+            ASSERT_TRUE(temp_wal_file.has_value());
             if (wal_files.size() == 1) {
                 ASSERT_EQ(ckp_commit_ts, wal_files[0].max_commit_ts_);
             } else {


### PR DESCRIPTION
### What problem does this PR solve?

Fix: recycle the wal file whose max_commit_ts is the same as the checkpoint task. (log_file.cpp WalFile::RecycleWalFile)

Add: skip checkpoint when not more commit after prev checkpoint.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
