### PR TITLE
Fix fullckp & Cleanup temp file

### DIFF
--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -68,7 +68,9 @@ private:
 
     bool RemoveFromGCQueue(BufferObj *buffer_obj);
 
-    void AddToCleanList(BufferObj *buffer_obj, bool free);
+    void AddToCleanList(BufferObj *buffer_obj, bool do_free);
+
+    void AddToCleanTempList(BufferObj *buffer_obj);
 
 private:
     bool RemoveFromGCQueueInner(BufferObj *buffer_obj);
@@ -90,6 +92,7 @@ private:
 
     std::mutex clean_locker_{};
     Vector<BufferObj *> clean_list_{};
+    Vector<BufferObj *> clean_temp_list_{};
 };
 
 } // namespace infinity

--- a/src/storage/buffer/buffer_obj.cppm
+++ b/src/storage/buffer/buffer_obj.cppm
@@ -75,7 +75,9 @@ public:
 
     void PickForCleanup();
 
-    void CleanupFile();
+    void CleanupFile() const;
+
+    void CleanupTempFile() const ;
 
     SizeT GetBufferSize() const { return file_worker_->GetMemoryCost(); }
 

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -96,17 +96,27 @@ void FileWorker::MoveFile() {
     fs.Rename(src_path, dest_path);
 }
 
-void FileWorker::CleanupFile() {
+void FileWorker::CleanupFile() const {
     LocalFileSystem fs;
+
     String path = fmt::format("{}/{}", ChooseFileDir(false), *file_name_);
     if (fs.Exists(path)) {
-        LOG_TRACE(fmt::format("Cleaning up file: {}", path));
         fs.DeleteFile(path);
-        LOG_TRACE(fmt::format("Cleaned file: {}", path));
+        LOG_INFO(fmt::format("Cleaned file: {}", path));
     } else {
-        // this may happen the same reason as in "CleanupScanner::CleanupDir"
-        // It may also happen when cleanup a table not been flushed (need a checkpoint txn),
-        // at that time there is not data file under dir.
+        // Now, we cannot check whether a buffer obj has been flushed to disk.
+        LOG_TRACE(fmt::format("Cleanup: File {} not found for deletion", path));
+    }
+}
+
+void FileWorker::CleanupTempFile() const {
+    LocalFileSystem fs;
+    String path = fmt::format("{}/{}", ChooseFileDir(true), *file_name_);
+    if (fs.Exists(path)) {
+        fs.DeleteFile(path);
+        LOG_INFO(fmt::format("Cleaned file: {}", path));
+    } else {
+        // Now, we cannot check whether a temp file is moved to data
         LOG_TRACE(fmt::format("Cleanup: File {} not found for deletion", path));
     }
 }

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -53,7 +53,9 @@ public:
     // Get file path. As key of buffer handle.
     String GetFilePath() const { return fmt::format("{}/{}", *file_dir_, *file_name_); }
 
-    void CleanupFile();
+    void CleanupFile() const;
+
+    void CleanupTempFile() const;
 
 protected:
     virtual void WriteToFileImpl(bool to_spill, bool &prepare_success) = 0;

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -226,7 +226,9 @@ SharedPtr<TableIndexEntry> TableIndexEntry::Deserialize(const nlohmann::json &in
     bool deleted = index_def_entry_json["deleted"];
 
     if (deleted) {
-        auto table_index_entry = ReplayTableIndexEntry(table_index_meta, true, nullptr, nullptr, txn_id, begin_ts, commit_ts);
+        auto index_name = table_index_meta->index_name();
+        auto table_index_entry =
+            ReplayTableIndexEntry(table_index_meta, true, MakeShared<IndexBase>(index_name), nullptr, txn_id, begin_ts, commit_ts);
         table_index_entry->commit_ts_.store(commit_ts);
         table_index_entry->begin_ts_ = begin_ts;
         return table_index_entry;

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -501,11 +501,11 @@ i64 WalManager::ReplayWalFile() {
         system_start_ts = replay_entries[replay_count]->commit_ts_;
         last_txn_id = replay_entries[replay_count]->txn_id_;
 
+        LOG_INFO(replay_entries[replay_count]->ToString());
         ReplayWalEntry(*replay_entries[replay_count]);
-        LOG_TRACE(replay_entries[replay_count]->ToString());
     }
 
-    LOG_TRACE(fmt::format("System start ts: {}, lastest txn id: {}", system_start_ts, last_txn_id));
+    LOG_INFO(fmt::format("System start ts: {}, lastest txn id: {}", system_start_ts, last_txn_id));
     storage_->catalog()->next_txn_id_ = last_txn_id;
     this->max_commit_ts_ = system_start_ts;
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Cleanup temp file when call `Save` on buffer_obj.
2. Fix: replay create index bug.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
