### PR TITLE
Fix filter expression can't include row_id

### DIFF
--- a/python/infinity/remote_thrift/utils.py
+++ b/python/infinity/remote_thrift/utils.py
@@ -42,28 +42,51 @@ def traverse_conditions(cons, fn=None) -> ttypes.ParsedExpr:
             arguments.append(expr)
         function_expr.arguments = arguments
 
-        paser_expr_type = ttypes.ParsedExprType()
-        paser_expr_type.function_expr = function_expr
+        parser_expr_type = ttypes.ParsedExprType()
+        parser_expr_type.function_expr = function_expr
 
-        parsed_expr.type = paser_expr_type
+        parsed_expr.type = parser_expr_type
 
         return parsed_expr
 
     elif isinstance(cons, exp.Column):
-        parsed_expr = ttypes.ParsedExpr()
-        column_expr = ttypes.ColumnExpr()
-        column_name = [cons.alias_or_name]
-        if cons.alias_or_name == "*":
-            column_expr.star = True
-        else:
-            column_expr.star = False
-        column_expr.column_name = column_name
 
-        paser_expr_type = ttypes.ParsedExprType()
-        paser_expr_type.column_expr = column_expr
+        match cons.alias_or_name:
+            case "_row_id":
+                func_expr = ttypes.FunctionExpr(function_name="row_id", arguments=[])
+                expr_type = ttypes.ParsedExprType(function_expr=func_expr)
+                parsed_expr = ttypes.ParsedExpr(type=expr_type)
+                return parsed_expr
+            case "_score":
+                func_expr = ttypes.FunctionExpr(function_name="score", arguments=[])
+                expr_type = ttypes.ParsedExprType(function_expr=func_expr)
+                parsed_expr = ttypes.ParsedExpr(type=expr_type)
+                return parsed_expr
+            case "_similarity":
+                func_expr = ttypes.FunctionExpr(function_name="similarity", arguments=[])
+                expr_type = ttypes.ParsedExprType(function_expr=func_expr)
+                parsed_expr = ttypes.ParsedExpr(type=expr_type)
+                return parsed_expr
+            case "_distance":
+                func_expr = ttypes.FunctionExpr(function_name="distance", arguments=[])
+                expr_type = ttypes.ParsedExprType(function_expr=func_expr)
+                parsed_expr = ttypes.ParsedExpr(type=expr_type)
+                return parsed_expr
+            case _:
+                parsed_expr = ttypes.ParsedExpr()
+                column_expr = ttypes.ColumnExpr()
+                column_name = [cons.alias_or_name]
+                if cons.alias_or_name == "*":
+                    column_expr.star = True
+                else:
+                    column_expr.star = False
+                column_expr.column_name = column_name
 
-        parsed_expr.type = paser_expr_type
-        return parsed_expr
+                parser_expr_type = ttypes.ParsedExprType()
+                parser_expr_type.column_expr = column_expr
+
+                parsed_expr.type = parser_expr_type
+                return parsed_expr
 
     elif isinstance(cons, exp.Literal):
         parsed_expr = ttypes.ParsedExpr()
@@ -81,10 +104,10 @@ def traverse_conditions(cons, fn=None) -> ttypes.ParsedExpr:
         else:
             raise InfinityException(3069, f"Unknown literal type: {cons}")
 
-        paser_expr_type = ttypes.ParsedExprType()
-        paser_expr_type.constant_expr = constant_expr
+        parser_expr_type = ttypes.ParsedExprType()
+        parser_expr_type.constant_expr = constant_expr
 
-        parsed_expr.type = paser_expr_type
+        parsed_expr.type = parser_expr_type
         return parsed_expr
 
     elif isinstance(cons, exp.Paren):
@@ -103,9 +126,9 @@ def traverse_conditions(cons, fn=None) -> ttypes.ParsedExpr:
             else:
                 raise InfinityException(3069, f"unknown literal type: {cons}")
 
-            paser_expr_type = ttypes.ParsedExprType()
-            paser_expr_type.constant_expr = constant_expr
-            parsed_expr.type = paser_expr_type
+            parser_expr_type = ttypes.ParsedExprType()
+            parser_expr_type.constant_expr = constant_expr
+            parsed_expr.type = parser_expr_type
 
             return parsed_expr
     else:


### PR DESCRIPTION
### What problem does this PR solve?

`res = table.output(["_row_id", "num", "body", "vec"]).filter("_row_id=1").to_pl()`

error:
`infinity.common.InfinityException: (3024, "Column: _row_id doesn't exist")`

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

