### PR TITLE
Remove spilled data during buffer manager initialized

### DIFF
--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -32,9 +32,12 @@ BufferManager::BufferManager(u64 memory_limit, SharedPtr<String> data_dir, Share
     if (!fs.Exists(*data_dir_)) {
         fs.CreateDirectory(*data_dir_);
     }
-    if (!fs.Exists(*temp_dir_)) {
-        fs.CreateDirectory(*temp_dir_);
+
+    if (fs.Exists(*temp_dir_)) {
+        fs.DeleteDirectory(*temp_dir_);
     }
+
+    fs.CreateDirectory(*temp_dir_);
 }
 
 BufferObj *BufferManager::Allocate(UniquePtr<FileWorker> file_worker) {


### PR DESCRIPTION
### What problem does this PR solve?

Spilled data won't be cleanup.

Better soluiton: 
- If new inserted data is spilled and the data is updated, the spilled data will be cleanup asynchronously
- Intermediate data between operator, if the data is read, the spilled data should be cleanup asynchronously

Current solution:
Spilled data will be cleanup at the startup phase of infinity.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring

