### PR TITLE
Fix garbage outputs of Chinese analyzer

### DIFF
--- a/src/common/analyzer/chinese_analyzer.cpp
+++ b/src/common/analyzer/chinese_analyzer.cpp
@@ -50,10 +50,14 @@ ChineseAnalyzer::ChineseAnalyzer(const String &path) : dict_path_(path) {}
 ChineseAnalyzer::ChineseAnalyzer(const ChineseAnalyzer &other) {
     own_jieba_ = false;
     jieba_ = other.jieba_;
+    stopwords_ = other.stopwords_;
 }
 ChineseAnalyzer::~ChineseAnalyzer() {
-    if (own_jieba_ && jieba_)
+    if (own_jieba_ && jieba_) {
         delete jieba_;
+        if (stopwords_)
+            delete stopwords_;
+    }
 }
 
 Status ChineseAnalyzer::Load() {
@@ -98,8 +102,9 @@ Status ChineseAnalyzer::Load() {
 void ChineseAnalyzer::LoadStopwordsDict(const String &stopwords_path) {
     std::ifstream ifs(stopwords_path);
     String line;
+    stopwords_ = new FlatHashSet<String>;
     while (getline(ifs, line)) {
-        stopwords_.insert(line);
+        stopwords_->insert(line);
     }
 }
 

--- a/src/common/analyzer/chinese_analyzer.cppm
+++ b/src/common/analyzer/chinese_analyzer.cppm
@@ -42,13 +42,13 @@ protected:
 
 private:
     void LoadStopwordsDict(const String &stopwords_path);
-    bool Accept_token(const String &term) { return !stopwords_.contains(term); }
+    bool Accept_token(const String &term) { return !stopwords_->contains(term); }
 
 private:
     cppjieba::Jieba *jieba_{nullptr};
     String dict_path_;
     bool own_jieba_{};
     Vector<cppjieba::Word> cut_words_;
-    FlatHashSet<String> stopwords_;
+    FlatHashSet<String> *stopwords_{nullptr};
 };
 } // namespace infinity


### PR DESCRIPTION
### What problem does this PR solve?

Copy constructor of ChineseAnalyzer does not copy the stopwords, as a result the outputs will contain stopword tokens.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
