### PR TITLE
Fix: show exceed capacity entries

### DIFF
--- a/python/test/test_show.py
+++ b/python/test/test_show.py
@@ -60,3 +60,17 @@ class TestDescribe(TestSdk):
         res = infinity_obj.disconnect()
         assert res.error_code == ErrorCode.OK
 
+    def test_show_big_databases(self):
+        infinity_obj = infinity.connect(common_values.TEST_REMOTE_HOST)
+
+        for i in range(8193):
+            infinity_obj.drop_database(f"test_show_big_databases_{i}", ConflictType.Ignore)
+
+        for i in range(8193):
+            infinity_obj.create_database(f"test_show_big_databases_{i}", ConflictType.Ignore)
+
+        res = infinity_obj.list_databases()
+        assert res.error_code == ErrorCode.OK
+
+        for i in range(8193):
+            infinity_obj.drop_database(f"test_show_big_databases_{i}", ConflictType.Ignore)

--- a/python/test_http_api/test_index.py
+++ b/python/test_http_api/test_index.py
@@ -537,6 +537,7 @@ class TestIndex(HttpTest):
             "header": False,
             "delimiter": "\t"
         })
+        self.drop_table(db_name, table_name)
 
         return
 

--- a/src/executor/operator/physical_show.cpp
+++ b/src/executor/operator/physical_show.cpp
@@ -799,9 +799,10 @@ void PhysicalShow::ExecuteShowDatabases(QueryContext *query_context, ShowOperato
     Vector<DatabaseDetail> databases_detail = txn->ListDatabases();
 
     // Prepare the output data block
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>> column_types{varchar_type};
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     for (auto &database_detail : databases_detail) {
         if (!output_block_ptr) {
@@ -855,10 +856,11 @@ void PhysicalShow::ExecuteShowTables(QueryContext *query_context, ShowOperatorSt
     }
 
     // Prepare the output data block
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>>
         column_types{varchar_type, varchar_type, varchar_type, bigint_type, bigint_type, bigint_type, bigint_type, bigint_type};
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     for (auto &table_detail : table_collections_detail) {
         // Initialize the output data block
@@ -1005,10 +1007,11 @@ void PhysicalShow::ExecuteShowViews(QueryContext *query_context, ShowOperatorSta
     }
 
     // Prepare the output data block
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>>
         column_types{varchar_type, varchar_type, varchar_type, bigint_type, bigint_type, bigint_type, bigint_type, bigint_type};
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     for (auto &view_detail : views_detail) {
         if (!output_block_ptr) {
@@ -1078,7 +1081,7 @@ void PhysicalShow::ExecuteShowProfiles(QueryContext *query_context, ShowOperator
     SharedPtr<TableDef> table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("profiles"), column_defs);
 
     // create data block for output state
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>> column_types{varchar_type,
                                              varchar_type,
                                              varchar_type,
@@ -1091,6 +1094,7 @@ void PhysicalShow::ExecuteShowProfiles(QueryContext *query_context, ShowOperator
                                              varchar_type,
                                              varchar_type};
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     auto records = catalog->GetProfilerRecords();
     for (SizeT i = 0; i < records.size(); ++i) {
@@ -1161,13 +1165,14 @@ void PhysicalShow::ExecuteShowColumns(QueryContext *query_context, ShowOperatorS
     SharedPtr<TableDef> table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("Views"), column_defs);
 
     // create data block for output state
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>> column_types{
         varchar_type,
         varchar_type,
         varchar_type,
     };
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     SizeT column_count = table_entry->ColumnCount();
     for (SizeT input_column_id = 0; input_column_id < column_count; ++input_column_id) {
@@ -1242,13 +1247,14 @@ void PhysicalShow::ExecuteShowSegments(QueryContext *query_context, ShowOperator
 
     auto varchar_type = MakeShared<DataType>(LogicalType::kVarchar);
     auto bigint_type = MakeShared<DataType>(LogicalType::kBigInt);
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>> column_types{
         bigint_type,
         varchar_type,
         varchar_type,
     };
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     for (auto &[_, segment_entry] : table_entry->segment_map()) {
         if (!output_block_ptr) {
@@ -1413,13 +1419,14 @@ void PhysicalShow::ExecuteShowBlocks(QueryContext *query_context, ShowOperatorSt
 
     auto bigint_type = MakeShared<DataType>(LogicalType::kBigInt);
     auto varchar_type = MakeShared<DataType>(LogicalType::kVarchar);
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>> column_types{
         bigint_type,
         varchar_type,
         bigint_type,
     };
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     auto segment_entry = table_entry->GetSegmentByID(*segment_id_, begin_ts);
     if (!segment_entry) {
@@ -2270,9 +2277,10 @@ void PhysicalShow::ExecuteShowIndexes(QueryContext *query_context, ShowOperatorS
 
     auto table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("Views"), column_defs);
 
-    UniquePtr<DataBlock> output_block_ptr = nullptr;
+    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
     Vector<SharedPtr<DataType>> column_types{varchar_type, varchar_type, bigint_type, varchar_type, varchar_type, varchar_type, varchar_type};
     SizeT row_count = 0;
+    output_block_ptr->Init(column_types);
 
     {
         auto map_guard = table_entry->IndexMetaMap();

--- a/src/executor/operator/physical_show.cpp
+++ b/src/executor/operator/physical_show.cpp
@@ -799,12 +799,15 @@ void PhysicalShow::ExecuteShowDatabases(QueryContext *query_context, ShowOperato
     Vector<DatabaseDetail> databases_detail = txn->ListDatabases();
 
     // Prepare the output data block
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>> column_types{varchar_type};
-
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     for (auto &database_detail : databases_detail) {
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
 
         SizeT column_id = 0;
         {
@@ -814,10 +817,19 @@ void PhysicalShow::ExecuteShowDatabases(QueryContext *query_context, ShowOperato
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
         }
+
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
     }
 
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 /**
@@ -843,13 +855,17 @@ void PhysicalShow::ExecuteShowTables(QueryContext *query_context, ShowOperatorSt
     }
 
     // Prepare the output data block
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>>
         column_types{varchar_type, varchar_type, varchar_type, bigint_type, bigint_type, bigint_type, bigint_type, bigint_type};
-
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     for (auto &table_detail : table_collections_detail) {
+        // Initialize the output data block
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
 
         SizeT column_id = 0;
         {
@@ -958,10 +974,19 @@ void PhysicalShow::ExecuteShowTables(QueryContext *query_context, ShowOperatorSt
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
         }
+
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
     }
 
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 void PhysicalShow::ExecuteShowViews(QueryContext *query_context, ShowOperatorState *show_operator_state) {
@@ -980,13 +1005,16 @@ void PhysicalShow::ExecuteShowViews(QueryContext *query_context, ShowOperatorSta
     }
 
     // Prepare the output data block
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>>
         column_types{varchar_type, varchar_type, varchar_type, bigint_type, bigint_type, bigint_type, bigint_type, bigint_type};
-
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     for (auto &view_detail : views_detail) {
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
 
         SizeT column_id = 0;
         {
@@ -1013,10 +1041,19 @@ void PhysicalShow::ExecuteShowViews(QueryContext *query_context, ShowOperatorSta
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
         }
+
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
     }
 
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 void PhysicalShow::ExecuteShowProfiles(QueryContext *query_context, ShowOperatorState *show_operator_state) {
@@ -1041,7 +1078,7 @@ void PhysicalShow::ExecuteShowProfiles(QueryContext *query_context, ShowOperator
     SharedPtr<TableDef> table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("profiles"), column_defs);
 
     // create data block for output state
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>> column_types{varchar_type,
                                              varchar_type,
                                              varchar_type,
@@ -1053,10 +1090,14 @@ void PhysicalShow::ExecuteShowProfiles(QueryContext *query_context, ShowOperator
                                              varchar_type,
                                              varchar_type,
                                              varchar_type};
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     auto records = catalog->GetProfilerRecords();
     for (SizeT i = 0; i < records.size(); ++i) {
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
 
         // Output record no
         ValueExpression record_no_expr(Value::MakeVarchar(fmt::format("{}", i)));
@@ -1078,9 +1119,19 @@ void PhysicalShow::ExecuteShowProfiles(QueryContext *query_context, ShowOperator
         NanoSeconds total_duration(total_cost);
         ValueExpression phase_cost_expr(Value::MakeVarchar(BaseProfiler::ElapsedToString(total_duration)));
         phase_cost_expr.AppendToChunk(output_block_ptr->column_vectors.back());
+
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
     }
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 /**
@@ -1110,17 +1161,21 @@ void PhysicalShow::ExecuteShowColumns(QueryContext *query_context, ShowOperatorS
     SharedPtr<TableDef> table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("Views"), column_defs);
 
     // create data block for output state
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>> column_types{
         varchar_type,
         varchar_type,
         varchar_type,
     };
-
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     SizeT column_count = table_entry->ColumnCount();
     for (SizeT input_column_id = 0; input_column_id < column_count; ++input_column_id) {
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
+
         const ColumnDef *column = table_entry->GetColumnDefByID(input_column_id);
 
         SizeT output_column_idx = 0;
@@ -1160,10 +1215,19 @@ void PhysicalShow::ExecuteShowColumns(QueryContext *query_context, ShowOperatorS
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[output_column_idx]);
         }
-    }
-    output_block_ptr->Finalize();
 
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
+    }
+
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 void PhysicalShow::ExecuteShowSegments(QueryContext *query_context, ShowOperatorState *show_operator_state) {
@@ -1178,15 +1242,20 @@ void PhysicalShow::ExecuteShowSegments(QueryContext *query_context, ShowOperator
 
     auto varchar_type = MakeShared<DataType>(LogicalType::kVarchar);
     auto bigint_type = MakeShared<DataType>(LogicalType::kBigInt);
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>> column_types{
         bigint_type,
         varchar_type,
         varchar_type,
     };
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     for (auto &[_, segment_entry] : table_entry->segment_map()) {
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
+
         SizeT column_id = 0;
         {
             Value value = Value::MakeBigInt(segment_entry->segment_id());
@@ -1208,10 +1277,19 @@ void PhysicalShow::ExecuteShowSegments(QueryContext *query_context, ShowOperator
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
         }
+
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
     }
 
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 void PhysicalShow::ExecuteShowSegmentDetail(QueryContext *query_context, ShowOperatorState *show_operator_state) {
@@ -1335,13 +1413,13 @@ void PhysicalShow::ExecuteShowBlocks(QueryContext *query_context, ShowOperatorSt
 
     auto bigint_type = MakeShared<DataType>(LogicalType::kBigInt);
     auto varchar_type = MakeShared<DataType>(LogicalType::kVarchar);
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>> column_types{
         bigint_type,
         varchar_type,
         bigint_type,
     };
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     auto segment_entry = table_entry->GetSegmentByID(*segment_id_, begin_ts);
     if (!segment_entry) {
@@ -1350,6 +1428,11 @@ void PhysicalShow::ExecuteShowBlocks(QueryContext *query_context, ShowOperatorSt
     }
     auto block_entry_iter = BlockEntryIter(segment_entry.get());
     for (auto *block_entry = block_entry_iter.Next(); block_entry != nullptr; block_entry = block_entry_iter.Next()) {
+        if (!output_block_ptr) {
+            output_block_ptr = DataBlock::MakeUniquePtr();
+            output_block_ptr->Init(column_types);
+        }
+
         SizeT column_id = 0;
         {
             Value value = Value::MakeBigInt(block_entry->block_id());
@@ -1371,10 +1454,19 @@ void PhysicalShow::ExecuteShowBlocks(QueryContext *query_context, ShowOperatorSt
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
         }
+
+        if (++row_count == output_block_ptr->capacity()) {
+            output_block_ptr->Finalize();
+            show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+            output_block_ptr = nullptr;
+            row_count = 0;
+        }
     }
 
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 void PhysicalShow::ExecuteShowBlockDetail(QueryContext *query_context, ShowOperatorState *show_operator_state) {
@@ -1606,7 +1698,7 @@ void PhysicalShow::ExecuteShowBlockColumn(QueryContext *query_context, ShowOpera
         ++column_id;
         {
             String outline_storage;
-            for(SizeT idx = 0; idx < outline_count; ++ idx) {
+            for (SizeT idx = 0; idx < outline_count; ++idx) {
                 outline_storage += *(column_block_entry->OutlineFilename(idx));
                 outline_storage += ";";
             }
@@ -2178,13 +2270,18 @@ void PhysicalShow::ExecuteShowIndexes(QueryContext *query_context, ShowOperatorS
 
     auto table_def = TableDef::Make(MakeShared<String>("default"), MakeShared<String>("Views"), column_defs);
 
-    UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
+    UniquePtr<DataBlock> output_block_ptr = nullptr;
     Vector<SharedPtr<DataType>> column_types{varchar_type, varchar_type, bigint_type, varchar_type, varchar_type, varchar_type, varchar_type};
-    output_block_ptr->Init(column_types);
+    SizeT row_count = 0;
 
     {
         auto map_guard = table_entry->IndexMetaMap();
         for (const auto &[index_name, index_meta] : *map_guard) {
+            if (!output_block_ptr) {
+                output_block_ptr = DataBlock::MakeUniquePtr();
+                output_block_ptr->Init(column_types);
+            }
+
             auto [table_index_entry, status] = index_meta->GetEntryNolock(txn->TxnID(), txn->BeginTS());
             if (!status.ok()) {
                 // Index isn't found.
@@ -2256,10 +2353,20 @@ void PhysicalShow::ExecuteShowIndexes(QueryContext *query_context, ShowOperatorS
                 ValueExpression value_expr(value);
                 value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
             }
+
+            if (++row_count == output_block_ptr->capacity()) {
+                output_block_ptr->Finalize();
+                show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+                output_block_ptr = nullptr;
+                row_count = 0;
+            }
         }
     }
-    output_block_ptr->Finalize();
-    show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+
+    if (output_block_ptr) {
+        output_block_ptr->Finalize();
+        show_operator_state->output_.emplace_back(std::move(output_block_ptr));
+    }
 }
 
 void PhysicalShow::ExecuteShowViewDetail(QueryContext *query_context,


### PR DESCRIPTION
### What problem does this PR solve?

`PhysicalShow`  only handle entries when the size less than the capacity of  `DataBlock`  (8192), which will cause segment faults if entries exceed that size.

Issue link:#961

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases
