### PR TITLE
Fix: abort early in column info check if ColumnExpression is special expression

### DIFF
--- a/src/planner/optimizer/secondary_index_scan/filter_expression_push_down.cpp
+++ b/src/planner/optimizer/secondary_index_scan/filter_expression_push_down.cpp
@@ -159,6 +159,16 @@ public:
                 return IsValidColumnExpression(expression->arguments()[0], sub_expr_depth + 1, is_valid_column_expression);
             }
             case ExpressionType::kColumn: {
+                auto column_expr = std::static_pointer_cast<ColumnExpression>(expression);
+                auto special = column_expr->special();
+                if (special.has_value()) {
+                    // TODO: now special column expr will not have any index or minmax info
+                    LOG_TRACE(
+                        fmt::format("Expression depth: {}. In IsValidColumnExpression(), unsupported expression {}. Expecting column expression.",
+                                    sub_expr_depth,
+                                    expression->Name()));
+                    return false;
+                }
                 return is_valid_column_expression(expression, sub_expr_depth);
             }
             default: {


### PR DESCRIPTION

### What problem does this PR solve?

Avoid invalid access to column binding of ROW_ID column

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
