### PR TITLE
Fix: incorrect catalog delta op merge.

### DIFF
--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -881,6 +881,8 @@ void Catalog::SaveFullCatalog(TxnTimeStamp max_commit_ts, String &full_catalog_p
     // Rename temp file to regular catalog file
     catalog_file_handler->Rename(catalog_tmp_path, full_catalog_path);
 
+    global_catalog_delta_entry_->InitFullCheckpointTs(max_commit_ts);
+
     LOG_INFO(fmt::format("Saved catalog to: {}", full_catalog_path));
 }
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -130,10 +130,8 @@ void Storage::UnInit() {
     txn_mgr_.reset();
     bg_processor_.reset();
     wal_mgr_.reset();
-    // Buffer Manager need to be destroyed before catalog. since buffer manage hold the raw pointer owned by catalog:
-    // such as index definition and index base of IndexFileWorker
-    buffer_mgr_.reset();
     new_catalog_.reset();
+    buffer_mgr_.reset();
     config_ptr_ = nullptr;
     fmt::print("Shutdown storage successfully\n");
 }

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -723,7 +723,7 @@ void AddDBEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp la
     MergeFlag flag = this->NextDeleteFlag(other->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*static_cast<AddDBEntryOp *>(other.get()));
-    if (commit_ts >= last_full_checkpoint_ts) {
+    if (commit_ts > last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }
@@ -739,7 +739,7 @@ void AddTableEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp
     //     LOG_INFO("AAA");
     // }
     *this = std::move(*add_table_op);
-    if (commit_ts >= last_full_checkpoint_ts) {
+    if (commit_ts > last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }
@@ -752,7 +752,7 @@ void AddSegmentEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeSta
     MergeFlag flag = this->NextDeleteFlag(add_segment_op->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*add_segment_op);
-    if (commit_ts >= last_full_checkpoint_ts) {
+    if (commit_ts > last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }
@@ -780,7 +780,7 @@ void AddTableIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTime
     MergeFlag flag = this->NextDeleteFlag(add_table_index_op->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*add_table_index_op);
-    if (commit_ts >= last_full_checkpoint_ts) {
+    if (commit_ts > last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -723,7 +723,7 @@ void AddDBEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp la
     MergeFlag flag = this->NextDeleteFlag(other->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*static_cast<AddDBEntryOp *>(other.get()));
-    if (commit_ts > last_full_checkpoint_ts) {
+    if (commit_ts >= last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }
@@ -739,7 +739,7 @@ void AddTableEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp
     //     LOG_INFO("AAA");
     // }
     *this = std::move(*add_table_op);
-    if (commit_ts > last_full_checkpoint_ts) {
+    if (commit_ts >= last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }
@@ -752,7 +752,7 @@ void AddSegmentEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeSta
     MergeFlag flag = this->NextDeleteFlag(add_segment_op->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*add_segment_op);
-    if (commit_ts > last_full_checkpoint_ts) {
+    if (commit_ts >= last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }
@@ -780,7 +780,7 @@ void AddTableIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTime
     MergeFlag flag = this->NextDeleteFlag(add_table_index_op->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*add_table_index_op);
-    if (commit_ts > last_full_checkpoint_ts) {
+    if (commit_ts >= last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
     }
 }

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -715,39 +715,48 @@ bool SetBlockStatusSealedOp::operator==(const CatalogDeltaOperation &rhs) const 
            block_filter_binary_data_ == rhs_op->block_filter_binary_data_;
 }
 
-void AddDBEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddDBEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_DATABASE_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     MergeFlag flag = this->NextDeleteFlag(other->merge_flag_);
+    TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*static_cast<AddDBEntryOp *>(other.get()));
-    this->merge_flag_ = flag;
+    if (commit_ts > last_full_checkpoint_ts) {
+        this->merge_flag_ = flag;
+    }
 }
 
-void AddTableEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddTableEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_TABLE_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     auto *add_table_op = static_cast<AddTableEntryOp *>(other.get());
     MergeFlag flag = this->NextDeleteFlag(add_table_op->merge_flag_);
+    TxnTimeStamp commit_ts = this->commit_ts_;
     // if (*add_table_op->table_name_ == "test_csv_with_different_delimiter" && flag == MergeFlag::kDeleteAndNew) {
     //     LOG_INFO("AAA");
     // }
     *this = std::move(*add_table_op);
-    this->merge_flag_ = flag;
+    if (commit_ts > last_full_checkpoint_ts) {
+        this->merge_flag_ = flag;
+    }
 }
 
-void AddSegmentEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddSegmentEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_SEGMENT_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     auto *add_segment_op = static_cast<AddSegmentEntryOp *>(other.get());
     MergeFlag flag = this->NextDeleteFlag(add_segment_op->merge_flag_);
+    TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*add_segment_op);
-    this->merge_flag_ = flag;
+    if (commit_ts > last_full_checkpoint_ts) {
+        this->merge_flag_ = flag;
+    }
 }
 
-void AddBlockEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddBlockEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_BLOCK_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
@@ -755,40 +764,43 @@ void AddBlockEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
     *this = std::move(*add_block_op);
 }
 
-void AddColumnEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddColumnEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_COLUMN_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     *this = std::move(*static_cast<AddColumnEntryOp *>(other.get()));
 }
 
-void AddTableIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddTableIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_TABLE_INDEX_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     auto *add_table_index_op = static_cast<AddTableIndexEntryOp *>(other.get());
     MergeFlag flag = this->NextDeleteFlag(add_table_index_op->merge_flag_);
+    TxnTimeStamp commit_ts = this->commit_ts_;
     *this = std::move(*add_table_index_op);
-    this->merge_flag_ = flag;
+    if (commit_ts > last_full_checkpoint_ts) {
+        this->merge_flag_ = flag;
+    }
 }
 
-void AddSegmentIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddSegmentIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_SEGMENT_INDEX_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     *this = std::move(*static_cast<AddSegmentIndexEntryOp *>(other.get()));
 }
 
-void AddChunkIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other) {
+void AddChunkIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_CHUNK_INDEX_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     *this = std::move(*static_cast<AddChunkIndexEntryOp *>(other.get()));
 }
 
-void SetSegmentStatusSealedOp::Merge(UniquePtr<CatalogDeltaOperation> other) { UnrecoverableError("SetSegmentStatusSealedOp::Merge not allowed"); }
+void SetSegmentStatusSealedOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) { UnrecoverableError("SetSegmentStatusSealedOp::Merge not allowed"); }
 
-void SetBlockStatusSealedOp::Merge(UniquePtr<CatalogDeltaOperation> other) { UnrecoverableError("SetBlockStatusSealedOp::Merge not allowed"); }
+void SetBlockStatusSealedOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) { UnrecoverableError("SetBlockStatusSealedOp::Merge not allowed"); }
 
 void AddBlockEntryOp::FlushDataToDisk(TxnTimeStamp max_commit_ts) {
     LOG_TRACE(fmt::format("BlockEntry {} flush to disk", block_entry_->block_id()));
@@ -1025,7 +1037,7 @@ void GlobalCatalogDeltaEntry::AddDeltaEntryInner(CatalogDeltaEntry *delta_entry)
             } else if (prune_flag == PruneFlag::kPruneSub) {
                 PruneOpWithSamePrefix(encode);
             }
-            op->Merge(std::move(new_op));
+            op->Merge(std::move(new_op), last_full_ckp_ts_);
         } else {
             PruneFlag prune_flag = CatalogDeltaOperation::ToPrune(None, new_op->merge_flag_);
             delta_ops_[encode] = std::move(new_op);

--- a/src/storage/wal/catalog_delta_entry.cppm
+++ b/src/storage/wal/catalog_delta_entry.cppm
@@ -118,7 +118,7 @@ public:
     }
     virtual const String EncodeIndex() const = 0;
     virtual bool operator==(const CatalogDeltaOperation &rhs) const;
-    virtual void Merge(UniquePtr<CatalogDeltaOperation> other) = 0;
+    virtual void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) = 0;
 
     static PruneFlag ToPrune(Optional<MergeFlag> old_merge_flag, MergeFlag new_merge_flag);
 
@@ -158,7 +158,7 @@ public:
     const String ToString() const final;
     const String EncodeIndex() const final { return String(fmt::format("#{}@{}", *db_name_, (u8)(type_))); }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -205,7 +205,7 @@ public:
     const String ToString() const final;
     const String EncodeIndex() const final { return String(fmt::format("#{}#{}@{}", *db_name_, *table_name_, (u8)(type_))); }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -256,7 +256,7 @@ public:
         return String(fmt::format("#{}#{}#{}@{}", *this->db_name_, *this->table_name_, this->segment_id_, (u8)(type_)));
     }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -306,7 +306,7 @@ public:
         return String(fmt::format("#{}#{}#{}#{}@{}", *db_name_, *table_name_, segment_id_, block_id_, (u8)(type_)));
     }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
     void FlushDataToDisk(TxnTimeStamp max_commit_ts);
 
