### PR TITLE
Opt deltaop performance 1

### DIFF
--- a/python/tmp_test.py
+++ b/python/tmp_test.py
@@ -1,0 +1,146 @@
+import infinity
+import time
+import json
+import infinity.index as index
+from infinity import NetworkAddress
+from infinity.common import ConflictType
+
+infinity_obj = infinity.connect(NetworkAddress("127.0.0.1", 23817))
+geonames_file_path = "test/data/benchmark/geonames/geonames.json"
+geonames_index_path = "test/data/benchmark/geonames/index.json"
+
+
+db_obj = infinity_obj.get_database("default_db")
+db_obj.drop_table("geonames")
+table_obj = db_obj.create_table(
+    "geonames",
+    {
+        "name": "varchar",
+        "feature_class": "varchar",
+        "cc2": "varchar",
+        "timezone": "varchar",
+        "dem": "varchar",
+        "country_code": "varchar",
+        "admin1_code": "varchar",
+        "admin2_code": "varchar",
+        "admin3_code": "varchar",
+        "admin4_code": "varchar",
+        "feature_code": "varchar",
+        "alternatenames": "varchar",
+        "asciiname": "varchar",
+    },
+    ConflictType.Error,
+)
+fields = [
+    "name",
+    "feature_class",
+    "cc2",
+    "timezone",
+    "dem",
+    "country_code",
+    "admin1_code",
+    "admin2_code",
+    "admin3_code",
+    "admin4_code",
+    "feature_code",
+    "alternatenames",
+    "asciiname",
+]
+start = time.time()
+with open(geonames_file_path, "r") as file:
+    values = []
+    for i, line in enumerate(file):
+        if i != 0 and i % 500 == 0:
+            table_obj.insert(values)
+            values = []
+        record = json.loads(line)
+        value = {}
+        for field in fields:
+            value[field] = record.get(field, "233")
+        values.append(value)
+    if len(values):
+        table_obj.insert(values)
+    table_obj.create_index(
+        "idx1",
+        [
+            index.IndexInfo("name", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx2",
+        [
+            index.IndexInfo("feature_class", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx3",
+        [
+            index.IndexInfo("cc2", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx4",
+        [
+            index.IndexInfo("timezone", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx5",
+        [
+            index.IndexInfo("dem", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx12",
+        [
+            index.IndexInfo("country_code", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx6",
+        [
+            index.IndexInfo("admin1_code", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx7",
+        [
+            index.IndexInfo("admin2_code", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx8",
+        [
+            index.IndexInfo("admin3_code", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx9",
+        [
+            index.IndexInfo("feature_code", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx10",
+        [
+            index.IndexInfo("alternatenames", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx11",
+        [
+            index.IndexInfo("asciiname", index.IndexType.FullText, []),
+        ],
+    )
+    table_obj.create_index(
+        "idx13",
+        [
+            index.IndexInfo("admin4_code", index.IndexType.FullText, []),
+        ],
+    )
+end = time.time()
+print("Time to index geonames: ", end - start)
+
+start = time.time()
+table_obj.output(["name"]).match("name", "Sankt Georgen").to_pl()
+end = time.time()

--- a/src/executor/operator/physical_import.cpp
+++ b/src/executor/operator/physical_import.cpp
@@ -586,8 +586,7 @@ void PhysicalImport::JSONLRowHandler(const nlohmann::json &line_json, Vector<Col
 }
 
 void PhysicalImport::SaveSegmentData(TableEntry *table_entry, Txn *txn, SharedPtr<SegmentEntry> segment_entry) {
-    TxnTimeStamp flush_ts = txn->BeginTS();
-    segment_entry->FlushNewData(flush_ts);
+    segment_entry->FlushNewData();
 
     const String &db_name = *table_entry->GetDBName();
     const String &table_name = *table_entry->GetTableName();

--- a/src/scheduler/task_scheduler.cpp
+++ b/src/scheduler/task_scheduler.cpp
@@ -273,7 +273,7 @@ void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id
             --worker_workloads_[worker_id];
             iter = task_lists.erase(iter);
         }
-        if (finish) {
+        if (finish || error) {
             fragment_ctx->notifier()->FinishTask(error, fragment_ctx);
         } else {
             fragment_ctx->notifier()->UnstartTask();

--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -250,10 +250,9 @@ void CompactSegmentsTask::SaveSegmentsData(CompactSegmentsTaskState &state) {
     Vector<WalSegmentInfo> segment_infos;
     Vector<SegmentID> old_segment_ids;
 
-    TxnTimeStamp flush_ts = txn_->BeginTS();
     for (auto &[new_segment, old_segments] : segment_data) {
         if (new_segment->row_count() > 0) {
-            new_segment->FlushNewData(flush_ts);
+            new_segment->FlushNewData();
             segment_infos.push_back(WalSegmentInfo(new_segment.get()));
         }
 

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -38,6 +38,8 @@ BufferManager::BufferManager(u64 memory_limit, SharedPtr<String> data_dir, Share
     fs.CleanupDirectory(*temp_dir_);
 }
 
+BufferManager::~BufferManager() { RemoveClean(); }
+
 BufferObj *BufferManager::Allocate(UniquePtr<FileWorker> file_worker) {
     String file_path = file_worker->GetFilePath();
     auto buffer_obj = MakeUnique<BufferObj>(this, true, std::move(file_worker));

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -149,7 +149,7 @@ void BufferManager::AddToCleanList(BufferObj *buffer_obj, bool free) {
         clean_list_.push_back(buffer_obj);
     }
     if (free) {
-        std::unique_lock lock(w_locker_);
+        std::unique_lock lock(gc_locker_);
         current_memory_size_ -= buffer_obj->GetBufferSize();
     }
 }

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -28,6 +28,8 @@ export class BufferManager {
 public:
     explicit BufferManager(u64 memory_limit, SharedPtr<String> data_dir, SharedPtr<String> temp_dir);
 
+    ~BufferManager();
+
 public:
     // Create a new BufferHandle, or in replay process. (read data block from wal)
     BufferObj *Allocate(UniquePtr<FileWorker> file_worker);

--- a/src/storage/buffer/buffer_obj.cppm
+++ b/src/storage/buffer/buffer_obj.cppm
@@ -82,6 +82,8 @@ public:
 
     String GetFilename() const { return file_worker_->GetFilePath(); }
 
+    FileWorker *file_worker() { return file_worker_.get(); }
+
 private:
     // Friend to encapsulate `Unload` interface and to increase `rc_`.
     friend class BufferHandle;

--- a/src/storage/buffer/file_worker/annivfflat_index_file_worker.cppm
+++ b/src/storage/buffer/file_worker/annivfflat_index_file_worker.cppm
@@ -60,7 +60,7 @@ public:
     void FreeInMemory() override;
 
 protected:
-    void WriteToFileImpl(bool &prepare_success) override;
+    void WriteToFileImpl(bool to_spill, bool &prepare_success) override;
 
     void ReadFromFileImpl() override;
 
@@ -119,7 +119,7 @@ void AnnIVFFlatIndexFileWorker<DataType>::FreeInMemory() {
 }
 
 template <typename DataType>
-void AnnIVFFlatIndexFileWorker<DataType>::WriteToFileImpl(bool &prepare_success) {
+void AnnIVFFlatIndexFileWorker<DataType>::WriteToFileImpl(bool to_spill, bool &prepare_success) {
     auto *index = static_cast<AnnIVFFlatIndexData<DataType> *>(data_);
     index->SaveIndexInner(*file_handler_);
     prepare_success = true;

--- a/src/storage/buffer/file_worker/data_file_worker.cpp
+++ b/src/storage/buffer/file_worker/data_file_worker.cpp
@@ -52,7 +52,8 @@ void DataFileWorker::FreeInMemory() {
     data_ = nullptr;
 }
 
-void DataFileWorker::WriteToFileImpl(bool &prepare_success) {
+// FIXME: to_spill
+void DataFileWorker::WriteToFileImpl(bool to_spill, bool &prepare_success) {
     LocalFileSystem fs;
     // File structure:
     // - header: magic number

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -56,7 +56,7 @@ void FileWorker::WriteToFile(bool to_spill) {
         file_handler_ = nullptr;
     });
 
-    WriteToFileImpl(prepare_success);
+    WriteToFileImpl(to_spill, prepare_success);
     if (prepare_success) {
         if (to_spill) {
             LOG_TRACE(fmt::format("Write to spill file {} finished. success {}", write_path, prepare_success));

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -56,7 +56,7 @@ public:
     void CleanupFile();
 
 protected:
-    virtual void WriteToFileImpl(bool &prepare_success) = 0;
+    virtual void WriteToFileImpl(bool to_spill, bool &prepare_success) = 0;
 
     virtual void ReadFromFileImpl() = 0;
 

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cpp
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cpp
@@ -91,7 +91,7 @@ void HnswFileWorker::FreeInMemory() {
     data_ = nullptr;
 }
 
-void HnswFileWorker::WriteToFileImpl(bool &prepare_success) {
+void HnswFileWorker::WriteToFileImpl(bool to_spill, bool &prepare_success) {
     if (!data_) {
         UnrecoverableError("WriteToFileImpl: Data is not allocated.");
     }

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cppm
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cppm
@@ -47,7 +47,7 @@ public:
     void FreeInMemory() override;
 
 protected:
-    void WriteToFileImpl(bool &prepare_success) override;
+    void WriteToFileImpl(bool to_spill, bool &prepare_success) override;
 
     void ReadFromFileImpl() override;
 

--- a/src/storage/buffer/file_worker/raw_file_worker.cpp
+++ b/src/storage/buffer/file_worker/raw_file_worker.cpp
@@ -57,7 +57,7 @@ void RawFileWorker::FreeInMemory() {
     data_ = nullptr;
 }
 
-void RawFileWorker::WriteToFileImpl(bool &prepare_success) {
+void RawFileWorker::WriteToFileImpl(bool to_spill, bool &prepare_success) {
     assert(data_ != nullptr && buffer_size_ > 0);
     LocalFileSystem fs;
     i64 nbytes = fs.Write(*file_handler_, data_, buffer_size_);

--- a/src/storage/buffer/file_worker/raw_file_worker.cppm
+++ b/src/storage/buffer/file_worker/raw_file_worker.cppm
@@ -39,7 +39,7 @@ public:
     SizeT GetMemoryCost() const override { return buffer_size_; }
 
 protected:
-    void WriteToFileImpl(bool &prepare_success) override;
+    void WriteToFileImpl(bool to_spill, bool &prepare_success) override;
 
     void ReadFromFileImpl() override;
 

--- a/src/storage/buffer/file_worker/secondary_index_file_worker.cpp
+++ b/src/storage/buffer/file_worker/secondary_index_file_worker.cpp
@@ -73,7 +73,7 @@ void SecondaryIndexFileWorker::FreeInMemory() {
     }
 }
 
-void SecondaryIndexFileWorker::WriteToFileImpl(bool &prepare_success) {
+void SecondaryIndexFileWorker::WriteToFileImpl(bool to_spill, bool &prepare_success) {
     if (data_) [[likely]] {
         if (worker_id_ == 0) {
             auto index = static_cast<SecondaryIndexDataHead *>(data_);

--- a/src/storage/buffer/file_worker/secondary_index_file_worker.cppm
+++ b/src/storage/buffer/file_worker/secondary_index_file_worker.cppm
@@ -59,7 +59,7 @@ public:
     void FreeInMemory() final;
 
 protected:
-    void WriteToFileImpl(bool &prepare_success) final;
+    void WriteToFileImpl(bool to_spill, bool &prepare_success) final;
 
     void ReadFromFileImpl() final;
 

--- a/src/storage/buffer/file_worker/version_file_worker.cpp
+++ b/src/storage/buffer/file_worker/version_file_worker.cpp
@@ -1,0 +1,79 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+module version_file_worker;
+
+import stl;
+import file_worker;
+import block_version;
+import infinity_exception;
+
+namespace infinity {
+
+VersionFileWorker::VersionFileWorker(SharedPtr<String> file_dir, SharedPtr<String> file_name, SizeT capacity)
+    : FileWorker(std::move(file_dir), std::move(file_name)), capacity_(capacity) {}
+
+VersionFileWorker::~VersionFileWorker() {
+    if (data_ != nullptr) {
+        FreeInMemory();
+        data_ = nullptr;
+    }
+}
+
+void VersionFileWorker::AllocateInMemory() {
+    if (data_ != nullptr) {
+        UnrecoverableError("Data is already allocated.");
+    }
+    if (capacity_ == 0) {
+        UnrecoverableError("Capacity is 0.");
+    }
+    auto *data = new BlockVersion(capacity_);
+    data_ = static_cast<void *>(data);
+}
+
+void VersionFileWorker::FreeInMemory() {
+    if (data_ == nullptr) {
+        UnrecoverableError("Data is already freed.");
+    }
+    auto *data = static_cast<BlockVersion *>(data_);
+    delete data;
+    data_ = nullptr;
+}
+
+// FIXME
+SizeT VersionFileWorker::GetMemoryCost() const { return capacity_ * sizeof(TxnTimeStamp); }
+
+void VersionFileWorker::WriteToFileImpl(bool to_spill, bool &prepare_success) {
+    if (data_ == nullptr) {
+        UnrecoverableError("Data is not allocated.");
+    }
+    auto *data = static_cast<BlockVersion *>(data_);
+    if (to_spill) {
+        data->SpillToFile(*file_handler_);
+    } else {
+        data->SaveToFile(checkpoint_ts_, *file_handler_);
+    }
+}
+
+void VersionFileWorker::ReadFromFileImpl() {
+    if (data_ != nullptr) {
+        UnrecoverableError("Data is already allocated.");
+    }
+    auto *data = BlockVersion::LoadFromFile(*file_handler_).release();
+    data_ = static_cast<void *>(data);
+}
+
+} // namespace infinity

--- a/src/storage/buffer/file_worker/version_file_worker.cppm
+++ b/src/storage/buffer/file_worker/version_file_worker.cppm
@@ -14,25 +14,27 @@
 
 module;
 
-export module data_file_worker;
+export module version_file_worker;
 
 import stl;
 import file_worker;
 
 namespace infinity {
 
-export class DataFileWorker : public FileWorker {
+export class VersionFileWorker : public FileWorker {
 public:
-    explicit DataFileWorker(SharedPtr<String> file_dir, SharedPtr<String> file_name, SizeT buffer_size);
+    explicit VersionFileWorker(SharedPtr<String> file_dir, SharedPtr<String> file_name, SizeT capacity);
 
-    virtual ~DataFileWorker() override;
+    virtual ~VersionFileWorker() override;
 
 public:
     void AllocateInMemory() override;
 
     void FreeInMemory() override;
 
-    SizeT GetMemoryCost() const override { return buffer_size_; }
+    SizeT GetMemoryCost() const override;
+
+    void SetCheckpointTS(TxnTimeStamp ts) { checkpoint_ts_ = ts; }
 
 protected:
     void WriteToFileImpl(bool to_spill, bool &prepare_success) override;
@@ -40,6 +42,8 @@ protected:
     void ReadFromFileImpl() override;
 
 private:
-    const SizeT buffer_size_;
+    SizeT capacity_{};
+    TxnTimeStamp checkpoint_ts_{};
 };
+
 } // namespace infinity

--- a/src/storage/compaction_process.cpp
+++ b/src/storage/compaction_process.cpp
@@ -91,8 +91,11 @@ void CompactionProcessor::ScanAndOptimize() {
             table_entry->OptimizeIndex(opt_txn);
         }
     }
-
-    txn_mgr_->CommitTxn(opt_txn);
+    try {
+        txn_mgr_->CommitTxn(opt_txn);
+    } catch (const RecoverableException &e) {
+        txn_mgr_->RollBackTxn(opt_txn);
+    }
 }
 
 void CompactionProcessor::Process() {

--- a/src/storage/definition/index_base.cppm
+++ b/src/storage/definition/index_base.cppm
@@ -40,6 +40,8 @@ protected:
         : index_type_(index_type), index_name_(index_name), file_name_(file_name), column_names_(std::move(column_names)){};
 
 public:
+    explicit IndexBase(SharedPtr<String> index_name) : index_name_(index_name){};
+
     virtual ~IndexBase() = default;
 
     bool operator==(const IndexBase &other) const;
@@ -57,7 +59,7 @@ public:
     static SharedPtr<IndexBase> ReadAdv(char *&ptr, i32 maxbytes);
 
     virtual String ToString() const;
-    virtual String BuildOtherParamsString() const = 0;
+    virtual String BuildOtherParamsString() const { return ""; }
     virtual nlohmann::json Serialize() const;
 
     static SharedPtr<IndexBase> Deserialize(const nlohmann::json &index_def_json);

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -531,8 +531,7 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         },
                         txn_id,
                         begin_ts);
-                }
-                if (merge_flag == MergeFlag::kUpdate) {
+                } else if (merge_flag == MergeFlag::kUpdate) {
                     UnrecoverableError("Update database entry is not supported.");
                 }
                 break;
@@ -570,45 +569,24 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         txn_id,
                         begin_ts);
                 }
+                auto init_table_entry = [&](TableMeta *table_meta, const SharedPtr<String> &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
+                    return TableEntry::ReplayTableEntry(false,
+                                                        table_meta,
+                                                        table_entry_dir,
+                                                        table_name,
+                                                        column_defs,
+                                                        entry_type,
+                                                        txn_id,
+                                                        begin_ts,
+                                                        commit_ts,
+                                                        row_count,
+                                                        unsealed_id,
+                                                        next_segment_id);
+                };
                 if (merge_flag == MergeFlag::kNew || merge_flag == MergeFlag::kDeleteAndNew) {
-                    db_entry->CreateTableReplay(
-                        table_name,
-                        [&](TableMeta *table_meta, const SharedPtr<String> &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
-                            return TableEntry::ReplayTableEntry(false,
-                                                                table_meta,
-                                                                table_entry_dir,
-                                                                table_name,
-                                                                column_defs,
-                                                                entry_type,
-                                                                txn_id,
-                                                                begin_ts,
-                                                                commit_ts,
-                                                                row_count,
-                                                                unsealed_id,
-                                                                next_segment_id);
-                        },
-                        txn_id,
-                        begin_ts);
-                }
-                if (merge_flag == MergeFlag::kUpdate) {
-                    db_entry->UpdateTableReplay(
-                        table_name,
-                        [&](TableMeta *table_meta, const SharedPtr<String> &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
-                            return TableEntry::ReplayTableEntry(false,
-                                                                table_meta,
-                                                                table_entry_dir,
-                                                                table_name,
-                                                                column_defs,
-                                                                entry_type,
-                                                                txn_id,
-                                                                begin_ts,
-                                                                commit_ts,
-                                                                row_count,
-                                                                unsealed_id,
-                                                                next_segment_id);
-                        },
-                        txn_id,
-                        begin_ts);
+                    db_entry->CreateTableReplay(table_name, init_table_entry, txn_id, begin_ts);
+                } else if (merge_flag == MergeFlag::kUpdate) {
+                    db_entry->UpdateTableReplay(table_name, init_table_entry, txn_id, begin_ts);
                 }
                 break;
             }
@@ -625,28 +603,35 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                 auto min_row_ts = add_segment_entry_op->min_row_ts_;
                 auto max_row_ts = add_segment_entry_op->max_row_ts_;
                 auto deprecate_ts = add_segment_entry_op->deprecate_ts_;
+                auto segment_filter_binary_data = add_segment_entry_op->segment_filter_binary_data_;
 
                 auto *db_entry = this->GetDatabaseReplay(*db_name, txn_id, begin_ts);
                 auto *table_entry = db_entry->GetTableReplay(*table_name, txn_id, begin_ts);
 
-                table_entry->AddSegmentReplay(
-                    [&]() {
-                        auto segment = SegmentEntry::NewReplaySegmentEntry(table_entry,
-                                                                           segment_id,
-                                                                           segment_status,
-                                                                           column_count,
-                                                                           row_count,
-                                                                           actual_row_count,
-                                                                           row_capacity,
-                                                                           min_row_ts,
-                                                                           max_row_ts,
-                                                                           commit_ts,
-                                                                           deprecate_ts,
-                                                                           begin_ts,
-                                                                           txn_id);
-                        return segment;
-                    },
-                    segment_id);
+                auto segment_entry = SegmentEntry::NewReplaySegmentEntry(table_entry,
+                                                                         segment_id,
+                                                                         segment_status,
+                                                                         column_count,
+                                                                         row_count,
+                                                                         actual_row_count,
+                                                                         row_capacity,
+                                                                         min_row_ts,
+                                                                         max_row_ts,
+                                                                         commit_ts,
+                                                                         deprecate_ts,
+                                                                         begin_ts,
+                                                                         txn_id);
+
+                if (merge_flag == MergeFlag::kNew) {
+                    if (!segment_filter_binary_data.empty()) {
+                        segment_entry->LoadFilterBinaryData(std::move(segment_filter_binary_data));
+                    }
+                    table_entry->AddSegmentReplay(segment_entry);
+                } else if (merge_flag == MergeFlag::kDelete || merge_flag == MergeFlag::kUpdate) {
+                    table_entry->UpdateSegmentReplay(segment_entry, std::move(segment_filter_binary_data));
+                } else {
+                    UnrecoverableError(fmt::format("Unsupported merge flag {} for segment entry", (i8)merge_flag));
+                }
                 break;
             }
             case CatalogDeltaOpType::ADD_BLOCK_ENTRY: {
@@ -661,22 +646,33 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                 auto max_row_ts = add_block_entry_op->max_row_ts_;
                 auto check_point_ts = add_block_entry_op->checkpoint_ts_;
                 auto check_point_row_count = add_block_entry_op->checkpoint_row_count_;
+                auto block_filter_binary_data = add_block_entry_op->block_filter_binary_data_;
 
                 auto *db_entry = this->GetDatabaseReplay(*db_name, txn_id, begin_ts);
                 auto *table_entry = db_entry->GetTableReplay(*table_name, txn_id, begin_ts);
+                auto *segment_entry = table_entry->segment_map_.at(segment_id).get();
 
-                auto segment_entry = table_entry->segment_map_.at(segment_id).get();
-                segment_entry->AddBlockReplay(BlockEntry::NewReplayBlockEntry(segment_entry,
-                                                                              block_id,
-                                                                              row_count,
-                                                                              row_capacity,
-                                                                              min_row_ts,
-                                                                              max_row_ts,
-                                                                              commit_ts,
-                                                                              check_point_ts,
-                                                                              check_point_row_count,
-                                                                              buffer_mgr),
-                                              block_id);
+                auto new_block = BlockEntry::NewReplayBlockEntry(segment_entry,
+                                                                 block_id,
+                                                                 row_count,
+                                                                 row_capacity,
+                                                                 min_row_ts,
+                                                                 max_row_ts,
+                                                                 commit_ts,
+                                                                 check_point_ts,
+                                                                 check_point_row_count,
+                                                                 buffer_mgr);
+
+                if (merge_flag == MergeFlag::kNew) {
+                    if (!block_filter_binary_data.empty()) {
+                        new_block->LoadFilterBinaryData(std::move(block_filter_binary_data));
+                    }
+                    segment_entry->AddBlockReplay(std::move(new_block));
+                } else if (merge_flag == MergeFlag::kUpdate) {
+                    segment_entry->UpdateBlockReplay(std::move(new_block), std::move(block_filter_binary_data));
+                } else {
+                    UnrecoverableError(fmt::format("Unsupported merge flag {} for block entry", (i8)merge_flag));
+                }
                 break;
             }
             case CatalogDeltaOpType::ADD_COLUMN_ENTRY: {
@@ -732,8 +728,7 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                         },
                         txn_id,
                         begin_ts);
-                }
-                if (merge_flag == MergeFlag::kUpdate) {
+                } else if (merge_flag == MergeFlag::kUpdate) {
                     table_entry->UpdateIndexReplay(*index_name, txn_id, begin_ts, commit_ts);
                 }
                 break;
@@ -801,35 +796,6 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                     auto *segment_index_entry = iter2->second.get();
                     segment_index_entry->AddChunkIndexEntryReplay(chunk_id, table_entry, base_name, base_rowid, row_count, buffer_mgr);
                 }
-                break;
-            }
-            case CatalogDeltaOpType::SET_SEGMENT_STATUS_SEALED: {
-                auto *set_segment_status_sealed_op = static_cast<SetSegmentStatusSealedOp *>(op.get());
-                const auto &db_name = set_segment_status_sealed_op->db_name_;
-                const auto &table_name = set_segment_status_sealed_op->table_name_;
-                auto segment_id = set_segment_status_sealed_op->segment_id_;
-                const auto &segment_filter_binary = set_segment_status_sealed_op->segment_filter_binary_data_;
-
-                auto *db_entry = this->GetDatabaseReplay(*db_name, txn_id, begin_ts);
-                auto *table_entry = db_entry->GetTableReplay(*table_name, txn_id, begin_ts);
-                auto *segment_entry = table_entry->segment_map_.at(segment_id).get();
-                segment_entry->SetSealed(); // ignore the return value.
-                segment_entry->LoadFilterBinaryData(segment_filter_binary);
-                break;
-            }
-            case CatalogDeltaOpType::SET_BLOCK_STATUS_SEALED: {
-                auto *set_block_status_sealed_op = static_cast<SetBlockStatusSealedOp *>(op.get());
-                const auto &db_name = set_block_status_sealed_op->db_name_;
-                const auto &table_name = set_block_status_sealed_op->table_name_;
-                auto segment_id = set_block_status_sealed_op->segment_id_;
-                auto block_id = set_block_status_sealed_op->block_id_;
-                const auto &block_filter_binary = set_block_status_sealed_op->block_filter_binary_data_;
-
-                auto *db_entry = this->GetDatabaseReplay(*db_name, txn_id, begin_ts);
-                auto *table_entry = db_entry->GetTableReplay(*table_name, txn_id, begin_ts);
-                auto *segment_entry = table_entry->segment_map_.at(segment_id).get();
-                auto *block_entry = segment_entry->GetBlockEntryByID(block_id).get();
-                block_entry->LoadFilterBinaryData(block_filter_binary);
                 break;
             }
             default:

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -716,7 +716,8 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                     table_entry->DropIndexReplay(
                         *index_name,
                         [&](TableIndexMeta *index_meta, TransactionID txn_id, TxnTimeStamp begin_ts) {
-                            auto index_entry = TableIndexEntry::NewTableIndexEntry(nullptr, true, nullptr, index_meta, txn_id, begin_ts);
+                            auto index_base = MakeShared<IndexBase>(index_meta->index_name());
+                            auto index_entry = TableIndexEntry::NewTableIndexEntry(index_base, true, nullptr, index_meta, txn_id, begin_ts);
                             index_entry->commit_ts_.store(commit_ts);
                             return index_entry;
                         },

--- a/src/storage/meta/entry/base_entry.cppm
+++ b/src/storage/meta/entry/base_entry.cppm
@@ -24,7 +24,6 @@ namespace infinity {
 class Catalog;
 
 export enum class EntryType : i8 {
-    kDummy,
     kDatabase,
     kTable,
     kTableIndex,
@@ -38,11 +37,8 @@ export enum class EntryType : i8 {
 };
 
 export struct BaseEntry {
-    explicit BaseEntry(EntryType entry_type, bool is_delete) : deleted_(is_delete), entry_type_(entry_type) {
-        if (entry_type == EntryType::kDummy) {
-            commit_ts_ = 0;
-        }
-    }
+    explicit BaseEntry(EntryType entry_type, bool is_delete, String encode)
+        : deleted_(is_delete), entry_type_(entry_type), encode_(std::move(encode)) {}
 
     virtual ~BaseEntry() = default;
 
@@ -58,13 +54,18 @@ public:
 
     bool Deleted() const { return deleted_; }
 
+    const String &encode() const { return encode_; }
+
 public:
     atomic_u64 txn_id_{0};
     TxnTimeStamp begin_ts_{0};
     atomic_u64 commit_ts_{UNCOMMIT_TS};
     const bool deleted_;
 
-    const EntryType entry_type_{EntryType::kDummy};
+    const EntryType entry_type_;
+
+private:
+    const String encode_;
 };
 
 } // namespace infinity

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -157,7 +157,7 @@ void BlockColumnEntry::Flush(BlockColumnEntry *block_column_entry, SizeT checkpo
 
             std::shared_lock lock(block_column_entry->mutex_);
             for (auto *outline_buffer : block_column_entry->outline_buffers_) {
-                if(outline_buffer != nullptr) {
+                if (outline_buffer != nullptr) {
                     outline_buffer->Save();
                 }
             }
@@ -223,10 +223,11 @@ BlockColumnEntry::Deserialize(const nlohmann::json &column_data_json, BlockEntry
 }
 
 void BlockColumnEntry::CommitColumn(TransactionID txn_id, TxnTimeStamp commit_ts) {
-    if (!this->Committed()) {
-        this->txn_id_ = txn_id;
-        this->Commit(commit_ts);
+    if (this->Committed()) {
+        UnrecoverableError("Column already committed");
     }
+    this->txn_id_ = txn_id;
+    this->Commit(commit_ts);
 }
 
 Vector<String> BlockColumnEntry::OutlinePaths() const {

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -38,8 +38,13 @@ import data_type;
 
 namespace infinity {
 
+String BlockColumnEntry::EncodeIndex(const ColumnID column_id, const BlockEntry *block_entry) {
+    return fmt::format("{}#{}", block_entry->encode(), column_id);
+}
+
 BlockColumnEntry::BlockColumnEntry(const BlockEntry *block_entry, ColumnID column_id, const SharedPtr<String> &base_dir_ref)
-    : BaseEntry(EntryType::kBlockColumn, false), block_entry_(block_entry), column_id_(column_id), base_dir_(base_dir_ref) {}
+    : BaseEntry(EntryType::kBlockColumn, false, BlockColumnEntry::EncodeIndex(column_id, block_entry)), block_entry_(block_entry),
+      column_id_(column_id), base_dir_(base_dir_ref) {}
 
 UniquePtr<BlockColumnEntry> BlockColumnEntry::NewBlockColumnEntry(const BlockEntry *block_entry, ColumnID column_id, Txn *txn) {
     UniquePtr<BlockColumnEntry> block_column_entry = MakeUnique<BlockColumnEntry>(block_entry, column_id, block_entry->base_dir());

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -114,7 +114,7 @@ void BlockColumnEntry::Append(const ColumnVector *input_column_vector, u16 input
     column_vector.AppendWith(*input_column_vector, input_column_vector_offset, append_rows);
 }
 
-void BlockColumnEntry::Flush(BlockColumnEntry *block_column_entry, SizeT checkpoint_row_count) {
+void BlockColumnEntry::Flush(BlockColumnEntry *block_column_entry, SizeT start_row_count, SizeT checkpoint_row_count) {
     // TODO: Opt, Flush certain row_count content
     DataType *column_type = block_column_entry->column_type_.get();
     switch (column_type->type()) {

--- a/src/storage/meta/entry/block_column_entry.cppm
+++ b/src/storage/meta/entry/block_column_entry.cppm
@@ -37,6 +37,8 @@ struct SegmentEntry;
 export struct BlockColumnEntry : public BaseEntry {
     friend struct BlockEntry;
 
+    static String EncodeIndex(const ColumnID column_id, const BlockEntry *block_entry);
+
 public:
     explicit BlockColumnEntry(const BlockEntry *block_entry, ColumnID column_id, const SharedPtr<String> &base_dir_ref);
 

--- a/src/storage/meta/entry/block_column_entry.cppm
+++ b/src/storage/meta/entry/block_column_entry.cppm
@@ -93,7 +93,7 @@ public:
 public:
     void Append(const ColumnVector *input_column_vector, u16 input_offset, SizeT append_rows, BufferManager *buffer_mgr);
 
-    static void Flush(BlockColumnEntry *block_column_entry, SizeT row_count);
+    static void Flush(BlockColumnEntry *block_column_entry, SizeT start_row_count, SizeT checkpoint_row_count);
 
     void Cleanup();
 

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -96,6 +96,17 @@ UniquePtr<BlockEntry> BlockEntry::NewReplayBlockEntry(const SegmentEntry *segmen
     return block_entry;
 }
 
+void BlockEntry::UpdateBlockReplay(SharedPtr<BlockEntry> block_entry, String block_filter_binary_data) {
+    row_count_ = block_entry->row_count_;
+    min_row_ts_ = block_entry->min_row_ts_;
+    max_row_ts_ = block_entry->max_row_ts_;
+    checkpoint_ts_ = block_entry->checkpoint_ts_;
+    checkpoint_row_count_ = block_entry->checkpoint_row_count_;
+    if (!block_filter_binary_data.empty()) {
+        LoadFilterBinaryData(block_filter_binary_data);
+    }
+}
+
 Pair<BlockOffset, BlockOffset> BlockEntry::GetVisibleRange(TxnTimeStamp begin_ts, u16 block_offset_begin) const {
     std::shared_lock lock(rw_locker_);
     begin_ts = std::min(begin_ts, this->max_row_ts_);

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -40,10 +40,14 @@ import buffer_obj;
 
 namespace infinity {
 
+String BlockEntry::EncodeIndex(const BlockID block_id, const SegmentEntry *segment_entry) {
+    return fmt::format("{}#{}", segment_entry->encode(), block_id);
+}
+
 /// class BlockEntry
 BlockEntry::BlockEntry(const SegmentEntry *segment_entry, BlockID block_id, TxnTimeStamp checkpoint_ts)
-    : BaseEntry(EntryType::kBlock, false), segment_entry_(segment_entry), block_id_(block_id), row_count_(0), row_capacity_(DEFAULT_VECTOR_SIZE),
-      checkpoint_ts_(checkpoint_ts) {}
+    : BaseEntry(EntryType::kBlock, false, BlockEntry::EncodeIndex(block_id, segment_entry)), segment_entry_(segment_entry), block_id_(block_id),
+      row_count_(0), row_capacity_(DEFAULT_VECTOR_SIZE), checkpoint_ts_(checkpoint_ts) {}
 
 UniquePtr<BlockEntry>
 BlockEntry::NewBlockEntry(const SegmentEntry *segment_entry, BlockID block_id, TxnTimeStamp checkpoint_ts, u64 column_count, Txn *txn) {

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -30,11 +30,13 @@ import internal_types;
 import infinity_exception;
 import data_type;
 import segment_entry;
-
+import version_file_worker;
 import column_vector;
 import bitmask;
 import block_version;
 import cleanup_scanner;
+import buffer_manager;
+import buffer_obj;
 
 namespace infinity {
 
@@ -56,7 +58,10 @@ BlockEntry::NewBlockEntry(const SegmentEntry *segment_entry, BlockID block_id, T
         auto column_entry = BlockColumnEntry::NewBlockColumnEntry(block_entry.get(), column_id, txn);
         block_entry->columns_.emplace_back(std::move(column_entry));
     }
-    block_entry->block_version_ = MakeUnique<BlockVersion>(block_entry->row_capacity_);
+
+    auto version_file_worker = MakeUnique<VersionFileWorker>(block_entry->block_dir_, BlockVersion::FileName(), block_entry->row_capacity_);
+    auto *buffer_mgr = txn->buffer_mgr();
+    block_entry->block_version_ = buffer_mgr->Allocate(std::move(version_file_worker));
     return block_entry;
 }
 
@@ -78,8 +83,10 @@ UniquePtr<BlockEntry> BlockEntry::NewReplayBlockEntry(const SegmentEntry *segmen
     block_entry->max_row_ts_ = max_row_ts;
     block_entry->commit_ts_ = commit_ts;
     block_entry->block_dir_ = BlockEntry::DetermineDir(*segment_entry->segment_dir(), block_id);
-    block_entry->block_version_ = MakeUnique<BlockVersion>(block_entry->row_capacity_);
-    block_entry->block_version_->created_.emplace_back((TxnTimeStamp)block_entry->min_row_ts_, (i32)block_entry->row_count_);
+
+    auto version_file_worker = MakeUnique<VersionFileWorker>(block_entry->block_dir_, BlockVersion::FileName(), row_capacity);
+    block_entry->block_version_ = buffer_mgr->Get(std::move(version_file_worker));
+
     block_entry->checkpoint_ts_ = check_point_ts;
     block_entry->checkpoint_row_count_ = checkpoint_row_count;
     return block_entry;
@@ -88,7 +95,10 @@ UniquePtr<BlockEntry> BlockEntry::NewReplayBlockEntry(const SegmentEntry *segmen
 Pair<BlockOffset, BlockOffset> BlockEntry::GetVisibleRange(TxnTimeStamp begin_ts, u16 block_offset_begin) const {
     std::shared_lock lock(rw_locker_);
     begin_ts = std::min(begin_ts, this->max_row_ts_);
-    auto &block_version = this->block_version_;
+
+    auto block_version_handle = this->block_version_->Load();
+    const auto *block_version = reinterpret_cast<const BlockVersion *>(block_version_handle.GetData());
+
     auto &deleted = block_version->deleted_;
     BlockOffset block_offset_end = block_version->GetRowCount(begin_ts);
     while (block_offset_begin < block_offset_end && deleted[block_offset_begin] != 0 && deleted[block_offset_begin] <= begin_ts) {
@@ -105,7 +115,10 @@ Pair<BlockOffset, BlockOffset> BlockEntry::GetVisibleRange(TxnTimeStamp begin_ts
 
 bool BlockEntry::CheckRowVisible(BlockOffset block_offset, TxnTimeStamp check_ts) const {
     std::shared_lock lock(rw_locker_);
-    auto &block_version = this->block_version_;
+
+    auto block_version_handle = this->block_version_->Load();
+    const auto *block_version = reinterpret_cast<const BlockVersion *>(block_version_handle.GetData());
+
     auto &deleted = block_version->deleted_;
     return deleted[block_offset] == 0 || deleted[block_offset] > check_ts;
 }
@@ -162,7 +175,8 @@ u16 BlockEntry::AppendData(TransactionID txn_id,
 
     this->row_count_ += actual_copied;
 
-    auto &block_version = this->block_version_;
+    auto block_version_handle = block_version_->Load();
+    auto *block_version = reinterpret_cast<BlockVersion *>(block_version_handle.GetDataMut());
     block_version->created_.emplace_back(commit_ts, this->row_count_);
 
     return actual_copied;
@@ -180,7 +194,9 @@ void BlockEntry::DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const 
     u32 segment_id = this->segment_entry_->segment_id();
     u16 block_id = this->block_id_;
 
-    auto &block_version = this->block_version_;
+    auto block_version_handle = block_version_->Load();
+    auto *block_version = reinterpret_cast<BlockVersion *>(block_version_handle.GetDataMut());
+
     for (BlockOffset block_offset : rows) {
         block_version->deleted_[block_offset] = commit_ts;
     }
@@ -189,13 +205,14 @@ void BlockEntry::DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const 
 }
 
 void BlockEntry::CommitFlushed(TxnTimeStamp commit_ts) {
-    auto &block_version = this->block_version_;
+    auto block_version_handle = block_version_->Load();
+    auto *block_version = reinterpret_cast<BlockVersion *>(block_version_handle.GetDataMut());
     if (!block_version->created_.empty()) {
         UnrecoverableError("BlockEntry::CommitFlushed: block_version->created_ is not empty");
     }
     block_version->created_.emplace_back(commit_ts, this->row_count_);
 
-    FlushVersion(*block_version);
+    FlushVersion(commit_ts);
 }
 
 void BlockEntry::CommitBlock(TransactionID txn_id, TxnTimeStamp commit_ts) {
@@ -221,76 +238,57 @@ void BlockEntry::CommitBlock(TransactionID txn_id, TxnTimeStamp commit_ts) {
     }
 }
 
-void BlockEntry::FlushData(int64_t checkpoint_row_count) {
+void BlockEntry::FlushData(SizeT start_row_count, SizeT checkpoint_row_count) {
     SizeT column_count = this->columns_.size();
     SizeT column_idx = 0;
     while (column_idx < column_count) {
         BlockColumnEntry *block_column_entry = this->columns_[column_idx].get();
-        BlockColumnEntry::Flush(block_column_entry, checkpoint_row_count);
+        BlockColumnEntry::Flush(block_column_entry, start_row_count, checkpoint_row_count);
         LOG_TRACE(fmt::format("ColumnData {} is flushed", block_column_entry->column_id()));
         ++column_idx;
     }
 }
 
-void BlockEntry::FlushVersion(BlockVersion &checkpoint_version) { checkpoint_version.SaveToFile(this->VersionFilePath()); }
+bool BlockEntry::FlushVersion(TxnTimeStamp checkpoint_ts) {
+    std::shared_lock<std::shared_mutex> lock(this->rw_locker_);
+    // Skip if entry has been flushed at some previous checkpoint, or is invisible at current checkpoint.
+    if (this->max_row_ts_ <= this->checkpoint_ts_ || this->min_row_ts_ > checkpoint_ts) {
+        return false;
+    }
 
-void BlockEntry::Flush(TxnTimeStamp checkpoint_ts, bool check_commit) {
+    auto *version_file_worker = static_cast<VersionFileWorker *>(block_version_->file_worker());
+    version_file_worker->SetCheckpointTS(checkpoint_ts);
+    block_version_->Save();
+
+    return true;
+}
+
+void BlockEntry::Flush(TxnTimeStamp checkpoint_ts) {
     LOG_TRACE(fmt::format("Segment: {}, Block: {} is flushing", this->segment_entry_->segment_id(), this->block_id_));
     if (checkpoint_ts < this->checkpoint_ts_) {
         UnrecoverableError(
             fmt::format("BlockEntry checkpoint_ts skew! checkpoint_ts: {}, this->checkpoint_ts_: {}", checkpoint_ts, this->checkpoint_ts_));
     }
-    int checkpoint_row_count = 0;
 
-    BlockVersion checkpoint_version(this->block_version_->deleted_.size());
-    {
-        std::shared_lock<std::shared_mutex> lock(this->rw_locker_);
-
-        if (check_commit) {
-            // Skip if entry has been flushed at some previous checkpoint, or is invisible at current checkpoint.
-            if (this->max_row_ts_ <= this->checkpoint_ts_ || this->min_row_ts_ > checkpoint_ts)
-                return;
-            checkpoint_row_count = this->block_version_->GetRowCount(checkpoint_ts);
-        } else {
-            checkpoint_row_count = this->row_count_;
-        }
-        if (checkpoint_row_count == 0) {
-            LOG_TRACE(fmt::format("Block entry {} is empty at checkpoint_ts {}", this->block_id_, checkpoint_ts));
-            return;
-        }
-        const Vector<TxnTimeStamp> &deleted = this->block_version_->deleted_;
-        if (checkpoint_row_count <= this->checkpoint_row_count_) {
-            // BlockEntry doesn't append rows between the previous checkpoint and checkpoint_ts.
-            bool deleted_between = false;
-            for (int i = 0; i < checkpoint_row_count; i++) {
-                if (deleted[i] > this->checkpoint_ts_ && deleted[i] <= checkpoint_ts) {
-                    deleted_between = true;
-                    break;
-                }
-            }
-            if (!deleted_between) // BlockEntry doesn't change between the previous checkpoint and checkpoint_ts.
-                return;
-        }
-        checkpoint_version.created_ = this->block_version_->created_;
-        checkpoint_version.deleted_ = deleted;
-    }
-    for (int i = 0; i < checkpoint_row_count; i++) {
-        if (checkpoint_version.deleted_[i] > checkpoint_ts) {
-            checkpoint_version.deleted_[i] = 0;
-        }
-    }
     LOG_TRACE("Block entry flush before flush version");
-    FlushVersion(checkpoint_version);
-    LOG_TRACE("Block entry flush before flush data");
-    FlushData(checkpoint_row_count);
-    this->checkpoint_ts_ = checkpoint_ts;
-    this->checkpoint_row_count_ = checkpoint_row_count;
-    LOG_TRACE(
-        fmt::format("Segment: {}, Block {} is flushed {} rows", this->segment_entry_->segment_id(), this->block_id_, this->checkpoint_row_count_));
-    return;
+    bool flush = FlushVersion(checkpoint_ts);
+    if (flush) {
+        auto block_version_handle = block_version_->Load();
+        auto *block_version = static_cast<const BlockVersion *>(block_version_handle.GetData());
+        SizeT checkpoint_row_count = block_version->GetRowCount(checkpoint_ts);
+
+        LOG_TRACE("Block entry flush before flush data");
+        FlushData(this->checkpoint_row_count_, checkpoint_row_count);
+        this->checkpoint_ts_ = checkpoint_ts;
+        this->checkpoint_row_count_ = checkpoint_row_count;
+        LOG_TRACE(fmt::format("Segment: {}, Block {} is flushed {} rows",
+                              this->segment_entry_->segment_id(),
+                              this->block_id_,
+                              this->checkpoint_row_count_));
+    }
 }
 
-void BlockEntry::FlushForImport(TxnTimeStamp checkpoint_ts) { this->Flush(checkpoint_ts, false); }
+void BlockEntry::FlushForImport() { FlushData(0, this->row_count_); }
 
 void BlockEntry::LoadFilterBinaryData(const String &block_filter_data) { fast_rough_filter_.DeserializeFromString(block_filter_data); }
 
@@ -298,7 +296,7 @@ void BlockEntry::Cleanup() {
     for (auto &block_column_entry : columns_) {
         block_column_entry->Cleanup();
     }
-    block_version_->Cleanup(this->VersionFilePath());
+    block_version_->Cleanup();
 
     CleanupScanner::CleanupDir(*block_dir_);
 }
@@ -355,11 +353,6 @@ UniquePtr<BlockEntry> BlockEntry::Deserialize(const nlohmann::json &block_entry_
 
     block_entry->begin_ts_ = block_entry_json["begin_ts"];
     block_entry->txn_id_ = block_entry_json["txn_id"];
-
-    block_entry->block_version_->LoadFromFile(block_entry->VersionFilePath());
-    if (block_entry->block_version_->created_.empty()) {
-        block_entry->block_version_->created_.emplace_back(block_entry->max_row_ts_, block_entry->row_count_);
-    }
 
     for (const auto &block_column_json : block_entry_json["columns"]) {
         block_entry->columns_.emplace_back(BlockColumnEntry::Deserialize(block_column_json, block_entry.get(), buffer_mgr));

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -45,9 +45,11 @@ export struct BlockEntry : public BaseEntry {
     friend struct SegmentEntry;
     friend struct WalBlockInfo;
 
+    static String EncodeIndex(const BlockID block_id, const SegmentEntry *segment_entry);
+
 public:
     // for iterator unit test
-    explicit BlockEntry() : BaseEntry(EntryType::kBlock, false){};
+    explicit BlockEntry() : BaseEntry(EntryType::kBlock, false, ""){};
 
     // Normal Constructor
     explicit BlockEntry(const SegmentEntry *segment_entry, BlockID block_id, TxnTimeStamp checkpoint_ts);

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -29,6 +29,7 @@ import block_column_entry;
 import block_version;
 import fast_rough_filter;
 import value;
+import buffer_obj;
 
 namespace infinity {
 
@@ -76,9 +77,9 @@ public:
 
     void Cleanup();
 
-    void Flush(TxnTimeStamp checkpoint_ts, bool check_commit = true);
+    void Flush(TxnTimeStamp checkpoint_ts);
 
-    void FlushForImport(TxnTimeStamp checkpoint_ts);
+    void FlushForImport();
 
     void LoadFilterBinaryData(const String &block_filter_data);
 
@@ -144,9 +145,9 @@ public:
     inline void IncreaseRowCount(SizeT increased_row_count) { row_count_ += increased_row_count; }
 
 private:
-    void FlushData(i64 checkpoint_row_count);
+    void FlushData(SizeT start_row_count, SizeT checkpoint_row_count);
 
-    void FlushVersion(BlockVersion &checkpoint_version);
+    bool FlushVersion(TxnTimeStamp checkpoint_ts);
 
 protected:
     mutable std::shared_mutex rw_locker_{};
@@ -158,7 +159,8 @@ protected:
     u16 row_count_{};
     u16 row_capacity_{};
 
-    UniquePtr<BlockVersion> block_version_{};
+    // UniquePtr<BlockVersion> block_version_{};
+    BufferObj *block_version_{};
 
     // check if a value must not exist in the block
     FastRoughFilter fast_rough_filter_;

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -68,6 +68,8 @@ public:
                                                      u16 checkpoint_row_count,
                                                      BufferManager *buffer_mgr);
 
+    void UpdateBlockReplay(SharedPtr<BlockEntry> block_entry, String block_filter_binary_data);
+
 public:
     nlohmann::json Serialize(TxnTimeStamp max_commit_ts);
 

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -88,6 +88,8 @@ protected:
 
     void DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const Vector<BlockOffset> &rows);
 
+    void CommitFlushed(TxnTimeStamp commit_ts);
+
     void CommitBlock(TransactionID txn_id, TxnTimeStamp commit_ts);
 
     static SharedPtr<String> DetermineDir(const String &parent_dir, BlockID block_id);

--- a/src/storage/meta/entry/block_version.cpp
+++ b/src/storage/meta/entry/block_version.cpp
@@ -28,6 +28,18 @@ import local_file_system;
 
 namespace infinity {
 
+void CreateField::SaveToFile(FileHandler &file_handler) const {
+    file_handler.Write(&create_ts_, sizeof(create_ts_));
+    file_handler.Write(&row_count_, sizeof(row_count_));
+}
+
+CreateField CreateField::LoadFromFile(FileHandler &file_handler) {
+    CreateField create_field;
+    file_handler.Read(&create_field.create_ts_, sizeof(create_field.create_ts_));
+    file_handler.Read(&create_field.row_count_, sizeof(create_field.row_count_));
+    return create_field;
+}
+
 bool BlockVersion::operator==(const BlockVersion &rhs) const {
     if (this->created_.size() != rhs.created_.size() || this->deleted_.size() != rhs.deleted_.size())
         return false;
@@ -42,7 +54,7 @@ bool BlockVersion::operator==(const BlockVersion &rhs) const {
     return true;
 }
 
-i32 BlockVersion::GetRowCount(TxnTimeStamp begin_ts) {
+i32 BlockVersion::GetRowCount(TxnTimeStamp begin_ts) const {
     if (created_.empty())
         return 0;
     i64 idx = created_.size() - 1;
@@ -55,60 +67,65 @@ i32 BlockVersion::GetRowCount(TxnTimeStamp begin_ts) {
     return created_[idx].row_count_;
 }
 
-void BlockVersion::LoadFromFile(const String &version_path) {
-    std::ifstream ifs(version_path);
-    if (!ifs.is_open()) {
-        LOG_WARN(fmt::format("Failed to open block_version file to read: {}", version_path));
-        // load the block_version file not exist return and create version
-        return;
+void BlockVersion::SaveToFile(TxnTimeStamp checkpoint_ts, FileHandler &file_handler) const {
+    BlockOffset create_size = created_.size();
+    while (create_size > 0 && created_[create_size - 1].create_ts_ > checkpoint_ts) {
+        --create_size;
     }
-    int buf_len = std::filesystem::file_size(version_path);
-    Vector<char> buf(buf_len);
-    ifs.read(buf.data(), buf_len);
-    ifs.close();
-    char *ptr = buf.data();
-    i32 created_size = ReadBufAdv<i32>(ptr);
-    i32 deleted_size = ReadBufAdv<i32>(ptr);
-    created_.resize(created_size);
-    deleted_.resize(deleted_size);
-    std::memcpy(created_.data(), ptr, created_size * sizeof(CreateField));
-    ptr += created_size * sizeof(CreateField);
-    std::memcpy(deleted_.data(), ptr, deleted_size * sizeof(TxnTimeStamp));
-    ptr += deleted_.size() * sizeof(TxnTimeStamp);
-    if (ptr - buf.data() != buf_len) {
-        UnrecoverableError(fmt::format("Failed to load block_version file: {}", version_path));
+
+    file_handler.Write(&create_size, sizeof(create_size));
+    for (SizeT j = 0; j < create_size; ++j) {
+        created_[j].SaveToFile(file_handler);
+    }
+
+    BlockOffset capacity = deleted_.size();
+    file_handler.Write(&capacity, sizeof(capacity));
+    TxnTimeStamp dump_ts = 0;
+    for (const auto &ts : deleted_) {
+        if (ts <= checkpoint_ts) {
+            file_handler.Write(&ts, sizeof(ts));
+        } else {
+            file_handler.Write(&dump_ts, sizeof(dump_ts));
+        }
     }
 }
 
-void BlockVersion::SaveToFile(const String &version_path) {
-    i32 exp_size = sizeof(i32) + created_.size() * sizeof(CreateField);
-    exp_size += sizeof(i32) + deleted_.size() * sizeof(TxnTimeStamp);
-    Vector<char> buf(exp_size, 0);
-    char *ptr = buf.data();
-    WriteBufAdv<i32>(ptr, i32(created_.size()));
-    WriteBufAdv<i32>(ptr, i32(deleted_.size()));
-    std::memcpy(ptr, created_.data(), created_.size() * sizeof(CreateField));
-    ptr += created_.size() * sizeof(CreateField);
-    std::memcpy(ptr, deleted_.data(), deleted_.size() * sizeof(TxnTimeStamp));
-    ptr += deleted_.size() * sizeof(TxnTimeStamp);
-    if (ptr - buf.data() != exp_size) {
-        UnrecoverableError(fmt::format("Failed to save block_version file: {}", version_path));
+void BlockVersion::SpillToFile(FileHandler &file_handler) const {
+    BlockOffset create_size = created_.size();
+    file_handler.Write(&create_size, sizeof(create_size));
+    for (const auto &create : created_) {
+        create.SaveToFile(file_handler);
     }
-    std::ofstream ofs = std::ofstream(version_path, std::ios::trunc | std::ios::binary);
-    if (!ofs.is_open()) {
-        UnrecoverableError(fmt::format("Failed to open block_version file: {}, {}", version_path, ofs.rdstate()));
-    }
-    ofs.write(buf.data(), ptr - buf.data());
-    ofs.flush();
-    ofs.close();
+
+    BlockOffset capacity = deleted_.size();
+    file_handler.Write(&capacity, sizeof(capacity));
+    file_handler.Write(deleted_.data(), capacity * sizeof(TxnTimeStamp));
 }
 
-void BlockVersion::Cleanup(const String &version_path) {
-    LocalFileSystem fs;
+UniquePtr<BlockVersion> BlockVersion::LoadFromFile(FileHandler &file_handler) {
+    auto block_version = MakeUnique<BlockVersion>();
 
-    if (fs.Exists(version_path)) {
-        fs.DeleteFile(version_path);
+    BlockOffset create_size;
+    file_handler.Read(&create_size, sizeof(create_size));
+    block_version->created_.reserve(create_size);
+    for (BlockOffset i = 0; i < create_size; i++) {
+        block_version->created_.push_back(CreateField::LoadFromFile(file_handler));
     }
+    BlockOffset capacity;
+    file_handler.Read(&capacity, sizeof(capacity));
+    block_version->deleted_.resize(capacity);
+    for (BlockOffset i = 0; i < capacity; i++) {
+        file_handler.Read(&block_version->deleted_[i], sizeof(TxnTimeStamp));
+    }
+    return block_version;
 }
+
+// void BlockVersion::Cleanup(const String &version_path) {
+//     LocalFileSystem fs;
+
+//     if (fs.Exists(version_path)) {
+//         fs.DeleteFile(version_path);
+//     }
+// }
 
 } // namespace infinity

--- a/src/storage/meta/entry/block_version.cppm
+++ b/src/storage/meta/entry/block_version.cppm
@@ -17,6 +17,7 @@ module;
 export module block_version;
 
 import stl;
+import file_system;
 
 namespace infinity {
 
@@ -29,19 +30,32 @@ struct CreateField {
     bool operator==(const CreateField &rhs) const { return create_ts_ == rhs.create_ts_ && row_count_ == rhs.row_count_; }
 
     bool operator!=(const CreateField &rhs) const { return !(*this == rhs); }
+
+    void SaveToFile(FileHandler &file_handler) const;
+
+    static CreateField LoadFromFile(FileHandler &file_handler);
 };
 
 export struct BlockVersion {
     constexpr static std::string_view PATH = "version";
 
+    static SharedPtr<String> FileName() { return MakeShared<String>(PATH); }
+
     explicit BlockVersion(SizeT capacity) : deleted_(capacity, 0) {}
+    BlockVersion() = default;
+
     bool operator==(const BlockVersion &rhs) const;
     bool operator!=(const BlockVersion &rhs) const { return !(*this == rhs); };
-    i32 GetRowCount(TxnTimeStamp begin_ts);
-    void LoadFromFile(const String &version_path);
-    void SaveToFile(const String &version_path);
 
-    void Cleanup(const String &version_path);
+    i32 GetRowCount(TxnTimeStamp begin_ts) const;
+
+    void SaveToFile(TxnTimeStamp checkpoint_ts, FileHandler &file_handler) const;
+
+    void SpillToFile(FileHandler &file_handler) const;
+
+    static UniquePtr<BlockVersion> LoadFromFile(FileHandler &file_handler);
+
+    // void Cleanup(const String &version_path);
 
     Vector<CreateField> created_{}; // second field width is same as timestamp, otherwise Valgrind will issue BlockVersion::SaveToFile has
                                     // risk to write uninitialized buffer. (ts, rows)

--- a/src/storage/meta/entry/chunk_index_entry.cpp
+++ b/src/storage/meta/entry/chunk_index_entry.cpp
@@ -40,9 +40,13 @@ import index_defines;
 
 namespace infinity {
 
+String ChunkIndexEntry::EncodeIndex(const ChunkID chunk_id, const SegmentIndexEntry *segment_index_entry) {
+    return fmt::format("{}#{}", segment_index_entry->encode(), chunk_id);
+}
+
 ChunkIndexEntry::ChunkIndexEntry(ChunkID chunk_id, SegmentIndexEntry *segment_index_entry, const String &base_name, RowID base_rowid, u32 row_count)
-    : BaseEntry(EntryType::kChunkIndex, false), chunk_id_(chunk_id), segment_index_entry_(segment_index_entry), base_name_(base_name),
-      base_rowid_(base_rowid), row_count_(row_count){};
+    : BaseEntry(EntryType::kChunkIndex, false, ChunkIndexEntry::EncodeIndex(chunk_id, segment_index_entry)), chunk_id_(chunk_id),
+      segment_index_entry_(segment_index_entry), base_name_(base_name), base_rowid_(base_rowid), row_count_(row_count){};
 
 UniquePtr<IndexFileWorker> ChunkIndexEntry::CreateFileWorker(const IndexBase *index_base,
                                                              const SharedPtr<String> &index_dir,

--- a/src/storage/meta/entry/chunk_index_entry.cppm
+++ b/src/storage/meta/entry/chunk_index_entry.cppm
@@ -40,6 +40,8 @@ struct SegmentEntry;
 // ChunkIndexEntry is an immutable chunk of SegmentIndexEntry. MemIndexer(for fulltext) is the mutable chunk of SegmentIndexEntry.
 export class ChunkIndexEntry : public BaseEntry, public EntryInterface {
 private:
+    static String EncodeIndex(const ChunkID chunk_id, const SegmentIndexEntry *segment_index_entry);
+
     ChunkIndexEntry(ChunkID chunk_id, SegmentIndexEntry *segment_index_entry, const String &base_name, RowID base_rowid, u32 row_count);
 
     static UniquePtr<IndexFileWorker> CreateFileWorker(const IndexBase *index_base,

--- a/src/storage/meta/entry/db_entry.cpp
+++ b/src/storage/meta/entry/db_entry.cpp
@@ -38,13 +38,15 @@ import cleanup_scanner;
 
 namespace infinity {
 
+String DBEntry::EncodeIndex(const String &db_name) { return fmt::format("#{}", db_name); }
+
 DBEntry::DBEntry(DBMeta *db_meta,
                  bool is_delete,
                  const SharedPtr<String> &db_entry_dir,
                  const SharedPtr<String> &db_name,
                  TransactionID txn_id,
                  TxnTimeStamp begin_ts)
-    : BaseEntry(EntryType::kDatabase, is_delete), db_meta_(db_meta), db_entry_dir_(db_entry_dir), db_name_(db_name) {
+    : BaseEntry(EntryType::kDatabase, is_delete, DBEntry::EncodeIndex(*db_name)), db_meta_(db_meta), db_entry_dir_(db_entry_dir), db_name_(db_name) {
     begin_ts_ = begin_ts;
     txn_id_.store(txn_id);
 }

--- a/src/storage/meta/entry/db_entry.cppm
+++ b/src/storage/meta/entry/db_entry.cppm
@@ -41,6 +41,8 @@ class DBMeta;
 export class DBEntry final : public BaseEntry, public EntryInterface {
     friend struct Catalog;
 
+    static String EncodeIndex(const String &db_name);
+
 public:
     explicit DBEntry(DBMeta *db_meta,
                      bool is_delete,

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -322,6 +322,12 @@ void SegmentEntry::DeleteData(TransactionID txn_id,
     }
 }
 
+void SegmentEntry::CommitFlushed(TxnTimeStamp commit_ts) {
+    for (auto &block_entry : block_entries_) {
+        block_entry->CommitFlushed(commit_ts);
+    }
+}
+
 void SegmentEntry::CommitSegment(TransactionID txn_id, TxnTimeStamp commit_ts) {
     std::unique_lock w_lock(rw_locker_);
     min_row_ts_ = std::min(min_row_ts_, commit_ts);

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -440,9 +440,9 @@ SharedPtr<SegmentEntry> SegmentEntry::Deserialize(const nlohmann::json &segment_
     return segment_entry;
 }
 
-void SegmentEntry::FlushNewData(TxnTimeStamp flush_ts) {
+void SegmentEntry::FlushNewData() {
     for (const auto &block_entry : this->block_entries_) {
-        block_entry->FlushForImport(flush_ts);
+        block_entry->FlushForImport();
     }
 }
 

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -46,14 +46,21 @@ import wal_entry;
 
 namespace infinity {
 
+String SegmentEntry::EncodeIndex(const SegmentID segment_id, const TableEntry *table_entry) {
+    if (table_entry == nullptr) {
+        return ""; // unit test
+    }
+    return fmt::format("{}#{}", table_entry->encode(), segment_id);
+}
+
 SegmentEntry::SegmentEntry(TableEntry *table_entry,
                            SharedPtr<String> segment_dir,
                            SegmentID segment_id,
                            SizeT row_capacity,
                            SizeT column_count,
                            SegmentStatus status)
-    : BaseEntry(EntryType::kSegment, false), table_entry_(table_entry), segment_dir_(segment_dir), segment_id_(segment_id),
-      row_capacity_(row_capacity), column_count_(column_count), status_(status) {}
+    : BaseEntry(EntryType::kSegment, false, SegmentEntry::EncodeIndex(segment_id, table_entry)), table_entry_(table_entry), segment_dir_(segment_dir),
+      segment_id_(segment_id), row_capacity_(row_capacity), column_count_(column_count), status_(status) {}
 
 SharedPtr<SegmentEntry> SegmentEntry::NewSegmentEntry(TableEntry *table_entry, SegmentID segment_id, Txn *txn) {
     SharedPtr<SegmentEntry> segment_entry = MakeShared<SegmentEntry>(table_entry,

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -93,7 +93,7 @@ public:
 
     void RollbackCompact();
 
-    void FlushNewData(TxnTimeStamp flush_ts);
+    void FlushNewData();
 
     static bool CheckDeleteConflict(Vector<Pair<SegmentEntry *, Vector<SegmentOffset>>> &&segments, TransactionID txn_id);
 

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -52,6 +52,8 @@ public:
     friend struct TableEntry;
     friend struct WalSegmentInfo;
 
+    static String EncodeIndex(const SegmentID segment_id, const TableEntry *table_entry);
+
 public:
     explicit SegmentEntry(TableEntry *table_entry,
                           SharedPtr<String> segment_dir,

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -164,6 +164,8 @@ public:
 
     void DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const HashMap<BlockID, Vector<BlockOffset>> &block_row_hashmap, Txn *txn);
 
+    void CommitFlushed(TxnTimeStamp commit_ts);
+
     void CommitSegment(TransactionID txn_id, TxnTimeStamp commit_ts);
 
     void RollbackBlocks(TxnTimeStamp commit_ts, const Vector<BlockEntry *> &block_entry);

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -78,12 +78,16 @@ public:
                                                          TxnTimeStamp begin_ts,
                                                          TransactionID txn_id);
 
+    void UpdateSegmentReplay(SharedPtr<SegmentEntry> segment_entry, String segment_filter_binary_data);
+
     nlohmann::json Serialize(TxnTimeStamp max_commit_ts);
 
     static SharedPtr<SegmentEntry> Deserialize(const nlohmann::json &table_entry_json, TableEntry *table_entry, BufferManager *buffer_mgr);
 
 public:
-    void AddBlockReplay(SharedPtr<BlockEntry> block_entry, BlockID block_id);
+    void AddBlockReplay(SharedPtr<BlockEntry> block_entry);
+
+    void UpdateBlockReplay(SharedPtr<BlockEntry> block_entry, String block_filter_binary_data);
 
     bool SetSealed();
 

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -61,9 +61,16 @@ import txn_store;
 
 namespace infinity {
 
+String SegmentIndexEntry::EncodeIndex(const SegmentID segment_id, const TableIndexEntry *table_index_entry) {
+    if (table_index_entry == nullptr) {
+        return ""; // unit test
+    }
+    return fmt::format("{}#{}", table_index_entry->encode(), segment_id);
+}
+
 SegmentIndexEntry::SegmentIndexEntry(TableIndexEntry *table_index_entry, SegmentID segment_id, Vector<BufferObj *> vector_buffer)
-    : BaseEntry(EntryType::kSegmentIndex, false), table_index_entry_(table_index_entry), segment_id_(segment_id),
-      vector_buffer_(std::move(vector_buffer)) {
+    : BaseEntry(EntryType::kSegmentIndex, false, SegmentIndexEntry::EncodeIndex(segment_id, table_index_entry)),
+      table_index_entry_(table_index_entry), segment_id_(segment_id), vector_buffer_(std::move(vector_buffer)) {
     if (table_index_entry != nullptr)
         index_dir_ = table_index_entry->index_dir();
 };

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -226,7 +226,8 @@ void SegmentIndexEntry::MemIndexInsert(SharedPtr<BlockEntry> block_entry,
                                        BufferManager *buffer_manager) {
     u32 seg_id = block_entry->segment_id();
     u16 block_id = block_entry->block_id();
-    RowID begin_row_id(seg_id, row_offset + u32(block_id) * block_entry->row_capacity());
+    SegmentOffset block_offset = u32(block_id) * block_entry->row_capacity();
+    RowID begin_row_id(seg_id, row_offset + block_offset);
 
     const SharedPtr<IndexBase> &index_base = table_index_entry_->table_index_def();
     const SharedPtr<ColumnDef> &column_def = table_index_entry_->column_def();
@@ -277,7 +278,7 @@ void SegmentIndexEntry::MemIndexInsert(SharedPtr<BlockEntry> block_entry,
             switch (embedding_info->Type()) {
                 case kElemFloat: {
                     AbstractHnsw<f32, SegmentOffset> abstract_hnsw(buffer_handle.GetDataMut(), index_hnsw);
-                    MemIndexInserterIter<f32> iter(0, block_column_entry, buffer_manager, row_offset, row_count);
+                    MemIndexInserterIter<f32> iter(block_offset, block_column_entry, buffer_manager, row_offset, row_count);
                     auto [start_i, end_i] = abstract_hnsw.InsertVecs(std::move(iter));
                     row_cnt = end_i;
                     break;

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -51,6 +51,8 @@ export struct PopulateEntireConfig {
 
 export class SegmentIndexEntry : public BaseEntry, public EntryInterface {
 
+    static String EncodeIndex(const SegmentID segment_id, const TableIndexEntry *table_index_entry);
+
 public:
     static SharedPtr<SegmentIndexEntry>
     NewIndexEntry(TableIndexEntry *table_index_entry, SegmentID segment_id, Txn *txn, CreateIndexParam *create_index_param);

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -135,7 +135,9 @@ private:
     void AddSegmentReplayWal(SharedPtr<SegmentEntry> segment_entry);
 
 public:
-    void AddSegmentReplay(std::function<SharedPtr<SegmentEntry>()> &&init_segment, SegmentID segment_id);
+    void AddSegmentReplay(SharedPtr<SegmentEntry> segment_entry);
+
+    void UpdateSegmentReplay(SharedPtr<SegmentEntry> segment_entry, String segment_filter_binary_data);
 
 public:
     TableMeta *GetTableMeta() const { return table_meta_; }

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -56,6 +56,8 @@ class AddTableEntryOp;
 export struct TableEntry final : public BaseEntry, public EntryInterface {
     friend struct Catalog;
 
+    static String EncodeIndex(const String &table_name, TableMeta *table_meta);
+
 public:
     using EntryOp = AddTableEntryOp;
 

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -44,14 +44,19 @@ import table_entry;
 
 namespace infinity {
 
+String TableIndexEntry::EncodeIndex(const String &index_name, TableIndexMeta *table_index_meta) {
+    return fmt::format("{}#{}", table_index_meta->GetTableEntry()->encode(), index_name);
+}
+
 TableIndexEntry::TableIndexEntry(const SharedPtr<IndexBase> &index_base,
                                  bool is_delete,
                                  TableIndexMeta *table_index_meta,
                                  const SharedPtr<String> &index_entry_dir,
                                  TransactionID txn_id,
                                  TxnTimeStamp begin_ts)
-    : BaseEntry(EntryType::kTableIndex, is_delete), byte_slice_pool_(), buffer_pool_(), inverting_thread_pool_(4), commiting_thread_pool_(2),
-      table_index_meta_(table_index_meta), index_base_(std::move(index_base)), index_dir_(index_entry_dir) {
+    : BaseEntry(EntryType::kTableIndex, is_delete, TableIndexEntry::EncodeIndex(*index_base->index_name_, table_index_meta)), byte_slice_pool_(),
+      buffer_pool_(), inverting_thread_pool_(4), commiting_thread_pool_(2), table_index_meta_(table_index_meta), index_base_(std::move(index_base)),
+      index_dir_(index_entry_dir) {
     if (!is_delete) {
         assert(index_base.get() != nullptr);
         const String &column_name = index_base->column_name();

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -49,6 +49,8 @@ class AddTableIndexEntryOp;
 export struct TableIndexEntry : public BaseEntry, public EntryInterface {
     friend struct TableEntry;
 
+    static String EncodeIndex(const String &index_name, TableIndexMeta *table_index_meta);
+
 public:
     using EntryOp = AddTableIndexEntryOp;
 

--- a/src/storage/meta/entry/view_entry.cppm
+++ b/src/storage/meta/entry/view_entry.cppm
@@ -41,7 +41,7 @@ public:
                        ViewMeta *view_meta,
                        TransactionID txn_id,
                        TxnTimeStamp begin_ts)
-        : BaseEntry(EntryType::kView, deleted), create_view_info_(create_view_info), base_dir_(base_dir), view_name_(std::move(view_name)),
+        : BaseEntry(EntryType::kView, deleted, ""), create_view_info_(create_view_info), base_dir_(base_dir), view_name_(std::move(view_name)),
           column_types_(std::move(column_types)), column_names_(std::move(column_names)), view_meta_(view_meta) {
         begin_ts_ = begin_ts;
         txn_id_ = txn_id;

--- a/src/storage/meta/table_index_meta.cppm
+++ b/src/storage/meta/table_index_meta.cppm
@@ -59,6 +59,7 @@ public:
 
     Tuple<SharedPtr<TableIndexEntry>, Status> DropTableIndexEntry(std::shared_lock<std::shared_mutex> &&r_lock,
                                                                   ConflictType conflict_type,
+                                                                  SharedPtr<String> index_name,
                                                                   TransactionID txn_id,
                                                                   TxnTimeStamp begin_ts,
                                                                   TxnManager *txn_mgr);

--- a/src/storage/meta/table_meta.cppm
+++ b/src/storage/meta/table_meta.cppm
@@ -61,6 +61,8 @@ public:
     [[nodiscard]] const SharedPtr<String> &db_entry_dir_ptr() const { return db_entry_dir_; }
     [[nodiscard]] const String &db_entry_dir() const { return *db_entry_dir_; }
 
+    DBEntry *db_entry() { return db_entry_; }
+
 private:
     Tuple<TableEntry *, Status> CreateEntry(std::shared_lock<std::shared_mutex> &&r_lock,
                                             TableEntryType table_entry_type,

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -405,6 +405,8 @@ WalEntry *Txn::GetWALEntry() const { return wal_entry_.get(); }
 // }
 
 TxnTimeStamp Txn::Commit() {
+    txn_store_.PrepareCommit1();
+
     //    TxnTimeStamp commit_ts = txn_mgr_->GetTimestamp(true);
     //    txn_context_.SetTxnCommitting(commit_ts);
 

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -337,7 +337,7 @@ void TxnTableStore::AddSegmentStore(SegmentEntry *segment_entry) {
 void TxnTableStore::AddBlockStore(SegmentEntry *segment_entry, BlockEntry *block_entry) {
     auto iter = txn_segments_store_.find(segment_entry->segment_id());
     if (iter == txn_segments_store_.end()) {
-        iter = txn_segments_store_.emplace(segment_entry->segment_id(), TxnSegmentStore::AddSegmentStore(segment_entry)).first;
+        iter = txn_segments_store_.emplace(segment_entry->segment_id(), TxnSegmentStore(segment_entry)).first;
     }
     iter->second.block_entries_.emplace_back(block_entry);
 }

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -365,11 +365,11 @@ void TxnTableStore::AddDeltaOp(CatalogDeltaEntry *local_delta_ops, TxnManager *t
         // now have minmax filter and optional bloom filter
         // serialize filter
         local_delta_ops->AddOperation(
-            MakeUnique<SetSegmentStatusSealedOp>(sealed_segment, sealed_segment->GetFastRoughFilter()->SerializeToString(), commit_ts));
+            MakeUnique<AddSegmentEntryOp>(sealed_segment, commit_ts, sealed_segment->GetFastRoughFilter()->SerializeToString()));
         // FIXME: hack here
         for (auto &block_entry : sealed_segment->block_entries()) {
             local_delta_ops->AddOperation(
-                MakeUnique<SetBlockStatusSealedOp>(block_entry.get(), block_entry->GetFastRoughFilter()->SerializeToString(), commit_ts));
+                MakeUnique<AddBlockEntryOp>(block_entry.get(), commit_ts, block_entry->GetFastRoughFilter()->SerializeToString()));
         }
     }
     if (compact_state_.task_type_ != CompactSegmentsTaskType::kInvalid) {

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -115,6 +115,8 @@ public:
 
     bool CheckConflict(Catalog *catalog) const;
 
+    void PrepareCommit1();
+
     void PrepareCommit(TransactionID txn_id, TxnTimeStamp commit_ts, BufferManager *buffer_mgr);
 
     void Commit(TransactionID txn_id, TxnTimeStamp commit_ts) const;
@@ -136,6 +138,7 @@ public: // Getter
 
 private:
     HashMap<SegmentID, TxnSegmentStore> txn_segments_store_{};
+    Vector<SegmentEntry *> flushed_segments_{};
     Vector<SegmentEntry *> set_sealed_segments_{};
 
     int ptr_seq_n_;
@@ -177,6 +180,8 @@ public:
     void MaintainCompactionAlg() const;
 
     bool CheckConflict() const;
+
+    void PrepareCommit1();
 
     void PrepareCommit(TransactionID txn_id, TxnTimeStamp commit_ts, BufferManager *buffer_mgr);
 

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -590,13 +590,14 @@ const String AddColumnEntryOp::ToString() const {
 }
 
 const String AddTableIndexEntryOp::ToString() const {
+    bool is_delete = merge_flag_ == MergeFlag::kDelete;
     return fmt::format("AddTableIndexEntryOp {} db_name: {} table_name: {} index_name: {} index_dir: {} index_base: {}",
                        CatalogDeltaOperation::ToString(),
                        *db_name_,
                        *table_name_,
                        *index_name_,
-                       index_dir_.get() != nullptr ? *index_dir_ : "nullptr",
-                       index_base_.get() != nullptr ? index_base_->ToString() : "nullptr");
+                       !is_delete ? *index_dir_ : "nullptr",
+                       !is_delete ? index_base_->ToString() : "nullptr");
 }
 
 const String AddSegmentIndexEntryOp::ToString() const {
@@ -1043,9 +1044,6 @@ void GlobalCatalogDeltaEntry::AddDeltaEntryInner(CatalogDeltaEntry *delta_entry)
             }
         }
         String encode = new_op->EncodeIndex();
-        // if (encode == "#default#test_csv_with_different_delimiter@2") {
-        //     LOG_INFO("AAA");
-        // }
         auto iter = delta_ops_.find(encode);
         if (iter != delta_ops_.end()) {
             auto *op = iter->second.get();

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -87,14 +87,6 @@ UniquePtr<CatalogDeltaOperation> CatalogDeltaOperation::ReadAdv(char *&ptr, i32 
             operation = AddChunkIndexEntryOp::ReadAdv(ptr);
             break;
         }
-        case CatalogDeltaOpType::SET_SEGMENT_STATUS_SEALED: {
-            operation = SetSegmentStatusSealedOp::ReadAdv(ptr);
-            break;
-        }
-        case CatalogDeltaOpType::SET_BLOCK_STATUS_SEALED: {
-            operation = SetBlockStatusSealedOp::ReadAdv(ptr);
-            break;
-        }
         default:
             UnrecoverableError(fmt::format("UNIMPLEMENTED ReadAdv for CatalogDeltaOperation type {}", int(operation_type)));
     }
@@ -191,6 +183,7 @@ MergeFlag CatalogDeltaOperation::NextDeleteFlag(MergeFlag new_merge_flag) const 
                     UnrecoverableError("Should prune before reach this.");
                     break;
                 }
+                case MergeFlag::kNew:
                 case MergeFlag::kUpdate:
                 case MergeFlag::kDeleteAndNew: {
                     return MergeFlag::kNew;
@@ -297,6 +290,7 @@ UniquePtr<AddSegmentEntryOp> AddSegmentEntryOp::ReadAdv(char *&ptr) {
     add_segment_op->min_row_ts_ = ReadBufAdv<TxnTimeStamp>(ptr);
     add_segment_op->max_row_ts_ = ReadBufAdv<TxnTimeStamp>(ptr);
     add_segment_op->deprecate_ts_ = ReadBufAdv<TxnTimeStamp>(ptr);
+    add_segment_op->segment_filter_binary_data_ = ReadBufAdv<String>(ptr);
     return add_segment_op;
 }
 
@@ -314,6 +308,7 @@ UniquePtr<AddBlockEntryOp> AddBlockEntryOp::ReadAdv(char *&ptr) {
     add_block_op->max_row_ts_ = ReadBufAdv<TxnTimeStamp>(ptr);
     add_block_op->checkpoint_ts_ = ReadBufAdv<TxnTimeStamp>(ptr);
     add_block_op->checkpoint_row_count_ = ReadBufAdv<u16>(ptr);
+    add_block_op->block_filter_binary_data_ = ReadBufAdv<String>(ptr);
     return add_block_op;
 }
 
@@ -374,29 +369,6 @@ UniquePtr<AddChunkIndexEntryOp> AddChunkIndexEntryOp::ReadAdv(char *&ptr) {
     return add_chunk_index_op;
 }
 
-UniquePtr<SetSegmentStatusSealedOp> SetSegmentStatusSealedOp::ReadAdv(char *&ptr) {
-    auto set_segment_status_sealed_op = MakeUnique<SetSegmentStatusSealedOp>();
-    set_segment_status_sealed_op->ReadAdvBase(ptr);
-
-    set_segment_status_sealed_op->db_name_ = MakeShared<String>(ReadBufAdv<String>(ptr));
-    set_segment_status_sealed_op->table_name_ = MakeShared<String>(ReadBufAdv<String>(ptr));
-    set_segment_status_sealed_op->segment_id_ = ReadBufAdv<SegmentID>(ptr);
-    set_segment_status_sealed_op->segment_filter_binary_data_ = ReadBufAdv<String>(ptr);
-    return set_segment_status_sealed_op;
-}
-
-UniquePtr<SetBlockStatusSealedOp> SetBlockStatusSealedOp::ReadAdv(char *&ptr) {
-    auto set_block_status_sealed_op = MakeUnique<SetBlockStatusSealedOp>();
-    set_block_status_sealed_op->ReadAdvBase(ptr);
-
-    set_block_status_sealed_op->db_name_ = MakeShared<String>(ReadBufAdv<String>(ptr));
-    set_block_status_sealed_op->table_name_ = MakeShared<String>(ReadBufAdv<String>(ptr));
-    set_block_status_sealed_op->segment_id_ = ReadBufAdv<SegmentID>(ptr);
-    set_block_status_sealed_op->block_id_ = ReadBufAdv<BlockID>(ptr);
-    set_block_status_sealed_op->block_filter_binary_data_ = ReadBufAdv<String>(ptr);
-    return set_block_status_sealed_op;
-}
-
 void AddDBEntryOp::WriteAdv(char *&buf) const {
     WriteAdvBase(buf);
     WriteBufAdv(buf, *this->db_name_);
@@ -439,6 +411,7 @@ void AddSegmentEntryOp::WriteAdv(char *&buf) const {
     WriteBufAdv(buf, this->min_row_ts_);
     WriteBufAdv(buf, this->max_row_ts_);
     WriteBufAdv(buf, this->deprecate_ts_);
+    WriteBufAdv(buf, this->segment_filter_binary_data_);
 }
 
 void AddBlockEntryOp::WriteAdv(char *&buf) const {
@@ -453,6 +426,7 @@ void AddBlockEntryOp::WriteAdv(char *&buf) const {
     WriteBufAdv(buf, this->max_row_ts_);
     WriteBufAdv(buf, this->checkpoint_ts_);
     WriteBufAdv(buf, this->checkpoint_row_count_);
+    WriteBufAdv(buf, this->block_filter_binary_data_);
 }
 
 void AddColumnEntryOp::WriteAdv(char *&buf) const {
@@ -498,23 +472,6 @@ void AddChunkIndexEntryOp::WriteAdv(char *&buf) const {
     WriteBufAdv(buf, this->base_name_);
     WriteBufAdv(buf, this->base_rowid_.ToUint64());
     WriteBufAdv(buf, this->row_count_);
-}
-
-void SetSegmentStatusSealedOp::WriteAdv(char *&buf) const {
-    WriteAdvBase(buf);
-    WriteBufAdv(buf, *this->db_name_);
-    WriteBufAdv(buf, *this->table_name_);
-    WriteBufAdv(buf, this->segment_id_);
-    WriteBufAdv(buf, this->segment_filter_binary_data_);
-}
-
-void SetBlockStatusSealedOp::WriteAdv(char *&buf) const {
-    WriteAdvBase(buf);
-    WriteBufAdv(buf, *this->db_name_);
-    WriteBufAdv(buf, *this->table_name_);
-    WriteBufAdv(buf, this->segment_id_);
-    WriteBufAdv(buf, this->block_id_);
-    WriteBufAdv(buf, this->block_filter_binary_data_);
 }
 
 const String AddDBEntryOp::ToString() const {
@@ -625,23 +582,6 @@ const String AddChunkIndexEntryOp::ToString() const {
         row_count_);
 }
 
-const String SetSegmentStatusSealedOp::ToString() const {
-    return fmt::format("SetSegmentStatusSealedOp {} db_name: {} table_name: {} segment_id: {}",
-                       CatalogDeltaOperation::ToString(),
-                       *db_name_,
-                       *table_name_,
-                       segment_id_);
-}
-
-const String SetBlockStatusSealedOp::ToString() const {
-    return fmt::format("SetBlockStatusSealedOp {} db_name: {} table_name: {} segment_id: {} block_id: {}",
-                       CatalogDeltaOperation::ToString(),
-                       *db_name_,
-                       *table_name_,
-                       segment_id_,
-                       block_id_);
-}
-
 bool AddDBEntryOp::operator==(const CatalogDeltaOperation &rhs) const {
     auto *rhs_op = dynamic_cast<const AddDBEntryOp *>(&rhs);
     return rhs_op != nullptr && CatalogDeltaOperation::operator==(rhs) && IsEqual(*db_name_, *rhs_op->db_name_) &&
@@ -711,20 +651,6 @@ bool AddChunkIndexEntryOp::operator==(const CatalogDeltaOperation &rhs) const {
            row_count_ == rhs_op->row_count_;
 }
 
-bool SetSegmentStatusSealedOp::operator==(const CatalogDeltaOperation &rhs) const {
-    auto *rhs_op = dynamic_cast<const SetSegmentStatusSealedOp *>(&rhs);
-    return rhs_op != nullptr && CatalogDeltaOperation::operator==(rhs) && IsEqual(*db_name_, *rhs_op->db_name_) &&
-           IsEqual(*table_name_, *rhs_op->table_name_) && segment_id_ == rhs_op->segment_id_ &&
-           segment_filter_binary_data_ == rhs_op->segment_filter_binary_data_;
-}
-
-bool SetBlockStatusSealedOp::operator==(const CatalogDeltaOperation &rhs) const {
-    auto *rhs_op = dynamic_cast<const SetBlockStatusSealedOp *>(&rhs);
-    return rhs_op != nullptr && CatalogDeltaOperation::operator==(rhs) && IsEqual(*db_name_, *rhs_op->db_name_) &&
-           IsEqual(*table_name_, *rhs_op->table_name_) && segment_id_ == rhs_op->segment_id_ && block_id_ == rhs_op->block_id_ &&
-           block_filter_binary_data_ == rhs_op->block_filter_binary_data_;
-}
-
 void AddDBEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
     if (other->type_ != CatalogDeltaOpType::ADD_DATABASE_ENTRY) {
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
@@ -760,9 +686,16 @@ void AddSegmentEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeSta
     auto *add_segment_op = static_cast<AddSegmentEntryOp *>(other.get());
     MergeFlag flag = this->NextDeleteFlag(add_segment_op->merge_flag_);
     TxnTimeStamp commit_ts = this->commit_ts_;
+    auto segment_filter_binary_data = std::move(segment_filter_binary_data_);
     *this = std::move(*add_segment_op);
     if (commit_ts > last_full_checkpoint_ts) {
         this->merge_flag_ = flag;
+    }
+    if (!segment_filter_binary_data.empty()) {
+        if (!segment_filter_binary_data_.empty()) {
+            UnrecoverableError("Serialize segment filter binary twice");
+        }
+        segment_filter_binary_data_ = std::move(segment_filter_binary_data);
     }
 }
 
@@ -771,7 +704,14 @@ void AddBlockEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     auto *add_block_op = static_cast<AddBlockEntryOp *>(other.get());
+    auto block_filter_binary_data = std::move(block_filter_binary_data_);
     *this = std::move(*add_block_op);
+    if (!block_filter_binary_data.empty()) {
+        if (!block_filter_binary_data_.empty()) {
+            UnrecoverableError("Serialize block filter binary twice");
+        }
+        block_filter_binary_data_ = std::move(block_filter_binary_data);
+    }
 }
 
 void AddColumnEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
@@ -806,14 +746,6 @@ void AddChunkIndexEntryOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTime
         UnrecoverableError(fmt::format("Merge failed, other type: {}", other->GetTypeStr()));
     }
     *this = std::move(*static_cast<AddChunkIndexEntryOp *>(other.get()));
-}
-
-void SetSegmentStatusSealedOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
-    UnrecoverableError("SetSegmentStatusSealedOp::Merge not allowed");
-}
-
-void SetBlockStatusSealedOp::Merge(UniquePtr<CatalogDeltaOperation> other, TxnTimeStamp last_full_checkpoint_ts) {
-    UnrecoverableError("SetBlockStatusSealedOp::Merge not allowed");
 }
 
 void AddBlockEntryOp::FlushDataToDisk(TxnTimeStamp max_commit_ts) {
@@ -1080,10 +1012,6 @@ void GlobalCatalogDeltaEntry::PruneOpWithSamePrefix(const String &encode1) {
         auto [iter1, iter2] = std::mismatch(encode1.begin(), end1, encode2.begin());
         if (iter1 != end1) {
             break;
-        }
-        if (iter2 == encode2.end()) { // encode == encode1
-            ++iter;
-            continue;
         }
         if (*iter2 != '#' && *iter2 != '@') {
             ++iter;

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -1000,17 +1000,16 @@ UniquePtr<CatalogDeltaEntry> GlobalCatalogDeltaEntry::PickFlushEntry(TxnTimeStam
     auto flush_delta_entry = MakeUnique<CatalogDeltaEntry>();
 
     {
-        for (auto &[_, delta_op] : delta_ops_) {
+        auto delta_ops = std::exchange(delta_ops_, {});
+        auto txn_ids = std::exchange(txn_ids_, {});
+        for (auto &[_, delta_op] : delta_ops) {
             if (delta_op->commit_ts_ <= full_ckp_ts) { // skip the delta op that is before full checkpoint
                 continue;
             }
             flush_delta_entry->AddOperation(std::move(delta_op));
         }
 
-        flush_delta_entry->set_txn_ids(Vector<TransactionID>(txn_ids_.begin(), txn_ids_.end()));
-
-        txn_ids_.clear();
-        delta_ops_.clear();
+        flush_delta_entry->set_txn_ids(Vector<TransactionID>(txn_ids.begin(), txn_ids.end()));
     }
     flush_delta_entry->set_commit_ts(max_commit_ts);
 

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -52,6 +52,7 @@ import table_index_entry;
 import log_file;
 import default_values;
 import defer_op;
+import index_base;
 
 module wal_manager;
 
@@ -666,7 +667,8 @@ void WalManager::WalCmdDropIndexReplay(const WalCmdDropIndex &cmd, TransactionID
     table_entry->DropIndexReplay(
         cmd.index_name_,
         [&](TableIndexMeta *index_meta, TransactionID txn_id, TxnTimeStamp begin_ts) {
-            auto index_entry = TableIndexEntry::NewTableIndexEntry(nullptr, true, nullptr, index_meta, txn_id, begin_ts);
+            auto index_base = MakeShared<IndexBase>(index_meta->index_name());
+            auto index_entry = TableIndexEntry::NewTableIndexEntry(index_base, true, nullptr, index_meta, txn_id, begin_ts);
             index_entry->commit_ts_.store(commit_ts);
             return index_entry;
         },

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -710,7 +710,7 @@ WalManager::ReplaySegment(TableEntry *table_entry, const WalSegmentInfo &segment
             auto column_entry = BlockColumnEntry::NewReplayBlockColumnEntry(block_entry.get(), column_id, buffer_mgr, next_idx, last_off, commit_ts);
             block_entry->AddColumnReplay(std::move(column_entry), column_id); // reuse function from delta catalog.
         }
-        segment_entry->AddBlockReplay(std::move(block_entry), block_id); // reuse function from delta catalog.
+        segment_entry->AddBlockReplay(std::move(block_entry)); // reuse function from delta catalog.
     }
     return segment_entry;
 }

--- a/src/unit_test/storage/meta/entry/block_entry.cpp
+++ b/src/unit_test/storage/meta/entry/block_entry.cpp
@@ -43,16 +43,13 @@ TEST_F(BlockVersionTest, SaveAndLoad) {
     LocalFileSystem fs;
 
     {
-        u8 file_flags = FileFlags::WRITE_FLAG | FileFlags::CREATE_FLAG;
-        auto file_handler = fs.OpenFile(version_path, file_flags, FileLockType::kNoLock);
+        auto file_handler = fs.OpenFile(version_path, FileFlags::WRITE_FLAG | FileFlags::CREATE_FLAG, FileLockType::kNoLock);
         block_version.SpillToFile(*file_handler);
     }
 
     {
-        u8 file_flags = FileFlags::READ_FLAG;
-        auto file_handler = fs.OpenFile(version_path, file_flags, FileLockType::kNoLock);
-        BlockVersion block_verson2(8192);
-        block_verson2.LoadFromFile(*file_handler);
-        ASSERT_EQ(block_version, block_verson2);
+        auto file_handler = fs.OpenFile(version_path, FileFlags::READ_FLAG, FileLockType::kNoLock);
+        auto block_version2 = BlockVersion::LoadFromFile(*file_handler);
+        ASSERT_EQ(block_version, *block_version2);
     }
 }

--- a/src/unit_test/storage/wal/catalog_delta_entry.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_entry.cpp
@@ -143,7 +143,7 @@ TEST_F(CatalogDeltaEntryTest, test_DeltaOpEntry) {
             catalog_delta_entry1->operations().push_back(std::move(op));
         }
         {
-            auto op = MakeUnique<SetSegmentStatusSealedOp>();
+            auto op = MakeUnique<AddSegmentEntryOp>();
             op->db_name_ = db_name;
             op->table_name_ = table_name;
             op->segment_id_ = segment_id;
@@ -151,7 +151,7 @@ TEST_F(CatalogDeltaEntryTest, test_DeltaOpEntry) {
             catalog_delta_entry1->operations().push_back(std::move(op));
         }
         {
-            auto op = MakeUnique<SetBlockStatusSealedOp>();
+            auto op = MakeUnique<AddBlockEntryOp>();
             op->db_name_ = db_name;
             op->table_name_ = table_name;
             op->segment_id_ = segment_id;
@@ -362,19 +362,19 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         local_catalog_delta_entry->operations().push_back(std::move(op1_same_name));
     }
     {
-        auto op1 = MakeUnique<SetSegmentStatusSealedOp>();
+        auto op1 = MakeUnique<AddSegmentEntryOp>();
 
         op1->db_name_ = db_name;
         op1->table_name_ = table_name;
         op1->segment_id_ = segment_id;
         op1->segment_filter_binary_data_ = "abcde";
 
-        op1->merge_flag_ = MergeFlag::kNew;
+        op1->merge_flag_ = MergeFlag::kUpdate;
 
         local_catalog_delta_entry->operations().push_back(std::move(op1));
     }
     {
-        auto op1 = MakeUnique<SetBlockStatusSealedOp>();
+        auto op1 = MakeUnique<AddBlockEntryOp>();
 
         op1->db_name_ = db_name;
         op1->table_name_ = table_name;
@@ -382,7 +382,7 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         op1->block_id_ = block_id;
         op1->block_filter_binary_data_ = "abcde";
 
-        op1->merge_flag_ = MergeFlag::kNew;
+        op1->merge_flag_ = MergeFlag::kUpdate;
 
         local_catalog_delta_entry->operations().push_back(std::move(op1));
     }

--- a/src/unit_test/storage/wal/catalog_delta_entry.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_entry.cpp
@@ -210,6 +210,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op2 = MakeUnique<AddDBEntryOp>();
         auto op1_same_name = MakeUnique<AddDBEntryOp>();
 
+        op1_same_name->encode_ = op2->encode_ = op1->encode_ = fmt::format("#{}", *db_name);
+
         op1_same_name->db_name_ = op2->db_name_ = op1->db_name_ = db_name;
 
         op1_same_name->merge_flag_ = op1->merge_flag_ = MergeFlag::kNew;
@@ -229,6 +231,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op1 = MakeUnique<AddTableEntryOp>();
         auto op2 = MakeUnique<AddTableEntryOp>();
         auto op1_same_name = MakeUnique<AddTableEntryOp>();
+
+        op1_same_name->encode_ = op2->encode_ = op1->encode_ = fmt::format("#{}#{}", *db_name, *table_name);
 
         op1_same_name->db_name_ = op2->db_name_ = op1->db_name_ = db_name;
         op1_same_name->table_name_ = op2->table_name_ = op1->table_name_ = table_name;
@@ -251,6 +255,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op1 = MakeUnique<AddSegmentEntryOp>();
         auto op2 = MakeUnique<AddSegmentEntryOp>();
         auto op1_same_name = MakeUnique<AddSegmentEntryOp>();
+
+        op1_same_name->encode_ = op2->encode_ = op1->encode_ = fmt::format("#{}#{}#{}", *db_name, *table_name, segment_id);
 
         op1_same_name->db_name_ = op2->db_name_ = op1->db_name_ = db_name;
         op1_same_name->table_name_ = op2->table_name_ = op1->table_name_ = table_name;
@@ -283,6 +289,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op1 = MakeUnique<AddBlockEntryOp>();
         auto op1_same_name = MakeUnique<AddBlockEntryOp>();
 
+        op1_same_name->encode_ = op1->encode_ = fmt::format("#{}#{}#{}#{}", *db_name, *table_name, segment_id, block_id);
+
         op1_same_name->db_name_ = op1->db_name_ = db_name;
         op1_same_name->table_name_ = op1->table_name_ = table_name;
         op1_same_name->segment_id_ = op1->segment_id_ = segment_id;
@@ -303,6 +311,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op1 = MakeUnique<AddColumnEntryOp>();
         auto op1_same_name = MakeUnique<AddColumnEntryOp>();
 
+        op1_same_name->encode_ = op1->encode_ = fmt::format("#{}#{}#{}#{}#{}", *db_name, *table_name, segment_id, block_id, column_id);
+
         op1_same_name->db_name_ = op1->db_name_ = db_name;
         op1_same_name->table_name_ = op1->table_name_ = table_name;
         op1_same_name->segment_id_ = op1->segment_id_ = segment_id;
@@ -321,6 +331,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op1 = MakeUnique<AddTableIndexEntryOp>();
         auto op2 = MakeUnique<AddTableIndexEntryOp>();
         auto op1_same_name = MakeUnique<AddTableIndexEntryOp>();
+
+        op1_same_name->encode_ = op2->encode_ = op1->encode_ = fmt::format("#{}#{}#{}", *db_name, *table_name, *index_name);
 
         op1_same_name->db_name_ = op2->db_name_ = op1->db_name_ = db_name;
         op1_same_name->table_name_ = op2->table_name_ = op1->table_name_ = table_name;
@@ -347,6 +359,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
         auto op1 = MakeUnique<AddSegmentIndexEntryOp>();
         auto op1_same_name = MakeUnique<AddSegmentIndexEntryOp>();
 
+        op1_same_name->encode_ = op1->encode_ = fmt::format("#{}#{}#{}#{}", *db_name, *table_name, *index_name, segment_id);
+
         op1_same_name->db_name_ = op1->db_name_ = db_name;
         op1_same_name->table_name_ = op1->table_name_ = table_name;
         op1_same_name->index_name_ = op1->index_name_ = index_name;
@@ -364,6 +378,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
     {
         auto op1 = MakeUnique<AddSegmentEntryOp>();
 
+        op1->encode_ = fmt::format("#{}#{}#{}", *db_name, *table_name, segment_id);
+
         op1->db_name_ = db_name;
         op1->table_name_ = table_name;
         op1->segment_id_ = segment_id;
@@ -375,6 +391,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
     }
     {
         auto op1 = MakeUnique<AddBlockEntryOp>();
+
+        op1->encode_ = fmt::format("#{}#{}#{}#{}", *db_name, *table_name, segment_id, block_id);
 
         op1->db_name_ = db_name;
         op1->table_name_ = table_name;
@@ -388,6 +406,8 @@ TEST_F(CatalogDeltaEntryTest, MergeEntries) {
     }
     {
         auto op = MakeUnique<AddSegmentEntryOp>();
+
+        op->encode_ = fmt::format("#{}#{}#{}", *db_name, *table_name, segment_id);
 
         op->db_name_ = db_name;
         op->table_name_ = table_name;
@@ -419,7 +439,9 @@ TEST_F(CatalogDeltaEntryTest, ComplicateMergeEntries) {
     auto global_catalog_delta_entry = std::make_unique<GlobalCatalogDeltaEntry>();
     auto AddDBEntry = [&](CatalogDeltaEntry *delta_entry, MergeFlag merge_flag, TxnTimeStamp commit_ts) {
         auto op1 = MakeUnique<AddDBEntryOp>();
-        op1->db_name_ = db_name;
+        op1->encode_ = fmt::format("#{}", *db_name);
+
+                           op1->db_name_ = db_name;
         op1->db_entry_dir_ = db_dir;
         op1->merge_flag_ = merge_flag;
         op1->commit_ts_ = commit_ts;
@@ -427,6 +449,8 @@ TEST_F(CatalogDeltaEntryTest, ComplicateMergeEntries) {
     };
     auto AddTableEntry = [&](CatalogDeltaEntry *delta_entry, MergeFlag merge_flag, TxnTimeStamp commit_ts) {
         auto op1 = MakeUnique<AddTableEntryOp>();
+        op1->encode_ = fmt::format("#{}#{}", *db_name, *table_name);
+
         op1->db_name_ = db_name;
         op1->table_name_ = table_name;
         op1->table_entry_dir_ = table_entry_dir;

--- a/src/unit_test/storage/wal/catalog_delta_replay.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_replay.cpp
@@ -326,8 +326,7 @@ TEST_F(CatalogDeltaReplayTest, replay_import) {
                 segment_entry->AppendBlockEntry(std::move(block_entry));
             }
 
-            TxnTimeStamp flush_ts = txn->BeginTS();
-            segment_entry->FlushNewData(flush_ts);
+            segment_entry->FlushNewData();
             txn->Import(*db_name, *table_name, segment_entry);
 
             last_commit_ts = txn_mgr->CommitTxn(txn);
@@ -850,8 +849,7 @@ TEST_F(CatalogDeltaReplayTest, replay_table_single_index) {
                 segment_entry->AppendBlockEntry(std::move(block_entry));
             }
 
-            TxnTimeStamp flush_ts = txn->BeginTS();
-            segment_entry->FlushNewData(flush_ts);
+            segment_entry->FlushNewData();
             txn->Import(*db_name, *table_name, segment_entry);
 
             last_commit_ts = txn_mgr->CommitTxn(txn);
@@ -1017,8 +1015,7 @@ TEST_F(CatalogDeltaReplayTest, replay_table_single_index_named_db) {
                 segment_entry->AppendBlockEntry(std::move(block_entry));
             }
 
-            TxnTimeStamp flush_ts = txn->BeginTS();
-            segment_entry->FlushNewData(flush_ts);
+            segment_entry->FlushNewData();
             txn->Import(*db_name, *table_name, segment_entry);
 
             last_commit_ts = txn_mgr->CommitTxn(txn);
@@ -1168,8 +1165,7 @@ TEST_F(CatalogDeltaReplayTest, replay_table_single_index_and_compact) {
                 segment_entry->AppendBlockEntry(std::move(block_entry));
             }
 
-            TxnTimeStamp flush_ts = txn->BeginTS();
-            segment_entry->FlushNewData(flush_ts);
+            segment_entry->FlushNewData();
             txn->Import(*db_name, *table_name, segment_entry);
 
             last_commit_ts = txn_mgr->CommitTxn(txn);

--- a/tools/generate_mem_hnsw.py
+++ b/tools/generate_mem_hnsw.py
@@ -1,0 +1,100 @@
+# generate 'test/sql/dml/mem_index/insert_with_hnsw_index_big.slt' and 'test/data/csv/insert_with_hnsw_index_big.csv'
+
+import os
+import argparse
+import random
+
+
+def generate(generate_if_exist: bool, copy_dir: str):
+    batch_n = 1000
+    insert_n = 10
+    dim = 16
+    table_name = "insert_with_hnsw_index_big"
+    index_name = "idx1"
+    M = 16
+    ef_construction = 200
+    metric = "l2"
+    ef = 8
+
+    csv_dir = "./test/data/csv"
+    slt_dir = "./test/sql/dml/mem_index"
+    slt_name = "/{}.slt".format(table_name)
+
+    slt_path = slt_dir + slt_name
+
+    os.makedirs(csv_dir, exist_ok=True)
+    os.makedirs(slt_dir, exist_ok=True)
+
+    if os.path.exists(slt_path) and generate_if_exist:
+        print("File {}  already existed. Skip Generating.".format(slt_path))
+        return
+
+    with open(slt_path, "w") as slt_file:
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
+        slt_file.write("\n")
+
+        slt_file.write("statement ok\n")
+        slt_file.write(
+            "CREATE TABLE {} (c1 INTEGER, c2 EMBEDDING(FLOAT, {}));\n".format(
+                table_name, dim
+            )
+        )
+        slt_file.write("\n")
+
+        slt_file.write("statement ok\n")
+        slt_file.write(
+            "CREATE INDEX {} ON {}(c2) USING Hnsw WITH (M = {}, ef_construction = {}, metric = {});\n".format(
+                index_name, table_name, M, ef_construction, metric
+            )
+        )
+        slt_file.write("\n")
+
+        row_id = 0
+        for i in range(insert_n):
+            slt_file.write("statement ok\n")
+            slt_file.write("INSERT INTO {} VALUES".format(table_name))
+            for j in range(batch_n):
+                slt_file.write(
+                    " ({}, [{}])".format(
+                        row_id, ",".join([str(row_id) for _ in range(dim)])
+                    )
+                )
+                row_id += 1
+                if j != batch_n - 1:
+                    slt_file.write(",")
+            slt_file.write(";\n")
+            slt_file.write("\n")
+
+        for i in range(insert_n):
+            row_id = i * batch_n + random.randint(0, batch_n - 1)
+            slt_file.write("query I\n")
+            slt_file.write(
+                "SELECT c1 FROM {} SEARCH KNN(c2, [{}], 'float', '{}', 1) WITH (ef = {});\n".format(
+                    table_name, ",".join([str(row_id) for _ in range(dim)]), metric, ef
+                )
+            )
+            slt_file.write("----\n")
+            slt_file.write("{}\n".format(row_id))
+            slt_file.write("\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate mem hnsw data for test")
+
+    parser.add_argument(
+        "-g",
+        "--generate",
+        type=bool,
+        default=False,
+        dest="generate_if_exists",
+    )
+    parser.add_argument(
+        "-c",
+        "--copy",
+        type=str,
+        default="/var/infinity/test_data",
+        dest="copy_dir",
+    )
+    args = parser.parse_args()
+    generate(args.generate_if_exists, args.copy_dir)

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -21,7 +21,7 @@ from generate_index_scan import generate as generate10
 from generate_many_import import generate as generate11
 from generate_big_point_query_test_fastroughfilter import generate as generate12
 from generate_many_import_drop import generate as generate13
-
+from generate_mem_hnsw import generate as generate14
 
 class SpinnerThread(threading.Thread):
     def __init__(self):
@@ -153,6 +153,7 @@ if __name__ == "__main__":
     generate11(args.generate_if_exists, args.copy)
     generate12(args.generate_if_exists, args.copy)
     generate13(args.generate_if_exists, args.copy)
+    generate14(args.generate_if_exists, args.copy)
     print("Generate file finshed.")
 
     print("Start copying data...")


### PR DESCRIPTION
### What problem does this PR solve?

1. Save entry encode in entry, not generate encode each time when adding delta op.
2. Use encode's string_view as key of std::map.
3. Fix: add too many delta ops when INSERT

Issue link:#1096

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Test cases
- [ ] Python SDK impacted, Need to update PyPI
- [ ] Other (please describe):
