### PR TITLE
Fix bug: Varchar expression introduces crash in delete where clause

### DIFF
--- a/python/test/test_delete.py
+++ b/python/test/test_delete.py
@@ -273,7 +273,6 @@ class TestDelete:
             db_obj.drop_table("test_delete_dropped_table")
 
     # various expression will be given in where clause, and check result correctness
-    @pytest.mark.slow
     @trace_expected_exceptions
     @pytest.mark.parametrize('column_types', ["int", "int8", "int16", "int32", "int64", "integer",
                                               "float", "float32", "double", "float64",

--- a/src/planner/optimizer/secondary_index_scan/filter_expression_push_down.cpp
+++ b/src/planner/optimizer/secondary_index_scan/filter_expression_push_down.cpp
@@ -568,6 +568,7 @@ public:
                             case FilterCompareType::kGreaterEqual: {
                                 return MakeUnique<FastRoughFilterEvaluatorMinMaxFilter>(column_id, std::move(value), compare_type);
                             }
+                            case FilterCompareType::kInvalid: // special cast expression, e.g., cast varchar column to int and compare with int
                             case FilterCompareType::kAlwaysTrue: {
                                 return ReturnAlwaysTrue();
                             }
@@ -633,6 +634,7 @@ public:
                                     }
                                 }
                             }
+                            case FilterCompareType::kInvalid: // special cast expression, e.g., cast varchar column to int and compare with int
                             case FilterCompareType::kAlwaysTrue: {
                                 return ReturnAlwaysTrue();
                             }

--- a/src/planner/optimizer/secondary_index_scan/filter_expression_push_down_helper.cpp
+++ b/src/planner/optimizer/secondary_index_scan/filter_expression_push_down_helper.cpp
@@ -135,9 +135,14 @@ inline bool IntegralContinueUnwind(DoubleT right_val_double, FilterCompareType &
             }
         }
         case FilterCompareType::kEqual: {
-            // TODO: does not allow expression like "(cast to double)(c1 (int type)) == 3.0" ?
-            compare_type = FilterCompareType::kInvalid;
-            // UnrecoverableError("IntegralContinueUnwind(): should not cast int type column to double in equality comparison.");
+            if (right_val_double >= lowest_val and right_val_double <= max_val) {
+                FromT int_val = static_cast<FromT>(right_val_double);
+                if (static_cast<DoubleT>(int_val) == right_val_double) {
+                    prev = int_val;
+                    return true;
+                }
+            }
+            compare_type = FilterCompareType::kAlwaysFalse;
             return false;
         }
         default: {

--- a/src/planner/optimizer/secondary_index_scan/filter_expression_push_down_helper.cpp
+++ b/src/planner/optimizer/secondary_index_scan/filter_expression_push_down_helper.cpp
@@ -137,7 +137,7 @@ inline bool IntegralContinueUnwind(DoubleT right_val_double, FilterCompareType &
         case FilterCompareType::kEqual: {
             // TODO: does not allow expression like "(cast to double)(c1 (int type)) == 3.0" ?
             compare_type = FilterCompareType::kInvalid;
-            UnrecoverableError("IntegralContinueUnwind(): should not cast int type column to double in equality comparison.");
+            // UnrecoverableError("IntegralContinueUnwind(): should not cast int type column to double in equality comparison.");
             return false;
         }
         default: {
@@ -357,7 +357,8 @@ FilterExpressionPushDownHelper::UnwindCast(SharedPtr<BaseExpression> &cast_expr,
                     }
                 }
                 default: {
-                    UnrecoverableError(fmt::format("UnwindCast(): error in: {}.", cast_expr->Name()));
+                    // possible case: cast varchar column to bigint and compare with bigint value
+                    // UnrecoverableError(fmt::format("UnwindCast(): error in: {}.", cast_expr->Name()));
                     return {0, Value::MakeNull(), FilterCompareType::kInvalid};
                 }
             }
@@ -408,12 +409,14 @@ FilterExpressionPushDownHelper::UnwindCast(SharedPtr<BaseExpression> &cast_expr,
                     return UnwindCast(source_expr, std::move(right_val), compare_type);
                 }
                 default: {
-                    UnrecoverableError(fmt::format("UnwindCast(): error in: {}.", cast_expr->Name()));
+                    // possible case: cast varchar column to double and compare with double value
+                    // UnrecoverableError(fmt::format("UnwindCast(): error in: {}.", cast_expr->Name()));
                     return {0, Value::MakeNull(), FilterCompareType::kInvalid};
                 }
             }
         }
-        UnrecoverableError(fmt::format("UnwindCast(): error in: {}.", cast_expr->Name()));
+        // possible case: cast column to varchar and compare with varchar value
+        // UnrecoverableError(fmt::format("UnwindCast(): error in: {}.", cast_expr->Name()));
         return {0, Value::MakeNull(), FilterCompareType::kInvalid};
     } else {
         UnrecoverableError(fmt::format("UnwindCast(): expression type error: {}.", cast_expr->Name()));

--- a/src/planner/optimizer/secondary_index_scan/secondary_index_scan_execute_expression.cppm
+++ b/src/planner/optimizer/secondary_index_scan/secondary_index_scan_execute_expression.cppm
@@ -126,10 +126,7 @@ export class FilterExecuteSingleRange {
     FilterIntervalRange interval_range_;
 
     inline void SetIntervalToEmpty() {
-        std::visit(Overload{[]<typename T>(FilterIntervalRangeT<T> &interval) { interval.SetAlwaysFalse(); },
-                            [](const std::monostate &empty) {
-                                UnrecoverableError("FilterExecuteSingleRange::SetIntervalToEmpty(): class member interval_range_ not initialized!");
-                            }},
+        std::visit(Overload{[]<typename T>(FilterIntervalRangeT<T> &interval) { interval.SetAlwaysFalse(); }, [](const std::monostate &empty) {}},
                    interval_range_);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix: Varchar expression introduces crash in delete where clause.
enable python test function test_various_expression_in_where_clause

Issue link:#965

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases
