### PR TITLE
Fix: rollback of populate index.

### DIFF
--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -45,106 +45,75 @@ BufferObj *BufferManager::Allocate(UniquePtr<FileWorker> file_worker) {
     auto buffer_obj = MakeUnique<BufferObj>(this, true, std::move(file_worker));
 
     BufferObj *res = buffer_obj.get();
-    std::unique_lock<std::mutex> lock(w_locker_);
+    std::unique_lock lock(w_locker_);
     if (auto iter = buffer_map_.find(file_path); iter != buffer_map_.end()) {
         UnrecoverableError(fmt::format("BufferManager::Allocate: file {} already exists.", file_path.c_str()));
     }
     buffer_map_.emplace(file_path, std::move(buffer_obj));
+
     return res;
 }
 
 BufferObj *BufferManager::Get(UniquePtr<FileWorker> file_worker) {
     String file_path = file_worker->GetFilePath();
     LOG_TRACE(fmt::format("Get buffer object: {}", file_path));
-    w_locker_.lock();
-    auto iter1 = buffer_map_.find(file_path);
-    w_locker_.unlock();
 
-    if (iter1 != buffer_map_.end()) {
+    std::unique_lock lock(w_locker_);
+    if (auto iter1 = buffer_map_.find(file_path); iter1 != buffer_map_.end()) {
         return iter1->second.get();
     }
 
     // Cannot find BufferHandle in buffer_map, read from disk
     auto buffer_obj = MakeUnique<BufferObj>(this, false, std::move(file_worker));
 
-    w_locker_.lock();
-    auto [iter2, insert_ok] = buffer_map_.emplace(std::move(file_path), std::move(buffer_obj));
-    // If insert_ok is false, it means another thread has inserted the same buffer handle. Return it.
-    w_locker_.unlock();
+    auto [iter2, _] = buffer_map_.emplace(std::move(file_path), std::move(buffer_obj));
+    BufferObj *res = iter2->second.get();
 
-    return iter2->second.get();
+    return res;
 }
 
-// return false if buffer_obj is not loaded
-void BufferManager::RemoveBufferObj(const String &file_path) {
-    LOG_TRACE(fmt::format("Erasing buffer object: {}", file_path));
-    std::unique_lock<std::mutex> lock(w_locker_);
-    deprecated_array_.clear();
-    deprecated_array_.emplace_back(buffer_map_[file_path]);
-    buffer_map_.erase(file_path);
-    LOG_TRACE(fmt::format("Erased buffer object: {}", file_path));
-}
+void BufferManager::RequestSpace(SizeT need_size) {
+    std::unique_lock lock(gc_locker_);
+    auto iter = gc_list_.begin();
+    while (current_memory_size_ + need_size > memory_limit_ && iter != gc_list_.end()) {
+        auto buffer_obj = *iter;
+        auto size = buffer_obj->GetBufferSize();
 
-void BufferManager::RemoveBufferObjects() {
-    FileWorker::BulkCleanup(file_path_delete_);
-    // remove buffer objects in bulk
-    deprecated_array_.clear();
+        buffer_obj->Free();
 
-    for (SizeT i = 0; i < obj_path_delete_.size(); i++) {
-        const auto &file_path = obj_path_delete_[i];
-        LOG_TRACE(fmt::format("Erasing buffer object: {}", file_path));
-        deprecated_array_.emplace_back(buffer_map_[file_path]);
-        LOG_TRACE(fmt::format("Erased buffer object: {}", file_path));
+        current_memory_size_ -= size;
+        iter = gc_list_.erase(iter);
+        gc_map_.erase(buffer_obj);
     }
-
-    {
-        std::unique_lock<std::mutex> lock(w_locker_);
-        for (SizeT i = 0; i < obj_path_delete_.size(); i++) {
-            const auto &file_path = obj_path_delete_[i];
-            LOG_TRACE(fmt::format("Erasing buffer map: {}", file_path));
-            buffer_map_.erase(file_path);
-            LOG_TRACE(fmt::format("Erased buffer map: {}", file_path));
-        }
-    }
-
-    // clear
-    file_path_delete_.clear();
-    obj_path_delete_.clear();
-}
-
-void BufferManager::RequestSpace(SizeT need_size, BufferObj *buffer_obj) {
-    while (current_memory_size_ + need_size > memory_limit_) {
-        BufferObj *buffer_obj1 = nullptr;
-        /// FIXME: Actually it is not a good idea to use the moodycamel::ConcurrentQueue.
-        /// When dealing with heavy concurrent read requests, and each request holds some buffer_objs that may cause
-        /// memory usage to exceed the memory_limit, the current handling will lead to some problems. We should consider
-        /// triggering the garbage collection (gc) to free up unnecessary buffer_objs in gc_queue. But currently, we
-        /// only attempt this once, and the service may crash if the head item of the queue shouldn't be freed.
-        /// TODO:
-        /// 1. Replace moodycamel::ConcurrentQueue with a queue using a replacement strategy.
-        /// 2. When encountering out-of-memory situations, first attempt to trigger the gc to try to free up some buffer_objs
-        ///    (not only once now) in gc_queue.
-        /// 3. If the memory usage still exceeds the memory_limit, then consider crashing the service or outputting a warning log.
-        if (gc_queue_.TryDequeue(buffer_obj1)) {
-            if (buffer_obj == buffer_obj1) {
-                UnrecoverableError("buffer object duplicated in gc_queue.");
-            }
-            auto size = buffer_obj1->GetBufferSize();
-            LOG_TRACE(fmt::format("Free buffer object: {}", buffer_obj1->GetFilename()));
-            if (buffer_obj1->Free()) {
-                current_memory_size_ -= size;
-            }
-            LOG_TRACE("Freed buffer object");
-        } else {
-            UnrecoverableError("Out of memory.");
-        }
+    if (current_memory_size_ + need_size > memory_limit_) {
+        UnrecoverableError("Out of memory.");
     }
     current_memory_size_ += need_size;
 }
 
 void BufferManager::PushGCQueue(BufferObj *buffer_obj) {
-    // gc_queue_ is lock-free. No lock is needed.
-    gc_queue_.Enqueue(buffer_obj);
+    std::unique_lock lock(gc_locker_);
+    auto iter = gc_map_.find(buffer_obj);
+    if (iter != gc_map_.end()) {
+        gc_list_.erase(iter->second);
+    }
+    gc_list_.push_back(buffer_obj);
+    gc_map_[buffer_obj] = --gc_list_.end();
+}
+
+void BufferManager::RemoveFromGCQueue(BufferObj *buffer_obj) {
+    std::unique_lock lock(gc_locker_);
+    if (auto iter = gc_map_.find(buffer_obj); iter != gc_map_.end()) {
+        gc_list_.erase(iter->second);
+        gc_map_.erase(iter);
+    }
+}
+
+void BufferManager::RemoveBufferObj(BufferObj *buffer_obj) {
+    RemoveFromGCQueue(buffer_obj);
+    std::unique_lock lock(w_locker_);
+    auto file_path = buffer_obj->GetFilename();
+    buffer_map_.erase(file_path);
 }
 
 } // namespace infinity

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -16,7 +16,7 @@ module;
 
 import stl;
 import file_worker;
-import specific_concurrent_queue;
+// import specific_concurrent_queue;
 
 export module buffer_manager;
 
@@ -35,8 +35,6 @@ public:
     // Get an existing BufferHandle from memory or disk.
     BufferObj *Get(UniquePtr<FileWorker> file_worker);
 
-    void RemoveBufferObj(const String &file_path);
-
     SharedPtr<String> GetDataDir() const { return data_dir_; }
 
     SharedPtr<String> GetTempDir() const { return temp_dir_; }
@@ -46,35 +44,37 @@ public:
         return memory_limit_;
     }
 
-    u64 memory_usage() const { return current_memory_size_.load(); }
-
-    void AddPathForDeletions(const String &path) { file_path_delete_.push_back(path); }
-
-    void AddBufferObjectForDeletion(const String &path) { obj_path_delete_.push_back(path); }
-
-    void RemoveBufferObjects();
+    u64 memory_usage() {
+        std::unique_lock<std::mutex> lock(gc_locker_);
+        return current_memory_size_;
+    }
 
 private:
     friend class BufferObj;
 
     // BufferHandle calls it, before allocate memory. It will start GC if necessary.
-    void RequestSpace(SizeT need_size, BufferObj *buffer_obj);
+    void RequestSpace(SizeT need_size);
 
     // BufferHandle calls it, after unload.
-    void PushGCQueue(BufferObj *buffer_handle);
+    void PushGCQueue(BufferObj *buffer_obj);
+
+    void RemoveFromGCQueue(BufferObj *buffer_obj);
+
+    void RemoveBufferObj(BufferObj *buffer_obj);
 
 private:
     std::mutex w_locker_{};
+    using GCListIter = List<BufferObj *>::iterator;
 
     SharedPtr<String> data_dir_;
     SharedPtr<String> temp_dir_;
     const u64 memory_limit_{};
-    atomic_u64 current_memory_size_{}; // TODO: need to be atomic
-    HashMap<String, SharedPtr<BufferObj>> buffer_map_{};
-    Vector<SharedPtr<BufferObj>> deprecated_array_{};
-    SpecificConcurrentQueue<BufferObj *> gc_queue_{};
+    u64 current_memory_size_{};
+    HashMap<String, UniquePtr<BufferObj>> buffer_map_{};
 
-    Vector<String> file_path_delete_;
-    Vector<String> obj_path_delete_;
+    std::mutex gc_locker_{};
+    HashMap<BufferObj *, GCListIter> gc_map_{};
+    List<BufferObj *> gc_list_{};
 };
+
 } // namespace infinity

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -58,7 +58,7 @@ private:
     // BufferHandle calls it, after unload.
     void PushGCQueue(BufferObj *buffer_obj);
 
