### PR TITLE
Optionally disable jemalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,12 @@ ADD_DEFINITIONS(-D INFINITY_DEBUG)
 
 # find_package(Boost REQUIRED)
 find_package(Lz4 REQUIRED)
-find_package(jemalloc REQUIRED)
+
+# You can disable jemalloc by passing the `-DENABLE_JEMALLOC=OFF` option to CMake.
+option(ENABLE_JEMALLOC "Enable jemalloc support" ON)
+if(ENABLE_JEMALLOC)
+    find_package(jemalloc REQUIRED)
+endif()
 
 add_subdirectory(src)
 add_subdirectory(third_party EXCLUDE_FROM_ALL)

--- a/benchmark/csv/CMakeLists.txt
+++ b/benchmark/csv/CMakeLists.txt
@@ -7,8 +7,11 @@ add_executable(csv_benchmark
 
 target_link_libraries(csv_benchmark
         zsv_parser
-        jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(csv_benchmark jemalloc.a)
+endif()
 
 target_include_directories(csv_benchmark
         PUBLIC "${CMAKE_SOURCE_DIR}/third_party/zsv/include")

--- a/benchmark/embedding/CMakeLists.txt
+++ b/benchmark/embedding/CMakeLists.txt
@@ -9,7 +9,6 @@ target_link_libraries(
     infinity_core
     sql_parser
     benchmark_profiler
-    jemalloc.a
 )
 
 add_executable(ann_ivfflat_benchmark
@@ -29,8 +28,12 @@ target_link_libraries(
         fastpfor
         atomic.a
         lz4.a
-        jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(hnsw_benchmark2 jemalloc.a)
+    target_link_libraries(ann_ivfflat_benchmark jemalloc.a)
+endif()
 
 # add_definitions(-march=native)
 # add_definitions(-msse4.2 -mfma)

--- a/benchmark/fst/CMakeLists.txt
+++ b/benchmark/fst/CMakeLists.txt
@@ -8,8 +8,11 @@ target_link_libraries(
     fst
     infinity_core
     benchmark_profiler
-    jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(fst jemalloc.a)
+endif()
 
 # add_definitions(-march=native)
 # add_definitions(-msse4.2 -mfma)

--- a/benchmark/local_infinity/CMakeLists.txt
+++ b/benchmark/local_infinity/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(
     fastpfor
     lz4.a
     atomic.a
-    jemalloc.a
 )
 
 # ########################################
@@ -37,7 +36,6 @@ target_link_libraries(
     fastpfor
     lz4.a
     atomic.a
-    jemalloc.a
 )
 
 # query benchmark
@@ -57,7 +55,6 @@ target_link_libraries(
     fastpfor
     lz4.a
     atomic.a
-    jemalloc.a
 )
 
 # ########################################
@@ -79,7 +76,6 @@ target_link_libraries(
     fastpfor
     lz4.a
     atomic.a
-    jemalloc.a
 )
 
 # query benchmark
@@ -99,8 +95,15 @@ target_link_libraries(
     fastpfor
     lz4.a
     atomic.a
-    jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(infinity_benchmark jemalloc.a)
+    target_link_libraries(knn_import_benchmark jemalloc.a)
+    target_link_libraries(knn_query_benchmark jemalloc.a)
+    target_link_libraries(fulltext_import_benchmark jemalloc.a)
+    target_link_libraries(fulltext_query_benchmark jemalloc.a)
+endif()
 
 # add_definitions(-march=native)
 # add_definitions(-msse4.2 -mfma)

--- a/benchmark/polling_scheduler/CMakeLists.txt
+++ b/benchmark/polling_scheduler/CMakeLists.txt
@@ -22,5 +22,8 @@ target_link_libraries(
         polling_scheduler_benchmark
         infinity_core
         benchmark_profiler
-        jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(polling_scheduler_benchmark jemalloc.a)
+endif()

--- a/benchmark/remote_infinity/CMakeLists.txt
+++ b/benchmark/remote_infinity/CMakeLists.txt
@@ -24,8 +24,11 @@ target_link_libraries(
         lz4.a
         atomic.a
         thrift.a
-        jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(remote_query_benchmark jemalloc.a)
+endif()
 
 # add_definitions(-march=native)
 # add_definitions(-msse4.2 -mfma)

--- a/cmake/Findjemalloc.cmake
+++ b/cmake/Findjemalloc.cmake
@@ -28,7 +28,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set JEMALLOC_FOUND to TRUE
 # if all listed variables are TRUE and the requested version matches.
-find_package_handle_standard_args(Jemalloc REQUIRED_VARS
+find_package_handle_standard_args(jemalloc REQUIRED_VARS
                                   JEMALLOC_LIBRARY JEMALLOC_INCLUDE_DIR
                                   VERSION_VAR JEMALLOC_VERSION)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -252,8 +252,12 @@ target_link_libraries(infinity
         atomic.a
         event.a
         oatpp.a
-        jemalloc.a
 )
+
+if(ENABLE_JEMALLOC)
+    target_link_libraries(infinity jemalloc.a)
+endif()
+
 target_link_directories(infinity PUBLIC "${CMAKE_BINARY_DIR}/lib")
 target_link_directories(infinity PUBLIC "${CMAKE_BINARY_DIR}/third_party/oatpp/src/")
 


### PR DESCRIPTION
### What problem does this PR solve?

Enable jemalloc by default. You can disable jemalloc by passing the `-DENABLE_JEMALLOC=OFF` option to CMake.

Issue link:#358

### Type of change

- [x] Refactoring
