### PR TITLE
Make Aggregate become materializable

### DIFF
--- a/src/executor/expression/expression_state.cpp
+++ b/src/executor/expression/expression_state.cpp
@@ -45,7 +45,7 @@ SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<BaseExpr
 
     switch (expression->type()) {
         case ExpressionType::kAggregate:
-            return CreateState(static_pointer_cast<AggregateExpression>(expression), agg_state);
+            return CreateState(static_pointer_cast<AggregateExpression>(expression), agg_state, AggregateFlag::kUninitialized);
         case ExpressionType::kCast:
             return CreateState(static_pointer_cast<CastExpression>(expression));
         case ExpressionType::kCase:
@@ -68,13 +68,14 @@ SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<BaseExpr
     return nullptr;
 }
 
-SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<AggregateExpression> &agg_expr, char *agg_state) {
+SharedPtr<ExpressionState> ExpressionState::CreateState(const SharedPtr<AggregateExpression> &agg_expr, char *agg_state, const AggregateFlag agg_flag) {
     if (agg_expr->arguments().size() != 1) {
         RecoverableError(Status::FunctionArgsError(agg_expr->ToString()));
     }
 
     SharedPtr<ExpressionState> result = MakeShared<ExpressionState>();
     result->agg_state_ = agg_state;
+    result->agg_flag_ = agg_flag;
     result->AddChild(agg_expr->arguments()[0]);
 
     // Aggregate function will only have one output value.

--- a/src/executor/expression/expression_state.cppm
+++ b/src/executor/expression/expression_state.cppm
@@ -1,4 +1,4 @@
-// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+    // Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,12 +29,19 @@ export module expression_state;
 
 namespace infinity {
 
+export enum class AggregateFlag : i8 {
+    kUninitialized = 0,
+    kRunning = 1,
+    kFinish = 2,
+    kRunAndFinish = 3,
+};
+
 export class ExpressionState {
 public:
     // Static functions
     static SharedPtr<ExpressionState> CreateState(const SharedPtr<BaseExpression> &expression, char * = nullptr);
 
-    static SharedPtr<ExpressionState> CreateState(const SharedPtr<AggregateExpression> &agg_expr, char *agg_state);
+    static SharedPtr<ExpressionState> CreateState(const SharedPtr<AggregateExpression> &agg_expr, char *agg_state, const AggregateFlag agg_flag);
 
     static SharedPtr<ExpressionState> CreateState(const SharedPtr<CaseExpression> &agg_expr);
 
@@ -56,6 +63,8 @@ public:
     SharedPtr<ColumnVector> &OutputColumnVector() { return column_vector_; }
 
     char *agg_state_{};
+
+    AggregateFlag agg_flag_{AggregateFlag::kUninitialized};
 
 private:
     Vector<SharedPtr<ExpressionState>> children_;

--- a/src/executor/fragment_builder.cpp
+++ b/src/executor/fragment_builder.cpp
@@ -127,8 +127,8 @@ void FragmentBuilder::BuildFragments(PhysicalOperator *phys_op, PlanFragment *cu
             if (phys_op->left() == nullptr) {
                 UnrecoverableError("No input node of aggregate operator");
             } else {
-                current_fragment_ptr->SetFragmentType(FragmentType::kParallelMaterialize);
                 BuildFragments(phys_op->left(), current_fragment_ptr);
+                current_fragment_ptr->SetFragmentType(FragmentType::kParallelMaterialize);
             }
             return;
         }

--- a/src/executor/operator/physical_aggregate.cpp
+++ b/src/executor/operator/physical_aggregate.cpp
@@ -61,8 +61,10 @@ bool PhysicalAggregate::Execute(QueryContext *query_context, OperatorState *oper
     if (group_count == 0) {
         // Aggregate without group by expression
         // e.g. SELECT count(a) FROM table;
-        auto result =
-            SimpleAggregateExecute(prev_op_state->data_block_array_, aggregate_operator_state->data_block_array_, aggregate_operator_state->states_);
+        auto result = SimpleAggregateExecute(prev_op_state->data_block_array_,
+                                             aggregate_operator_state->data_block_array_,
+                                             aggregate_operator_state->states_,
+                                             prev_op_state->Complete());
         prev_op_state->data_block_array_.clear();
         if (prev_op_state->Complete()) {
             aggregate_operator_state->SetComplete();
@@ -578,7 +580,8 @@ void PhysicalAggregate::GenerateGroupByResult(const SharedPtr<DataTable> &input_
 
 bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>> &input_blocks,
                                                Vector<UniquePtr<DataBlock>> &output_blocks,
-                                               Vector<UniquePtr<char[]>> &states) {
+                                               Vector<UniquePtr<char[]>> &states,
+                                               bool task_completed) {
     SizeT aggregates_count = aggregates_.size();
     if (aggregates_count <= 0) {
         UnrecoverableError("Simple Aggregate without aggregate expression.");
@@ -604,9 +607,12 @@ bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>
     Vector<SharedPtr<DataType>> output_types;
     output_types.reserve(aggregates_count);
 
+    AggregateFlag flag = output_blocks.empty() ? (!task_completed ? AggregateFlag::kUninitialized : AggregateFlag::kRunAndFinish)
+                                               : (!task_completed ? AggregateFlag::kRunning : AggregateFlag::kFinish);
+
     for (i64 idx = 0; auto &expr : aggregates_) {
         // expression state
-        expr_states.emplace_back(ExpressionState::CreateState(std::static_pointer_cast<AggregateExpression>(expr), states[idx].get()));
+        expr_states.emplace_back(ExpressionState::CreateState(std::static_pointer_cast<AggregateExpression>(expr), states[idx].get(), flag));
 
         SharedPtr<DataType> output_type = MakeShared<DataType>(expr->Type());
 
@@ -620,13 +626,18 @@ bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>
         ++idx;
     }
 
+    if (output_blocks.empty()) {
+        for (SizeT block_idx = 0; block_idx < input_block_count; ++block_idx) {
+            output_blocks.emplace_back(DataBlock::MakeUniquePtr());
+            auto out_put_block = output_blocks.back().get();
+            out_put_block->Init(*GetOutputTypes());
+        }
+    }
+
     for (SizeT block_idx = 0; block_idx < input_block_count; ++block_idx) {
         DataBlock *input_data_block = input_blocks[block_idx].get();
 
-        output_blocks.emplace_back(DataBlock::MakeUniquePtr());
-
-        DataBlock *output_data_block = output_blocks.back().get();
-        output_data_block->Init(*GetOutputTypes());
+        DataBlock *output_data_block = output_blocks[block_idx].get();
 
         ExpressionEvaluator evaluator;
         evaluator.Init(input_data_block);
@@ -637,7 +648,10 @@ bool PhysicalAggregate::SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>
             LOG_TRACE("Physical aggregate Execute");
             evaluator.Execute(aggregates_[expr_idx], expr_states[expr_idx], output_data_block->column_vectors[expr_idx]);
         }
-        output_data_block->Finalize();
+        if (task_completed) {
+            // Finalize the output block (e.g. calculate the average value
+            output_data_block->Finalize();
+        }
         // {
         //     auto row = input_data_block->row_count();
         //     if (row == 0) {

--- a/src/executor/operator/physical_aggregate.cppm
+++ b/src/executor/operator/physical_aggregate.cppm
@@ -71,7 +71,8 @@ public:
 
     bool SimpleAggregateExecute(const Vector<UniquePtr<DataBlock>> &input_blocks,
                                 Vector<UniquePtr<DataBlock>> &output_blocks,
-                                Vector<UniquePtr<char[]>> &states);
+                                Vector<UniquePtr<char[]>> &states,
+                                bool task_completed);
 
     inline u64 GroupTableIndex() const { return groupby_index_; }
 

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -764,7 +764,7 @@ void FragmentContext::MakeSinkState(i64 parallel_count) {
             UnrecoverableError("Unexpected operator type");
         }
         case PhysicalOperatorType::kAggregate: {
-            if (fragment_type_ != FragmentType::kParallelStream) {
+            if (fragment_type_ != FragmentType::kParallelMaterialize) {
                 UnrecoverableError(fmt::format("{} should in parallel stream fragment", PhysicalOperatorToString(last_operator->operator_type())));
             }
 

--- a/src/scheduler/fragment_task.cpp
+++ b/src/scheduler/fragment_task.cpp
@@ -61,11 +61,11 @@ void FragmentTask::OnExecute() {
     PhysicalSource *source_op = fragment_context->GetSourceOperator();
     if(source_state_->state_type_ == SourceStateType::kQueue) {
         // For debug
-        LOG_INFO(PhysOpsToString());
+        LOG_TRACE(PhysOpsToString());
     }
 
     bool execute_success{false};
-    source_op->Execute(fragment_context->query_context(), source_state_.get());
+    source_op->Execute(query_context, source_state_.get());
     Status operator_status{};
     if (source_state_->status_.ok()) {
         // No source error
@@ -80,8 +80,8 @@ void FragmentTask::OnExecute() {
                 profiler.StartOperator(operator_refs[op_idx]);
                 DeferFn defer_fn([&]() { profiler.StopOperator(operator_states_[op_idx].get()); });
 
-                operator_refs[op_idx]->InputLoad(fragment_context->query_context(), operator_states_[op_idx].get(), table_refs);
-                execute_success = operator_refs[op_idx]->Execute(fragment_context->query_context(), operator_states_[op_idx].get());
+                operator_refs[op_idx]->InputLoad(query_context, operator_states_[op_idx].get(), table_refs);
+                execute_success = operator_refs[op_idx]->Execute(query_context, operator_states_[op_idx].get());
                 operator_refs[op_idx]->FillingTableRefs(table_refs);
 
                 if (!operator_states_[op_idx]->status_.ok()) {


### PR DESCRIPTION
### What problem does this PR solve?

Modify the implementation of aggregation before, now an aggregate fragment task processing multiple blocks will only output single `DataBlock`  . Then these  `DataBlock`s produced from parallel tasks will be sent to  `MergeAggregate`  .

Issue link:#962

### Type of change

- [x] Refactoring
