### PR TITLE
[Feature Request]: Batch deprecated object cleanup #978

### DIFF
--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -58,7 +58,6 @@ export namespace std {
     using std::forward;
     using std::move;
     using std::exchange;
-    using std::greater;
     using std::swap;
 
     using std::max;

--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -47,6 +47,7 @@ module;
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <queue>
 
 export module stl;
 
@@ -57,7 +58,7 @@ export namespace std {
     using std::forward;
     using std::move;
     using std::exchange;
-
+    using std::greater;
     using std::swap;
 
     using std::max;
@@ -270,6 +271,9 @@ namespace infinity {
 
     template<typename S>
     using HashSet = std::unordered_set<S>;
+
+    template<typename T>
+    using MultiSet = std::multiset<T>;
 
     template<typename T>
     using MaxHeap = std::priority_queue<T>;

--- a/src/storage/background_process.cpp
+++ b/src/storage/background_process.cpp
@@ -28,6 +28,7 @@ import infinity_exception;
 import wal_manager;
 import catalog;
 import third_party;
+import buffer_manager;
 
 namespace infinity {
 

--- a/src/storage/bg_task/periodic_trigger.cpp
+++ b/src/storage/bg_task/periodic_trigger.cpp
@@ -39,7 +39,9 @@ void CleanupPeriodicTrigger::Trigger() {
     }
     last_visible_ts_ = visible_ts;
     LOG_INFO(fmt::format("Cleanup visible timestamp: {}", visible_ts));
-    auto cleanup_task = MakeShared<CleanupTask>(catalog_, visible_ts);
+
+    auto buffer_mgr = txn_mgr_->GetBufferMgr();
+    auto cleanup_task = MakeShared<CleanupTask>(catalog_, visible_ts, buffer_mgr);
     bg_processor_->Submit(std::move(cleanup_task));
 }
 

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -92,9 +92,17 @@ void BufferManager::ExecuteDeletions() {
         const auto &file_path = obj_path_delete_[i];
         LOG_TRACE(fmt::format("Erasing buffer object: {}", file_path));
         deprecated_array_.emplace_back(buffer_map_[file_path]);
-        buffer_map_.erase(file_path);
         LOG_TRACE(fmt::format("Erased buffer object: {}", file_path));
     }
+
+    std::unique_lock<std::mutex> lock(w_locker_);
+    for (size_t i = 0; i < obj_path_delete_.size(); i++) {
+        const auto &file_path = obj_path_delete_[i];
+        LOG_TRACE(fmt::format("Erasing buffer map: {}", file_path));
+        buffer_map_.erase(file_path);
+        LOG_TRACE(fmt::format("Erased buffer map: {}", file_path));
+    }
+
     // clear
     file_path_delete_.clear();
     obj_path_delete_.clear();

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -88,19 +88,16 @@ void BufferManager::RemoveBufferObjsInBulk(const Vector<String> &paths_to_delete
     deprecated_array_.clear();
 
     for (unsigned long i = 0; i < paths_to_delete.size(); i++) {
-        const auto& file_path = paths_to_delete[i];
-        if (buffer_map_.find(file_path) != buffer_map_.end()) {
-            deprecated_array_.emplace_back(buffer_map_[file_path]);
-            buffer_map_.erase(file_path);
-            LOG_TRACE(fmt::format("Erased buffer object: {}", file_path));
-        } else {
-            LOG_TRACE(fmt::format("Buffer object not found for: {}", file_path));
-        }
+        const auto &file_path = paths_to_delete[i];
+        LOG_TRACE(fmt::format("Erasing buffer object: {}", file_path));
+        deprecated_array_.emplace_back(buffer_map_[file_path]);
+        buffer_map_.erase(file_path);
+        LOG_TRACE(fmt::format("Erased buffer object: {}", file_path));
     }
 }
 
 void BufferManager::ExecuteDeletions() {
-    FileWorker::DeleteFilesInBulk(file_path_delete);
+    FileWorker::CleanupFilesInBulk(file_path_delete);
     RemoveBufferObjsInBulk(obj_path_delete);
     file_path_delete.clear();
     obj_path_delete.clear();

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -97,10 +97,10 @@ void BufferManager::RemoveBufferObjsInBulk(const Vector<String> &paths_to_delete
 }
 
 void BufferManager::ExecuteDeletions() {
-    FileWorker::CleanupFilesInBulk(file_path_delete);
-    RemoveBufferObjsInBulk(obj_path_delete);
-    file_path_delete.clear();
-    obj_path_delete.clear();
+    FileWorker::CleanupFilesInBulk(file_path_delete_);
+    RemoveBufferObjsInBulk(obj_path_delete_);
+    file_path_delete_.clear();
+    obj_path_delete_.clear();
 }
 
 void BufferManager::RequestSpace(SizeT need_size, BufferObj *buffer_obj) {

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -48,11 +48,9 @@ public:
 
     u64 memory_usage() const { return current_memory_size_.load(); }
 
-    void AddFilePath(const String &path) { file_path_delete_.push_back(path); }
+    void AddPathForDeletions(const String &path) { file_path_delete_.push_back(path); }
 
-    void AddBufferObjPath(const String &path) { obj_path_delete_.push_back(path); }
-
-    void RemoveBufferObjsInBulk(const Vector<String> &paths_to_delete);
+    void AddBufferObjectForDeletion(const String &path) { obj_path_delete_.push_back(path); }
 
     void ExecuteDeletions();
 

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -48,9 +48,9 @@ public:
 
     u64 memory_usage() const { return current_memory_size_.load(); }
 
-    void AddFilePath(const String &path) { file_path_delete.push_back(path); }
+    void AddFilePath(const String &path) { file_path_delete_.push_back(path); }
 
-    void AddBufferObjPath(const String &path) { obj_path_delete.push_back(path); }
+    void AddBufferObjPath(const String &path) { obj_path_delete_.push_back(path); }
 
     void RemoveBufferObjsInBulk(const Vector<String> &paths_to_delete);
 
@@ -76,7 +76,7 @@ private:
     Vector<SharedPtr<BufferObj>> deprecated_array_{};
     SpecificConcurrentQueue<BufferObj *> gc_queue_{};
 
-    Vector<String> file_path_delete;
-    Vector<String> obj_path_delete;
+    Vector<String> file_path_delete_;
+    Vector<String> obj_path_delete_;
 };
 } // namespace infinity

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -48,6 +48,14 @@ public:
 
     u64 memory_usage() const { return current_memory_size_.load(); }
 
+    void AddFilePath(const String &path) { file_path_delete.push_back(path); }
+
+    void AddBufferObjPath(const String &path) { obj_path_delete.push_back(path); }
+
+    void RemoveBufferObjsInBulk(const Vector<String> &paths_to_delete);
+
+    void ExecuteDeletions();
+
 private:
     friend class BufferObj;
 
@@ -67,5 +75,8 @@ private:
     HashMap<String, SharedPtr<BufferObj>> buffer_map_{};
     Vector<SharedPtr<BufferObj>> deprecated_array_{};
     SpecificConcurrentQueue<BufferObj *> gc_queue_{};
+
+    Vector<String> file_path_delete;
+    Vector<String> obj_path_delete;
 };
 } // namespace infinity

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -166,7 +166,7 @@ bool BufferObj::Save() {
         }
         type_ = BufferType::kPersistent;
     }
-    if(write) {
+    if (write) {
         file_worker_->Sync();
         file_worker_->CloseFile();
     }
@@ -187,7 +187,8 @@ void BufferObj::SetAndTryCleanup() {
             if (!wait_for_gc_) {
                 UnrecoverableError("Assert: unloaded buffer object should in gc_queue.");
             }
-            file_worker_->CleanupFile();
+            String file_path = fmt::format("{}/{}", *(file_worker_->file_dir_), *(file_worker_->file_name_));
+            buffer_mgr_->AddFilePath(file_path);
             status_ = BufferStatus::kClean;
             break;
         }
@@ -197,9 +198,11 @@ void BufferObj::SetAndTryCleanup() {
             }
             String file_name = this->GetFilename();
             LOG_TRACE(fmt::format("Remove file: {}", file_name));
-            file_worker_->CleanupFile();
+
+            String file_path = fmt::format("{}/{}", *(file_worker_->file_dir_), *(file_worker_->file_name_));
+            buffer_mgr_->AddFilePath(file_path);
             LOG_TRACE(fmt::format("Remove from buffer: {}", file_name));
-            buffer_mgr_->RemoveBufferObj(file_name);
+            buffer_mgr_->AddBufferObjPath(file_name);
             LOG_TRACE(fmt::format("Removed file and buffer: {}", file_name));
             break;
         }

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -201,9 +201,9 @@ void BufferObj::SetAndTryCleanup() {
 
             String file_path = fmt::format("{}/{}", *(file_worker_->file_dir_), *(file_worker_->file_name_));
             buffer_mgr_->AddFilePath(file_path);
-            LOG_TRACE(fmt::format("Remove from buffer: {}", file_name));
+            LOG_TRACE(fmt::format("Add the file to be deleted from buffer: {}", file_name));
             buffer_mgr_->AddBufferObjPath(file_name);
-            LOG_TRACE(fmt::format("Removed file and buffer: {}", file_name));
+            LOG_TRACE(fmt::format("Add the file and buffer to be deleted: {}", file_name));
             break;
         }
         default: {

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -188,7 +188,7 @@ void BufferObj::SetAndTryCleanup() {
                 UnrecoverableError("Assert: unloaded buffer object should in gc_queue.");
             }
             String file_path = fmt::format("{}/{}", *(file_worker_->file_dir_), *(file_worker_->file_name_));
-            buffer_mgr_->AddFilePath(file_path);
+            buffer_mgr_->AddPathForDeletions(file_path);
             status_ = BufferStatus::kClean;
             break;
         }
@@ -200,9 +200,9 @@ void BufferObj::SetAndTryCleanup() {
             LOG_TRACE(fmt::format("Remove file: {}", file_name));
 
             String file_path = fmt::format("{}/{}", *(file_worker_->file_dir_), *(file_worker_->file_name_));
-            buffer_mgr_->AddFilePath(file_path);
+            buffer_mgr_->AddPathForDeletions(file_path);
             LOG_TRACE(fmt::format("Add the file to be deleted from buffer: {}", file_name));
-            buffer_mgr_->AddBufferObjPath(file_name);
+            buffer_mgr_->AddBufferObjectForDeletion(file_name);
             LOG_TRACE(fmt::format("Add the file and buffer to be deleted: {}", file_name));
             break;
         }

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -119,5 +119,18 @@ void FileWorker::CleanupFile() {
     LOG_TRACE(fmt::format("Cleaned file: {}", file_path));
 }
 
+void FileWorker::DeleteFilesInBulk(const Vector<String> &file_paths) {
+    LocalFileSystem fs;
+    for (unsigned long i = 0; i < file_paths.size(); i++) {
+        const auto &path = file_paths[i];
+        if (fs.Exists(path)) {
+            LOG_TRACE(fmt::format("Cleaning up file: {}", path));
+            fs.DeleteFile(path);
+            LOG_TRACE(fmt::format("Cleaned file: {}", path));
+        } else {
+            LOG_TRACE(fmt::format("Cleanup: File {} not found for deletion", path));
+        }
+    }
+}
 
 } // namespace infinity

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -119,7 +119,7 @@ void FileWorker::CleanupFile() {
     LOG_TRACE(fmt::format("Cleaned file: {}", file_path));
 }
 
-void FileWorker::DeleteFilesInBulk(const Vector<String> &file_paths) {
+void FileWorker::CleanupFilesInBulk(const Vector<String> &file_paths) {
     LocalFileSystem fs;
     for (unsigned long i = 0; i < file_paths.size(); i++) {
         const auto &path = file_paths[i];

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -65,7 +65,7 @@ void FileWorker::WriteToFile(bool to_spill) {
             file_handler_->Close();
             file_handler_ = nullptr;
         }
-        if(to_spill) {
+        if (to_spill) {
             LOG_TRACE(fmt::format("Write to spill file {} finished. success {}", write_path, prepare_success));
         }
     });
@@ -109,7 +109,7 @@ void FileWorker::CleanupFile() {
     String file_path = fmt::format("{}/{}", *file_dir_, *file_name_);
     if (!fs.Exists(file_path)) {
         // this may happen the same reason as in "CleanupScanner::CleanupDir"
-        // It may also happen when cleanup a table not been flushed (need a checkpoint txn), 
+        // It may also happen when cleanup a table not been flushed (need a checkpoint txn),
         // at that time there is not data file under dir.
         LOG_TRACE(fmt::format("Cleanup: File {} not found.", file_path));
         return;
@@ -118,5 +118,6 @@ void FileWorker::CleanupFile() {
     fs.DeleteFile(file_path);
     LOG_TRACE(fmt::format("Cleaned file: {}", file_path));
 }
+
 
 } // namespace infinity

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -37,8 +37,6 @@ public:
 
     void MoveFile();
 
-    void CleanupFile();
-
     virtual void AllocateInMemory() = 0;
 
     virtual void FreeInMemory() = 0;
@@ -59,7 +57,7 @@ public:
 
     void CloseFile();
 
-    static void CleanupFilesInBulk(const Vector<String> &file_paths);
+    static void BulkCleanup(const Vector<String> &file_paths);
 protected:
     virtual void WriteToFileImpl(bool &prepare_success) = 0;
 

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -19,9 +19,6 @@ export module file_worker;
 import stl;
 import file_system;
 import third_party;
-import local_file_system;
-import file_system_type;
-import logger;
 
 namespace infinity {
 
@@ -62,19 +59,7 @@ public:
 
     void CloseFile();
 
-    static void DeleteFilesInBulk(const Vector<String> &file_paths) {
-        LocalFileSystem fs;
-        for (unsigned long i = 0; i < file_paths.size(); i++) {
-            const auto& path = file_paths[i];
-            if (fs.Exists(path)) {
-                LOG_TRACE(fmt::format("Cleaning up file: {}", path));
-                fs.DeleteFile(path);
-                LOG_TRACE(fmt::format("Cleaned file: {}", path));
-            } else {
-                LOG_TRACE(fmt::format("Cleanup: File {} not found for deletion", path));
-            }
-        }
-    }
+    static void DeleteFilesInBulk(const Vector<String> &file_paths);
 protected:
     virtual void WriteToFileImpl(bool &prepare_success) = 0;
 

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -19,6 +19,9 @@ export module file_worker;
 import stl;
 import file_system;
 import third_party;
+import local_file_system;
+import file_system_type;
+import logger;
 
 namespace infinity {
 
@@ -59,6 +62,19 @@ public:
 
     void CloseFile();
 
+    static void DeleteFilesInBulk(const Vector<String> &file_paths) {
+        LocalFileSystem fs;
+        for (unsigned long i = 0; i < file_paths.size(); i++) {
+            const auto& path = file_paths[i];
+            if (fs.Exists(path)) {
+                LOG_TRACE(fmt::format("Cleaning up file: {}", path));
+                fs.DeleteFile(path);
+                LOG_TRACE(fmt::format("Cleaned file: {}", path));
+            } else {
+                LOG_TRACE(fmt::format("Cleanup: File {} not found for deletion", path));
+            }
+        }
+    }
 protected:
     virtual void WriteToFileImpl(bool &prepare_success) = 0;
 

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -59,7 +59,7 @@ public:
 
     void CloseFile();
 
-    static void DeleteFilesInBulk(const Vector<String> &file_paths);
+    static void CleanupFilesInBulk(const Vector<String> &file_paths);
 protected:
     virtual void WriteToFileImpl(bool &prepare_success) = 0;
 

--- a/src/storage/meta/cleanup_scanner.cpp
+++ b/src/storage/meta/cleanup_scanner.cpp
@@ -29,7 +29,7 @@ import third_party;
 
 namespace infinity {
 
-CleanupScanner::CleanupScanner(Catalog *catalog, TxnTimeStamp visible_ts) : catalog_(catalog), visible_ts_(visible_ts) {}
+CleanupScanner::CleanupScanner(Catalog *catalog, TxnTimeStamp visible_ts, BufferManager *buffer_mgr) : catalog_(catalog), visible_ts_(visible_ts), buffer_mgr_(buffer_mgr) {}
 
 void CleanupScanner::AddEntry(SharedPtr<EntryInterface> entry) { entries_.emplace_back(std::move(entry)); }
 
@@ -39,6 +39,8 @@ void CleanupScanner::Cleanup() && {
     for (auto &entry : entries_) {
         std::move(*entry).Cleanup();
     }
+
+    buffer_mgr_->ExecuteDeletions();
 }
 
 void CleanupScanner::CleanupDir(const String &dir) {

--- a/src/storage/meta/cleanup_scanner.cppm
+++ b/src/storage/meta/cleanup_scanner.cppm
@@ -17,6 +17,7 @@ module;
 export module cleanup_scanner;
 
 import stl;
+import buffer_manager;
 
 namespace infinity {
 
@@ -26,7 +27,7 @@ class MetaInterface;
 
 export class CleanupScanner {
 public:
-    CleanupScanner(Catalog *catalog, TxnTimeStamp visible_ts);
+    CleanupScanner(Catalog *catalog, TxnTimeStamp visible_ts, BufferManager *buffer_mgr);
 
     void Scan();
 
@@ -40,8 +41,11 @@ public:
 
 private:
     Catalog *const catalog_;
+
     const TxnTimeStamp visible_ts_;
 
+    BufferManager *buffer_mgr_;
+    
     Vector<SharedPtr<EntryInterface>> entries_;
 };
 

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -149,12 +149,12 @@ bool TxnManager::Stopped() { return !is_running_.load(); }
 TxnTimeStamp TxnManager::CommitTxn(Txn *txn) {
     TxnTimeStamp txn_ts = txn->Commit();
     rw_locker_.lock();
-    // txn_map_.erase(txn->TxnID());
     // Remove the transaction's timestamp from the active set
     auto it = TxnTimestampsSet_.find(txn->BeginTS());
     if (it != TxnTimestampsSet_.end()) {
         TxnTimestampsSet_.erase(it);
     }
+    txn_map_.erase(txn->TxnID());
     rw_locker_.unlock();
     return txn_ts;
 }
@@ -162,12 +162,12 @@ TxnTimeStamp TxnManager::CommitTxn(Txn *txn) {
 void TxnManager::RollBackTxn(Txn *txn) {
     txn->Rollback();
     rw_locker_.lock();
-    // txn_map_.erase(txn->TxnID());
     // Remove the transaction's timestamp from the active set
     auto it = TxnTimestampsSet_.find(txn->BeginTS());
     if (it != TxnTimestampsSet_.end()) {
         TxnTimestampsSet_.erase(it);
     }
+    txn_map_.erase(txn->TxnID());
     rw_locker_.unlock();
 }
 
@@ -178,8 +178,13 @@ void TxnManager::AddWaitFlushTxn(TransactionID txn_id) {
     // }
     // LOG_INFO(fmt::format("Current wait flush set: {}, add txn: {} to wait flush set", ss.str(), txn_id));
     std::unique_lock w_lock(rw_locker_);
-    // wait_flush_txns_.insert(txn_id);
-    TxnTimestampsSet_.insert(GetTxn(txn_id)->BeginTS());
+    if (txn_map_.find(txn_id) != txn_map_.end()) {
+        // TxnTimestampsSet_.insert(txn_map_.at(txn_id).get()->BeginTS());
+        auto it = TxnTimestampsSet_.find(txn_map_.at(txn_id).get()->BeginTS());
+        if (it != TxnTimestampsSet_.end()) {
+            TxnTimestampsSet_.erase(it);
+        }
+    }
 }
 
 void TxnManager::RemoveWaitFlushTxns(const Vector<TransactionID> &txn_ids) {
@@ -193,40 +198,21 @@ void TxnManager::RemoveWaitFlushTxns(const Vector<TransactionID> &txn_ids) {
     // }
     // LOG_INFO(fmt::format("Current wait flush set: {}, Remove txn: {} from wait flush set", ss1.str(), ss2.str()));
     std::unique_lock w_lock(rw_locker_);
-    // for (auto txn_id : txn_ids) {
-    //     if (!wait_flush_txns_.erase(txn_id)) {
-    //         UnrecoverableError(fmt::format("Txn: {} not found in wait flush set", txn_id));
-    //     }
-    // }
     for (auto txn_id : txn_ids) {
-        auto txn = GetTxn(txn_id);
-        if (txn) {
-            auto it = TxnTimestampsSet_.find(txn->BeginTS());
-            if (it != TxnTimestampsSet_.end()) {
-                TxnTimestampsSet_.erase(it);
+        if (txn_map_.find(txn_id) != txn_map_.end()) {
+            auto txn = txn_map_.at(txn_id).get();
+            if (txn) {
+                auto it = TxnTimestampsSet_.find(txn->BeginTS());
+                if (it != TxnTimestampsSet_.end()) {
+                    TxnTimestampsSet_.erase(it);
+                }
             }
-        } else {
-            LOG_ERROR(fmt::format("Txn: {} not found", txn_id));
         }
     }
 }
 
 TxnTimeStamp TxnManager::GetMinUnflushedTS() {
     std::unique_lock w_locker(rw_locker_);
-    // for (auto iter = ts_map_.begin(); iter != ts_map_.end();) {
-    //     auto &[ts, txn_id] = *iter;
-    //     if (txn_map_.find(txn_id) != txn_map_.end()) {
-    //         LOG_TRACE(fmt::format("Txn: {} not found in txn map", txn_id));
-    //         return ts;
-    //     }
-    //     if (wait_flush_txns_.find(txn_id) != wait_flush_txns_.end()) {
-    //         LOG_TRACE(fmt::format("Txn: {} wait flush", txn_id));
-    //         return ts;
-    //     }
-    //     iter = ts_map_.erase(iter);
-    // }
-    // LOG_TRACE(fmt::format("No txn is active, return the next ts {}", start_ts_));
-    // return start_ts_;
     if (!TxnTimestampsSet_.empty()) {
         return *TxnTimestampsSet_.begin();
     }

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -68,6 +68,8 @@ Txn *TxnManager::BeginTxn() {
     Txn *res = new_txn.get();
     txn_map_[new_txn_id] = std::move(new_txn);
     ts_map_.emplace(ts, new_txn_id);
+
+    TxnTimestampsSet_.insert(ts);
     rw_locker_.unlock();
 
     LOG_TRACE(fmt::format("Txn: {} is Begin. begin ts: {}", new_txn_id, ts));
@@ -147,7 +149,12 @@ bool TxnManager::Stopped() { return !is_running_.load(); }
 TxnTimeStamp TxnManager::CommitTxn(Txn *txn) {
     TxnTimeStamp txn_ts = txn->Commit();
     rw_locker_.lock();
-    txn_map_.erase(txn->TxnID());
+    // txn_map_.erase(txn->TxnID());
+    // Remove the transaction's timestamp from the active set
+    auto it = TxnTimestampsSet_.find(txn->BeginTS());
+    if (it != TxnTimestampsSet_.end()) {
+        TxnTimestampsSet_.erase(it);
+    }
     rw_locker_.unlock();
     return txn_ts;
 }
@@ -155,7 +162,12 @@ TxnTimeStamp TxnManager::CommitTxn(Txn *txn) {
 void TxnManager::RollBackTxn(Txn *txn) {
     txn->Rollback();
     rw_locker_.lock();
-    txn_map_.erase(txn->TxnID());
+    // txn_map_.erase(txn->TxnID());
+    // Remove the transaction's timestamp from the active set
+    auto it = TxnTimestampsSet_.find(txn->BeginTS());
+    if (it != TxnTimestampsSet_.end()) {
+        TxnTimestampsSet_.erase(it);
+    }
     rw_locker_.unlock();
 }
 
@@ -166,7 +178,8 @@ void TxnManager::AddWaitFlushTxn(TransactionID txn_id) {
     // }
     // LOG_INFO(fmt::format("Current wait flush set: {}, add txn: {} to wait flush set", ss.str(), txn_id));
     std::unique_lock w_lock(rw_locker_);
-    wait_flush_txns_.insert(txn_id);
+    // wait_flush_txns_.insert(txn_id);
+    TxnTimestampsSet_.insert(GetTxn(txn_id)->BeginTS());
 }
 
 void TxnManager::RemoveWaitFlushTxns(const Vector<TransactionID> &txn_ids) {
@@ -180,28 +193,43 @@ void TxnManager::RemoveWaitFlushTxns(const Vector<TransactionID> &txn_ids) {
     // }
     // LOG_INFO(fmt::format("Current wait flush set: {}, Remove txn: {} from wait flush set", ss1.str(), ss2.str()));
     std::unique_lock w_lock(rw_locker_);
+    // for (auto txn_id : txn_ids) {
+    //     if (!wait_flush_txns_.erase(txn_id)) {
+    //         UnrecoverableError(fmt::format("Txn: {} not found in wait flush set", txn_id));
+    //     }
+    // }
     for (auto txn_id : txn_ids) {
-        if (!wait_flush_txns_.erase(txn_id)) {
-            UnrecoverableError(fmt::format("Txn: {} not found in wait flush set", txn_id));
+        auto txn = GetTxn(txn_id);
+        if (txn) {
+            auto it = TxnTimestampsSet_.find(txn->BeginTS());
+            if (it != TxnTimestampsSet_.end()) {
+                TxnTimestampsSet_.erase(it);
+            }
+        } else {
+            LOG_ERROR(fmt::format("Txn: {} not found", txn_id));
         }
     }
 }
 
 TxnTimeStamp TxnManager::GetMinUnflushedTS() {
     std::unique_lock w_locker(rw_locker_);
-    for (auto iter = ts_map_.begin(); iter != ts_map_.end();) {
-        auto &[ts, txn_id] = *iter;
-        if (txn_map_.find(txn_id) != txn_map_.end()) {
-            LOG_TRACE(fmt::format("Txn: {} not found in txn map", txn_id));
-            return ts;
-        }
-        if (wait_flush_txns_.find(txn_id) != wait_flush_txns_.end()) {
-            LOG_TRACE(fmt::format("Txn: {} wait flush", txn_id));
-            return ts;
-        }
-        iter = ts_map_.erase(iter);
+    // for (auto iter = ts_map_.begin(); iter != ts_map_.end();) {
+    //     auto &[ts, txn_id] = *iter;
+    //     if (txn_map_.find(txn_id) != txn_map_.end()) {
+    //         LOG_TRACE(fmt::format("Txn: {} not found in txn map", txn_id));
+    //         return ts;
+    //     }
+    //     if (wait_flush_txns_.find(txn_id) != wait_flush_txns_.end()) {
+    //         LOG_TRACE(fmt::format("Txn: {} wait flush", txn_id));
+    //         return ts;
+    //     }
+    //     iter = ts_map_.erase(iter);
+    // }
+    // LOG_TRACE(fmt::format("No txn is active, return the next ts {}", start_ts_));
+    // return start_ts_;
+    if (!TxnTimestampsSet_.empty()) {
+        return *TxnTimestampsSet_.begin();
     }
-    LOG_TRACE(fmt::format("No txn is active, return the next ts {}", start_ts_));
     return start_ts_;
 }
 

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -216,6 +216,7 @@ TxnTimeStamp TxnManager::GetMinUnflushedTS() {
     if (!TxnTimestampsSet_.empty()) {
         return *TxnTimestampsSet_.begin();
     }
+    LOG_TRACE(fmt::format("No txn is active, return the next ts {}", start_ts_));
     return start_ts_;
 }
 

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -112,7 +112,6 @@ private:
     u64 sequence_{};
 
     MultiSet<TxnTimeStamp> TxnTimestampsSet_;
-    Atomic<TxnTimeStamp> oldestVisibleTs_{}; // oldest Ts
 };
 
 } // namespace infinity

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -59,6 +59,8 @@ public:
 
     TxnTimeStamp GetTimestamp();
 
+    TxnTimeStamp GetBeginTimestamp(TransactionID txn_id);
+
     void Invalidate(TxnTimeStamp commit_ts);
 
     void SendToWAL(Txn *txn);
@@ -110,8 +112,6 @@ private:
     bool enable_compaction_{};
 
     u64 sequence_{};
-
-    MultiSet<TxnTimeStamp> TxnTimestampsSet_;
 };
 
 } // namespace infinity

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -110,6 +110,9 @@ private:
     bool enable_compaction_{};
 
     u64 sequence_{};
+
+    MultiSet<TxnTimeStamp> TxnTimestampsSet_;
+    Atomic<TxnTimeStamp> oldestVisibleTs_{}; // oldest Ts
 };
 
 } // namespace infinity

--- a/src/unit_test/storage/bg_task/cleanup_task.cpp
+++ b/src/unit_test/storage/bg_task/cleanup_task.cpp
@@ -63,7 +63,9 @@ protected:
             }
             usleep(1000 * 1000);
         }
-        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts);
+
+        auto buffer_mgr = txn_mgr->GetBufferMgr();
+        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts, buffer_mgr);
         cleanup_task->Execute();
     }
 };

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -94,7 +94,9 @@ public:
             }
             usleep(1000 * 1000);
         }
-        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts);
+
+        auto buffer_mgr = txn_mgr->GetBufferMgr();
+        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts, buffer_mgr);
         cleanup_task->Execute();
     }
 };

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -322,6 +322,7 @@ TEST_F(BufferObjTest, test_status_clean) {
 
     // kUnloaded, kEphemeral -> kClean, kEphemeral
     buf1->SetAndTryCleanup();
+    buffer_manager.ExecuteDeletions();
     EXPECT_EQ(buf1->status(), BufferStatus::kClean);
     buf1->CheckState();
 
@@ -347,6 +348,7 @@ TEST_F(BufferObjTest, test_status_clean) {
 
     // kFreed, kEphemeral -> kNew, kEphemeral
     buf1->SetAndTryCleanup();
+    buffer_manager.ExecuteDeletions();
     auto file_worker1_new1 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
     buf1 = buffer_manager.Allocate(std::move(file_worker1_new1));
     EXPECT_EQ(buf1->status(), BufferStatus::kNew);
@@ -381,6 +383,7 @@ TEST_F(BufferObjTest, test_status_clean) {
 
     // kUnloaded, kTemp -> kClean, kTemp
     buf1->SetAndTryCleanup();
+    buffer_manager.ExecuteDeletions();
     EXPECT_EQ(buf1->status(), BufferStatus::kClean);
     buf1->CheckState();
 
@@ -413,6 +416,7 @@ TEST_F(BufferObjTest, test_status_clean) {
 
     // kFreed, kTemp -> kNew, kTemp
     buf1->SetAndTryCleanup();
+    buffer_manager.ExecuteDeletions();
     auto file_worker1_new2 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
     buf1 = buffer_manager.Allocate(std::move(file_worker1_new2));
     EXPECT_EQ(buf1->status(), BufferStatus::kNew);
@@ -473,6 +477,7 @@ TEST_F(BufferObjTest, test_status_clean) {
 
     // kFreed, kPersistent -> kClean, kPersistent
     buf1->SetAndTryCleanup();
+    buffer_manager.ExecuteDeletions();
     auto file_worker1_new3 = MakeUnique<DataFileWorker>(file_dir1, test_fname1, test_size1);
     buf1 = buffer_manager.Allocate(std::move(file_worker1_new3));
     EXPECT_EQ(buf1->status(), BufferStatus::kNew);

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -94,7 +94,9 @@ protected:
             }
             usleep(1000 * 1000);
         }
-        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts);
+
+        auto buffer_mgr = txn_mgr->GetBufferMgr();
+        auto cleanup_task = MakeShared<CleanupTask>(catalog, visible_ts, buffer_mgr);
         cleanup_task->Execute();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

This PR aims to enhance the cleanup mechanism by addressing two main drawbacks identified in issue #978:

Improving the mechanism for recording the oldest visible timestamp to avoid unnecessary access to txn_map.
Optimizing the cleanup process to allow bulk deletion of files and records, potentially saving significant file IO operations. Additionally, bulk deletion from the buffer manager can reduce lock conflicts.

Issue link:#978

### Type of change

-New Feature (non-breaking change which adds functionality)

### Basic Thinking
Use set (red black tree data structure) to save oldestTs, replacing the original txn_map
Change the deletion of one by one to batch one-time deletion. After completing this, it is necessary to modify the unit testing of buffer_obj