### PR TITLE
Fix: move compact task to seperate thread.

### DIFF
--- a/src/storage/background_process.cpp
+++ b/src/storage/background_process.cpp
@@ -37,25 +37,49 @@ BGTaskProcessor::BGTaskProcessor(WalManager *wal_manager, Catalog *catalog) : wa
 void BGTaskProcessor::Start() {
     processor_thread_ = Thread([this] { Process(); });
     LOG_INFO("Background processor is started.");
+
+    compact_thread_ = Thread([this] { CompactProcess(); });
+    LOG_INFO("Compact processor is started.");
 }
 
 void BGTaskProcessor::Stop() {
-    LOG_INFO("Background processor is stopping.");
-    SharedPtr<StopProcessorTask> stop_task = MakeShared<StopProcessorTask>();
-    task_queue_.Enqueue(stop_task);
-    stop_task->Wait();
-    processor_thread_.join();
-    LOG_INFO("Background processor is stopped.");
+    {
+        LOG_INFO("Compact processor is stopping.");
+        SharedPtr<StopProcessorTask> stop_task = MakeShared<StopProcessorTask>();
+        compact_queue_.Enqueue(stop_task);
+        stop_task->Wait();
+        compact_thread_.join();
+        LOG_INFO("Compact processor is stopped.");
+    }
+    {
+        LOG_INFO("Background processor is stopping.");
+        SharedPtr<StopProcessorTask> stop_task = MakeShared<StopProcessorTask>();
+        task_queue_.Enqueue(stop_task);
+        stop_task->Wait();
+        processor_thread_.join();
+        LOG_INFO("Background processor is stopped.");
+    }
 }
 
-void BGTaskProcessor::Submit(SharedPtr<BGTask> bg_task) { task_queue_.Enqueue(std::move(bg_task)); }
+void BGTaskProcessor::Submit(SharedPtr<BGTask> bg_task) {
+    switch (bg_task->type_) {
+        case BGTaskType::kCompactSegments: {
+            compact_queue_.Enqueue(std::move(bg_task));
+            break;
+        }
+        default: {
+            task_queue_.Enqueue(std::move(bg_task));
+            break;
+        }
+    }
+}
 
 void BGTaskProcessor::Process() {
     bool running{true};
     Deque<SharedPtr<BGTask>> tasks;
     while (running) {
         task_queue_.DequeueBulk(tasks);
-        for(const auto& bg_task: tasks) {
+        for (const auto &bg_task : tasks) {
             switch (bg_task->type_) {
                 case BGTaskType::kStopProcessor: {
                     LOG_INFO("Stop the background processor");
@@ -84,18 +108,6 @@ void BGTaskProcessor::Process() {
                     LOG_INFO("Checkpoint in background done");
                     break;
                 }
-                case BGTaskType::kCompactSegments: {
-                    LOG_INFO("Compact segments in background");
-                    auto *task = static_cast<CompactSegmentsTask *>(bg_task.get());
-//                    task->BeginTxn();
-                    task->Execute();
-                    if (task->TryCommitTxn()) {
-                        LOG_INFO("Compact segments in background done");
-                    } else {
-                        LOG_WARN("Compact segments in background rollbacked");
-                    }
-                    break;
-                }
                 case BGTaskType::kCleanup: {
                     LOG_INFO("Cleanup in background");
                     auto task = static_cast<CleanupTask *>(bg_task.get());
@@ -119,6 +131,41 @@ void BGTaskProcessor::Process() {
             bg_task->Complete();
         }
         tasks.clear();
+    }
+}
+
+void BGTaskProcessor::CompactProcess() {
+    bool running{true};
+    Deque<SharedPtr<BGTask>> bg_tasks;
+    while (running) {
+        compact_queue_.DequeueBulk(bg_tasks);
+        for (const auto &bg_task : bg_tasks) {
+            switch (bg_task->type_) {
+                case BGTaskType::kStopProcessor: {
+                    LOG_INFO("Stop the background processor");
+                    running = false;
+                    break;
+                }
+                case BGTaskType::kCompactSegments: {
+                    LOG_INFO("Compact segments in background");
+                    auto *task = static_cast<CompactSegmentsTask *>(bg_task.get());
+                    //                    task->BeginTxn();
+                    task->Execute();
+                    if (task->TryCommitTxn()) {
+                        LOG_INFO("Compact segments in background done");
+                    } else {
+                        LOG_WARN("Compact segments in background rollbacked");
+                    }
+                    break;
+                }
+                default: {
+                    UnrecoverableError("Invalid background task");
+                    break;
+                }
+            }
+            bg_task->Complete();
+        }
+        bg_tasks.clear();
     }
 }
 

--- a/src/storage/background_process.cppm
+++ b/src/storage/background_process.cppm
@@ -36,10 +36,14 @@ public:
 
 private:
     void Process();
+    void CompactProcess();
 
 private:
     BlockingQueue<SharedPtr<BGTask>> task_queue_;
+    BlockingQueue<SharedPtr<BGTask>> compact_queue_;
+
     Thread processor_thread_{};
+    Thread compact_thread_{};
 
     WalManager *wal_manager_{};
     Catalog *catalog_{};

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -125,8 +125,8 @@ void Storage::UnInit() {
     fmt::print("Shutdown storage ...\n");
     periodic_trigger_thread_->Stop();
     bg_processor_->Stop();
-
     wal_mgr_->Stop();
+
     txn_mgr_.reset();
     bg_processor_.reset();
     wal_mgr_.reset();


### PR DESCRIPTION
### What problem does this PR solve?

Move compact task to a seperate task.
> To avoid dead lock when back ground compact task trigger another compact task.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
