### PR TITLE
Fix: ts_map_ is not set when begin a txn

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infinity_sdk"
-version = "0.1.0-dev13"
+version = "0.1.0-dev14"
 dependencies = [
     "sqlglot==11.7.1",
     "pydantic",

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -93,13 +93,6 @@ TxnTimeStamp TxnManager::GetTimestamp() {
     return ts;
 }
 
-// TxnTimeStamp TxnManager::GetBeginTimestamp(TransactionID txn_id) {
-//     TxnTimeStamp ts = GetTimestamp();
-//     std::unique_lock<std::shared_mutex> w_locker(rw_locker_);
-//     ts_map_.emplace(ts, txn_id);
-//     return ts;
-// }
-
 void TxnManager::SendToWAL(Txn *txn) {
     // Check if the is_running_ is true
     if (is_running_.load() == false) {

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -197,7 +197,6 @@ void TxnManager::RemoveWaitFlushTxns(const Vector<TransactionID> &txn_ids) {
 TxnTimeStamp TxnManager::GetMinUnflushedTS() {
     std::shared_lock r_locker(rw_locker_);
     for (auto iter = ts_map_.begin(); iter != ts_map_.end();) {
-        LOG_ERROR("GetMinUnflushedTS");
         auto &[ts, txn_id] = *iter;
         if (txn_map_.find(txn_id) != txn_map_.end()) {
             LOG_TRACE(fmt::format("Txn: {} not found in txn map", txn_id));

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -59,7 +59,7 @@ public:
 
     TxnTimeStamp GetTimestamp();
 
-    TxnTimeStamp GetBeginTimestamp(TransactionID txn_id);
+    // TxnTimeStamp GetBeginTimestamp(TransactionID txn_id);
 
     void Invalidate(TxnTimeStamp commit_ts);
 

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -59,8 +59,6 @@ public:
 
     TxnTimeStamp GetTimestamp();
 
-    // TxnTimeStamp GetBeginTimestamp(TransactionID txn_id);
-
     void Invalidate(TxnTimeStamp commit_ts);
 
     void SendToWAL(Txn *txn);


### PR DESCRIPTION
### What problem does this PR solve?

PR #924 Merged Txn create and begin into  `TxnManager::BeginTxn()`  , but  `ts_map_`  is not set in the method which will cause error result in  `TxnManager::GetMinUnflushedTS()`  related to cleanup.

The pr fixed the problem reported in CI action tests #2327

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