-    void RemoveFromGCQueue(BufferObj *buffer_obj);
+    bool RemoveFromGCQueue(BufferObj *buffer_obj);
 
     void RemoveBufferObj(BufferObj *buffer_obj);
 

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -51,7 +51,9 @@ BufferHandle BufferObj::Load() {
             break;
         }
         case BufferStatus::kUnloaded: {
-            buffer_mgr_->RemoveFromGCQueue(this);
+            if (!buffer_mgr_->RemoveFromGCQueue(this)) {
+                UnrecoverableError("Invalid call.");
+            }
             break;
         }
         case BufferStatus::kFreed: {
@@ -129,38 +131,6 @@ void BufferObj::Free() {
     }
     file_worker_->FreeInMemory();
     status_ = BufferStatus::kFreed;
-
-    // std::unique_lock<std::shared_mutex> w_locker(rw_locker_);
-    // switch (status_) {
-    //     case BufferStatus::kFreed: {
-    //         UnrecoverableError("Invalid call.");
-    //     }
-    //     case BufferStatus::kLoaded: {
-    //         // loaded again after free, do nothing.
-    //         // Or has been freed in fronter of the queue.
-    //         return false;
-    //     }
-    //     case BufferStatus::kUnloaded: {
-    //         switch (type_) {
-    //             case BufferType::kTemp:
-    //             case BufferType::kPersistent: {
-    //                 // do nothing
-    //                 break;
-    //             }
-    //             case BufferType::kEphemeral: {
-    //                 file_worker_->WriteToFile(true);
-    //                 break;
-    //             }
-    //         }
-    //         file_worker_->FreeInMemory();
-    //         status_ = BufferStatus::kFreed;
-    //         break;
-    //     }
-    //     case BufferStatus::kNew: {
-    //         UnrecoverableError("Invalid call.");
-    //     }
-    // }
-    // return true;
 }
 
 bool BufferObj::Save() {

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -53,11 +53,19 @@ BufferHandle BufferObj::Load() {
         }
         case BufferStatus::kFreed: {
             buffer_mgr_->RequestSpace(GetBufferSize(), this);
-            file_worker_->ReadFromFile(type_ != BufferType::kPersistent);
+            bool load_success = true;
+            try {
+                file_worker_->ReadFromFile(type_ != BufferType::kPersistent);
+            } catch (const UnrecoverableException &e) {
+                load_success = false;
+            }
             if (type_ == BufferType::kEphemeral) {
                 type_ = BufferType::kTemp;
             }
-            break;
+            if (load_success) {
+                break;
+            }
+            type_ = BufferType::kEphemeral;
         }
         case BufferStatus::kNew: {
             LOG_TRACE(fmt::format("Request memory {}", GetBufferSize()));

--- a/src/storage/buffer/buffer_obj.cppm
+++ b/src/storage/buffer/buffer_obj.cppm
@@ -28,7 +28,7 @@ export enum class BufferStatus {
     kLoaded,
     kUnloaded,
     kFreed,
-    kClean,
+    // kClean,
     kNew,
 };
 
@@ -46,8 +46,6 @@ export String BufferStatusToString(BufferStatus status) {
             return "Unloaded";
         case BufferStatus::kFreed:
             return "Freed";
-        case BufferStatus::kClean:
-            return "Clean";
         case BufferStatus::kNew:
             return "New";
         default:
@@ -71,12 +69,12 @@ public:
 
     // called by BufferMgr in GC process.
     // return true if is freed.
-    bool Free();
+    void Free();
 
     // called when checkpoint. or in "IMPORT" operator.
     bool Save();
 
-    void SetAndTryCleanup();
+    void Cleanup();
 
     SizeT GetBufferSize() const { return file_worker_->GetMemoryCost(); }
 
@@ -114,7 +112,6 @@ protected:
     BufferStatus status_{BufferStatus::kNew};
     BufferType type_{BufferType::kTemp};
     u64 rc_{0};
-    bool wait_for_gc_{false};
     const UniquePtr<FileWorker> file_worker_;
 };
 

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -324,10 +324,10 @@ void Catalog::CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp com
     table_index_entry->CommitCreateIndex(txn_index_store, commit_ts, is_replay);
 }
 
-void Catalog::RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn) {
-    auto *table_index_entry = txn_index_store->table_index_entry_;
-    table_index_entry->RollbackPopulateIndex(txn_index_store, txn);
-}
+// void Catalog::RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn) {
+//     auto *table_index_entry = txn_index_store->table_index_entry_;
+//     table_index_entry->RollbackPopulateIndex(txn_index_store, txn);
+// }
 
 void Catalog::Append(TableEntry *table_entry, TransactionID txn_id, void *txn_store, TxnTimeStamp commit_ts, BufferManager *buffer_mgr) {
     return table_entry->AppendData(txn_id, txn_store, commit_ts, buffer_mgr);

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -312,10 +312,10 @@ Catalog::GetTableIndexInfo(const String &db_name, const String &table_name, cons
     return table_entry->GetTableIndexInfo(index_name, txn_id, begin_ts);
 }
 
-Status Catalog::RemoveIndexEntry(const String &index_name, TableIndexEntry *table_index_entry, TransactionID txn_id) {
-    const TableIndexMeta *table_index_meta = table_index_entry->table_index_meta();
-    TableEntry *table_entry = table_index_meta->GetTableEntry();
-    table_entry->RemoveIndexEntry(index_name, txn_id);
+Status Catalog::RemoveIndexEntry(TableIndexEntry *table_index_entry, TransactionID txn_id) {
+    TableIndexMeta *table_index_meta = table_index_entry->table_index_meta();
+    LOG_TRACE(fmt::format("Remove a index entry: {}", *table_index_entry->GetIndexName()));
+    table_index_meta->DeleteEntry(txn_id);
     return Status::OK();
 }
 
@@ -324,9 +324,9 @@ void Catalog::CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp com
     table_index_entry->CommitCreateIndex(txn_index_store, commit_ts, is_replay);
 }
 
-void Catalog::RollbackCreateIndex(TxnIndexStore *txn_index_store) {
+void Catalog::RollbackPopulateIndex(TxnIndexStore *txn_index_store) {
     auto *table_index_entry = txn_index_store->table_index_entry_;
-    table_index_entry->RollbackCreateIndex(txn_index_store);
+    table_index_entry->RollbackPopulateIndex(txn_index_store);
 }
 
 void Catalog::Append(TableEntry *table_entry, TransactionID txn_id, void *txn_store, TxnTimeStamp commit_ts, BufferManager *buffer_mgr) {

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -324,9 +324,9 @@ void Catalog::CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp com
     table_index_entry->CommitCreateIndex(txn_index_store, commit_ts, is_replay);
 }
 
-void Catalog::RollbackPopulateIndex(TxnIndexStore *txn_index_store) {
+void Catalog::RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn) {
     auto *table_index_entry = txn_index_store->table_index_entry_;
-    table_index_entry->RollbackPopulateIndex(txn_index_store);
+    table_index_entry->RollbackPopulateIndex(txn_index_store, txn);
 }
 
 void Catalog::Append(TableEntry *table_entry, TransactionID txn_id, void *txn_store, TxnTimeStamp commit_ts, BufferManager *buffer_mgr) {

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -195,7 +195,7 @@ public:
 
     static void CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp commit_ts, bool is_replay = false);
 
-    static void RollbackPopulateIndex(TxnIndexStore *txn_index_store);
+    static void RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn);
 
     // Append related functions
     static void Append(TableEntry *table_entry, TransactionID txn_id, void *txn_store, TxnTimeStamp commit_ts, BufferManager *buffer_mgr);

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -191,11 +191,11 @@ public:
     Tuple<SharedPtr<TableIndexInfo>, Status>
     GetTableIndexInfo(const String &db_name, const String &table_name, const String &index_name, TransactionID txn_id, TxnTimeStamp begin_ts);
 
-    static Status RemoveIndexEntry(const String &index_name, TableIndexEntry *table_index_entry, TransactionID txn_id);
+    static Status RemoveIndexEntry(TableIndexEntry *table_index_entry, TransactionID txn_id);
 
     static void CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp commit_ts, bool is_replay = false);
 
