### PR TITLE
Update builder image to use gcc12 and clang18

### DIFF
--- a/python/infinity/infinity.py
+++ b/python/infinity/infinity.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from enum import Enum
 
-from infinity import URI
 
 # abstract class
 class InfinityConnection(ABC):

--- a/scripts/Dockerfile_infinity_builder_centos7
+++ b/scripts/Dockerfile_infinity_builder_centos7
@@ -3,10 +3,10 @@
 # NOTICE: You can use the download_deps_infinity_builder_centos7.sh script to download them
 # bison-3.8.2.tar.xz
 # binutils-2.41.tar.xz
-# gcc-13.2.0.tar.xz
+# gcc-12.2.0.tar.xz
 # cmake-3.29.3-linux-x86_64.tar.gz
 # ninja-linux.zip
-# llvm-project-17.0.6.src.tar.xz
+# llvm-project-18.1.8.src.tar.xz
 # boost_1_81_0.tar.bz2
 # flex-2.6.4.tar.gz
 # liburing-2.5.tar.gz
@@ -39,15 +39,15 @@ RUN --mount=type=bind,source=binutils-2.41.tar.xz,target=/root/binutils-2.41.tar
     && make -j && make install-strip \
     && ldconfig && cd /root && rm -rf binutils-2.41
 
-# Install gcc-13.2.0
-RUN --mount=type=bind,source=gcc-13.2.0.tar.xz,target=/root/gcc-13.2.0.tar.xz \
-    cd /root && tar xf gcc-13.2.0.tar.xz \
-    && cd gcc-13.2.0 && ./contrib/download_prerequisites \
+# Install gcc-12.2.0
+RUN --mount=type=bind,source=gcc-12.2.0.tar.xz,target=/root/gcc-12.2.0.tar.xz \
+    cd /root && tar xf gcc-12.2.0.tar.xz \
+    && cd gcc-12.2.0 && ./contrib/download_prerequisites \
     && cd /root && mkdir build-gcc && cd build-gcc \
-    && ../gcc-13.2.0/configure --enable-languages=c,c++ \
+    && ../gcc-12.2.0/configure --enable-languages=c,c++ \
         --disable-multilib --with-pic \
     && make -j12 && make install-strip \
-    && cd /root && rm -rf build-gcc && rm -rf gcc-13.2.0 \
+    && cd /root && rm -rf build-gcc && rm -rf gcc-12.2.0 \
     && ln -s gcc /usr/local/bin/cc && ldconfig
 
 ENV LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
@@ -64,12 +64,12 @@ RUN --mount=type=bind,source=ninja-linux.zip,target=/root/ninja-linux.zip \
     cd /root && unzip ninja-linux.zip \
     && cp ninja /usr/local/bin && rm ninja
 
-# Install clang-17.0.6
+# Install clang-18.1.8
 # Add -DCLANG_DEFAULT_LINKER=lld to use lld by default
 # infinity seems to be incompatible with the lld linker
-RUN --mount=type=bind,source=llvm-project-17.0.6.src.tar.xz,target=/root/llvm-project-17.0.6.src.tar.xz \
-    cd /root && tar xf llvm-project-17.0.6.src.tar.xz \
-    && cd llvm-project-17.0.6.src && mkdir build && cd build \
+RUN --mount=type=bind,source=llvm-project-18.1.8.src.tar.xz,target=/root/llvm-project-18.1.8.src.tar.xz \
+    cd /root && tar xf llvm-project-18.1.8.src.tar.xz \
+    && cd llvm-project-18.1.8.src && mkdir build && cd build \
     && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_JOB_POOLS:STRING=link_pool=1 \
         -DCMAKE_JOB_POOL_LINK:STRING=link_pool \
@@ -78,8 +78,8 @@ RUN --mount=type=bind,source=llvm-project-17.0.6.src.tar.xz,target=/root/llvm-pr
         -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
         -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON \
         -DLLVM_TARGETS_TO_BUILD=X86 ../llvm \
-    && ninja -j12 install/strip \
-    && ldconfig && cd /root && rm -rf llvm-project-17.0.6.src
+    && ninja install/strip \
+    && ldconfig && cd /root && rm -rf llvm-project-18.1.8.src
 
 # Install boost-1.81.0
 RUN --mount=type=bind,source=boost_1_81_0.tar.bz2,target=/root/boost_1_81_0.tar.bz2 \
@@ -107,7 +107,7 @@ RUN --mount=type=bind,source=libevent-2.1.12-stable.tar.gz,target=/root/libevent
     && cd libevent-2.1.12-stable && mkdir build && cd build \
     && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_FLAGS="-fPIC" .. \
-    && ninja -j0 install \
+    && ninja install \
     && ldconfig && cd /root && rm -rf libevent-2.1.12-stable
 
 # Install lz4-1.9.4

--- a/scripts/download_deps_infinity_builder_centos7.sh
+++ b/scripts/download_deps_infinity_builder_centos7.sh
@@ -13,10 +13,10 @@ download()
 # https://stackoverflow.com/questions/24628076/convert-multiline-string-to-array
 names="https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz
 https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.xz
-https://ftp.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz
+https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.xz
 https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz
 https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
-https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/llvm-project-17.0.6.src.tar.xz
+https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz
 https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
 https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
 https://github.com/axboe/liburing/archive/refs/tags/liburing-2.5.tar.gz

--- a/src/common/stl.cppm
+++ b/src/common/stl.cppm
@@ -28,7 +28,6 @@ module;
 #include <cstdlib>
 #include <cstring>
 #include <exception>
-#include <source_location>
 #include <filesystem>
 #include <forward_list>
 #include <functional>
@@ -41,6 +40,8 @@ module;
 #include <random>
 #include <set>
 #include <shared_mutex>
+#include <source_location>
+#include <span>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -83,10 +84,11 @@ export namespace std {
     using std::strtod;
 
     using std::bit_cast;
-    using std::memcpy;
-    using std::strcmp;
-    using std::memset;
+    using std::bit_ceil;
     using std::memcmp;
+    using std::memcpy;
+    using std::memset;
+    using std::strcmp;
     using std::strlen;
 
     using std::time;

--- a/src/network/buffer_reader.cpp
+++ b/src/network/buffer_reader.cpp
@@ -165,8 +165,8 @@ void BufferReader::receive_more(SizeT bytes) {
     } else {
         bytes_read = boost::asio::read(
             *socket_,
-            std::array<boost::asio::mutable_buffer, 2>{boost::asio::buffer(current_pos_.position_addr(), PG_MSG_BUFFER_SIZE - current_pos_.position_),
-                                                       boost::asio::buffer(&data_[0], start_pos_.position_ - 1)},
+            Array<boost::asio::mutable_buffer, 2>{boost::asio::buffer(current_pos_.position_addr(), PG_MSG_BUFFER_SIZE - current_pos_.position_),
+                                                  boost::asio::buffer(&data_[0], start_pos_.position_ - 1)},
             boost::asio::transfer_at_least(bytes - size()),
             boost_error);
     }

--- a/src/network/buffer_writer.cpp
+++ b/src/network/buffer_writer.cpp
@@ -120,8 +120,8 @@ void BufferWriter::flush(SizeT bytes) {
     if ((RingBufferIterator::Distance(start_pos_, current_pos_) < 0)) {
         bytes_sent = boost::asio::write(
             *socket_,
-            std::array<boost::asio::mutable_buffer, 2>{boost::asio::buffer(start_pos_.position_addr(), PG_MSG_BUFFER_SIZE - start_pos_.position_),
-                                                       boost::asio::buffer(data_.begin(), current_pos_.position_)},
+            Array<boost::asio::mutable_buffer, 2>{boost::asio::buffer(start_pos_.position_addr(), PG_MSG_BUFFER_SIZE - start_pos_.position_),
+                                                  boost::asio::buffer(data_.begin(), current_pos_.position_)},
             boost::asio::transfer_at_least(bytes_to_send),
             boost_error);
     } else {

--- a/src/parser/type/datetime/date_type.cpp
+++ b/src/parser/type/datetime/date_type.cpp
@@ -14,7 +14,7 @@
 
 #include "date_type.h"
 #include "parser_assert.h"
-#include <format>
+#include "spdlog/fmt/fmt.h"
 
 namespace infinity {
 
@@ -109,10 +109,10 @@ void DateType::FromString(const char *date_ptr, size_t length, size_t &end_lengt
 std::string DateType::ToString() const {
     int32_t year{0}, month{0}, day{0};
     if (!Date2YMD(value, year, month, day)) {
-        ParserError(std::format("Invalid date: {}-{}-{}", year, month, day));
+        ParserError(fmt::format("Invalid date: {}-{}-{}", year, month, day));
     }
     // TODO: format for negative year?
-    return std::format("{:04d}-{:02d}-{:02d}", year, month, day);
+    return fmt::format("{:04d}-{:02d}-{:02d}", year, month, day);
 }
 
 bool DateType::ConvertFromString(const char *date_ptr, size_t length, DateType &date, size_t &end_length) {

--- a/src/parser/type/datetime/time_type.cpp
+++ b/src/parser/type/datetime/time_type.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "time_type.h"
-#include <format>
+#include "spdlog/fmt/fmt.h"
 
 namespace infinity {
 // min time: 00:00:00.000
@@ -49,9 +49,9 @@ void TimeType::FromString(const char *time_ptr, size_t length) {
 std::string TimeType::ToString() const {
     int32_t hour{}, minute{}, second{};
     if (!Time2HMS(value, hour, minute, second)) {
-        ParserError(std::format("Invalid second value: {}", value));
+        ParserError(fmt::format("Invalid second value: {}", value));
     }
-    return std::format("{:02d}:{:02d}:{:02d}", hour, minute, second);
+    return fmt::format("{:02d}:{:02d}:{:02d}", hour, minute, second);
 }
 
 bool TimeType::Add(TimeType input, IntervalType interval, TimeType &output) {

--- a/src/planner/optimizer/secondary_index_scan/filter_expression_push_down.cpp
+++ b/src/planner/optimizer/secondary_index_scan/filter_expression_push_down.cpp
@@ -15,6 +15,7 @@
 module;
 
 #include <string>
+
 module filter_expression_push_down;
 
 import stl;
@@ -356,8 +357,8 @@ private:
             case ExpressionType::kFunction: {
                 auto function_expression = std::static_pointer_cast<FunctionExpression>(expression);
                 auto const &f_name = function_expression->ScalarFunctionName();
-                static constexpr std::array<const char *, 5> IndexScanSupportedCompareFunctionNames = {"<", ">", "<=", ">=", "="};
-                static constexpr std::array<const char *, 5> IndexScanSupportedCompareFunctionNamesCorrespondingReverse = {">", "<", ">=", "<=", "="};
+                static constexpr Array<const char *, 5> IndexScanSupportedCompareFunctionNames = {"<", ">", "<=", ">=", "="};
+                static constexpr Array<const char *, 5> IndexScanSupportedCompareFunctionNamesCorrespondingReverse = {">", "<", ">=", "<=", "="};
                 // depth 0: <, >, <=, >=, = function
                 if (auto name_iter = std::find(IndexScanSupportedCompareFunctionNames.begin(), IndexScanSupportedCompareFunctionNames.end(), f_name);
                     name_iter != IndexScanSupportedCompareFunctionNames.end()) {
@@ -619,15 +620,15 @@ public:
         // known expression 3 : "and" or "or" expression
         switch (expression->type()) {
             case ExpressionType::kFunction: {
-                static constexpr std::array<const char *, 4> Case2FunctionNames = {"<", ">", "<=", ">="};
-                static constexpr std::array<FilterCompareType, 4> Case2CompareTypes = {FilterCompareType::kLess,
-                                                                                       FilterCompareType::kGreater,
-                                                                                       FilterCompareType::kLessEqual,
-                                                                                       FilterCompareType::kGreaterEqual};
-                static constexpr std::array<FilterCompareType, 4> Case2ReverseCompareTypes = {FilterCompareType::kGreater,
-                                                                                              FilterCompareType::kLess,
-                                                                                              FilterCompareType::kGreaterEqual,
-                                                                                              FilterCompareType::kLessEqual};
+                static constexpr Array<const char *, 4> Case2FunctionNames = {"<", ">", "<=", ">="};
+                static constexpr Array<FilterCompareType, 4> Case2CompareTypes = {FilterCompareType::kLess,
+                                                                                  FilterCompareType::kGreater,
+                                                                                  FilterCompareType::kLessEqual,
+                                                                                  FilterCompareType::kGreaterEqual};
+                static constexpr Array<FilterCompareType, 4> Case2ReverseCompareTypes = {FilterCompareType::kGreater,
+                                                                                         FilterCompareType::kLess,
+                                                                                         FilterCompareType::kGreaterEqual,
+                                                                                         FilterCompareType::kLessEqual};
                 auto function_expression = std::static_pointer_cast<FunctionExpression>(expression);
                 if (auto const &f_name = function_expression->ScalarFunctionName(); f_name == "AND") {
                     // known expression 3

--- a/src/planner/optimizer/secondary_index_scan/secondary_index_scan_middle_expression.cpp
+++ b/src/planner/optimizer/secondary_index_scan/secondary_index_scan_middle_expression.cpp
@@ -15,7 +15,6 @@
 module;
 
 #include <memory>
-#include <string>
 
 module secondary_index_scan_middle_expression;
 
@@ -76,12 +75,12 @@ private:
                 }
             } else {
                 // "[cast] x compare value_expr"
-                static constexpr std::array<const char *, 5> compare_functions = {"<", ">", "<=", ">=", "="};
-                static constexpr std::array<FilterCompareType, 5> corresponding_compare_types = {FilterCompareType::kLess,
-                                                                                                 FilterCompareType::kGreater,
-                                                                                                 FilterCompareType::kLessEqual,
-                                                                                                 FilterCompareType::kGreaterEqual,
-                                                                                                 FilterCompareType::kEqual};
+                static constexpr Array<const char *, 5> compare_functions = {"<", ">", "<=", ">=", "="};
+                static constexpr Array<FilterCompareType, 5> corresponding_compare_types = {FilterCompareType::kLess,
+                                                                                            FilterCompareType::kGreater,
+                                                                                            FilterCompareType::kLessEqual,
+                                                                                            FilterCompareType::kGreaterEqual,
+                                                                                            FilterCompareType::kEqual};
                 if (auto it = std::find(compare_functions.begin(), compare_functions.end(), function_name); it != compare_functions.end()) {
                     auto compare_type = corresponding_compare_types[std::distance(compare_functions.begin(), it)];
                     auto &left = function_expression->arguments()[0];  // [cast] x

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -104,7 +104,7 @@ void BufferManager::RemoveClean() {
         std::unique_lock lock(w_locker_);
         for (auto *buffer_obj : clean_list) {
             auto file_path = buffer_obj->GetFilename();
-            size_t remove_n = buffer_map_.erase(file_path);
+            SizeT remove_n = buffer_map_.erase(file_path);
             if (remove_n != 1) {
                 String error_message = fmt::format("BufferManager::RemoveClean: file {} not found.", file_path.c_str());
                 LOG_CRITICAL(error_message);

--- a/src/storage/definition/index_emvb.cpp
+++ b/src/storage/definition/index_emvb.cpp
@@ -15,9 +15,7 @@
 module;
 
 #include <algorithm>
-#include <array>
 #include <sstream>
-#include <string>
 
 module index_emvb;
 
@@ -65,8 +63,8 @@ String IndexEMVB::BuildOtherParamsString() const {
     return fmt::format("pq_subspace_num = {}, pq_subspace_bits = {}.", residual_pq_subspace_num_, residual_pq_subspace_bits_);
 }
 
-constexpr std::array<u32, 8> accepable_residual_pq_subspace_num = {1, 2, 4, 8, 16, 32, 64, 128};
-constexpr std::array<u32, 2> accepable_residual_pq_subspace_bits = {8, 16};
+constexpr Array<u32, 8> accepable_residual_pq_subspace_num = {1, 2, 4, 8, 16, 32, 64, 128};
+constexpr Array<u32, 2> accepable_residual_pq_subspace_bits = {8, 16};
 
 SharedPtr<IndexBase>
 IndexEMVB::Make(SharedPtr<String> index_name, const String &file_name, Vector<String> column_names, const Vector<InitParameter *> &index_param_list) {

--- a/src/storage/fast_rough_filter/min_max_data_filter.cpp
+++ b/src/storage/fast_rough_filter/min_max_data_filter.cpp
@@ -37,7 +37,7 @@ void VariantEmplaceFunc(InnerMinMaxDataFilter *ptr) {
 
 template <std::size_t... I>
 consteval auto GetVariantEmplaceFuncs(std::index_sequence<I...>) {
-    return std::array<VariantEmplaceFuncType *, sizeof...(I)>{VariantEmplaceFunc<I>...};
+    return Array<VariantEmplaceFuncType *, sizeof...(I)>{VariantEmplaceFunc<I>...};
 }
 
 static constexpr auto VariantEmplaceFuncs = GetVariantEmplaceFuncs(std::make_index_sequence<std::variant_size_v<InnerMinMaxDataFilter>>{});

--- a/src/storage/knn_index/emvb/emvb_search.cpp
+++ b/src/storage/knn_index/emvb/emvb_search.cpp
@@ -15,7 +15,6 @@
 module;
 
 #include <algorithm>
-#include <array>
 #include <bitset>
 #include <cassert>
 #include <cstdlib>
@@ -258,7 +257,7 @@ auto EMVBSearch<FIXED_QUERY_TOKEN_NUM>::compute_topk_documents_selected(const f3
         embedding_id_buffer.Resize(doclen + 8);
         const auto embedding_id_ptr = embedding_id_buffer.GetPtr();
         // auto buffer_centroids = embedding_id_ptr
-        std::array<f32, FIXED_QUERY_TOKEN_NUM> maxs = {};
+        Array<f32, FIXED_QUERY_TOKEN_NUM> maxs = {};
         for (u32 query_token_id = 0; query_token_id < FIXED_QUERY_TOKEN_NUM; ++query_token_id) {
             // TODO: transpose?
             for (u32 j = 0; j < doclen; ++j) {

--- a/src/unit_test/storage/binary_fuse_filter/binary_fuse_filter_test.cpp
+++ b/src/unit_test/storage/binary_fuse_filter/binary_fuse_filter_test.cpp
@@ -22,7 +22,7 @@ class BinaryFuseFilterTest : public BaseTest {};
 TEST_F(BinaryFuseFilterTest, test_2000) {
     using namespace infinity;
     constexpr u64 NUM = 2000;
-    std::array<u64, NUM> data;
+    Array<u64, NUM> data;
     for (u64 i = 0; i < NUM; ++i) {
         data[i] = i * NUM;
     }

--- a/src/unit_test/storage/knnindex/emvb_search/test_simd.cpp
+++ b/src/unit_test/storage/knnindex/emvb_search/test_simd.cpp
@@ -29,7 +29,7 @@ class SIMDTest : public BaseTest {};
 TEST_F(SIMDTest, testsum256) {
     constexpr u32 test_sum256_loop = 20;
 
-    std::array<f32, 8> random_f32 = {};
+    Array<f32, 8> random_f32 = {};
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_real_distribution<f32> dis(-1024.0f, 1024.0f);

--- a/src/unit_test/storage/secondary_index/test_pgm.cpp
+++ b/src/unit_test/storage/secondary_index/test_pgm.cpp
@@ -41,7 +41,7 @@ template <typename T>
 class TestPGM : public BaseTest {
 public:
     using PGM = PGMT<T>::type;
-    std::array<T, TestNum> data;
+    Array<T, TestNum> data;
     uint32_t cnt = TestNum;
     std::unique_ptr<PGM> pgm;
 


### PR DESCRIPTION
### What problem does this PR solve?

Update builder image to use gcc12 and clang18.
Python module shall dynamic link with libstdc++. The linked libstdc++ version should be old enough so that the python module can be loaded on old platform such as Ubuntu 22.04(with gcc 11 and gcc 12 in its official repo). Current builder image use gcc13.

### Type of change

- [x] Refactoring
- [x] Python SDK impacted, Need to update PyPI