@@ -359,7 +359,7 @@ public:
         return String(fmt::format("#{}#{}#{}#{}#{}@{}", *db_name_, *table_name_, segment_id_, block_id_, column_id_, (u8)(type_)));
     }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -402,7 +402,7 @@ public:
     const String ToString() const final;
     const String EncodeIndex() const final { return String(fmt::format("#{}#{}#{}@{}", *db_name_, *table_name_, *index_name_, (u8)(type_))); }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -444,7 +444,7 @@ public:
     }
     void FlushDataToDisk(TxnTimeStamp max_commit_ts);
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SegmentIndexEntry *segment_index_entry_{};
@@ -500,7 +500,7 @@ public:
     }
     void Flush(TxnTimeStamp max_commit_ts);
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -540,7 +540,7 @@ public:
     const String ToString() const final;
     const String EncodeIndex() const final { return String(fmt::format("#{}#{}#{}@{}", *db_name_, *table_name_, segment_id_, (u8)(type_))); }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -582,7 +582,7 @@ public:
         return String(fmt::format("#{}#{}#{}#{}@{}", *db_name_, *table_name_, segment_id_, block_id_, (u8)(type_)));
     }
     bool operator==(const CatalogDeltaOperation &rhs) const override;
-    void Merge(UniquePtr<CatalogDeltaOperation> other) override;
+    void Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) override;
 
 public:
     SharedPtr<String> db_name_{};
@@ -648,6 +648,8 @@ public:
     // Must be called before any checkpoint.
     void InitMaxCommitTS(TxnTimeStamp max_commit_ts) { max_commit_ts_ = max_commit_ts; }
 
+    void InitFullCheckpointTs(TxnTimeStamp last_full_ckp_ts) { last_full_ckp_ts_ = last_full_ckp_ts; }
+
     void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size);
 
     void ReplayDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
@@ -673,6 +675,7 @@ private:
     HashSet<TransactionID> txn_ids_;
     // update by add delta entry, read by bg_process::checkpoint
     TxnTimeStamp max_commit_ts_{0};
+    TxnTimeStamp last_full_ckp_ts_{0};
     i64 wal_size_{};
 };
 

--- a/src/unit_test/storage/wal/catalog_delta_entry.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_entry.cpp
@@ -408,7 +408,7 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
     // merge
     global_catalog_delta_entry->ReplayDeltaEntry(std::move(local_catalog_delta_entry));
     // check ops
-    EXPECT_EQ(global_catalog_delta_entry->OpSize(), 4u);
+    EXPECT_EQ(global_catalog_delta_entry->OpSize(), 5u);
 
     infinity::InfinityContext::instance().UnInit();
 }

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -50,6 +50,8 @@ import logger;
 import infinity_exception;
 import default_values;
 import global_resource_usage;
+import infinity;
+import background_process;
 
 using namespace infinity;
 
@@ -217,14 +219,14 @@ TEST_F(CheckpointTest, test_cleanup_and_checkpoint) {
 #endif
 }
 
-TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint) {
+TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
 #ifdef INFINITY_DEBUG
     infinity::GlobalResourceUsage::Init();
 #endif
     auto config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_catalog_delta.toml");
 
     auto db_name = std::make_shared<std::string>("default");
-    auto table_name = std::make_shared<std::string>("test_index_replay_with_full_and_delta_checkpoint");
+    auto table_name = std::make_shared<std::string>("test_index_replay_with_full_and_delta_checkpoint1");
     auto column_name = std::make_shared<std::string>("col1");
     auto index_name = std::make_shared<std::string>("idx1");
     Vector<SharedPtr<ColumnDef>> columns;
@@ -312,6 +314,122 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint) {
         auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);
         txn->CreateIndexFinish(table_entry, table_index_entry);
         EXPECT_TRUE(status3.ok());
