### PR TITLE
Fix: data missing when flush block version file

### DIFF
--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -165,9 +165,9 @@ public:
     inline void IncreaseRowCount(SizeT increased_row_count) { row_count_ += increased_row_count; }
 
 private:
-    void FlushData(SizeT start_row_count, SizeT checkpoint_row_count);
+    void FlushDataNoLock(SizeT start_row_count, SizeT checkpoint_row_count);
 
-    bool FlushVersion(TxnTimeStamp checkpoint_ts);
+    bool FlushVersionNoLock(TxnTimeStamp checkpoint_ts);
 
 protected:
     mutable std::shared_mutex rw_locker_{};

--- a/src/storage/meta/entry/block_version.cpp
+++ b/src/storage/meta/entry/block_version.cpp
@@ -60,7 +60,7 @@ i32 BlockVersion::GetRowCount(TxnTimeStamp begin_ts) const {
     auto iter =
         std::upper_bound(created_.begin(), created_.end(), begin_ts, [](TxnTimeStamp ts, const CreateField &field) { return ts < field.create_ts_; });
     if (iter == created_.begin()) {
-        return false;
+        return 0;
     }
     --iter;
     return iter->row_count_;
@@ -121,8 +121,9 @@ UniquePtr<BlockVersion> BlockVersion::LoadFromFile(FileHandler &file_handler) {
 
 void BlockVersion::GetCreateTS(SizeT offset, SizeT size, ColumnVector &res) const {
     // find the first create_field that has row_count_ >= offset
-    auto iter =
-        std::lower_bound(created_.begin(), created_.end(), offset, [](const CreateField &field, i64 offset) { return field.row_count_ < offset; });
+    auto iter = std::lower_bound(created_.begin(), created_.end(), static_cast<i64>(offset), [](const CreateField &field, const i64 offset_cp) {
+        return field.row_count_ < offset_cp;
+    });
     SizeT i = 0;
     for (; i < size; ++i) {
         if (iter == created_.end()) {

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -391,6 +391,7 @@ SizeT SegmentEntry::DeleteData(TransactionID txn_id,
 }
 
 void SegmentEntry::CommitFlushed(TxnTimeStamp commit_ts) {
+    std::shared_lock w_lock(rw_locker_);
     for (auto &block_entry : block_entries_) {
         block_entry->CommitFlushed(commit_ts);
     }


### PR DESCRIPTION
### What problem does this PR solve?

When block version is flushed with an earlier timestamp, it can not be flushed again unless a newer modification happens.

Issue link:#1402

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
