### PR TITLE
Add vector definition in HTTP API

### DIFF
--- a/docs/references/http_api_reference.md
+++ b/docs/references/http_api_reference.md
@@ -168,6 +168,12 @@ curl --request POST \
             "type": "integer",
             "constraints": ["not null"]
         }
+        "my_vector"
+        {
+            "type": "vector",
+            "dimension": 1024,
+            "element_type": "float"
+        }
     ],
     "properties": 
     [


### PR DESCRIPTION
### What problem does this PR solve?

`       
 "my_vector"
{
      "type": "vector",
      "dimension": 1024,
      "element_type": "float"
}
`

### Type of change

- [x] Documentation Update