+
+        txn_mgr->CommitTxn(txn);
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+#ifdef INFINITY_DEBUG
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+    infinity::GlobalResourceUsage::UnInit();
+#endif
+}
+
+TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
+    constexpr u64 kInsertN = 10;
+    constexpr u64 kInsertSize = 8192;
+
+#ifdef INFINITY_DEBUG
+    infinity::GlobalResourceUsage::Init();
+#endif
+    auto config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_catalog_delta.toml");
+
+    auto db_name = std::make_shared<std::string>("default");
+    auto table_name = std::make_shared<std::string>("test_index_replay_with_full_and_delta_checkpoint2");
+    auto column_name = std::make_shared<std::string>("col1");
+    auto index_name = std::make_shared<std::string>("idx1");
+    // String analyzer = "standard";
+    Vector<SharedPtr<ColumnDef>> columns;
+    Vector<InitParameter *> index_param_list;
+    TxnTimeStamp last_commit_ts = 0;
+
+    // create table
+    // create index, insert data and shutdown
+    {
+        infinity::InfinityContext::instance().Init(config_path);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+        BGTaskProcessor *bg_processor = storage->bg_processor();
+
+        {
+            i64 column_id = 0;
+            {
+                HashSet<ConstraintType> constraints;
+                auto column_def_ptr =
+                    MakeShared<ColumnDef>(column_id++, MakeShared<DataType>(DataType(LogicalType::kVarchar)), *column_name, constraints);
+                columns.emplace_back(column_def_ptr);
+            }
+        }
+        {
+            auto tbl1_def = MakeUnique<TableDef>(db_name, table_name, columns);
+            auto *txn = txn_mgr->BeginTxn();
+            Status status = txn->CreateTable(*db_name, std::move(tbl1_def), ConflictType::kIgnore);
+            EXPECT_TRUE(status.ok());
+            txn_mgr->CommitTxn(txn);
+        }
+
+        auto *txn = txn_mgr->BeginTxn();
+        SharedPtr<IndexBase> index_base =
+            IndexFullText::Make(index_name, fmt::format("{}_{}", *table_name, *index_name), {*column_name}, index_param_list);
+        auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
+        EXPECT_TRUE(status1.ok());
+
+        TxnTimeStamp begin_ts = txn->BeginTS();
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
+        EXPECT_TRUE(status2.ok());
+        auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);
+        txn->CreateIndexFinish(table_entry, table_index_entry);
+        EXPECT_TRUE(status3.ok());
+        txn_mgr->CommitTxn(txn);
+
+        {
+            auto *txn = txn_mgr->BeginTxn();
+            SharedPtr<ForceCheckpointTask> force_ckp_task = MakeShared<ForceCheckpointTask>(txn, true /*full_check_point*/);
+            bg_processor->Submit(force_ckp_task);
+            force_ckp_task->Wait();
+            txn_mgr->CommitTxn(txn);
+        }
+
+        for (SizeT i = 0; i < kInsertN; ++i) {
+            auto *txn = txn_mgr->BeginTxn();
+            auto [table_entry, status] = txn->GetTableByName(*db_name, *table_name);
+            EXPECT_TRUE(status.ok());
+
+            Vector<SharedPtr<ColumnVector>> column_vectors;
+            SharedPtr<ColumnVector> column_vector = ColumnVector::Make(columns[0]->type());
+            column_vector->Initialize();
+            for (SizeT j = 0; j < kInsertSize; ++j) {
+                String str = fmt::format("{}", i * 10000 + j);
+                Value v = Value::MakeVarchar(str);
+                column_vector->AppendValue(v);
+            }
+            column_vectors.push_back(column_vector);
+            auto data_block = DataBlock::Make();
+            data_block->Init(column_vectors);
+
+            auto append_status = txn->Append(*db_name, *table_name, data_block);
+            ASSERT_TRUE(append_status.ok());
+
+            last_commit_ts = txn_mgr->CommitTxn(txn);
+        }
+
+        usleep(5000 * 1000);
+        WaitFlushDeltaOp(txn_mgr, last_commit_ts);
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+    // now restart and recreate index should be ok
+    {
+        infinity::InfinityContext::instance().Init(config_path);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+
+        auto *txn = txn_mgr->BeginTxn();
+        SharedPtr<IndexBase> index_base = IndexSecondary::Make(index_name, fmt::format("{}_{}", *table_name, *index_name), {*column_name});
+        auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
+        EXPECT_TRUE(status1.ok());
 
         txn_mgr->CommitTxn(txn);
 

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -435,7 +435,6 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
 
         txn_mgr->CommitTxn(txn);
 
-        usleep(5000 * 1000);
         infinity::InfinityContext::instance().UnInit();
     }
 #ifdef INFINITY_DEBUG

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -435,6 +435,7 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
 
         txn_mgr->CommitTxn(txn);
 
+        usleep(5000 * 1000);
         infinity::InfinityContext::instance().UnInit();
     }
 #ifdef INFINITY_DEBUG


### PR DESCRIPTION
### What problem does this PR solve?

The bug comes from  `CatalogDeltaOperation::Merge`  which will cause  `IndexEntry`  disappeared when replay from both FULL and DELTA checkpoint.
Consider such a situation, a  `CreateTable`  operation is flushed into FULL catalog, but its delta operation is still alive until next DELTA checkpoint, at that moment the following operation will merge the initial operation, but it still keep the NEW flag. When replay from DELTA checkpoint, it will create a new  `TableEntry`  without information of index, and the new one will replace the other constructed from FULL catalog. That will cause restart error if there exists some delta operation about index.

Solution:
Add member  `last_full_ckp_ts`  in  `GlobalCatalogDeltaEntry`  to fix delta operation merge.

Issue link:#943

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
- [x] Test cases