### PR TITLE
Fix path to build_from_source.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ sudo systemctl start infinity
 ```
 #### 🛠️ Build from Source
 
-See [Build from Source](docs/build_from_source.md).
+See [Build from Source](docs/getstarted/build_from_source.md).
 
 ### Install Infinity's Python client
 

--- a/docs/references/benchmark.md
+++ b/docs/references/benchmark.md
@@ -109,7 +109,7 @@ Infinity provides a Python script for benchmarking the SIFT1M and GIST1M dataset
 You have two options for building Infinity. Choose the option that best fits your needs:
 
 - [Build Infinity using Docker](https://github.com/infiniflow/infinity/blob/main/README.md)
-- [Build from source](../build_from_source.md)
+- [Build from source](../getstarted/build_from_source.md)
 
 ### Download the Benchmark datasets
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix path to refer to build_from_source.md in document after #1173.


### Type of change

- [x] Documentation Update
