### PR TITLE
Fix: physical import

### DIFF
--- a/python/test/test_import.py
+++ b/python/test/test_import.py
@@ -322,7 +322,8 @@ class TestImport:
         db_obj = get_infinity_db
         db_obj.drop_table("test_import_embedding_with_not_match_definition")
         with pytest.raises(Exception):
-            table_obj = db_obj.create_table("test_import_embedding_with_not_match_definition", {"c1": "int", "c2": types})
+            table_obj = db_obj.create_table("test_import_embedding_with_not_match_definition",
+                                            {"c1": "int", "c2": types})
             test_csv_dir = common_values.TEST_TMP_DIR + "embedding_int_dim3.csv"
             res = table_obj.import_data(test_csv_dir, import_options={"file_type": "csv"})
             assert res.error_code == ErrorCode.OK
@@ -383,6 +384,24 @@ class TestImport:
         with pytest.raises(Exception, match="ERROR:3039, Column count mismatch: CSV file row count isn't match with table schema*"):
             res = table_obj.import_data(test_csv_dir)
             assert res.error_code == ErrorCode.OK
+
+        res = table_obj.output(["*"]).to_df()
+        print(res)
+
+    @pytest.mark.parametrize("check_data", [{"file_name": "pysdk_test_import_with_different_size.csv",
+                                             "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
+    @pytest.mark.parametrize("data_size", [1, 8191, 8192, 8193])
+    def test_import_with_different_size(self, get_infinity_db, check_data, data_size):
+        generate_big_rows_csv(data_size, "pysdk_test_import_with_different_size.csv")
+        copy_data("pysdk_test_import_with_different_size.csv")
+
+        db_obj = get_infinity_db
+        db_obj.drop_table("test_import_with_different_size")
+        table_obj = db_obj.create_table("test_import_with_different_size", {"c1": "int", "c2": "varchar"})
+
+        test_csv_dir = common_values.TEST_TMP_DIR + "pysdk_test_import_with_different_size.csv"
+        res = table_obj.import_data(test_csv_dir)
+        assert res.error_code == ErrorCode.OK
 
         res = table_obj.output(["*"]).to_df()
         print(res)

--- a/python/test/test_import.py
+++ b/python/test/test_import.py
@@ -403,8 +403,8 @@ class TestImport:
         res = table_obj.import_data(test_csv_dir)
         assert res.error_code == ErrorCode.OK
 
-        res = table_obj.output(["*"]).to_df()
-        print(res)
+        res = table_obj.output(["count(*)"]).to_pl()
+        assert res.height == 1 and res.width == 1 and res.item(0, 0) == data_size
 
     # import table with column value exceeding invalid value range
     @pytest.mark.parametrize("check_data", [{"file_name": "pysdk_test_big_varchar_rows.csv",

--- a/src/executor/operator/physical_import.cpp
+++ b/src/executor/operator/physical_import.cpp
@@ -235,11 +235,15 @@ void PhysicalImport::ImportCSV(QueryContext *query_context, ImportOperatorState 
         auto &block_entry = parser_context->block_entry_;
         if (block_entry->row_count() > 0) {
             segment_entry->AppendBlockEntry(std::move(block_entry));
-            SaveSegmentData(table_entry_, txn, segment_entry);
         } else {
             parser_context->column_vectors_.clear();
             std::move(*block_entry).Cleanup();
+        }
+        if (segment_entry->row_count() == 0) {
+            parser_context->column_vectors_.clear();
             std::move(*segment_entry).Cleanup();
+        } else {
+            SaveSegmentData(table_entry_, txn, segment_entry);
         }
     }
     fclose(fp);


### PR DESCRIPTION
### What problem does this PR solve?

Fix error behavior of  `PhysicalImport`, which will not actually import data when last block is empty before.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases