### PR TITLE
Fix parallel readwrite on 0.1.x

### DIFF
--- a/src/executor/operator/physical_index_scan.cppm
+++ b/src/executor/operator/physical_index_scan.cppm
@@ -39,6 +39,8 @@ import bitmask;
 
 namespace infinity {
 
+class Txn;
+
 // for int range filter, x > n is equivalent to x >= n + 1
 // for float range filter, x > f is equivalent to x >= std::nextafter(f, INFINITY)
 // we can use this to simplify the filter
@@ -110,6 +112,6 @@ export std::variant<Vector<u32>, Bitmask> SolveSecondaryIndexFilter(const Vector
                                                                     const SegmentID segment_id,
                                                                     const u32 segment_row_count,
                                                                     const u32 segment_row_actual_count,
-                                                                    const TxnTimeStamp ts);
+                                                                    Txn *txn);
 
 } // namespace infinity

--- a/src/executor/operator/physical_knn_scan.cpp
+++ b/src/executor/operator/physical_knn_scan.cpp
@@ -241,9 +241,10 @@ SizeT PhysicalKnnScan::BlockEntryCount() const { return base_table_ref_->block_i
 
 template <typename DataType, template <typename, typename> typename C>
 void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperatorState *operator_state) {
-    TxnTimeStamp begin_ts = query_context->GetTxn()->BeginTS();
+    Txn *txn = query_context->GetTxn();
+    TxnTimeStamp begin_ts = txn->BeginTS();
 
-    if (!common_query_filter_->TryFinishBuild(begin_ts, query_context->GetTxn()->buffer_mgr())) {
+    if (!common_query_filter_->TryFinishBuild(txn)) {
         // not ready, abort and wait for next time
         return;
     }
@@ -484,7 +485,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                                 if (block_entry == nullptr) {
                                     UnrecoverableError(
                                         fmt::format("Cannot find segment id: {}, block id: {}, index chunk is {}", segment_id, block_id, chunk_id));
-                                }
+                                } // this is for debug
                             }
                             merge_heap->Search(0, d_ptr.get(), row_ids.get(), result_n);
                         }
@@ -493,7 +494,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                     auto [chunk_index_entries, memory_index_entry] = segment_index_entry->GetHnswIndexSnapshot();
                     int i = 0;
                     for (auto &chunk_index_entry : chunk_index_entries) {
-                        if (chunk_index_entry->CheckVisible(begin_ts)) {
+                        if (chunk_index_entry->CheckVisible(txn)) {
                             BufferHandle index_handle = chunk_index_entry->GetIndex();
                             hnsw_search(index_handle, false, i++);
                         }

--- a/src/executor/operator/physical_match.cpp
+++ b/src/executor/operator/physical_match.cpp
@@ -23,7 +23,7 @@ module;
 module physical_match;
 
 import stl;
-
+import txn;
 import query_context;
 import operator_state;
 import physical_operator;
@@ -556,9 +556,8 @@ bool PhysicalMatch::ExecuteInnerHomebrewed(QueryContext *query_context, Operator
     auto execute_start_time = std::chrono::high_resolution_clock::now();
     // 1. build QueryNode tree
     // 1.1 populate column2analyzer
-    TransactionID txn_id = query_context->GetTxn()->TxnID();
-    TxnTimeStamp begin_ts = query_context->GetTxn()->BeginTS();
-    QueryBuilder query_builder(txn_id, begin_ts, base_table_ref_);
+    Txn *txn = query_context->GetTxn();
+    QueryBuilder query_builder(txn, base_table_ref_);
     auto finish_init_query_builder_time = std::chrono::high_resolution_clock::now();
     TimeDurationType query_builder_init_duration = finish_init_query_builder_time - execute_start_time;
     LOG_TRACE(fmt::format("PhysicalMatch Part 0.1: Init QueryBuilder time: {} ms", query_builder_init_duration.count()));
@@ -849,7 +848,8 @@ bool PhysicalMatch::Execute(QueryContext *query_context, OperatorState *operator
     auto start_time = std::chrono::high_resolution_clock::now();
     assert(common_query_filter_);
     {
-        bool try_result = common_query_filter_->TryFinishBuild(query_context->GetTxn()->BeginTS(), query_context->GetTxn()->buffer_mgr());
+        Txn *txn = query_context->GetTxn();
+        bool try_result = common_query_filter_->TryFinishBuild(txn);
         auto finish_filter_time = std::chrono::high_resolution_clock::now();
         std::chrono::duration<float, std::milli> filter_duration = finish_filter_time - start_time;
         LOG_TRACE(fmt::format("PhysicalMatch Prepare: Filter time: {} ms", filter_duration.count()));

--- a/src/planner/bound/base_table_ref.cppm
+++ b/src/planner/bound/base_table_ref.cppm
@@ -21,7 +21,7 @@ export module base_table_ref;
 import stl;
 import table_ref;
 import table_entry;
-
+import txn;
 import table_function;
 import block_index;
 import internal_types;
@@ -48,8 +48,8 @@ public:
     explicit BaseTableRef(TableEntry *table_entry, SharedPtr<BlockIndex> block_index)
         : TableRef(TableRefType::kTable, ""), table_entry_ptr_(table_entry), block_index_(std::move(block_index)) {}
 
-    static SharedPtr<BaseTableRef> FakeTableRef(TableEntry *table_entry, TxnTimeStamp ts) {
-        SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(ts);
+    static SharedPtr<BaseTableRef> FakeTableRef(TableEntry *table_entry, Txn *txn) {
+        SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(txn);
         return MakeShared<BaseTableRef>(table_entry, std::move(block_index));
     }
 

--- a/src/planner/query_binder.cpp
+++ b/src/planner/query_binder.cpp
@@ -71,6 +71,7 @@ import data_type;
 import logical_type;
 import base_entry;
 import view_entry;
+import txn;
 
 namespace infinity {
 
@@ -425,10 +426,9 @@ SharedPtr<BaseTableRef> QueryBinder::BuildBaseTable(QueryContext *query_context,
         columns.emplace_back(idx);
     }
 
-//    TransactionID txn_id = query_context->GetTxn()->TxnID();
-    TxnTimeStamp begin_ts = query_context->GetTxn()->BeginTS();
+    Txn *txn = query_context->GetTxn();
 
-    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(begin_ts);
+    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(txn);
 
     u64 table_index = bind_context_ptr_->GenerateTableIndex();
     auto table_ref = MakeShared<BaseTableRef>(table_entry, std::move(columns), block_index, alias, table_index, names_ptr, types_ptr);

--- a/src/storage/bg_task/compact_segments_task.cpp
+++ b/src/storage/bg_task/compact_segments_task.cpp
@@ -148,7 +148,7 @@ void CompactSegmentsTask::CompactSegments(CompactSegmentsTaskState &state) {
         }
 
         auto new_segment = CompactSegmentsToOne(state, to_compact_segments);
-        block_index->Insert(new_segment.get(), UNCOMMIT_TS, false);
+        block_index->Insert(new_segment.get(), txn_);
 
         segment_data.emplace_back(new_segment, std::move(to_compact_segments));
         old_segments.insert(old_segments.end(), to_compact_segments.begin(), to_compact_segments.end());

--- a/src/storage/common/block_index.cppm
+++ b/src/storage/common/block_index.cppm
@@ -23,6 +23,7 @@ namespace infinity {
 
 struct BlockEntry;
 struct SegmentEntry;
+class Txn;
 
 export struct BlockIndex {
 private:
@@ -32,7 +33,7 @@ private:
     };
 
 public:
-    void Insert(SegmentEntry *segment_entry, TxnTimeStamp timestamp, bool check_ts = true);
+    void Insert(SegmentEntry *segment_entry, Txn *txn);
 
     void Reserve(SizeT n);
 

--- a/src/storage/invertedindex/column_index_reader.cppm
+++ b/src/storage/invertedindex/column_index_reader.cppm
@@ -31,6 +31,7 @@ export module column_index_reader;
 namespace infinity {
 struct TableEntry;
 class BlockMaxTermDocIterator;
+class Txn;
 
 export class ColumnIndexReader {
 public:
@@ -75,7 +76,7 @@ export class TableIndexReaderCache {
 public:
     void UpdateKnownUpdateTs(TxnTimeStamp ts, std::shared_mutex &segment_update_ts_mutex, TxnTimeStamp &segment_update_ts);
 
-    IndexReader GetIndexReader(TransactionID txn_id, TxnTimeStamp begin_ts, TableEntry *table_entry_ptr);
+    IndexReader GetIndexReader(Txn *txn, TableEntry *table_entry_ptr);
 
 private:
     std::mutex mutex_;

--- a/src/storage/invertedindex/search/query_builder.cpp
+++ b/src/storage/invertedindex/search/query_builder.cpp
@@ -37,9 +37,8 @@ import third_party;
 
 namespace infinity {
 
-QueryBuilder::QueryBuilder(TransactionID txn_id, TxnTimeStamp begin_ts, SharedPtr<BaseTableRef> &base_table_ref)
-    : txn_id_(txn_id), begin_ts_(begin_ts), table_entry_(base_table_ref->table_entry_ptr_),
-      index_reader_(table_entry_->GetFullTextIndexReader(txn_id_, begin_ts_)) {
+QueryBuilder::QueryBuilder(Txn *txn, SharedPtr<BaseTableRef> &base_table_ref)
+    : table_entry_(base_table_ref->table_entry_ptr_), index_reader_(table_entry_->GetFullTextIndexReader(txn)) {
     u64 total_row_count = 0;
     for (SegmentEntry *segment_entry : base_table_ref->block_index_->segments_) {
         total_row_count += segment_entry->row_count();

--- a/src/storage/invertedindex/search/query_builder.cppm
+++ b/src/storage/invertedindex/search/query_builder.cppm
@@ -27,6 +27,7 @@ import base_table_ref;
 
 namespace infinity {
 
+class Txn;
 struct QueryNode;
 export struct FullTextQueryContext {
     UniquePtr<QueryNode> query_tree_;
@@ -37,7 +38,7 @@ class EarlyTerminateIterator;
 
 export class QueryBuilder {
 public:
-    QueryBuilder(TransactionID txn_id, TxnTimeStamp begin_ts, SharedPtr<BaseTableRef> &base_table_ref);
+    QueryBuilder(Txn *txn, SharedPtr<BaseTableRef> &base_table_ref);
 
     ~QueryBuilder();
 
@@ -50,8 +51,6 @@ public:
     inline float Score(RowID doc_id) { return scorer_.Score(doc_id); }
 
 private:
-    TransactionID txn_id_{};
-    TxnTimeStamp begin_ts_{};
     TableEntry *table_entry_{nullptr};
     IndexReader index_reader_;
     Scorer scorer_;

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -208,7 +208,9 @@ Tuple<SharedPtr<TableEntry>, Status> Catalog::DropTableByName(const String &db_n
     return db_entry->DropTable(table_name, conflict_type, txn_id, begin_ts, txn_mgr);
 }
 
-Status Catalog::GetTables(const String &db_name, Vector<TableDetail> &output_table_array, TransactionID txn_id, TxnTimeStamp begin_ts) {
+Status Catalog::GetTables(const String &db_name, Vector<TableDetail> &output_table_array, Txn *txn) {
+    TransactionID txn_id = txn->TxnID();
+    TxnTimeStamp begin_ts = txn->BeginTS();
     // Check the db entries
     auto [db_entry, status] = this->GetDatabase(db_name, txn_id, begin_ts);
     if (!status.ok()) {
@@ -216,7 +218,7 @@ Status Catalog::GetTables(const String &db_name, Vector<TableDetail> &output_tab
         LOG_ERROR(fmt::format("Database: {} is invalid.", db_name));
         return status;
     }
-    return db_entry->GetTablesDetail(txn_id, begin_ts, output_table_array);
+    return db_entry->GetTablesDetail(txn, output_table_array);
 }
 
 Tuple<TableEntry *, Status> Catalog::GetTableByName(const String &db_name, const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
@@ -231,8 +233,9 @@ Tuple<TableEntry *, Status> Catalog::GetTableByName(const String &db_name, const
     return db_entry->GetTableCollection(table_name, txn_id, begin_ts);
 }
 
-Tuple<SharedPtr<TableInfo>, Status>
-Catalog::GetTableInfo(const String &db_name, const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
+Tuple<SharedPtr<TableInfo>, Status> Catalog::GetTableInfo(const String &db_name, const String &table_name, Txn *txn) {
+    TransactionID txn_id = txn->TxnID();
+    TxnTimeStamp begin_ts = txn->BeginTS();
     auto [db_entry, status] = this->GetDatabase(db_name, txn_id, begin_ts);
     if (!status.ok()) {
         // Error
@@ -240,7 +243,7 @@ Catalog::GetTableInfo(const String &db_name, const String &table_name, Transacti
         return {nullptr, status};
     }
 
-    return db_entry->GetTableInfo(table_name, txn_id, begin_ts);
+    return db_entry->GetTableInfo(table_name, txn);
 }
 
 Status Catalog::RemoveTableEntry(TableEntry *table_entry, TransactionID txn_id) {
@@ -659,7 +662,8 @@ void Catalog::LoadFromEntryDelta(TxnTimeStamp max_commit_ts, BufferManager *buff
                                                                  commit_ts,
                                                                  check_point_ts,
                                                                  check_point_row_count,
-                                                                 buffer_mgr);
+                                                                 buffer_mgr,
+                                                                 txn_id);
 
                 if (merge_flag == MergeFlag::kNew) {
                     if (!block_filter_binary_data.empty()) {

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -159,11 +159,11 @@ public:
                                                          TxnTimeStamp begin_ts,
                                                          TxnManager *txn_mgr);
 
-    Status GetTables(const String &db_name, Vector<TableDetail> &output_table_array, TransactionID txn_id, TxnTimeStamp begin_ts);
+    Status GetTables(const String &db_name, Vector<TableDetail> &output_table_array, Txn *txn);
 
     Tuple<TableEntry *, Status> GetTableByName(const String &db_name, const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts);
 
-    Tuple<SharedPtr<TableInfo>, Status> GetTableInfo(const String &db_name, const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts);
+    Tuple<SharedPtr<TableInfo>, Status> GetTableInfo(const String &db_name, const String &table_name, Txn *txn);
 
     static Status RemoveTableEntry(TableEntry *table_entry, TransactionID txn_id);
 

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -71,7 +71,8 @@ public:
                                                      TxnTimeStamp commit_ts,
                                                      TxnTimeStamp check_point_ts,
                                                      u16 checkpoint_row_count,
-                                                     BufferManager *buffer_mgr);
+                                                     BufferManager *buffer_mgr,
+                                                     TransactionID txn_id);
 
     void UpdateBlockReplay(SharedPtr<BlockEntry> block_entry, String block_filter_binary_data);
 

--- a/src/storage/meta/entry/chunk_index_entry.cppm
+++ b/src/storage/meta/entry/chunk_index_entry.cppm
@@ -114,7 +114,7 @@ public:
         deprecate_ts_.store(commit_ts);
     }
 
-    bool CheckVisible(TxnTimeStamp ts) {
+    bool CheckVisibleByTS(TxnTimeStamp ts) { // FIXME: should overload BaseEntry::CheckVisible
         TxnTimeStamp deprecate_ts = deprecate_ts_.load();
         TxnTimeStamp commit_ts = commit_ts_.load();
         assert(commit_ts == UNCOMMIT_TS || commit_ts < deprecate_ts);

--- a/src/storage/meta/entry/db_entry.cpp
+++ b/src/storage/meta/entry/db_entry.cpp
@@ -55,7 +55,7 @@ DBEntry::DBEntry(DBMeta *db_meta,
                  TxnTimeStamp begin_ts)
     : BaseEntry(EntryType::kDatabase, is_delete, DBEntry::EncodeIndex(*db_name)), db_meta_(db_meta), db_entry_dir_(db_entry_dir), db_name_(db_name) {
     begin_ts_ = begin_ts;
-    txn_id_.store(txn_id);
+    txn_id_ = txn_id;
 }
 
 SharedPtr<DBEntry> DBEntry::NewDBEntry(DBMeta *db_meta,
@@ -111,14 +111,14 @@ Tuple<TableEntry *, Status> DBEntry::GetTableCollection(const String &table_name
     return table_meta->GetEntry(std::move(r_lock), txn_id, begin_ts);
 }
 
-Tuple<SharedPtr<TableInfo>, Status> DBEntry::GetTableInfo(const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts) {
+Tuple<SharedPtr<TableInfo>, Status> DBEntry::GetTableInfo(const String &table_name, Txn *txn) {
     LOG_TRACE(fmt::format("Get a table entry {}", table_name));
     auto [table_meta, status, r_lock] = table_meta_map_.GetExistMeta(table_name, ConflictType::kError);
     if (table_meta == nullptr) {
         return {nullptr, status};
     }
 
-    return table_meta->GetTableInfo(std::move(r_lock), txn_id, begin_ts);
+    return table_meta->GetTableInfo(std::move(r_lock), txn);
 }
 
 void DBEntry::RemoveTableEntry(const String &table_name, TransactionID txn_id) {
@@ -200,7 +200,9 @@ Vector<TableEntry *> DBEntry::TableCollections(TransactionID txn_id, TxnTimeStam
     return results;
 }
 
-Status DBEntry::GetTablesDetail(TransactionID txn_id, TxnTimeStamp begin_ts, Vector<TableDetail> &output_table_array) {
+Status DBEntry::GetTablesDetail(Txn *txn, Vector<TableDetail> &output_table_array) {
+    TransactionID txn_id = txn->TxnID();
+    TxnTimeStamp begin_ts = txn->BeginTS();
     Vector<TableEntry *> table_collection_entries = this->TableCollections(txn_id, begin_ts);
     output_table_array.reserve(table_collection_entries.size());
     for (TableEntry *table_entry : table_collection_entries) {
@@ -213,7 +215,7 @@ Status DBEntry::GetTablesDetail(TransactionID txn_id, TxnTimeStamp begin_ts, Vec
         table_detail.segment_capacity_ = DEFAULT_SEGMENT_CAPACITY;
         table_detail.block_capacity_ = DEFAULT_BLOCK_CAPACITY;
 
-        SharedPtr<BlockIndex> segment_index = table_entry->GetBlockIndex(begin_ts);
+        SharedPtr<BlockIndex> segment_index = table_entry->GetBlockIndex(txn);
 
         table_detail.segment_count_ = segment_index->SegmentCount();
         table_detail.block_count_ = segment_index->BlockCount();
@@ -236,7 +238,7 @@ nlohmann::json DBEntry::Serialize(TxnTimeStamp max_commit_ts) {
     {
         std::shared_lock<std::shared_mutex> lck(this->rw_locker());
         json_res["db_name"] = *this->db_name_;
-        json_res["txn_id"] = this->txn_id_.load();
+        json_res["txn_id"] = this->txn_id_;
         json_res["begin_ts"] = this->begin_ts_;
         json_res["commit_ts"] = this->commit_ts_.load();
         json_res["deleted"] = this->deleted_;

--- a/src/storage/meta/entry/db_entry.cppm
+++ b/src/storage/meta/entry/db_entry.cppm
@@ -95,7 +95,7 @@ public:
 
     Tuple<TableEntry *, Status> GetTableCollection(const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts);
 
-    Tuple<SharedPtr<TableInfo>, Status> GetTableInfo(const String &table_name, TransactionID txn_id, TxnTimeStamp begin_ts);
+    Tuple<SharedPtr<TableInfo>, Status> GetTableInfo(const String &table_name, Txn *txn);
 
     void RemoveTableEntry(const String &table_collection_name, TransactionID txn_id);
 
@@ -120,7 +120,7 @@ public:
 
     Vector<TableEntry *> TableCollections(TransactionID txn_id, TxnTimeStamp begin_ts);
 
-    Status GetTablesDetail(TransactionID txn_id, TxnTimeStamp begin_ts, Vector<TableDetail> &output_table_array);
+    Status GetTablesDetail(Txn *txn, Vector<TableDetail> &output_table_array);
 
 private:
     static SharedPtr<String> DetermineDBDir(const String &parent_dir, const String &db_name) {

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -233,9 +233,10 @@ bool SegmentEntry::CheckDeleteVisible(HashMap<BlockID, Vector<BlockOffset>> &blo
     return true;
 }
 
-bool SegmentEntry::CheckVisible(TxnTimeStamp check_ts) const {
+bool SegmentEntry::CheckVisible(Txn *txn) const {
+    TxnTimeStamp begin_ts = txn->BeginTS();
     std::shared_lock lock(rw_locker_);
-    return min_row_ts_ <= check_ts && check_ts <= deprecate_ts_;
+    return begin_ts < deprecate_ts_ && BaseEntry::CheckVisible(txn);
 }
 
 bool SegmentEntry::CheckDeprecate(TxnTimeStamp check_ts) const {
@@ -403,7 +404,7 @@ void SegmentEntry::CommitFlushed(TxnTimeStamp commit_ts) {
     }
 }
 
-void SegmentEntry::CommitSegment(TransactionID txn_id, TxnTimeStamp commit_ts) {
+void SegmentEntry::CommitSegment(TransactionID txn_id, TxnTimeStamp commit_ts, const TxnSegmentStore &segment_store) {
     std::unique_lock w_lock(rw_locker_);
     min_row_ts_ = std::min(min_row_ts_, commit_ts);
     if (commit_ts < max_row_ts_) {
@@ -411,8 +412,11 @@ void SegmentEntry::CommitSegment(TransactionID txn_id, TxnTimeStamp commit_ts) {
     }
     max_row_ts_ = commit_ts;
     if (!this->Committed()) {
-        this->txn_id_ = txn_id;
         this->Commit(commit_ts);
+    }
+    // hold the lock here
+    for (const auto &[block_id, block_entry] : segment_store.block_entries_) {
+        block_entry->CommitBlock(txn_id, commit_ts);
     }
 }
 

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -242,16 +242,18 @@ void SegmentIndexEntry::MemIndexInsert(SharedPtr<BlockEntry> block_entry,
             const IndexFullText *index_fulltext = static_cast<const IndexFullText *>(index_base.get());
             if (memory_indexer_.get() == nullptr) {
                 String base_name = fmt::format("ft_{:016x}", begin_row_id.ToUint64());
-                std::unique_lock<std::shared_mutex> lck(rw_locker_);
-                memory_indexer_ = MakeUnique<MemoryIndexer>(*table_index_entry_->index_dir(),
-                                                            base_name,
-                                                            begin_row_id,
-                                                            index_fulltext->flag_,
-                                                            index_fulltext->analyzer_,
-                                                            table_index_entry_->GetFulltextByteSlicePool(),
-                                                            table_index_entry_->GetFulltextBufferPool(),
-                                                            table_index_entry_->GetFulltextInvertingThreadPool(),
-                                                            table_index_entry_->GetFulltextCommitingThreadPool());
+                {
+                    std::unique_lock<std::shared_mutex> lck(rw_locker_);
+                    memory_indexer_ = MakeUnique<MemoryIndexer>(*table_index_entry_->index_dir(),
+                                                                base_name,
+                                                                begin_row_id,
+                                                                index_fulltext->flag_,
+                                                                index_fulltext->analyzer_,
+                                                                table_index_entry_->GetFulltextByteSlicePool(),
+                                                                table_index_entry_->GetFulltextBufferPool(),
+                                                                table_index_entry_->GetFulltextInvertingThreadPool(),
+                                                                table_index_entry_->GetFulltextCommitingThreadPool());
+                }
                 table_index_entry_->UpdateFulltextSegmentTs(commit_ts);
             } else {
                 RowID exp_begin_row_id = memory_indexer_->GetBaseRowId() + memory_indexer_->GetDocCount();
@@ -780,7 +782,7 @@ ChunkIndexEntry *SegmentIndexEntry::RebuildChunkIndexEntries(TxnTableStore *txn_
                     return nullptr;
                 }
                 for (const auto &chunk_index_entry : chunk_index_entries_) {
-                    if (chunk_index_entry->CheckVisible(begin_ts)) {
+                    if (chunk_index_entry->CheckVisible(txn)) {
                         row_count += chunk_index_entry->row_count_;
                         old_chunks.push_back(chunk_index_entry.get());
                     }
@@ -829,7 +831,7 @@ ChunkIndexEntry *SegmentIndexEntry::RebuildChunkIndexEntries(TxnTableStore *txn_
                     return nullptr;
                 }
                 for (const auto &chunk_index_entry : chunk_index_entries_) {
-                    if (chunk_index_entry->CheckVisible(begin_ts)) {
+                    if (chunk_index_entry->CheckVisible(txn)) {
                         row_count += chunk_index_entry->GetRowCount();
                         old_chunks.push_back(chunk_index_entry.get());
                     }

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -139,7 +139,7 @@ public:
         SizeT num = chunk_index_entries_.size();
         for (SizeT i = 0; i < num; i++) {
             auto &chunk_index_entry = chunk_index_entries_[i];
-            if (chunk_index_entry->CheckVisible(begin_ts)) {
+            if (chunk_index_entry->CheckVisibleByTS(begin_ts)) {
                 chunk_index_entries.push_back(chunk_index_entry);
             }
         }

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -217,7 +217,7 @@ public:
 
     Pair<SizeT, Status> GetSegmentRowCountBySegmentID(u32 seg_id);
 
-    SharedPtr<BlockIndex> GetBlockIndex(TxnTimeStamp begin_ts);
+    SharedPtr<BlockIndex> GetBlockIndex(Txn *txn);
 
     void GetFulltextAnalyzers(TransactionID txn_id, TxnTimeStamp begin_ts, Map<String, String> &column2analyzer);
 
@@ -235,15 +235,13 @@ public:
 
     const Vector<SharedPtr<ColumnDef>> &column_defs() const { return columns_; }
 
-    IndexReader GetFullTextIndexReader(TransactionID txn_id, TxnTimeStamp begin_ts);
+    IndexReader GetFullTextIndexReader(Txn *txn);
 
     void UpdateFullTextSegmentTs(TxnTimeStamp ts, std::shared_mutex &segment_update_ts_mutex, TxnTimeStamp &segment_update_ts) {
         return fulltext_column_index_cache_.UpdateKnownUpdateTs(ts, segment_update_ts_mutex, segment_update_ts);
     }
 
     bool CheckDeleteVisible(DeleteState &delete_state, Txn *txn);
-
-    bool CheckVisible(SegmentID segment_id, TxnTimeStamp check_ts) const;
 
 private:
     TableMeta *const table_meta_{};

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -111,13 +111,14 @@ SharedPtr<TableIndexEntry> TableIndexEntry::ReplayTableIndexEntry(TableIndexMeta
     return table_index_entry;
 }
 
-Map<SegmentID, SharedPtr<SegmentIndexEntry>> TableIndexEntry::GetIndexBySegmentSnapshot(const TableEntry *table_entry, TxnTimeStamp begin_ts) {
+Map<SegmentID, SharedPtr<SegmentIndexEntry>> TableIndexEntry::GetIndexBySegmentSnapshot(const TableEntry *table_entry, Txn *txn) {
     std::shared_lock<std::shared_mutex> lck(this->rw_locker_);
     Map<SegmentID, SharedPtr<SegmentIndexEntry>> index_by_segment_snapshot;
     for (const auto &[segment_id, segment_index_entry] : this->index_by_segment_) {
-        bool visible = table_entry->CheckVisible(segment_id, begin_ts);
-        if (!visible)
+        auto segment_entry = table_entry->GetSegmentByID(segment_id, txn);
+        if (segment_entry.get() == nullptr) {
             continue;
+        }
         index_by_segment_snapshot.emplace(segment_id, segment_index_entry);
     }
     return index_by_segment_snapshot;
@@ -190,7 +191,7 @@ nlohmann::json TableIndexEntry::Serialize(TxnTimeStamp max_commit_ts) {
     Vector<SharedPtr<SegmentIndexEntry>> segment_index_entry_candidates;
     {
         std::shared_lock<std::shared_mutex> lck(this->rw_locker_);
-        json["txn_id"] = this->txn_id_.load();
+        json["txn_id"] = this->txn_id_;
         json["begin_ts"] = this->begin_ts_;
         json["commit_ts"] = this->commit_ts_.load();
         json["deleted"] = this->deleted_;
@@ -307,12 +308,12 @@ TableIndexEntry::CreateIndexPrepare(TableEntry *table_entry, BlockIndex *block_i
     return {segment_index_entries, Status::OK()};
 }
 
-Status TableIndexEntry::CreateIndexDo(const TableEntry *table_entry, HashMap<SegmentID, atomic_u64> &create_index_idxes) {
+Status TableIndexEntry::CreateIndexDo(const TableEntry *table_entry, HashMap<SegmentID, atomic_u64> &create_index_idxes, Txn *txn) {
     if (this->index_base_->column_names_.size() != 1) {
         // TODO
         RecoverableError(Status::NotSupport("Not implemented"));
     }
-    Map<SegmentID, SharedPtr<SegmentIndexEntry>> index_by_segment = GetIndexBySegmentSnapshot(table_entry, MAX_TIMESTAMP);
+    Map<SegmentID, SharedPtr<SegmentIndexEntry>> index_by_segment = GetIndexBySegmentSnapshot(table_entry, txn);
     for (auto &[segment_id, segment_index_entry] : index_by_segment) {
         atomic_u64 &create_index_idx = create_index_idxes.at(segment_id);
         auto status = segment_index_entry->CreateIndexDo(create_index_idx);

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -95,7 +95,7 @@ public:
     inline const SharedPtr<ColumnDef> &column_def() const { return column_def_; }
 
     Map<SegmentID, SharedPtr<SegmentIndexEntry>> &index_by_segment() { return index_by_segment_; }
-    Map<SegmentID, SharedPtr<SegmentIndexEntry>> GetIndexBySegmentSnapshot(const TableEntry *table_entry, TxnTimeStamp begin_ts);
+    Map<SegmentID, SharedPtr<SegmentIndexEntry>> GetIndexBySegmentSnapshot(const TableEntry *table_entry, Txn *txn);
     const SharedPtr<String> &index_dir() const { return index_dir_; }
     String GetPathNameTail() const;
     bool GetOrCreateSegment(SegmentID segment_id, Txn *txn, SharedPtr<SegmentIndexEntry> &segment_index_entry);
@@ -115,7 +115,7 @@ public:
     Tuple<Vector<SegmentIndexEntry *>, Status>
     CreateIndexPrepare(TableEntry *table_entry, BlockIndex *block_index, Txn *txn, bool prepare, bool is_replay, bool check_ts = true);
 
-    Status CreateIndexDo(const TableEntry *table_entry, HashMap<SegmentID, atomic_u64> &create_index_idxes);
+    Status CreateIndexDo(const TableEntry *table_entry, HashMap<SegmentID, atomic_u64> &create_index_idxes, Txn *txn);
 
     MemoryPool &GetFulltextByteSlicePool() { return byte_slice_pool_; }
     RecyclePool &GetFulltextBufferPool() { return buffer_pool_; }

--- a/src/storage/meta/table_meta.cppm
+++ b/src/storage/meta/table_meta.cppm
@@ -36,6 +36,7 @@ namespace infinity {
 
 class DBEntry;
 class TxnManager;
+class Txn;
 
 export struct TableMeta : public MetaInterface {
     using EntryT = TableEntry;
@@ -80,7 +81,7 @@ private:
                                                    const String &table_name,
                                                    ConflictType conflict_type);
 
-    Tuple<SharedPtr<TableInfo>, Status> GetTableInfo(std::shared_lock<std::shared_mutex> &&r_lock, TransactionID txn_id, TxnTimeStamp begin_ts);
+    Tuple<SharedPtr<TableInfo>, Status> GetTableInfo(std::shared_lock<std::shared_mutex> &&r_lock, Txn *txn);
 
     Tuple<TableEntry *, Status> GetEntry(std::shared_lock<std::shared_mutex> &&r_lock, TransactionID txn_id, TxnTimeStamp begin_ts) {
         return table_entry_list_.GetEntry(std::move(r_lock), txn_id, begin_ts);

--- a/src/storage/secondary_index/common_query_filter.cpp
+++ b/src/storage/secondary_index/common_query_filter.cpp
@@ -130,7 +130,9 @@ CommonQueryFilter::CommonQueryFilter(SharedPtr<BaseExpression> original_filter, 
     }
 }
 
-void CommonQueryFilter::BuildFilter(u32 task_id, TxnTimeStamp begin_ts, BufferManager *buffer_mgr) {
+void CommonQueryFilter::BuildFilter(u32 task_id, Txn *txn) {
+    auto *buffer_mgr = txn->buffer_mgr();
+    TxnTimeStamp begin_ts = txn->BeginTS();
     const HashMap<SegmentID, SegmentEntry *> &segment_index = base_table_ref_->block_index_->segment_index_;
     const SegmentID segment_id = tasks_[task_id];
     const SegmentEntry *segment_entry = segment_index.at(segment_id);
@@ -145,7 +147,7 @@ void CommonQueryFilter::BuildFilter(u32 task_id, TxnTimeStamp begin_ts, BufferMa
                                                  segment_id,
                                                  segment_row_count,
                                                  segment_actual_row_count,
-                                                 begin_ts);
+                                                 txn);
     if (std::visit(Overload{[](const Vector<u32> &v) -> bool { return v.empty(); }, [](const Bitmask &) -> bool { return false; }}, result_elem)) {
         // empty result
         return;

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -205,9 +205,7 @@ Vector<DatabaseDetail> Txn::ListDatabases() {
 Status Txn::GetTables(const String &db_name, Vector<TableDetail> &output_table_array) {
     this->CheckTxn(db_name);
 
-    TxnTimeStamp begin_ts = txn_context_.GetBeginTS();
-
-    return catalog_->GetTables(db_name, output_table_array, txn_id_, begin_ts);
+    return catalog_->GetTables(db_name, output_table_array, this);
 }
 
 Status Txn::CreateTable(const String &db_name, const SharedPtr<TableDef> &table_def, ConflictType conflict_type) {
@@ -300,7 +298,7 @@ Status Txn::CreateIndexDo(BaseTableRef *table_ref, const String &index_name, Has
         UnrecoverableError("Index is not created by this txn. Something error happened.");
     }
 
-    return table_index_entry->CreateIndexDo(table_entry, create_index_idxes);
+    return table_index_entry->CreateIndexDo(table_entry, create_index_idxes, this);
 }
 
 Status Txn::CreateIndexFinish(const TableEntry *table_entry, const TableIndexEntry *table_index_entry) {
@@ -349,8 +347,7 @@ Tuple<TableEntry *, Status> Txn::GetTableByName(const String &db_name, const Str
 }
 
 Tuple<SharedPtr<TableInfo>, Status> Txn::GetTableInfo(const String &db_name, const String &table_name) {
-    TxnTimeStamp begin_ts = txn_context_.GetBeginTS();
-    return catalog_->GetTableInfo(db_name, table_name, txn_id_, begin_ts);
+    return catalog_->GetTableInfo(db_name, table_name, this);
 }
 
 Status Txn::CreateCollection(const String &, const String &, ConflictType, BaseEntry *&) {

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -86,7 +86,29 @@ SharedPtr<Txn> TxnManager::GetTxnPtr(TransactionID txn_id) {
     return res;
 }
 
-TxnState TxnManager::GetTxnState(TransactionID txn_id) { return GetTxn(txn_id)->GetTxnState(); }
+TxnState TxnManager::GetTxnState(TransactionID txn_id) {
+    std::lock_guard guard(rw_locker_);
+    auto iter = txn_map_.find(txn_id);
+    if (iter == txn_map_.end()) {
+        return TxnState::kCommitted;
+    }
+    Txn *txn = iter->second.get();
+    return txn->GetTxnState();
+}
+
+bool TxnManager::CheckIfCommitting(TransactionID txn_id, TxnTimeStamp begin_ts) {
+    std::lock_guard guard(rw_locker_);
+    auto iter = txn_map_.find(txn_id);
+    if (iter == txn_map_.end()) {
+        return true; // Txn is already committed
+    }
+    Txn *txn = iter->second.get();
+    auto state = txn->GetTxnState();
+    if (state != TxnState::kCommitting && state != TxnState::kCommitted) {
+        return false;
+    }
+    return txn->CommitTS() < begin_ts;
+}
 
 TxnTimeStamp TxnManager::GetCommitTimeStampR(Txn *txn) {
     std::lock_guard guard(rw_locker_);

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -49,6 +49,8 @@ public:
 
     TxnState GetTxnState(TransactionID txn_id);
 
+    bool CheckIfCommitting(TransactionID txn_id, TxnTimeStamp begin_ts);
+
     inline void Lock() { rw_locker_.lock(); }
 
     inline void UnLock() { rw_locker_.unlock(); }

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -643,7 +643,8 @@ void WalManager::WalCmdCreateIndexReplay(const WalCmdCreateIndex &cmd, Transacti
 
     auto fake_txn = Txn::NewReplayTxn(storage_->buffer_manager(), storage_->txn_manager(), storage_->catalog(), txn_id);
 
-    auto block_index = table_entry->GetBlockIndex(commit_ts);
+    auto txn = MakeUnique<Txn>(nullptr /*buffer_mgr*/, nullptr /*txn_mgr*/, nullptr /*catalog*/, txn_id, begin_ts);
+    auto block_index = table_entry->GetBlockIndex(txn.get());
     table_index_entry->CreateIndexPrepare(table_entry, block_index.get(), fake_txn.get(), false, true);
 
     auto *txn_store = fake_txn->GetTxnTableStore(table_entry);
@@ -699,7 +700,8 @@ WalManager::ReplaySegment(TableEntry *table_entry, const WalSegmentInfo &segment
                                                            commit_ts,             /*commit_ts*/
                                                            commit_ts,             /*checkpoint_ts*/
                                                            block_info.row_count_, /*checkpoint_row_count*/
-                                                           buffer_mgr);
+                                                           buffer_mgr,
+                                                           txn_id);
         for (ColumnID column_id = 0; column_id < (ColumnID)block_info.outline_infos_.size(); ++column_id) {
             auto [next_idx, last_off] = block_info.outline_infos_[column_id];
             auto column_entry = BlockColumnEntry::NewReplayBlockColumnEntry(block_entry.get(), column_id, buffer_mgr, next_idx, last_off, commit_ts);

--- a/src/unit_test/storage/bg_task/cleanup_task.cpp
+++ b/src/unit_test/storage/bg_task/cleanup_task.cpp
@@ -58,7 +58,7 @@ protected:
             }
             // wait for at most 10s
             if (end - start > 10) {
-                UnrecoverableException("WaitCleanup timeout");
+                UnrecoverableError("WaitCleanup timeout");
             }
             usleep(1000 * 1000);
         }
@@ -450,8 +450,7 @@ TEST_F(CleanupTaskTest, test_with_index_compact_and_cleanup) {
         auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
         EXPECT_TRUE(status1.ok());
 
-        TxnTimeStamp begin_ts = txn->BeginTS();
-        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
         auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
         EXPECT_TRUE(status2.ok());
 

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -564,7 +564,7 @@ TEST_F(BufferObjTest, test_hnsw_index_buffer_obj_shutdown) {
         auto [table_entry, table_status] = txn->GetTableByName(db_name, table_name);
         EXPECT_EQ(table_status.ok(), true);
         {
-            auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn->BeginTS());
+            auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
             auto result = txn->CreateIndexDef(table_entry, index_base_hnsw, conflict_type);
             auto *table_index_entry = std::get<0>(result);
             auto status = std::get<1>(result);

--- a/src/unit_test/storage/knnindex/merge_optimize/test_optimize.cpp
+++ b/src/unit_test/storage/knnindex/merge_optimize/test_optimize.cpp
@@ -76,7 +76,7 @@ protected:
             }
             // wait for at most 10s
             if (end - start > 10) {
-                UnrecoverableException("WaitCleanup timeout");
+                UnrecoverableError("WaitCleanup timeout");
             }
             usleep(1000 * 1000);
         }

--- a/src/unit_test/storage/wal/catalog_delta_replay.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_replay.cpp
@@ -66,7 +66,7 @@ protected:
         //     auto end = std::chrono::steady_clock::now();
         //     auto duration = std::chrono::duration_cast<Seconds>(end - start);
         //     if (duration.count() > 10) {
-        //         UnrecoverableException("WaitFlushDeltaOp timeout");
+        //         UnrecoverableError("WaitFlushDeltaOp timeout");
         //     }
         //     std::this_thread::sleep_for(Seconds(1));
         // };
@@ -81,7 +81,7 @@ protected:
             // wait for at most 10s
             time_t end = time(nullptr);
             if (end - start > 10) {
-                UnrecoverableException("WaitFlushDeltaOp timeout");
+                UnrecoverableError("WaitFlushDeltaOp timeout");
             }
         }
     }
@@ -889,8 +889,7 @@ TEST_F(CatalogDeltaReplayTest, replay_table_single_index) {
                         columns.emplace_back(idx);
                     }
 
-                    TxnTimeStamp begin_ts = txn_idx->BeginTS();
-                    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(begin_ts);
+                    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(txn_idx);
 
                     u64 table_idx = 0;
                     auto table_ref = MakeShared<BaseTableRef>(table_entry, std::move(columns), block_index, alias, table_idx, names_ptr, types_ptr);
@@ -1055,8 +1054,7 @@ TEST_F(CatalogDeltaReplayTest, replay_table_single_index_named_db) {
                         columns.emplace_back(idx);
                     }
 
-                    TxnTimeStamp begin_ts = txn_idx->BeginTS();
-                    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(begin_ts);
+                    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(txn_idx);
 
                     u64 table_idx = 0;
                     auto table_ref = MakeShared<BaseTableRef>(table_entry, std::move(columns), block_index, alias, table_idx, names_ptr, types_ptr);
@@ -1205,8 +1203,7 @@ TEST_F(CatalogDeltaReplayTest, replay_table_single_index_and_compact) {
                         columns.emplace_back(idx);
                     }
 
-                    TxnTimeStamp begin_ts = txn_idx->BeginTS();
-                    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(begin_ts);
+                    SharedPtr<BlockIndex> block_index = table_entry->GetBlockIndex(txn_idx);
 
                     u64 table_idx = 0;
                     auto table_ref = MakeShared<BaseTableRef>(table_entry, std::move(columns), block_index, alias, table_idx, names_ptr, types_ptr);

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -78,7 +78,7 @@ protected:
             }
             // wait for at most 10s
             if (end - start > 10) {
-                UnrecoverableException("WaitFlushDeltaOp timeout");
+                UnrecoverableError("WaitFlushDeltaOp timeout");
             }
         }
     }
@@ -96,7 +96,7 @@ protected:
             }
             // wait for at most 10s
             if (end - start > 10) {
-                UnrecoverableException("WaitCleanup timeout");
+                UnrecoverableError("WaitCleanup timeout");
             }
             usleep(1000 * 1000);
         }
@@ -271,8 +271,7 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
         auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
         EXPECT_TRUE(status1.ok());
 
-        TxnTimeStamp begin_ts = txn->BeginTS();
-        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
         auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
         EXPECT_TRUE(status2.ok());
         auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);
@@ -313,8 +312,7 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
         auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
         EXPECT_TRUE(status1.ok());
 
-        TxnTimeStamp begin_ts = txn->BeginTS();
-        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
         auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
         EXPECT_TRUE(status2.ok());
         auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);
@@ -381,8 +379,7 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
         auto [table_entry, status1] = txn->GetTableByName(*db_name, *table_name);
         EXPECT_TRUE(status1.ok());
 
-        TxnTimeStamp begin_ts = txn->BeginTS();
-        auto table_ref = BaseTableRef::FakeTableRef(table_entry, begin_ts);
+        auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
         auto [table_index_entry, status2] = txn->CreateIndexDef(table_entry, index_base, ConflictType::kError);
         EXPECT_TRUE(status2.ok());
         auto status3 = txn->CreateIndexPrepare(table_index_entry, table_ref.get(), false);

--- a/src/unit_test/storage/wal/wal_replay.cpp
+++ b/src/unit_test/storage/wal/wal_replay.cpp
@@ -846,7 +846,7 @@ TEST_F(WalReplayTest, wal_replay_create_index_IvfFlat) {
             auto [table_entry, table_status] = txn->GetTableByName(db_name, table_name);
             EXPECT_EQ(table_status.ok(), true);
             {
-                auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn->BeginTS());
+                auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
                 auto result = txn->CreateIndexDef(table_entry, index_base_ivf, conflict_type);
                 auto *table_index_entry = std::get<0>(result);
                 auto status = std::get<1>(result);
@@ -953,7 +953,7 @@ TEST_F(WalReplayTest, wal_replay_create_index_hnsw) {
             auto [table_entry, table_status] = txn->GetTableByName(db_name, table_name);
             EXPECT_EQ(table_status.ok(), true);
             {
-                auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn->BeginTS());
+                auto table_ref = BaseTableRef::FakeTableRef(table_entry, txn);
                 auto result = txn->CreateIndexDef(table_entry, index_base_hnsw, conflict_type);
                 auto *table_index_entry = std::get<0>(result);
                 auto status = std::get<1>(result);


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: visible check of entry created by committing txn.
2. Fix: dead lock in `SegmentIndexEntry::MemIndexInsert`

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)