### PR TITLE
Fix: error when restart serivce from mix checkpoint

### DIFF
--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -514,6 +514,9 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         txn_id,
                         begin_ts);
                 }
+                if (merge_flag == MergeFlag::kUpdate) {
+                    UnrecoverableError("Update database entry is not supported.");
+                }
                 break;
             }
             case CatalogDeltaOpType::ADD_TABLE_ENTRY: {
@@ -529,6 +532,7 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
 
                 auto *db_entry = this->GetDatabaseReplay(*db_name, txn_id, begin_ts);
                 if (merge_flag == MergeFlag::kDelete || merge_flag == MergeFlag::kDeleteAndNew) {
+                    // Actually the table entry replayed doesn't have full information cause index entry are lacked, but that is ok for now.
                     db_entry->DropTableReplay(
                         *table_name,
                         [&](TableMeta *table_meta, const SharedPtr<String> &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
@@ -548,8 +552,28 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         txn_id,
                         begin_ts);
                 }
-                if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kUpdate || merge_flag == MergeFlag::kDeleteAndNew) {
+                if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kDeleteAndNew) {
                     db_entry->CreateTableReplay(
+                        table_name,
+                        [&](TableMeta *table_meta, const SharedPtr<String> &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
+                            return TableEntry::ReplayTableEntry(false,
+                                                                table_meta,
+                                                                table_entry_dir,
+                                                                table_name,
+                                                                column_defs,
+                                                                entry_type,
+                                                                txn_id,
+                                                                begin_ts,
+                                                                commit_ts,
+                                                                row_count,
+                                                                unsealed_id,
+                                                                next_segment_id);
+                        },
+                        txn_id,
+                        begin_ts);
+                }
+                if (merge_flag == MergeFlag::kUpdate) {
+                    db_entry->UpdateTableReplay(
                         table_name,
                         [&](TableMeta *table_meta, const SharedPtr<String> &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
                             return TableEntry::ReplayTableEntry(false,
@@ -671,9 +695,17 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                 auto *db_entry = this->GetDatabaseReplay(*db_name, txn_id, begin_ts);
                 auto *table_entry = db_entry->GetTableReplay(*table_name, txn_id, begin_ts);
                 if (merge_flag == MergeFlag::kDelete || merge_flag == MergeFlag::kDeleteAndNew) {
-                    table_entry->DropIndexReplay(*index_name, txn_id, begin_ts);
+                    table_entry->DropIndexReplay(
+                        *index_name,
+                        [&](TableIndexMeta *index_meta, TransactionID txn_id, TxnTimeStamp begin_ts) {
+                            auto index_entry = TableIndexEntry::NewTableIndexEntry(nullptr, true, nullptr, index_meta, txn_id, begin_ts);
+                            index_entry->commit_ts_.store(commit_ts);
+                            return index_entry;
+                        },
+                        txn_id,
+                        begin_ts);
                 }
-                if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kUpdate || merge_flag == MergeFlag::kDeleteAndNew) {
+                if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kDeleteAndNew) {
                     table_entry->CreateIndexReplay(
                         index_name,
                         [&](TableIndexMeta *index_meta, TransactionID txn_id, TxnTimeStamp begin_ts) {
@@ -681,6 +713,9 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         },
                         txn_id,
                         begin_ts);
+                }
+                if (merge_flag == MergeFlag::kUpdate) {
+                    table_entry->UpdateIndexReplay(*index_name, txn_id, begin_ts, commit_ts);
                 }
                 break;
             }

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -505,7 +505,7 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         txn_id,
                         begin_ts);
                 }
-                if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kUpdate || merge_flag == MergeFlag::kDeleteAndNew) {
+                if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kDeleteAndNew) {
                     this->CreateDatabaseReplay(
                         db_name,
                         [&](DBMeta *db_meta, const SharedPtr<String> &db_name, TransactionID txn_id, TxnTimeStamp begin_ts) {

--- a/src/storage/meta/entry/db_entry.cpp
+++ b/src/storage/meta/entry/db_entry.cpp
@@ -132,6 +132,23 @@ void DBEntry::CreateTableReplay(const SharedPtr<String> &table_name,
                                   begin_ts);
 }
 
+void DBEntry::UpdateTableReplay(const SharedPtr<String> &table_name,
+                                std::function<SharedPtr<TableEntry>(TableMeta *, SharedPtr<String>, TransactionID, TxnTimeStamp)> &&init_entry,
+                                TransactionID txn_id,
+                                TxnTimeStamp begin_ts) {
+    auto [table_meta, status] = table_meta_map_.GetExistMetaNoLock(*table_name, ConflictType::kError);
+    if (!status.ok()) {
+        UnrecoverableError(status.message());
+    }
+    table_meta->UpdateEntryReplay(
+        [&](SharedPtr<TableEntry> dst_table_entry, TransactionID txn_id, TxnTimeStamp begin_ts) {
+            auto src_table_entry = init_entry(table_meta, table_name, txn_id, begin_ts);
+            dst_table_entry->UpdateEntryReplay(src_table_entry);
+        },
+        txn_id,
+        begin_ts);
+}
+
 void DBEntry::DropTableReplay(const String &table_name,
                               std::function<SharedPtr<TableEntry>(TableMeta *, SharedPtr<String>, TransactionID, TxnTimeStamp)> &&init_entry,
                               TransactionID txn_id,
@@ -286,7 +303,7 @@ void DBEntry::MemIndexCommit() {
     }
 }
 
-void DBEntry::MemIndexRecover(BufferManager* buffer_manager) {
+void DBEntry::MemIndexRecover(BufferManager *buffer_manager) {
     auto table_meta_map_guard = table_meta_map_.GetMetaMap();
     for (auto &[_, table_meta] : *table_meta_map_guard) {
         auto [table_entry, status] = table_meta->GetEntryNolock(0UL, MAX_TIMESTAMP);

--- a/src/storage/meta/entry/db_entry.cppm
+++ b/src/storage/meta/entry/db_entry.cppm
@@ -100,6 +100,11 @@ public:
                            TransactionID txn_id,
                            TxnTimeStamp begin_ts);
 
+    void UpdateTableReplay(const SharedPtr<String> &table_name,
+                           std::function<SharedPtr<TableEntry>(TableMeta *, SharedPtr<String>, TransactionID, TxnTimeStamp)> &&init_entry,
+                           TransactionID txn_id,
+                           TxnTimeStamp begin_ts);
+
     void DropTableReplay(const String &table_name,
                          std::function<SharedPtr<TableEntry>(TableMeta *, SharedPtr<String>, TransactionID, TxnTimeStamp)> &&init_entry,
                          TransactionID txn_id,
@@ -139,6 +144,6 @@ public:
     void Cleanup() override;
 
     void MemIndexCommit();
-    void MemIndexRecover(BufferManager* buffer_manager);
+    void MemIndexRecover(BufferManager *buffer_manager);
 };
 } // namespace infinity

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -109,12 +109,19 @@ public:
     MetaMap<TableIndexMeta>::MapGuard IndexMetaMap() { return index_meta_map_.GetMetaMap(); }
 
     // replay
+    void UpdateEntryReplay(const SharedPtr<TableEntry> &table_entry);
+
     TableIndexEntry *CreateIndexReplay(const SharedPtr<String> &index_name,
                                        std::function<SharedPtr<TableIndexEntry>(TableIndexMeta *, TransactionID, TxnTimeStamp)> &&init_entry,
                                        TransactionID txn_id,
                                        TxnTimeStamp begin_ts);
 
-    void DropIndexReplay(const String &index_name, TransactionID txn_id, TxnTimeStamp begin_ts);
+    void UpdateIndexReplay(const String &index_name, TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
+
+    void DropIndexReplay(const String &index_name,
+                         std::function<SharedPtr<TableIndexEntry>(TableIndexMeta *, TransactionID, TxnTimeStamp)> &&init_entry,
+                         TransactionID txn_id,
+                         TxnTimeStamp begin_ts);
 
     TableIndexEntry *GetIndexReplay(const String &index_name, TransactionID txn_id, TxnTimeStamp begin_ts);
 

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -419,4 +419,10 @@ void TableIndexEntry::UpdateFulltextSegmentTs(TxnTimeStamp ts) {
     return table_index_meta()->GetTableEntry()->UpdateFullTextSegmentTs(ts, segment_update_ts_mutex_, segment_update_ts_);
 }
 
+void TableIndexEntry::UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts) {
+    commit_ts_.store(commit_ts);
+    begin_ts_ = begin_ts;
+    txn_id_ = txn_id;
+}
+
 } // namespace infinity

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -132,6 +132,9 @@ public:
 
     void RollbackCreateIndex(TxnIndexStore *txn_index_store);
 
+    // replay
+    void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
+
 private:
     static SharedPtr<String> DetermineIndexDir(const String &parent_dir, const String &index_name) {
         return DetermineRandomString(parent_dir, fmt::format("index_{}", index_name));

--- a/src/storage/meta/table_index_meta.cppm
+++ b/src/storage/meta/table_index_meta.cppm
@@ -81,7 +81,11 @@ public:
                                        TransactionID txn_id,
                                        TxnTimeStamp begin_ts);
 
-    void DropEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts);
+    void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
+
+    void DropEntryReplay(std::function<SharedPtr<TableIndexEntry>(TableIndexMeta *, TransactionID, TxnTimeStamp)> &&init_entry,
+                         TransactionID txn_id,
+                         TxnTimeStamp begin_ts);
 
     TableIndexEntry *GetEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts);
 

--- a/src/storage/meta/table_meta.cpp
+++ b/src/storage/meta/table_meta.cpp
@@ -118,6 +118,15 @@ void TableMeta::CreateEntryReplay(std::function<SharedPtr<TableEntry>(Transactio
     }
 }
 
+void TableMeta::UpdateEntryReplay(std::function<void(SharedPtr<TableEntry>, TransactionID, TxnTimeStamp)> &&update_entry,
+                                  TransactionID txn_id,
+                                  TxnTimeStamp begin_ts) {
+    auto status = table_entry_list_.UpdateEntryReplay(std::move(update_entry), txn_id, begin_ts);
+    if (!status.ok()) {
+        UnrecoverableError(status.message());
+    }
+}
+
 void TableMeta::DropEntryReplay(std::function<SharedPtr<TableEntry>(TransactionID, TxnTimeStamp)> &&init_entry,
                                 TransactionID txn_id,
                                 TxnTimeStamp begin_ts) {

--- a/src/storage/meta/table_meta.cppm
+++ b/src/storage/meta/table_meta.cppm
@@ -94,6 +94,10 @@ private:
     void
     CreateEntryReplay(std::function<SharedPtr<TableEntry>(TransactionID, TxnTimeStamp)> &&init_entry, TransactionID txn_id, TxnTimeStamp begin_ts);
 
+    void UpdateEntryReplay(std::function<void(SharedPtr<TableEntry>, TransactionID, TxnTimeStamp)> &&update_entry,
+                           TransactionID txn_id,
+                           TxnTimeStamp begin_ts);
+
     void DropEntryReplay(std::function<SharedPtr<TableEntry>(TransactionID, TxnTimeStamp)> &&init_entry, TransactionID txn_id, TxnTimeStamp begin_ts);
 
     // GetEntryReplay(txn_id, begin_ts);

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -132,7 +132,7 @@ void TxnManager::Stop() {
     auto it = txn_map_.begin();
     while (it != txn_map_.end()) {
         // remove and notify the wal manager condition variable
-        Txn* txn_ptr = it->second.get();
+        Txn *txn_ptr = it->second.get();
         if (txn_ptr != nullptr) {
             txn_ptr->CancelCommitBottom();
         }

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -1,0 +1,325 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "unit_test/base_test.h"
+
+import statement_common;
+import internal_types;
+import stl;
+import infinity_context;
+import storage;
+import column_def;
+import logical_type;
+import data_type;
+import txn_manager;
+import table_def;
+import extra_ddl_info;
+import column_vector;
+import value;
+import catalog;
+import segment_entry;
+import block_entry;
+import buffer_manager;
+import physical_import;
+import status;
+import compilation_config;
+import compact_segments_task;
+import index_base;
+import index_base;
+import third_party;
+import base_table_ref;
+import index_secondary;
+import data_block;
+import query_context;
+import txn;
+import index_base;
+import index_full_text;
+import bg_task;
+import logger;
+import infinity_exception;
+import default_values;
+import global_resource_usage;
+
+using namespace infinity;
+
+class CheckpointTest : public BaseTest {
+protected:
+    static std::shared_ptr<std::string> config_path() {
+        return std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_checkpoint.toml");
+    }
+
+    void SetUp() override { system("rm -rf /tmp/infinity"); }
+
+    void TearDown() override { system("rm -rf /tmp/infinity"); }
+
+    void WaitFlushDeltaOp(TxnManager *txn_mgr, TxnTimeStamp last_commit_ts) {
+        TxnTimeStamp visible_ts = 0;
+        time_t start = time(nullptr);
+        while (true) {
+            visible_ts = txn_mgr->GetMinUnflushedTS();
+            if (visible_ts >= last_commit_ts) {
+                break;
+            }
+            // wait for at most 10s
+            time_t end = time(nullptr);
+            if (end - start > 10) {
+                UnrecoverableException("WaitFlushDeltaOp timeout");
+            }
+        }
+    }
+
+    void WaitCleanup(Catalog *catalog, TxnManager *txn_mgr, TxnTimeStamp last_commit_ts) {
+        TxnTimeStamp visible_ts = 0;
+        time_t start = time(nullptr);
+        while (true) {
+            visible_ts = txn_mgr->GetMinUnflushedTS();
+            if (visible_ts >= last_commit_ts) {
+                break;
+            }
+            // wait for at most 10s
+            time_t end = time(nullptr);
+            if (end - start > 10) {
+                UnrecoverableException("WaitCleanup timeout");
+            }
+            usleep(1000 * 1000);
+        }
+        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts);
+        cleanup_task->Execute();
+    }
+
+    void AddSegments(TxnManager *txn_mgr, const String &table_name, const Vector<SizeT> &segment_sizes, BufferManager *buffer_mgr) {
+        for (SizeT segment_size : segment_sizes) {
+            auto *txn = txn_mgr->BeginTxn();
+
+            auto [table_entry, status] = txn->GetTableByName("default", table_name);
+            table_entry->SetCompactionAlg(nullptr); // close auto compaction to test manual compaction
+            auto column_count = table_entry->ColumnCount();
+
+            SegmentID segment_id = Catalog::GetNextSegmentID(table_entry);
+            auto segment_entry = SegmentEntry::NewSegmentEntry(table_entry, segment_id, txn);
+            auto block_entry = BlockEntry::NewBlockEntry(segment_entry.get(), 0, 0, column_count, txn);
+
+            while (segment_size > 0) {
+                SizeT write_size = std::min(SizeT(DEFAULT_BLOCK_CAPACITY), segment_size);
+                segment_size -= write_size;
+                Vector<ColumnVector> column_vectors;
+                {
+                    auto column_vector = ColumnVector(MakeShared<DataType>(LogicalType::kTinyInt));
+                    column_vector.Initialize();
+                    Value v = Value::MakeTinyInt(static_cast<TinyIntT>(1));
+                    for (int i = 0; i < (int)write_size; ++i) {
+                        column_vector.AppendValue(v);
+                    }
+                    column_vectors.push_back(std::move(column_vector));
+                }
+                block_entry->AppendBlock(column_vectors, 0, write_size, buffer_mgr);
+                segment_entry->AppendBlockEntry(std::move(block_entry));
+                block_entry = BlockEntry::NewBlockEntry(segment_entry.get(), segment_entry->GetNextBlockID(), 0, 1, txn);
+            }
+            PhysicalImport::SaveSegmentData(table_entry, txn, segment_entry);
+            txn_mgr->CommitTxn(txn);
+        }
+    }
+};
+
+TEST_F(CheckpointTest, test_cleanup_and_checkpoint) {
+    auto db_name = MakeShared<String>("default");
+    auto table_name = MakeShared<String>("test_cleanup_and_checkpoint");
+    auto column_name = MakeShared<String>("col1");
+
+#ifdef INFINITY_DEBUG
+    infinity::GlobalResourceUsage::Init();
+#endif
+    std::shared_ptr<std::string> config_path = CheckpointTest::config_path();
+    infinity::InfinityContext::instance().Init(config_path);
+
+    Storage *storage = infinity::InfinityContext::instance().storage();
+    BufferManager *buffer_manager = storage->buffer_manager();
+    TxnManager *txn_mgr = storage->txn_manager();
+    Catalog *catalog = storage->catalog();
+    TxnTimeStamp last_commit_ts = 0;
+
+    Vector<SharedPtr<ColumnDef>> columns;
+    {
+        i64 column_id = 0;
+        {
+            HashSet<ConstraintType> constraints;
+            auto column_def_ptr =
+                MakeShared<ColumnDef>(column_id++, MakeShared<DataType>(DataType(LogicalType::kTinyInt)), "tiny_int_col", constraints);
+            columns.emplace_back(column_def_ptr);
+        }
+    }
+    { // create table
+        auto tbl1_def = MakeUnique<TableDef>(db_name, table_name, columns);
+        auto *txn = txn_mgr->BeginTxn();
+
+        Status status = txn->CreateTable(*db_name, std::move(tbl1_def), ConflictType::kIgnore);
+        EXPECT_TRUE(status.ok());
+
+        txn_mgr->CommitTxn(txn);
+    }
+    Vector<SizeT> segment_sizes{1, 10, 100, 1000, 10000, 100000};
+    this->AddSegments(txn_mgr, *table_name, segment_sizes, buffer_manager);
+
+    { // add compact
+        auto txn4 = txn_mgr->BeginTxn();
+
+        auto [table_entry, status] = txn4->GetTableByName(*db_name, *table_name);
+        EXPECT_NE(table_entry, nullptr);
+
+        {
+            auto compact_task = CompactSegmentsTask::MakeTaskWithWholeTable(table_entry, txn4);
+            compact_task->Execute();
+        }
+        txn_mgr->CommitTxn(txn4);
+    }
+
+    {
+        auto txn5 = txn_mgr->BeginTxn();
+        TxnTimeStamp begin_ts = txn5->BeginTS();
+        auto [table_entry, status] = txn5->GetTableByName(*db_name, *table_name);
+        EXPECT_NE(table_entry, nullptr);
+
+        size_t test_segment_n = segment_sizes.size();
+        size_t row_count = std::accumulate(segment_sizes.begin(), segment_sizes.end(), 0);
+
+        for (size_t i = 0; i < test_segment_n; ++i) {
+            auto segment_entry = table_entry->GetSegmentByID(i, begin_ts);
+            EXPECT_NE(segment_entry, nullptr);
+            EXPECT_EQ(segment_entry->status(), SegmentStatus::kDeprecated);
+        }
+        auto compact_segment = table_entry->GetSegmentByID(test_segment_n, begin_ts);
+        EXPECT_NE(compact_segment, nullptr);
+        EXPECT_NE(compact_segment->status(), SegmentStatus::kDeprecated);
+        EXPECT_EQ(compact_segment->actual_row_count(), row_count);
+
+        txn_mgr->CommitTxn(txn5);
+    }
+    WaitCleanup(catalog, txn_mgr, last_commit_ts);
+    usleep(5000 * 1000);
+    WaitFlushDeltaOp(txn_mgr, last_commit_ts);
+    infinity::InfinityContext::instance().UnInit();
+#ifdef INFINITY_DEBUG
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+    infinity::GlobalResourceUsage::UnInit();
+#endif
+}
+
+TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint) {
+#ifdef INFINITY_DEBUG
+    infinity::GlobalResourceUsage::Init();
+#endif
+    auto config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_catalog_delta.toml");
+
+    auto db_name = std::make_shared<std::string>("default");
+    auto table_name = std::make_shared<std::string>("test_index_replay_with_full_and_delta_checkpoint");
+    auto column_name = std::make_shared<std::string>("col1");
+    auto index_name = std::make_shared<std::string>("idx1");
+    Vector<SharedPtr<ColumnDef>> columns;
+
+    // create table and shutdown
+    {
+        infinity::InfinityContext::instance().Init(config_path);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+        {
+            i64 column_id = 0;
+            {
+                HashSet<ConstraintType> constraints;
+                auto column_def_ptr =
+                    MakeShared<ColumnDef>(column_id++, MakeShared<DataType>(DataType(LogicalType::kTinyInt)), *column_name, constraints);
+                columns.emplace_back(column_def_ptr);
+            }
+        }
+        {
+            auto tbl1_def = MakeUnique<TableDef>(db_name, table_name, columns);
+            auto *txn = txn_mgr->BeginTxn();
+            Status status = txn->CreateTable(*db_name, std::move(tbl1_def), ConflictType::kIgnore);
+            EXPECT_TRUE(status.ok());
+            txn_mgr->CommitTxn(txn);
+        }
+        infinity::InfinityContext::instance().UnInit();
+    }
+    // create index and shutdown
+    {
+        infinity::InfinityContext::instance().Init(config_path);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+
+        auto *txn = txn_mgr->BeginTxn();
+        SharedPtr<IndexBase> index_base = IndexSecondary::Make(index_name, fmt::format("{}_{}", *table_name, *index_name), {*column_name});
+        auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
+        EXPECT_TRUE(status1.ok());
+
+        TxnTimeStamp begin_ts = txn->BeginTS();
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
+        EXPECT_TRUE(status2.ok());
+        auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);
+        txn->CreateIndexFinish(table_entry, table_index_entry);
+        EXPECT_TRUE(status3.ok());
+
+        txn_mgr->CommitTxn(txn);
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+    // drop index and shutdown
+    {
+        infinity::InfinityContext::instance().Init(config_path);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+
+        auto *txn = txn_mgr->BeginTxn();
+        auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
+        EXPECT_TRUE(status1.ok());
+
+        auto status3 = txn->DropIndexByName(*db_name, *table_name, *index_name, ConflictType::kInvalid);
+        EXPECT_TRUE(status3.ok());
+
+        auto last_commit_ts = txn_mgr->CommitTxn(txn);
+
+        WaitFlushDeltaOp(txn_mgr, last_commit_ts);
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+    // now restart and recreate index should be ok
+    {
+        infinity::InfinityContext::instance().Init(config_path);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+
+        auto *txn = txn_mgr->BeginTxn();
+        SharedPtr<IndexBase> index_base = IndexSecondary::Make(index_name, fmt::format("{}_{}", *table_name, *index_name), {*column_name});
+        auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
+        EXPECT_TRUE(status1.ok());
+
+        TxnTimeStamp begin_ts = txn->BeginTS();
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
+        EXPECT_TRUE(status2.ok());
+        auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);
+        txn->CreateIndexFinish(table_entry, table_index_entry);
+        EXPECT_TRUE(status3.ok());
+
+        txn_mgr->CommitTxn(txn);
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+#ifdef INFINITY_DEBUG
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+    infinity::GlobalResourceUsage::UnInit();
+#endif
+}

--- a/test/data/config/test_checkpoint.toml
+++ b/test/data/config/test_checkpoint.toml
@@ -1,0 +1,12 @@
+[general]
+version = "0.1.0"
+timezone = "utc-8"
+
+[resource]
+cleanup_interval = 0
+# close auto compaction
+enable_compaction = false
+
+[wal]
+#short checkpoint interval to allow quick cleanup
+delta_checkpoint_interval_sec = 5


### PR DESCRIPTION
### What problem does this PR solve?

When restart service, the  `IndexEntry`  maybe lost which causes service crashes. This happens when  `CreateIndex`  operation is flushed into FULL checkpoint file, but  `DropIndex`  operation is only flushed into DELTA checkpoint file.

Issue link:#892, #943

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
- [x] Test cases