### PR TITLE
Clang18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,9 @@ jobs:
         sudo docker rm -f infinity_build && sudo docker run -d --privileged --name infinity_build --network=host -e TZ=$TZ -v $PWD:/infinity infiniflow/infinity_builder:centos7
 
     - name: Build release version
-      run: sudo docker exec infinity_build bash -c "git config --global safe.directory \"*\" && cd /infinity && rm -fr cmake-build-release && mkdir -p cmake-build-release && cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCPACK_PACKAGE_VERSION=${{ env.RELEASE_TAG }} -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=amd64 -DCMAKE_JOB_POOL_LINK:STRING=link_pool -DCMAKE_JOB_POOLS:STRING=link_pool=1 -S /infinity -B /infinity/cmake-build-release && cmake --build /infinity/cmake-build-release --target infinity"
+      run: |
+        sed -i "s/^version = \".*\"/version = \"$(echo $RELEASE_TAG | cut -c2-)\"/" pyproject.toml
+        sudo docker exec infinity_build bash -c "git config --global safe.directory \"*\" && cd /infinity && rm -fr cmake-build-release && mkdir -p cmake-build-release && cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCPACK_PACKAGE_VERSION=${{ env.RELEASE_TAG }} -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=amd64 -DCMAKE_JOB_POOL_LINK:STRING=link_pool -DCMAKE_JOB_POOLS:STRING=link_pool=1 -S /infinity -B /infinity/cmake-build-release && cmake --build /infinity/cmake-build-release --target infinity"
 
     - name: Download resources
       run: rm -rf resource && git clone --depth=1 https://github.com/infiniflow/resource.git
@@ -120,8 +122,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
         sudo rm -f cmake-build-release/*.deb cmake-build-release/*.rpm cmake-build-release/*.gz
-        sed -i "s/^version = \".*\"/version = \"$(echo $RELEASE_TAG | cut -c2-)\"/" pyproject.toml
-        sudo docker exec infinity_build bash -c "cd /infinity/ && rm -rf dist wheelhouse && /usr/local/bin/pip3.10 wheel . -v -w dist --config-settings=wheel.py-api=cp310 --config-settings=build-dir='cmake-build-release' && /usr/local/bin/pip3.11 wheel . -v -w dist --config-settings=wheel.py-api=cp311 --config-settings=build-dir='cmake-build-release' && /usr/local/bin/pip3.12 wheel . -v -w dist --config-settings=wheel.py-api=cp312 --config-settings=build-dir='cmake-build-release' && mkdir wheelhouse && cp dist/infinity*.whl wheelhouse && wheel tags --remove --platform-tag manylinux_2_17_x86_64 wheelhouse/infinity*linux_x86_64.whl"
+        sudo docker exec infinity_build bash -c "cd /infinity/ && rm -rf dist && /usr/local/bin/pip3.10 wheel . -v -w dist --config-settings=wheel.py-api=cp310 --config-settings=build-dir='cmake-build-release' && /usr/local/bin/pip3.11 wheel . -v -w dist --config-settings=wheel.py-api=cp311 --config-settings=build-dir='cmake-build-release' && /usr/local/bin/pip3.12 wheel . -v -w dist --config-settings=wheel.py-api=cp312 --config-settings=build-dir='cmake-build-release' && auditwheel repair --plat manylinux_2_17_x86_64 dist/infinity*linux_x86_64.whl"
 
     - name: Publish package distributions to PyPI
       if: startsWith(github.ref, 'refs/tags/v')

--- a/centos7-vault.repo
+++ b/centos7-vault.repo
@@ -1,0 +1,23 @@
+[C7.9.2009-base]
+name=CentOS-7.9.2009 - Base
+baseurl=http://mirrors.aliyun.com/centos-vault/7.9.2009/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[C7.9.2009-updates]
+name=CentOS-7.9.2009 - Updates
+baseurl=http://mirrors.aliyun.com/centos-vault/7.9.2009/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[C7.9.2009-extras]
+name=CentOS-7.9.2009 - Extras
+baseurl=http://mirrors.aliyun.com/centos-vault/7.9.2009/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[C7.9.2009-centosplus]
+name=CentOS-7.9.2009 - Plus
+baseurl=http://mirrors.aliyun.com/centos-vault/7.9.2009/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/scripts/Dockerfile_infinity_builder_centos7
+++ b/scripts/Dockerfile_infinity_builder_centos7
@@ -6,10 +6,9 @@
 # gcc-13.2.0.tar.xz
 # cmake-3.29.3-linux-x86_64.tar.gz
 # ninja-linux.zip
-# llvm-project-17.0.6.src.tar.xz
+# llvm-project-18.1.8.src.tar.xz
 # boost_1_81_0.tar.bz2
 # flex-2.6.4.tar.gz
-# liburing-2.5.tar.gz
 # libevent-2.1.12-stable.tar.gz
 # lz4-1.9.4.tar.gz
 # jemalloc-5.3.0.tar.bz2
@@ -17,12 +16,16 @@
 # openssl-1.1.1w.tar.gz
 # Python-3.12.4.tar.xz
 
-FROM centos:7
+FROM centos:7.9.2009
 
-RUN yum -y upgrade \
-    && yum -y install git make wget which vim file gcc-c++ \
+RUN rm -f /etc/yum.repos.d/* && sed -i 's/^enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+# https://www.getpagespeed.com/server-setup/how-to-fix-yum-after-centos-6-went-eol
+COPY centos7-vault.repo /etc/yum.repos.d/
+
+RUN yum -y install git make wget which vim file gcc-c++ \
         python3 python3-devel gettext-devel openssl-devel \
         unzip bzip2 libtool m4 tree rpm-build postgresql \
+    && yum clean all \
     && echo '/usr/local/lib' >> /etc/ld.so.conf.d/local.conf \
     && echo '/usr/local/lib64' >> /etc/ld.so.conf.d/local.conf
 
@@ -64,22 +67,22 @@ RUN --mount=type=bind,source=ninja-linux.zip,target=/root/ninja-linux.zip \
     cd /root && unzip ninja-linux.zip \
     && cp ninja /usr/local/bin && rm ninja
 
-# Install clang-17.0.6
+# Install clang-18.1.8
 # Add -DCLANG_DEFAULT_LINKER=lld to use lld by default
 # infinity seems to be incompatible with the lld linker
-RUN --mount=type=bind,source=llvm-project-17.0.6.src.tar.xz,target=/root/llvm-project-17.0.6.src.tar.xz \
-    cd /root && tar xf llvm-project-17.0.6.src.tar.xz \
-    && cd llvm-project-17.0.6.src && mkdir build && cd build \
+RUN --mount=type=bind,source=llvm-project-18.1.8.src.tar.xz,target=/root/llvm-project-18.1.8.src.tar.xz \
+    cd /root && tar xf llvm-project-18.1.8.src.tar.xz \
+    && cd llvm-project-18.1.8.src && mkdir build && cd build \
     && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_JOB_POOLS:STRING=link_pool=1 \
+        -DCMAKE_JOB_POOLS:STRING=link_pool=3 \
         -DCMAKE_JOB_POOL_LINK:STRING=link_pool \
         -DGCC_INSTALL_PREFIX=/usr/local \
         -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb" \
-        -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
-        -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON \
+        -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
+        -DLIBCXXABI_USE_LLVM_UNWINDER=ON \
         -DLLVM_TARGETS_TO_BUILD=X86 ../llvm \
-    && ninja -j12 install/strip \
-    && ldconfig && cd /root && rm -rf llvm-project-17.0.6.src
+    && ninja install/strip \
+    && ldconfig && cd /root && rm -rf llvm-project-18.1.8.src
 
 # Install boost-1.81.0
 RUN --mount=type=bind,source=boost_1_81_0.tar.bz2,target=/root/boost_1_81_0.tar.bz2 \
@@ -95,19 +98,13 @@ RUN --mount=type=bind,source=flex-2.6.4.tar.gz,target=/root/flex-2.6.4.tar.gz  \
     && make -j && make install \
     && ldconfig && cd /root && rm -rf flex-2.6.4
 
-# Install liburing-2.5
-RUN --mount=type=bind,source=liburing-2.5.tar.gz,target=/root/liburing-2.5.tar.gz  \
-    cd /root && tar xf liburing-2.5.tar.gz \
-    && cd liburing-liburing-2.5 && make -j install \
-    && ldconfig && cd /root && rm -rf liburing-liburing-2.5
-
 # Install libevent-2.1.12
 RUN --mount=type=bind,source=libevent-2.1.12-stable.tar.gz,target=/root/libevent-2.1.12-stable.tar.gz  \
     cd /root && tar xf libevent-2.1.12-stable.tar.gz \
     && cd libevent-2.1.12-stable && mkdir build && cd build \
     && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_FLAGS="-fPIC" .. \
-    && ninja -j0 install \
+    && ninja install \
     && ldconfig && cd /root && rm -rf libevent-2.1.12-stable
 
 # Install lz4-1.9.4
@@ -188,6 +185,10 @@ RUN --mount=type=bind,source=python/requirements.txt,target=/root/requirements.t
 RUN --mount=type=bind,source=python/requirements.txt,target=/root/requirements.txt /usr/local/bin/python3.11 -m venv /usr/local/venv311 && source /usr/local/venv311/bin/activate && pip3 install --no-input wheel && pip3 install --no-input -r /root/requirements.txt
 
 RUN --mount=type=bind,source=python/requirements.txt,target=/root/requirements.txt /usr/local/bin/python3.12 -m venv /usr/local/venv312 && source /usr/local/venv312/bin/activate && pip3 install --no-input wheel && pip3 install --no-input -r /root/requirements.txt
+
+# https://github.com/llvm/llvm-project/issues/96210
+# https://github.com/llvm/llvm-project/issues/57276
+RUN cp /usr/local/include/x86_64-unknown-linux-gnu/c++/v1/__config_site /usr/local/include/c++/v1
 
 ENV PATH="/usr/local/venv310/bin:$PATH"
 

--- a/scripts/download_deps_infinity_builder_centos7.sh
+++ b/scripts/download_deps_infinity_builder_centos7.sh
@@ -16,10 +16,9 @@ https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.xz
 https://ftp.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz
 https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz
 https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
-https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/llvm-project-17.0.6.src.tar.xz
+https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz
 https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
 https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
-https://github.com/axboe/liburing/archive/refs/tags/liburing-2.5.tar.gz
 https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
 https://github.com/lz4/lz4/releases/download/v1.9.4/lz4-1.9.4.tar.gz
 https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz


### PR DESCRIPTION
Update clang toolchain inside build image to 18 

https://github.com/pytorch/pytorch/issues/4101
The underlying issue was wrt statically linking libstdc++ and we no longer do that.

infinity-sdk python module segment fault if it's staticly link with libstdc++. However if it dynamically link with libstdc++, it requires the runtime libstdc++ be no older than the version of compilation time (gcc13). This makes deployment complicated.

infinity-sdk cannot link with libstdc++ older as gcc11 since gcc11 doesn't support C++20 module well.
The python wheel `manylinux_2_17` actually uses gcc10.

Looks dead end...

The solution is let infinity-sdk python module static link with libc++ which's a part of clang toolchain.

- [x] Other (please describe):
toolchain
