### PR TITLE
Fix xfail error

### DIFF
--- a/python/test/test_index.py
+++ b/python/test/test_index.py
@@ -344,8 +344,10 @@ class TestIndex:
                                                          index.InitParameter("metric", "l2")])], ConflictType.Error)
 
     # create index then insert / import data
-    @pytest.mark.xfail(reason="ERROR:3009, Attempt to create IVFFLAT/full-text index on column: c2, data type")
-    @pytest.mark.parametrize("index_type", [index.IndexType.IVFFlat, index.IndexType.FullText])
+    @pytest.mark.parametrize("index_type", [
+        index.IndexType.IVFFlat,
+        pytest.param(index.IndexType.FullText, marks=pytest.mark.xfail(reason="ERROR:3009, Attempt to create IVFFLAT/full-text index on column: c2, data type"))
+    ])
     @pytest.mark.parametrize("file_format", ["csv"])
     def test_create_index_import_data(self, get_infinity_db, index_type, file_format):
         # connect

--- a/python/test/test_table.py
+++ b/python/test/test_table.py
@@ -406,18 +406,17 @@ class TestTable:
 
     # create/drop table with different invalid options
     @pytest.mark.parametrize("invalid_option_array", [
-        pytest.param([], marks=pytest.mark.xfail),
-        pytest.param((), marks=pytest.mark.xfail),
-        pytest.param({}, marks=pytest.mark.xfail),
-        pytest.param(1, marks=pytest.mark.xfail),
-        pytest.param(1.1, marks=pytest.mark.xfail),
-        pytest.param('', marks=pytest.mark.xfail),
-        pytest.param(' ', marks=pytest.mark.xfail),
-        pytest.param('12', marks=pytest.mark.xfail),
-        pytest.param('name-12', marks=pytest.mark.xfail),
-        pytest.param('12name', marks=pytest.mark.xfail),
-        pytest.param('数据库名', marks=pytest.mark.xfail),
-        pytest.param(''.join('x' for i in range(65536 + 1)), marks=pytest.mark.xfail),
+        pytest.param([]),
+        pytest.param(()),
+        pytest.param({}),
+        pytest.param(1.1),
+        pytest.param(''),
+        pytest.param(' '),
+        pytest.param('12'),
+        pytest.param('name-12'),
+        pytest.param('12name'),
+        pytest.param('数据库名'),
+        pytest.param(''.join('x' for i in range(65536 + 1))),
         None,
     ])
     def test_table_with_different_invalid_options(self, get_infinity_db, invalid_option_array):

--- a/python/test/test_update.py
+++ b/python/test/test_update.py
@@ -393,7 +393,6 @@ class TestUpdate:
         assert res.error_code == ErrorCode.OK
 
     # update new value type is not match with table
-    # @pytest.mark.xfail(reason="Invalid constant expression.")
     @pytest.mark.parametrize("types", ["int", "float"])
     @pytest.mark.parametrize("types_example", [
         1,

--- a/python/test/test_update.py
+++ b/python/test/test_update.py
@@ -393,9 +393,14 @@ class TestUpdate:
         assert res.error_code == ErrorCode.OK
 
     # update new value type is not match with table
-    @pytest.mark.xfail(reason="Invalid constant expression.")
+    # @pytest.mark.xfail(reason="Invalid constant expression.")
     @pytest.mark.parametrize("types", ["int", "float"])
-    @pytest.mark.parametrize("types_example", [1, 1.333, "1", [1, 2, 3]])
+    @pytest.mark.parametrize("types_example", [
+        1,
+        1.333,
+        "1",
+        pytest.param([1, 2, 3], marks=pytest.mark.xfail(reason="Invalid constant expression."))
+    ])
     def test_update_new_value(self, types, types_example):
         # connect
         infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)


### PR DESCRIPTION
### What problem does this PR solve?
Checked the function test code again and fixed an issue where xfail would output `x` and `X`.

### Type of change

- [x] Test cases