-    static void RollbackCreateIndex(TxnIndexStore *txn_index_store);
+    static void RollbackPopulateIndex(TxnIndexStore *txn_index_store);
 
     // Append related functions
     static void Append(TableEntry *table_entry, TransactionID txn_id, void *txn_store, TxnTimeStamp commit_ts, BufferManager *buffer_mgr);
@@ -303,7 +303,7 @@ private: // TODO: remove this
     void MemIndexCommitLoop();
 
 public:
-    void MemIndexRecover(BufferManager* buffer_manager);
+    void MemIndexRecover(BufferManager *buffer_manager);
 
     void PickCleanup(CleanupScanner *scanner);
 

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -195,7 +195,7 @@ public:
 
     static void CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp commit_ts, bool is_replay = false);
 
-    static void RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn);
+    // static void RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn);
 
     // Append related functions
     static void Append(TableEntry *table_entry, TransactionID txn_id, void *txn_store, TxnTimeStamp commit_ts, BufferManager *buffer_mgr);

--- a/src/storage/meta/cleanup_scanner.cpp
+++ b/src/storage/meta/cleanup_scanner.cpp
@@ -39,8 +39,6 @@ void CleanupScanner::Cleanup() && {
     for (auto &entry : entries_) {
         std::move(*entry).Cleanup();
     }
-
-    buffer_mgr_->RemoveBufferObjects();
 }
 
 void CleanupScanner::CleanupDir(const String &dir) {

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -183,11 +183,11 @@ void BlockColumnEntry::Flush(BlockColumnEntry *block_column_entry, SizeT checkpo
 
 void BlockColumnEntry::Cleanup() {
     if (buffer_ != nullptr) {
-        buffer_->SetAndTryCleanup();
+        buffer_->Cleanup();
     }
     for (auto *outline_buffer : outline_buffers_) {
         if (outline_buffer) {
-            outline_buffer->SetAndTryCleanup();
+            outline_buffer->Cleanup();
         }
     }
 }

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -309,7 +309,7 @@ nlohmann::json BlockEntry::Serialize(TxnTimeStamp max_commit_ts) {
         json_res["columns"].emplace_back(block_column_entry->Serialize());
     }
     json_res["min_row_ts"] = this->min_row_ts_;
-    json_res["max_row_ts"] = this->max_row_ts_;
+    json_res["max_row_ts"] = std::min(this->max_row_ts_, max_commit_ts);
     json_res["version_file"] = this->VersionFilePath();
 
     json_res["commit_ts"] = TxnTimeStamp(this->commit_ts_);

--- a/src/storage/meta/entry/chunk_index_entry.cpp
+++ b/src/storage/meta/entry/chunk_index_entry.cpp
@@ -120,7 +120,7 @@ SharedPtr<ChunkIndexEntry> ChunkIndexEntry::Deserialize(const nlohmann::json &in
 
 void ChunkIndexEntry::Cleanup() {
     if (buffer_obj_) {
-        buffer_obj_->SetAndTryCleanup();
+        buffer_obj_->Cleanup();
     }
 }
 

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -616,7 +616,7 @@ void SegmentIndexEntry::Cleanup() {
         if (buffer_obj == nullptr) {
             UnrecoverableError("vector_buffer should not has nullptr.");
         }
-        buffer_obj->SetAndTryCleanup();
+        buffer_obj->Cleanup();
     }
     for (auto &chunk_index_entry : chunk_index_entries_) {
         chunk_index_entry->Cleanup();

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -128,6 +128,15 @@ public:
         chunk_index_entries.insert(chunk_index_entries.end(), chunk_index_entries_.begin(), chunk_index_entries_.end());
     }
 
+    void RemoveChunkIndexEntry(ChunkIndexEntry *chunk_index_entry) {
+        RowID base_rowid = chunk_index_entry->base_rowid_;
+        std::unique_lock lock(rw_locker_);
+        chunk_index_entries_.erase(std::remove_if(chunk_index_entries_.begin(),
+                                                  chunk_index_entries_.end(),
+                                                  [base_rowid](const SharedPtr<ChunkIndexEntry> &entry) { return entry->base_rowid_ == base_rowid; }),
+                                   chunk_index_entries_.end());
+    }
+
     void ReplaceChunkIndexEntries(SharedPtr<ChunkIndexEntry> merged_chunk_index_entry) {
         std::shared_lock lock(rw_locker_);
         SizeT num_entries = chunk_index_entries_.size();

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -148,7 +148,7 @@ void TableIndexEntry::CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeS
     }
 }
 
-void TableIndexEntry::RollbackPopulateIndex(TxnIndexStore *txn_index_store) {
+void TableIndexEntry::RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn) {
     std::unique_lock w_lock(rw_locker_);
     for (auto *chunk_index_entry : txn_index_store->chunk_index_entries_) {
         chunk_index_entry->Cleanup();
@@ -156,6 +156,9 @@ void TableIndexEntry::RollbackPopulateIndex(TxnIndexStore *txn_index_store) {
         segment_index_entry->RemoveChunkIndexEntry(chunk_index_entry);
     }
     for (const auto &[segment_id, segment_index_entry] : txn_index_store->index_entry_map_) {
+        if (segment_index_entry->begin_ts_ != txn->BeginTS()) {
+            continue;
+        }
         segment_index_entry->Cleanup();
         if (index_by_segment_.erase(segment_id) == 0) {
             UnrecoverableError("Failed to erase segment index entry");

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -148,23 +148,23 @@ void TableIndexEntry::CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeS
     }
 }
 
-void TableIndexEntry::RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn) {
-    std::unique_lock w_lock(rw_locker_);
-    for (auto *chunk_index_entry : txn_index_store->chunk_index_entries_) {
-        chunk_index_entry->Cleanup();
-        SegmentIndexEntry *segment_index_entry = chunk_index_entry->segment_index_entry_;
-        segment_index_entry->RemoveChunkIndexEntry(chunk_index_entry);
-    }
-    for (const auto &[segment_id, segment_index_entry] : txn_index_store->index_entry_map_) {
-        if (segment_index_entry->begin_ts_ != txn->BeginTS()) {
-            continue;
-        }
-        segment_index_entry->Cleanup();
-        if (index_by_segment_.erase(segment_id) == 0) {
-            UnrecoverableError("Failed to erase segment index entry");
-        }
-    }
-}
+// void TableIndexEntry::RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn) {
+//     std::unique_lock w_lock(rw_locker_);
+//     for (auto *chunk_index_entry : txn_index_store->chunk_index_entries_) {
+//         chunk_index_entry->Cleanup();
+//         SegmentIndexEntry *segment_index_entry = chunk_index_entry->segment_index_entry_;
+//         segment_index_entry->RemoveChunkIndexEntry(chunk_index_entry);
+//     }
+//     for (const auto &[segment_id, segment_index_entry] : txn_index_store->index_entry_map_) {
+//         if (segment_index_entry->begin_ts_ != txn->BeginTS()) {
+//             continue;
+//         }
+//         segment_index_entry->Cleanup();
+//         if (index_by_segment_.erase(segment_id) == 0) {
+//             UnrecoverableError("Failed to erase segment index entry");
+//         }
+//     }
+// }
 
 nlohmann::json TableIndexEntry::Serialize(TxnTimeStamp max_commit_ts) {
     nlohmann::json json;

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -125,7 +125,7 @@ public:
 
     void CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp commit_ts, bool is_replay = false);
 
-    void RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn);
+    // void RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn);
 
     // replay
     void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -125,7 +125,7 @@ public:
 
     void CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp commit_ts, bool is_replay = false);
 
-    void RollbackPopulateIndex(TxnIndexStore *txn_index_store);
+    void RollbackPopulateIndex(TxnIndexStore *txn_index_store, Txn *txn);
 
     // replay
     void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -84,7 +84,7 @@ public:
     // Getter
     const SharedPtr<String> &GetIndexName() const { return index_base_->index_name_; }
 
-    inline const TableIndexMeta *table_index_meta() const { return table_index_meta_; }
+    inline TableIndexMeta *table_index_meta() { return table_index_meta_; }
     inline const IndexBase *index_base() const { return index_base_.get(); }
     const SharedPtr<IndexBase> &table_index_def() const { return index_base_; }
     inline const SharedPtr<ColumnDef> &column_def() const { return column_def_; }
@@ -125,7 +125,7 @@ public:
 
     void CommitCreateIndex(TxnIndexStore *txn_index_store, TxnTimeStamp commit_ts, bool is_replay = false);
 
-    void RollbackCreateIndex(TxnIndexStore *txn_index_store);
+    void RollbackPopulateIndex(TxnIndexStore *txn_index_store);
 
     // replay
     void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -69,7 +69,7 @@ void TxnIndexStore::AddDeltaOp(CatalogDeltaEntry *local_delta_ops, TxnTimeStamp 
     for (auto [segment_id, segment_index_entry] : index_entry_map_) {
         local_delta_ops->AddOperation(MakeUnique<AddSegmentIndexEntryOp>(segment_index_entry, commit_ts));
     }
-    for (auto chunk_index_entry : chunk_index_entries_) {
+    for (auto *chunk_index_entry : chunk_index_entries_) {
         local_delta_ops->AddOperation(MakeUnique<AddChunkIndexEntryOp>(chunk_index_entry, commit_ts));
     }
 }
@@ -78,7 +78,7 @@ void TxnIndexStore::Commit(TransactionID txn_id, TxnTimeStamp commit_ts) const {
     for (const auto &[segment_id, segment_index_entry] : index_entry_map_) {
         segment_index_entry->CommitSegmentIndex(txn_id, commit_ts);
     }
-    for (auto chunk_index_entry : chunk_index_entries_) {
+    for (auto *chunk_index_entry : chunk_index_entries_) {
         chunk_index_entry->Commit(commit_ts);
     }
 }
@@ -232,13 +232,15 @@ void TxnTableStore::Rollback(TransactionID txn_id, TxnTimeStamp abort_ts) {
         LOG_TRACE(fmt::format("Rollback prepare appended data in table: {}", *table_entry_->GetTableName()));
     }
     for (auto &[index_name, txn_index_store] : txn_indexes_store_) {
-        Catalog::RollbackCreateIndex(txn_index_store.get());
-        auto *table_index_entry = txn_index_store->table_index_entry_;
-        table_index_entry->Cleanup();
-        Catalog::RemoveIndexEntry(index_name, table_index_entry, txn_id);
+        Catalog::RollbackPopulateIndex(txn_index_store.get());
     }
     Catalog::RollbackCompact(table_entry_, txn_id, abort_ts, compact_state_);
     blocks_.clear();
+
+    for (auto &[table_index_entry, ptr_seq_n] : txn_indexes_) {
+        table_index_entry->Cleanup();
+        Catalog::RemoveIndexEntry(table_index_entry, txn_id); // fix me
+    }
 }
 
 bool TxnTableStore::CheckConflict(Catalog *catalog) const {

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -232,7 +232,7 @@ void TxnTableStore::Rollback(TransactionID txn_id, TxnTimeStamp abort_ts) {
         LOG_TRACE(fmt::format("Rollback prepare appended data in table: {}", *table_entry_->GetTableName()));
     }
     for (auto &[index_name, txn_index_store] : txn_indexes_store_) {
-        Catalog::RollbackPopulateIndex(txn_index_store.get());
+        Catalog::RollbackPopulateIndex(txn_index_store.get(), txn_);
     }
     Catalog::RollbackCompact(table_entry_, txn_id, abort_ts, compact_state_);
     blocks_.clear();

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -231,9 +231,9 @@ void TxnTableStore::Rollback(TransactionID txn_id, TxnTimeStamp abort_ts) {
         Catalog::RollbackAppend(table_entry_, txn_id, abort_ts, this);
         LOG_TRACE(fmt::format("Rollback prepare appended data in table: {}", *table_entry_->GetTableName()));
     }
-    for (auto &[index_name, txn_index_store] : txn_indexes_store_) {
-        Catalog::RollbackPopulateIndex(txn_index_store.get(), txn_);
-    }
+    // for (auto &[index_name, txn_index_store] : txn_indexes_store_) {
+    //     Catalog::RollbackPopulateIndex(txn_index_store.get(), txn_);
+    // }
     Catalog::RollbackCompact(table_entry_, txn_id, abort_ts, compact_state_);
     blocks_.clear();
 

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -139,7 +139,7 @@ private:
     Vector<SegmentEntry *> set_sealed_segments_{};
 
     int ptr_seq_n_;
-    Map<TableIndexEntry *, int> txn_indexes_{};
+    HashMap<TableIndexEntry *, int> txn_indexes_{};
     HashMap<String, UniquePtr<TxnIndexStore>> txn_indexes_store_{};
 
     TxnCompactStore compact_state_;
@@ -187,8 +187,8 @@ private:
     Txn *txn_{}; // TODO: remove this
     Catalog *catalog_{};
     int ptr_seq_n_{};
-    Map<DBEntry *, int> txn_dbs_{};
-    Map<TableEntry *, int> txn_tables_{};
+    HashMap<DBEntry *, int> txn_dbs_{};
+    HashMap<TableEntry *, int> txn_tables_{};
     // Key: table name Value: TxnTableStore
     HashMap<String, SharedPtr<TxnTableStore>> txn_tables_store_{};
 };

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -63,8 +63,8 @@ class BufferObjTest : public BaseTest {
     }
 
     void TearDown() override {
-        system("rm -rf /tmp/infinity/log /tmp/infinity/data /tmp/infinity/wal");
         infinity::InfinityContext::instance().UnInit();
+        system("rm -rf /tmp/infinity/log /tmp/infinity/data /tmp/infinity/wal");
 
 #ifdef INFINITY_DEBUG
         EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -284,205 +284,205 @@ TEST_F(BufferObjTest, test1) {
 }
 
 // unit test for BufferStatus::kClean transformation
-TEST_F(BufferObjTest, test_status_clean) {
-    SizeT memory_limit = 1024;
-    auto temp_dir = MakeShared<String>("/tmp/infinity/spill");
-    auto base_dir = MakeShared<String>("/tmp/infinity/data");
+// TEST_F(BufferObjTest, test_status_clean) {
+//     SizeT memory_limit = 1024;
+//     auto temp_dir = MakeShared<String>("/tmp/infinity/spill");
+//     auto base_dir = MakeShared<String>("/tmp/infinity/data");
 
-    BufferManager buffer_manager(memory_limit, base_dir, temp_dir);
+//     BufferManager buffer_manager(memory_limit, base_dir, temp_dir);
 
-    SizeT test_size1 = 1024;
-    auto file_dir1 = MakeShared<String>("/tmp/infinity/data/dir1");
-    auto test_fname1 = MakeShared<String>("test1");
-    auto file_worker1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-    auto buf1 = buffer_manager.Allocate(std::move(file_worker1));
+//     SizeT test_size1 = 1024;
+//     auto file_dir1 = MakeShared<String>("/tmp/infinity/data/dir1");
+//     auto test_fname1 = MakeShared<String>("test1");
+//     auto file_worker1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//     auto buf1 = buffer_manager.Allocate(std::move(file_worker1));
 
-    SizeT test_size2 = 1024;
-    auto file_dir2 = MakeShared<String>("/tmp/infinity/data/dir2");
-    auto test_fname2 = MakeShared<String>("test2");
-    auto file_worker2 = MakeUnique<DataFileWorker>(file_dir2, test_fname2, test_size2);
-    auto buf2 = buffer_manager.Allocate(std::move(file_worker2));
+//     SizeT test_size2 = 1024;
+//     auto file_dir2 = MakeShared<String>("/tmp/infinity/data/dir2");
+//     auto test_fname2 = MakeShared<String>("test2");
+//     auto file_worker2 = MakeUnique<DataFileWorker>(file_dir2, test_fname2, test_size2);
+//     auto buf2 = buffer_manager.Allocate(std::move(file_worker2));
 
-    /// kEphemeral
-    // kNew, kEphemeral
-    EXPECT_EQ(buf1->status(), BufferStatus::kNew);
-    EXPECT_EQ(buf1->type(), BufferType::kEphemeral);
-    buf1->CheckState();
+//     /// kEphemeral
+//     // kNew, kEphemeral
+//     EXPECT_EQ(buf1->status(), BufferStatus::kNew);
+//     EXPECT_EQ(buf1->type(), BufferType::kEphemeral);
+//     buf1->CheckState();
 
-    {
-        auto handle1 = buf1->Load();
-        // kNew, kEphemeral -> kLoaded, kEphemeral
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
+//     {
+//         auto handle1 = buf1->Load();
+//         // kNew, kEphemeral -> kLoaded, kEphemeral
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
 
-    // kLoaded, kEphemeral -> kUnloaded, kEphemeral
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
+//     // kLoaded, kEphemeral -> kUnloaded, kEphemeral
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
 
-    // kUnloaded, kEphemeral -> kClean, kEphemeral
-    buf1->SetAndTryCleanup();
-    buffer_manager.RemoveBufferObjects();
-    EXPECT_EQ(buf1->status(), BufferStatus::kClean);
-    buf1->CheckState();
+//     // kUnloaded, kEphemeral -> kClean, kEphemeral
+//     buf1->SetAndTryCleanup();
+//     buffer_manager.ExecuteDeletions();
+//     EXPECT_EQ(buf1->status(), BufferStatus::kClean);
+//     buf1->CheckState();
 
-    // kClean, kEphemeral -> kLoaded, kEphemeral
-    { auto handle2 = buf2->Load(); }
-    {
-        auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-        buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
-        auto handle1 = buf1->Load();
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        EXPECT_EQ(buf1->type(), BufferType::kEphemeral);
-        buf1->CheckState();
-    }
+//     // kClean, kEphemeral -> kLoaded, kEphemeral
+//     { auto handle2 = buf2->Load(); }
+//     {
+//         auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//         buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
+//         auto handle1 = buf1->Load();
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         EXPECT_EQ(buf1->type(), BufferType::kEphemeral);
+//         buf1->CheckState();
+//     }
 
-    // kLoaded, kEphemeral -> kUnloaded, kEphemeral
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
+//     // kLoaded, kEphemeral -> kUnloaded, kEphemeral
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
 
-    { auto handle2 = buf2->Load(); }
-    // kUnloaded, kEphemeral -> kFreed, kEphemeral
-    EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
-    buf1->CheckState();
+//     { auto handle2 = buf2->Load(); }
+//     // kUnloaded, kEphemeral -> kFreed, kEphemeral
+//     EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
+//     buf1->CheckState();
 
-    // kFreed, kEphemeral -> kNew, kEphemeral
-    buf1->SetAndTryCleanup();
-    buffer_manager.RemoveBufferObjects();
-    auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-    buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
-    EXPECT_EQ(buf1->status(), BufferStatus::kNew);
-    buf1->CheckState();
+//     // kFreed, kEphemeral -> kNew, kEphemeral
+//     buf1->SetAndTryCleanup();
+//     buffer_manager.ExecuteDeletions();
+//     auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//     buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
+//     EXPECT_EQ(buf1->status(), BufferStatus::kNew);
+//     buf1->CheckState();
 
-    {
-        auto handle1 = buf1->Load();
-        // kNew, kEphemeral -> kLoaded, kEphemeral
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
-    // kLoaded, kEphemeral -> kUnloaded, kEphemeral
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
-    { auto handle2 = buf2->Load(); }
-    // kUnloaded, kEphemeral -> kFreed, kEphemeral
-    EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
-    buf1->CheckState();
+//     {
+//         auto handle1 = buf1->Load();
+//         // kNew, kEphemeral -> kLoaded, kEphemeral
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
+//     // kLoaded, kEphemeral -> kUnloaded, kEphemeral
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
+//     { auto handle2 = buf2->Load(); }
+//     // kUnloaded, kEphemeral -> kFreed, kEphemeral
+//     EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
+//     buf1->CheckState();
 
-    /// kTemp
-    // kFreed, kEphemeral -> kLoaded, kTemp
-    {
-        auto handle1 = buf1->Load();
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        EXPECT_EQ(buf1->type(), BufferType::kTemp);
-        buf1->CheckState();
-    }
+//     /// kTemp
+//     // kFreed, kEphemeral -> kLoaded, kTemp
+//     {
+//         auto handle1 = buf1->Load();
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         EXPECT_EQ(buf1->type(), BufferType::kTemp);
+//         buf1->CheckState();
+//     }
 
-    // kLoaded, kTemp -> kUnloaded, kTemp
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
+//     // kLoaded, kTemp -> kUnloaded, kTemp
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
 
-    // kUnloaded, kTemp -> kClean, kTemp
-    buf1->SetAndTryCleanup();
-    buffer_manager.RemoveBufferObjects();
-    EXPECT_EQ(buf1->status(), BufferStatus::kClean);
-    buf1->CheckState();
+//     // kUnloaded, kTemp -> kClean, kTemp
+//     buf1->SetAndTryCleanup();
+//     buffer_manager.ExecuteDeletions();
+//     EXPECT_EQ(buf1->status(), BufferStatus::kClean);
+//     buf1->CheckState();
 
-    // kClean, kTemp -> kLoaded, kTemp
-    { auto handle2 = buf2->Load(); }
-    {
-        auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-        buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
-        auto handle1 = buf1->Load();
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
-    { auto handle2 = buf2->Load(); }
-    EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
-    {
-        auto handle1 = buf1->Load();
-        // kFreed, kTemp -> kLoaded, kTemp
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
+//     // kClean, kTemp -> kLoaded, kTemp
+//     { auto handle2 = buf2->Load(); }
+//     {
+//         auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//         buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
+//         auto handle1 = buf1->Load();
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
+//     { auto handle2 = buf2->Load(); }
+//     EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
+//     {
+//         auto handle1 = buf1->Load();
+//         // kFreed, kTemp -> kLoaded, kTemp
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
 
-    // kLoaded, kTemp -> kUnloaded, kTemp
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
+//     // kLoaded, kTemp -> kUnloaded, kTemp
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
 
-    { auto handle2 = buf2->Load(); }
-    // kUnloaded, kTemp -> kFreed, kTemp
-    EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
-    buf1->CheckState();
+//     { auto handle2 = buf2->Load(); }
+//     // kUnloaded, kTemp -> kFreed, kTemp
+//     EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
+//     buf1->CheckState();
 
-    // kFreed, kTemp -> kNew, kTemp
-    buf1->SetAndTryCleanup();
-    buffer_manager.RemoveBufferObjects();
-    auto file_worker1_new2 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-    buf1 = buffer_manager.Allocate(std::move(file_worker1_new2));
-    EXPECT_EQ(buf1->status(), BufferStatus::kNew);
-    buf1->CheckState();
+//     // kFreed, kTemp -> kNew, kTemp
+//     buf1->SetAndTryCleanup();
+//     buffer_manager.ExecuteDeletions();
+//     auto file_worker1_new2 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//     buf1 = buffer_manager.Allocate(std::move(file_worker1_new2));
+//     EXPECT_EQ(buf1->status(), BufferStatus::kNew);
+//     buf1->CheckState();
 
-    {
-        auto handle1 = buf1->Load();
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
+//     {
+//         auto handle1 = buf1->Load();
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
 
-    /// kPersistent
-    SaveBufferObj(buf1);
-    // kNew, kTemp -> kNew, kPersistent
-    EXPECT_EQ(buf1->type(), BufferType::kPersistent);
+//     /// kPersistent
+//     SaveBufferObj(buf1);
+//     // kNew, kTemp -> kNew, kPersistent
+//     EXPECT_EQ(buf1->type(), BufferType::kPersistent);
 
-    {
-        auto handle1 = buf1->Load();
-        // kNew, kPersistent -> kLoaded, kPersistent
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
+//     {
+//         auto handle1 = buf1->Load();
+//         // kNew, kPersistent -> kLoaded, kPersistent
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
 
-    // kLoaded, kPersistent -> kUnloaded, kPersistent
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
+//     // kLoaded, kPersistent -> kUnloaded, kPersistent
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
 
-    // kUnloaded, kPersistent -> kClean, kPersistent
-    buf1->SetAndTryCleanup();
-    EXPECT_EQ(buf1->status(), BufferStatus::kClean);
-    buf1->CheckState();
+//     // kUnloaded, kPersistent -> kClean, kPersistent
+//     buf1->SetAndTryCleanup();
+//     EXPECT_EQ(buf1->status(), BufferStatus::kClean);
+//     buf1->CheckState();
 
-    // kClean, kPersistent -> kLoaded, kPersistent
-    { auto handle2 = buf2->Load(); }
-    {
-        auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-        buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
-        auto handle1 = buf1->Load();
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
-    SaveBufferObj(buf1);
-    {
-        auto handle1 = buf1->Load();
-        EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
-        buf1->CheckState();
-    }
+//     // kClean, kPersistent -> kLoaded, kPersistent
+//     { auto handle2 = buf2->Load(); }
+//     {
+//         auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//         buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
+//         auto handle1 = buf1->Load();
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
+//     SaveBufferObj(buf1);
+//     {
+//         auto handle1 = buf1->Load();
+//         EXPECT_EQ(buf1->status(), BufferStatus::kLoaded);
+//         buf1->CheckState();
+//     }
 
-    // kLoaded, kPersistent -> kUnloaded, kPersistent
-    EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
-    buf1->CheckState();
+//     // kLoaded, kPersistent -> kUnloaded, kPersistent
+//     EXPECT_EQ(buf1->status(), BufferStatus::kUnloaded);
+//     buf1->CheckState();
 
-    { auto handle2 = buf2->Load(); }
+//     { auto handle2 = buf2->Load(); }
 
-    // kUnloaded, kPersistent -> kFreed, kPersistent
-    EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
-    buf1->CheckState();
+//     // kUnloaded, kPersistent -> kFreed, kPersistent
+//     EXPECT_EQ(buf1->status(), BufferStatus::kFreed);
+//     buf1->CheckState();
 
-    // kFreed, kPersistent -> kClean, kPersistent
-    buf1->SetAndTryCleanup();
-    buffer_manager.RemoveBufferObjects();
-    auto file_worker1_new3 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
-    buf1 = buffer_manager.Allocate(std::move(file_worker1_new3));
-    EXPECT_EQ(buf1->status(), BufferStatus::kNew);
-    buf1->CheckState();
-}
+//     // kFreed, kPersistent -> kClean, kPersistent
+//     buf1->SetAndTryCleanup();
+//     buffer_manager.ExecuteDeletions();
+//     auto file_worker1_new3 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
+//     buf1 = buffer_manager.Allocate(std::move(file_worker1_new3));
+//     EXPECT_EQ(buf1->status(), BufferStatus::kNew);
+//     buf1->CheckState();
+// }
 
 TEST_F(BufferObjTest, test_hnsw_index_buffer_obj_shutdown) {
 #ifdef INFINITY_DEBUG


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: rollback create index will not erase the index that not created in the txn.
2. Fix: buffer obj replay bug.
3. Fix: full checkpoint max_row_ts should less than checkpoint_ts.
4. Refactor: buffer manager (use lru)

Issue link: #1018
Issue link: #1021

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring