### PR TITLE
Fix: cleanup temp unproperly.

### DIFF
--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -70,7 +70,11 @@ private:
 
     void AddToCleanList(BufferObj *buffer_obj, bool do_free);
 
-    void AddToCleanTempList(BufferObj *buffer_obj);
+    void AddTemp(BufferObj *buffer_obj);
+
+    void RemoveTemp(BufferObj *buffer_obj);
+
+    void MoveTemp(BufferObj *buffer_obj);
 
 private:
     bool RemoveFromGCQueueInner(BufferObj *buffer_obj);
@@ -92,7 +96,10 @@ private:
 
     std::mutex clean_locker_{};
     Vector<BufferObj *> clean_list_{};
-    Vector<BufferObj *> clean_temp_list_{};
+
+    std::mutex temp_locker_{};
+    HashSet<BufferObj *> temp_set_;
+    HashSet<BufferObj *> clean_temp_set_;
 };
 
 } // namespace infinity

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -116,8 +116,7 @@ void FileWorker::CleanupTempFile() const {
         fs.DeleteFile(path);
         LOG_INFO(fmt::format("Cleaned file: {}", path));
     } else {
-        // Now, we cannot check whether a temp file is moved to data
-        LOG_TRACE(fmt::format("Cleanup: File {} not found for deletion", path));
+        UnrecoverableError(fmt::format("Cleanup: File {} not found for deletion", path));
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: Remove buffer obj from temp cleanup list when spill again.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)