### PR TITLE
Fix optimize index

### DIFF
--- a/python/benchmark/mldr_benchmark/insert_data.py
+++ b/python/benchmark/mldr_benchmark/insert_data.py
@@ -126,7 +126,7 @@ class InfinityClientForInsert:
                                                                                                   "compress")])],
                                                ConflictType.Error)
         assert res.error_code == ErrorCode.OK
-        self.infinity_table.optimize("bmp_index", {"topk": "1000"})
+        self.infinity_table.optimize("bmp_index", {"topk": "1000", "bp_reorder": ""})
         print("Finish creating BMP index.")
 
 

--- a/python/benchmark/mldr_benchmark/insert_data_50000.py
+++ b/python/benchmark/mldr_benchmark/insert_data_50000.py
@@ -133,7 +133,7 @@ class InfinityClientForInsert:
                                                                                                   "compress")])],
                                                ConflictType.Error)
         assert res.error_code == ErrorCode.OK
-        self.infinity_table.optimize("bmp_index", {"topk": "1000"})
+        self.infinity_table.optimize("bmp_index", {"topk": "1000", "bp_reorder": {}})
         print("Finish creating BMP index.")
 
 

--- a/python/infinity/remote_thrift/table.py
+++ b/python/infinity/remote_thrift/table.py
@@ -494,8 +494,8 @@ class RemoteTable(Table, ABC):
 
     def optimize(self, index_name: str, opt_params: dict[str, str]):
         opt_options = ttypes.OptimizeOptions()
-        opt_options.index_name_ = index_name
-        opt_options.opt_params_ = [ttypes.InitParameter(k, v) for k, v in opt_params.items()]
+        opt_options.index_name = index_name
+        opt_options.opt_params = [ttypes.InitParameter(k, v) for k, v in opt_params.items()]
         return self._conn.optimize(db_name=self._db_name, table_name=self._table_name, optimize_opt=opt_options)
 
     def _execute_query(self, query: Query) -> tuple[dict[str, list[Any]], dict[str, Any]]:

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cpp
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cpp
@@ -103,13 +103,12 @@ void HnswFileWorker::FreeInMemory() {
     data_ = nullptr;
 }
 
-void HnswFileWorker::CompressToLVQ() {
+void HnswFileWorker::CompressToLVQ(IndexHnsw *index_hnsw) {
     if (!data_) {
         String error_message = "CompressToLVQ: Data is not allocated.";
         LOG_CRITICAL(error_message);
         UnrecoverableError(error_message);
     }
-    const IndexHnsw *index_hnsw = static_cast<const IndexHnsw *>(index_base_.get());
     EmbeddingDataType embedding_type = GetType();
     switch (embedding_type) {
         case kElemFloat: {

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cppm
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cppm
@@ -19,7 +19,7 @@ export module hnsw_file_worker;
 import stl;
 import index_file_worker;
 import hnsw_alg;
-
+import index_hnsw;
 import index_base;
 import knn_expr;
 import column_def;
@@ -50,7 +50,7 @@ public:
 
     FileWorkerType Type() const override { return FileWorkerType::kHNSWIndexFile; }
 
-    void CompressToLVQ();
+    void CompressToLVQ(IndexHnsw *index_hnsw);
 
 protected:
     void WriteToFileImpl(bool to_spill, bool &prepare_success) override;

--- a/src/storage/knn_index/knn_hnsw/hnsw_util.cppm
+++ b/src/storage/knn_index/knn_hnsw/hnsw_util.cppm
@@ -1,0 +1,45 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <vector>
+
+export module hnsw_util;
+
+import stl;
+import statement_common;
+
+namespace infinity {
+
+export struct HnswOptimizeOptions {
+    bool compress_to_lvq = false;
+};
+
+export struct HnswUtil {
+    static Optional<HnswOptimizeOptions> ParseOptimizeOptions(const Vector<UniquePtr<InitParameter>> &opt_params) {
+        HnswOptimizeOptions options;
+        for (const auto &param : opt_params) {
+            if (IsEqual(param->param_name_, "compress_to_lvq")) {
+                options.compress_to_lvq = true;
+            }
+        }
+        if (!options.compress_to_lvq) {
+            return None;
+        }
+        return options;
+    }
+};
+
+} // namespace infinity

--- a/src/storage/knn_index/sparse/bmp_alg.cpp
+++ b/src/storage/knn_index/sparse/bmp_alg.cpp
@@ -253,6 +253,12 @@ void BMPAlg<DataType, IdxType, CompressType>::AddDoc(const SparseVecRef<DataType
 }
 
 template <typename DataType, typename IdxType, BMPCompressType CompressType>
+SizeT BMPAlg<DataType, IdxType, CompressType>::DocNum() const {
+    std::shared_lock lock(mtx_);
+    return doc_ids_.size();
+}
+
+template <typename DataType, typename IdxType, BMPCompressType CompressType>
 void BMPAlg<DataType, IdxType, CompressType>::Optimize(const BMPOptimizeOptions &options) {
     std::unique_lock lock(mtx_);
 

--- a/src/storage/knn_index/sparse/bmp_alg.cppm
+++ b/src/storage/knn_index/sparse/bmp_alg.cppm
@@ -135,6 +135,8 @@ public:
     template <DataIteratorConcept<SparseVecRef<DataType, IdxType>, BMPDocID> Iterator>
     SizeT AddDocs(Iterator iter);
 
+    SizeT DocNum() const;
+
     void Optimize(const BMPOptimizeOptions &options);
 
     Pair<Vector<BMPDocID>, Vector<DataType>> SearchKnn(const SparseVecRef<DataType, IdxType> &query, i32 topk, const BmpSearchOptions &options) const;

--- a/src/storage/meta/entry/base_entry.cppm
+++ b/src/storage/meta/entry/base_entry.cppm
@@ -61,9 +61,9 @@ export struct BaseEntry {
 public:
     // Reserved
     inline void Commit(TxnTimeStamp commit_ts) {
-        // assert(!Committed() || commit_ts_ == commit_ts);
-        // assert(commit_ts != UNCOMMIT_TS);
-        commit_ts_.store(commit_ts);
+        if (commit_ts_ == UNCOMMIT_TS) {
+            commit_ts_.store(commit_ts);
+        }
     }
 
     [[nodiscard]] inline bool Committed() const { return commit_ts_ != UNCOMMIT_TS; }

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -63,6 +63,8 @@ import secondary_index_in_mem;
 import emvb_index;
 import emvb_index_in_mem;
 import bmp_util;
+import hnsw_util;
+import wal_entry;
 
 namespace infinity {
 
@@ -395,24 +397,24 @@ void SegmentIndexEntry::MemIndexCommit() {
     memory_indexer_->Commit();
 }
 
-SharedPtr<ChunkIndexEntry> SegmentIndexEntry::MemIndexDump(bool spill) {
+SharedPtr<ChunkIndexEntry> SegmentIndexEntry::MemIndexDump(Txn *txn, bool spill) {
     SharedPtr<ChunkIndexEntry> chunk_index_entry = nullptr;
     const IndexBase *index_base = table_index_entry_->index_base();
     switch (index_base->index_type_) {
         case IndexType::kBMP:
         case IndexType::kHnsw: {
             if (memory_hnsw_indexer_.get() == nullptr) {
-                return nullptr;
+                break;
             }
             std::unique_lock lck(rw_locker_);
-            auto dump_indexer = std::exchange(memory_hnsw_indexer_, nullptr);
-            dump_indexer->SaveIndexFile();
-            chunk_index_entries_.push_back(dump_indexer);
-            return dump_indexer;
+            chunk_index_entry = std::exchange(memory_hnsw_indexer_, nullptr);
+            chunk_index_entry->SaveIndexFile();
+            chunk_index_entries_.push_back(chunk_index_entry);
+            break;
         }
         case IndexType::kFullText: {
             if (memory_indexer_.get() == nullptr) {
-                return nullptr;
+                break;
             }
             memory_indexer_->Dump(false, spill);
             if (!spill) {
@@ -421,18 +423,18 @@ SharedPtr<ChunkIndexEntry> SegmentIndexEntry::MemIndexDump(bool spill) {
                 this->UpdateFulltextColumnLenInfo(memory_indexer_->GetColumnLengthSum(), memory_indexer_->GetDocCount());
                 memory_indexer_.reset();
             }
-            return chunk_index_entry;
+            break;
         }
         case IndexType::kSecondary: {
             if (memory_secondary_index_.get() == nullptr) {
-                return nullptr;
+                break;
             }
             std::unique_lock lck(rw_locker_);
             chunk_index_entry = memory_secondary_index_->Dump(this, buffer_manager_);
             chunk_index_entry->SaveIndexFile();
             chunk_index_entries_.push_back(chunk_index_entry);
             memory_secondary_index_.reset();
-            return chunk_index_entry;
+            break;
         }
         case IndexType::kEMVB: {
             if (memory_emvb_index_.get() == nullptr) {
@@ -443,12 +445,26 @@ SharedPtr<ChunkIndexEntry> SegmentIndexEntry::MemIndexDump(bool spill) {
             chunk_index_entry->SaveIndexFile();
             chunk_index_entries_.push_back(chunk_index_entry);
             memory_emvb_index_.reset();
-            return chunk_index_entry;
+            break;
         }
         default: {
-            return nullptr;
+            UnrecoverableError("Not implemented.");
+            break;
         }
     }
+    if (txn != nullptr) {
+        String index_name = *table_index_entry_->GetIndexName();
+        TableEntry *table_entry = table_index_entry_->table_index_meta()->GetTableEntry();
+        String table_name = *table_entry->GetTableName();
+        String db_name = *table_entry->GetDBName();
+
+        Vector<WalChunkIndexInfo> chunk_infos;
+        chunk_infos.emplace_back(chunk_index_entry.get());
+        auto wal_cmd =
+            MakeShared<WalCmdDumpIndex>(std::move(db_name), std::move(table_name), std::move(index_name), segment_id_, std::move(chunk_infos));
+        txn->AddWalCmd(wal_cmd);
+    }
+    return chunk_index_entry;
 }
 
 void SegmentIndexEntry::MemIndexLoad(const String &base_name, RowID base_row_id) {
@@ -585,7 +601,7 @@ void SegmentIndexEntry::PopulateEntirely(const SegmentEntry *segment_entry, Txn 
                 BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
                 memory_secondary_index_->Insert(block_id, block_column_entry, buffer_mgr, 0, block_entry->row_count());
             }
-            MemIndexDump();
+            MemIndexDump(txn);
             break;
         }
         case IndexType::kEMVB: {
@@ -804,7 +820,11 @@ void SegmentIndexEntry::CommitOptimize(ChunkIndexEntry *new_chunk, const Vector<
     // LOG_INFO(ss.str());
 }
 
-void SegmentIndexEntry::OptimizeIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay) {
+void SegmentIndexEntry::OptimizeIndex(IndexBase *index_base,
+                                      Txn *txn,
+                                      TxnTableStore *txn_table_store,
+                                      const Vector<UniquePtr<InitParameter>> &opt_params,
+                                      bool replay) {
     switch (table_index_entry_->index_base()->index_type_) {
         case IndexType::kBMP: {
             Optional<BMPOptimizeOptions> ret = BMPUtil::ParseBMPOptimizeOptions(opt_params);
@@ -837,7 +857,7 @@ void SegmentIndexEntry::OptimizeIndex(TxnTableStore *txn_table_store, const Vect
                 auto abstract_bmp = static_cast<BMPIndexFileWorker *>(buffer_handle.GetFileWorkerMut())->GetAbstractIndex();
                 optimize_index(abstract_bmp);
 
-                auto dump_index_entry = this->MemIndexDump(false /*spill*/);
+                auto dump_index_entry = this->MemIndexDump(txn, false /*spill*/);
                 txn_table_store->AddChunkIndexStore(table_index_entry_, dump_index_entry.get());
             }
             break;
@@ -846,20 +866,26 @@ void SegmentIndexEntry::OptimizeIndex(TxnTableStore *txn_table_store, const Vect
             if (replay) {
                 break;
             }
+            auto params = HnswUtil::ParseOptimizeOptions(opt_params);
+            if (!params) {
+                return;
+            }
+            auto optimize_index = [&](ChunkIndexEntry *chunk_index_entry) {
+                BufferHandle buffer_handle = chunk_index_entry->GetIndex();
+                auto *file_worker = static_cast<HnswFileWorker *>(buffer_handle.GetFileWorkerMut());
+                if (params->compress_to_lvq) {
+                    file_worker->CompressToLVQ(static_cast<IndexHnsw *>(index_base));
+                }
+            };
 
             const auto [chunk_index_entries, memory_index_entry] = this->GetHnswIndexSnapshot();
             for (const auto &chunk_index_entry : chunk_index_entries) {
-                BufferHandle buffer_handle = chunk_index_entry->GetIndex();
-                auto *file_worker = static_cast<HnswFileWorker *>(buffer_handle.GetFileWorkerMut());
-                file_worker->CompressToLVQ();
+                optimize_index(chunk_index_entry.get());
                 chunk_index_entry->SaveIndexFile();
             }
             if (memory_index_entry.get() != nullptr) {
-                BufferHandle buffer_handle = memory_index_entry->GetIndex();
-                auto *file_worker = static_cast<HnswFileWorker *>(buffer_handle.GetFileWorkerMut());
-                file_worker->CompressToLVQ();
-
-                auto dump_index_entry = this->MemIndexDump(false /*spill*/);
+                optimize_index(memory_index_entry.get());
+                auto dump_index_entry = this->MemIndexDump(txn, false /*spill*/);
                 txn_table_store->AddChunkIndexStore(table_index_entry_, dump_index_entry.get());
             }
             break;
@@ -1110,6 +1136,19 @@ SharedPtr<ChunkIndexEntry> SegmentIndexEntry::AddFtChunkIndexEntry(const String 
     SharedPtr<ChunkIndexEntry> chunk_index_entry = ChunkIndexEntry::NewFtChunkIndexEntry(this, base_name, base_rowid, row_count, buffer_manager_);
     chunk_index_entries_.push_back(chunk_index_entry);
     return chunk_index_entry;
+}
+
+SharedPtr<ChunkIndexEntry> SegmentIndexEntry::AddChunkIndexEntryReplayWal(ChunkID chunk_id,
+                                                                          TableEntry *table_entry,
+                                                                          const String &base_name,
+                                                                          RowID base_rowid,
+                                                                          u32 row_count,
+                                                                          TxnTimeStamp commit_ts,
+                                                                          TxnTimeStamp deprecate_ts,
+                                                                          BufferManager *buffer_mgr) {
+    auto ret = this->AddChunkIndexEntryReplay(chunk_id, table_entry, base_name, base_rowid, row_count, commit_ts, deprecate_ts, buffer_mgr);
+    ++next_chunk_id_;
+    return ret;
 }
 
 SharedPtr<ChunkIndexEntry> SegmentIndexEntry::AddChunkIndexEntryReplay(ChunkID chunk_id,

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -89,8 +89,6 @@ public:
 
     void SaveIndexFile();
 
-    void SaveHnsw();
-
     static UniquePtr<SegmentIndexEntry>
     Deserialize(const nlohmann::json &index_entry_json, TableIndexEntry *table_index_entry, BufferManager *buffer_mgr, TableEntry *table_entry);
 
@@ -98,7 +96,7 @@ public:
 
     void CommitOptimize(ChunkIndexEntry *new_chunk, const Vector<ChunkIndexEntry *> &old_chunks, TxnTimeStamp commit_ts);
 
-    void OptimizeIndex(Txn *txn, const Vector<UniquePtr<InitParameter>> &opt_params);
+    void OptimizeIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
 
     bool Flush(TxnTimeStamp checkpoint_ts);
 

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -96,7 +96,8 @@ public:
 
     void CommitOptimize(ChunkIndexEntry *new_chunk, const Vector<ChunkIndexEntry *> &old_chunks, TxnTimeStamp commit_ts);
 
-    void OptimizeIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
+    void
+    OptimizeIndex(IndexBase *index_base, Txn *txn, TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
 
     bool Flush(TxnTimeStamp checkpoint_ts);
 
@@ -121,7 +122,7 @@ public:
     void MemIndexCommit();
 
     // Dump or spill the memory indexer
-    SharedPtr<ChunkIndexEntry> MemIndexDump(bool spill = false);
+    SharedPtr<ChunkIndexEntry> MemIndexDump(Txn *txn, bool spill = false);
 
     // Init the mem index from previously spilled one.
     void MemIndexLoad(const String &base_name, RowID base_row_id);
@@ -217,6 +218,15 @@ public:
     void AddChunkIndexEntry(SharedPtr<ChunkIndexEntry> chunk_index_entry);
 
     SharedPtr<ChunkIndexEntry> AddFtChunkIndexEntry(const String &base_name, RowID base_rowid, u32 row_count);
+
+    SharedPtr<ChunkIndexEntry> AddChunkIndexEntryReplayWal(ChunkID chunk_id,
+                                                           TableEntry *table_entry,
+                                                           const String &base_name,
+                                                           RowID base_rowid,
+                                                           u32 row_count,
+                                                           TxnTimeStamp commit_ts,
+                                                           TxnTimeStamp deprecate_ts,
+                                                           BufferManager *buffer_mgr);
 
     SharedPtr<ChunkIndexEntry> AddChunkIndexEntryReplay(ChunkID chunk_id,
                                                         TableEntry *table_entry,

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -714,7 +714,7 @@ void TableEntry::MemIndexInsertInner(TableIndexEntry *table_index_entry, Txn *tx
         segment_index_entry->MemIndexInsert(block_entry, range.start_offset_, range.row_count_, txn->CommitTS(), txn->buffer_mgr());
         if ((i == dump_idx && segment_index_entry->MemIndexRowCount() >= infinity::InfinityContext::instance().config()->MemIndexCapacity()) ||
             (i == num_ranges - 1 && segment_entry->Room() <= 0)) {
-            SharedPtr<ChunkIndexEntry> chunk_index_entry = segment_index_entry->MemIndexDump();
+            SharedPtr<ChunkIndexEntry> chunk_index_entry = segment_index_entry->MemIndexDump(txn);
             String *index_name = index_base->index_name_.get();
             String message = fmt::format("Table {}.{} index {} segment {} MemIndex dumped.", *GetDBName(), *table_name_, *index_name, seg_id);
             LOG_INFO(message);
@@ -738,7 +738,7 @@ void TableEntry::MemIndexDump(Txn *txn, bool spill) {
         if (!status.ok())
             continue;
         TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry);
-        SharedPtr<ChunkIndexEntry> chunk_index_entry = table_index_entry->MemIndexDump(txn_index_store, spill);
+        SharedPtr<ChunkIndexEntry> chunk_index_entry = table_index_entry->MemIndexDump(txn, txn_index_store, spill);
         if (chunk_index_entry.get() != nullptr) {
             chunk_index_entry->Commit(txn->CommitTS());
             txn_table_store->AddChunkIndexStore(table_index_entry, chunk_index_entry.get());

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -24,7 +24,7 @@ import local_file_system;
 import default_values;
 import index_base;
 import segment_iter;
-
+import hnsw_util;
 import infinity_exception;
 import index_full_text;
 import catalog_delta_entry;
@@ -398,49 +398,47 @@ void TableIndexEntry::UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin
     txn_id_ = txn_id;
 }
 
-Vector<SegmentIndexEntry *> TableIndexEntry::OptimizeIndex(Txn *txn, Vector<UniquePtr<InitParameter>> opt_params, bool replay) {
+void TableIndexEntry::OptimizeIndex(Txn *txn, Vector<UniquePtr<InitParameter>> opt_params, bool replay) {
+    auto *table_entry = table_index_meta_->GetTableEntry();
+    auto *txn_table_store = txn->GetTxnTableStore(table_entry);
     switch (index_base_->index_type_) {
         case IndexType::kBMP: {
-            Vector<SegmentIndexEntry *> segment_indexes;
-            {
-                SegmentIndexesGuard segment_indexes_guard = this->GetSegmentIndexesGuard();
-                for (const auto &[segment_id, segment_index_entry] : segment_indexes_guard.index_by_segment_) {
-                    segment_indexes.push_back(segment_index_entry.get());
-                }
+            if (replay) {
+                break;
             }
-            for (auto *segment_index_entry : segment_indexes) {
-                segment_index_entry->OptimizeIndex(txn, opt_params);
+            std::unique_lock w_lock(rw_locker_);
+            for (const auto &[segment_id, segment_index_entry] : index_by_segment_) {
+                segment_index_entry->OptimizeIndex(txn_table_store, opt_params, false /*replay*/);
             }
-            return {};
+            break;
         }
         case IndexType::kHnsw: {
             std::unique_lock w_lock(rw_locker_);
-            Vector<SegmentIndexEntry *> segment_indexes;
-            for (const auto &[segment_id, segment_index_entry] : index_by_segment_) {
-                segment_indexes.push_back(segment_index_entry.get());
-            }
-            auto *hnsw_index = static_cast<IndexHnsw *>(index_base_.get());
-            if (hnsw_index->encode_type_ != HnswEncodeType::kPlain) {
-                LOG_WARN("Not implemented");
+
+            auto params = HnswUtil::ParseOptimizeOptions(opt_params);
+            if (!params) {
                 break;
             }
-            if (!replay) {
-                for (auto *segment_index_entry : segment_indexes) {
-                    segment_index_entry->OptimizeIndex(txn, opt_params);
+            auto *hnsw_index = static_cast<IndexHnsw *>(index_base_.get());
+            if (params->compress_to_lvq) {
+                if (hnsw_index->encode_type_ != HnswEncodeType::kPlain) {
+                    LOG_WARN("Not implemented");
+                    break;
                 }
+                if (!replay) {
+                    for (const auto &[segment_id, segment_index_entry] : index_by_segment_) {
+                        segment_index_entry->OptimizeIndex(txn_table_store, opt_params, false /*replay*/);
+                    }
+                }
+                hnsw_index->encode_type_ = HnswEncodeType::kLVQ;
+                txn_table_store->AddIndexStore(this);
             }
-
-            hnsw_index->encode_type_ = HnswEncodeType::kLVQ;
-            for (auto *segment_index_entry : segment_indexes) {
-                segment_index_entry->SaveHnsw();
-            }
-            return segment_indexes;
+            break;
         }
         default: {
             LOG_WARN("Not implemented");
         }
     }
-    return {};
 }
 
 } // namespace infinity

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -139,7 +139,7 @@ public:
     // replay
     void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
 
-    Vector<SegmentIndexEntry *> OptimizeIndex(Txn *txn, Vector<UniquePtr<InitParameter>> opt_params, bool replay);
+    void OptimizeIndex(Txn *txn, Vector<UniquePtr<InitParameter>> opt_params, bool replay);
 
 private:
     static SharedPtr<String> DetermineIndexDir(const String &base_dir, const String &parent_dir, const String &index_name) {

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -114,7 +114,7 @@ public:
 
     // MemIndexCommit is blocking.
     // Dump or spill the memory indexer
-    SharedPtr<ChunkIndexEntry> MemIndexDump(TxnIndexStore *txn_index_store, bool spill = false);
+    SharedPtr<ChunkIndexEntry> MemIndexDump(Txn *txn, TxnIndexStore *txn_index_store, bool spill = false);
 
     // PopulateEntirely is blocking.
     // Populate index entirely for the segment
@@ -139,7 +139,7 @@ public:
     // replay
     void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
 
-    void OptimizeIndex(Txn *txn, Vector<UniquePtr<InitParameter>> opt_params, bool replay);
+    void OptimizeIndex(Txn *txn, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
 
 private:
     static SharedPtr<String> DetermineIndexDir(const String &base_dir, const String &parent_dir, const String &index_name) {

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -130,7 +130,7 @@ Txn::Compact(TableEntry *table_entry, Vector<Pair<SharedPtr<SegmentEntry>, Vecto
 }
 
 Status Txn::OptimizeIndex(TableIndexEntry *table_index_entry, Vector<UniquePtr<InitParameter>> init_params) {
-    table_index_entry->OptimizeIndex(this, std::move(init_params), false /*replay*/);
+    table_index_entry->OptimizeIndex(this, init_params, false /*replay*/);
 
     wal_entry_->cmds_.push_back(MakeShared<WalCmdOptimize>(db_name_,
                                                            *table_index_entry->table_index_meta()->table_entry()->GetTableName(),

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -130,11 +130,7 @@ Txn::Compact(TableEntry *table_entry, Vector<Pair<SharedPtr<SegmentEntry>, Vecto
 }
 
 Status Txn::OptimizeIndex(TableIndexEntry *table_index_entry, Vector<UniquePtr<InitParameter>> init_params) {
-    Vector<SegmentIndexEntry *> segment_index_entries = table_index_entry->OptimizeIndex(this, std::move(init_params), false /*replay*/);
-    TableEntry *table_entry = table_index_entry->table_index_meta()->table_entry();
-    auto *txn_table_store = txn_store_.GetTxnTableStore(table_entry);
-
-    txn_table_store->AddSegmentIndexesStore(table_index_entry, std::move(segment_index_entries));
+    table_index_entry->OptimizeIndex(this, std::move(init_params), false /*replay*/);
 
     wal_entry_->cmds_.push_back(MakeShared<WalCmdOptimize>(db_name_,
                                                            *table_index_entry->table_index_meta()->table_entry()->GetTableName(),

--- a/src/storage/wal/wal_entry.cpp
+++ b/src/storage/wal/wal_entry.cpp
@@ -34,6 +34,8 @@ import internal_types;
 import logger;
 import block_entry;
 import segment_entry;
+import segment_index_entry;
+import chunk_index_entry;
 import local_file_system;
 
 namespace infinity {
@@ -184,6 +186,44 @@ String WalSegmentInfo::ToString() const {
     return ss.str();
 }
 
+WalChunkIndexInfo::WalChunkIndexInfo(ChunkIndexEntry *chunk_index_entry)
+    : chunk_id_(chunk_index_entry->chunk_id_), base_name_(chunk_index_entry->base_name_), base_rowid_(chunk_index_entry->base_rowid_),
+      row_count_(chunk_index_entry->row_count_), deprecate_ts_(chunk_index_entry->deprecate_ts_) {}
+
+bool WalChunkIndexInfo::operator==(const WalChunkIndexInfo &other) const {
+    return chunk_id_ == other.chunk_id_ && base_name_ == other.base_name_ && base_rowid_ == other.base_rowid_ && row_count_ == other.row_count_ &&
+           deprecate_ts_ == other.deprecate_ts_;
+}
+
+i32 WalChunkIndexInfo::GetSizeInBytes() const {
+    return sizeof(ChunkID) + sizeof(i32) + base_name_.size() + sizeof(base_rowid_) + sizeof(row_count_) + sizeof(deprecate_ts_);
+}
+
+void WalChunkIndexInfo::WriteBufferAdv(char *&buf) const {
+    WriteBufAdv(buf, chunk_id_);
+    WriteBufAdv(buf, base_name_);
+    WriteBufAdv(buf, base_rowid_);
+    WriteBufAdv(buf, row_count_);
+    WriteBufAdv(buf, deprecate_ts_);
+}
+
+WalChunkIndexInfo WalChunkIndexInfo::ReadBufferAdv(char *&ptr) {
+    WalChunkIndexInfo chunk_index_info;
+    chunk_index_info.chunk_id_ = ReadBufAdv<ChunkID>(ptr);
+    chunk_index_info.base_name_ = ReadBufAdv<String>(ptr);
+    chunk_index_info.base_rowid_ = ReadBufAdv<RowID>(ptr);
+    chunk_index_info.row_count_ = ReadBufAdv<u32>(ptr);
+    chunk_index_info.deprecate_ts_ = ReadBufAdv<TxnTimeStamp>(ptr);
+    return chunk_index_info;
+}
+
+String WalChunkIndexInfo::ToString() const {
+    std::stringstream ss;
+    ss << "chunk_id: " << chunk_id_ << ", base_name: " << base_name_ << ", base_rowid: " << base_rowid_.ToString() << ", row_count: " << row_count_
+       << ", deprecate_ts: " << deprecate_ts_;
+    return ss.str();
+}
+
 SharedPtr<WalCmd> WalCmd::ReadAdv(char *&ptr, i32 max_bytes) {
     char *const ptr_end = ptr + max_bytes;
     SharedPtr<WalCmd> cmd = nullptr;
@@ -328,6 +368,19 @@ SharedPtr<WalCmd> WalCmd::ReadAdv(char *&ptr, i32 max_bytes) {
             cmd = MakeShared<WalCmdOptimize>(std::move(db_name), std::move(table_name), std::move(index_name), std::move(params));
             break;
         }
+        case WalCommandType::DUMP_INDEX: {
+            String db_name = ReadBufAdv<String>(ptr);
+            String table_name = ReadBufAdv<String>(ptr);
+            String index_name = ReadBufAdv<String>(ptr);
+            SegmentID segment_id = ReadBufAdv<SegmentID>(ptr);
+            i32 chunk_n = ReadBufAdv<i32>(ptr);
+            Vector<WalChunkIndexInfo> chunk_infos;
+            for (i32 i = 0; i < chunk_n; ++i) {
+                chunk_infos.push_back(WalChunkIndexInfo::ReadBufferAdv(ptr));
+            }
+            cmd = MakeShared<WalCmdDumpIndex>(std::move(db_name), std::move(table_name), std::move(index_name), segment_id, std::move(chunk_infos));
+            break;
+        }
         default: {
             String error_message = fmt::format("UNIMPLEMENTED ReadAdv for WAL command {}", int(cmd_type));
             LOG_CRITICAL(error_message);
@@ -440,6 +493,12 @@ bool WalCmdOptimize::operator==(const WalCmd &other) const {
            IsEqual(index_name_, other_cmd->index_name_);
 }
 
+bool WalCmdDumpIndex::operator==(const WalCmd &other) const {
+    auto other_cmd = dynamic_cast<const WalCmdDumpIndex *>(&other);
+    return other_cmd != nullptr && IsEqual(db_name_, other_cmd->db_name_) && IsEqual(table_name_, other_cmd->table_name_) &&
+           IsEqual(index_name_, other_cmd->index_name_) && segment_id_ == other_cmd->segment_id_ && chunk_infos_ == other_cmd->chunk_infos_;
+}
+
 i32 WalCmdCreateDatabase::GetSizeInBytes() const {
     return sizeof(WalCommandType) + sizeof(i32) + this->db_name_.size() + sizeof(i32) + this->db_dir_tail_.size();
 }
@@ -514,6 +573,15 @@ i32 WalCmdOptimize::GetSizeInBytes() const {
     size += sizeof(i32);
     for (const auto &param : this->params_) {
         size += param->GetSizeInBytes();
+    }
+    return size;
+}
+
+i32 WalCmdDumpIndex::GetSizeInBytes() const {
+    i32 size = sizeof(WalCommandType) + sizeof(i32) + this->db_name_.size() + sizeof(i32) + this->table_name_.size() + sizeof(i32) +
+               this->index_name_.size() + sizeof(SegmentID) + sizeof(i32);
+    for (const auto &chunk_info : this->chunk_infos_) {
+        size += chunk_info.GetSizeInBytes();
     }
     return size;
 }
@@ -643,6 +711,18 @@ void WalCmdOptimize::WriteAdv(char *&buf) const {
     WriteBufAdv(buf, static_cast<i32>(this->params_.size()));
     for (const auto &param : this->params_) {
         param->WriteAdv(buf);
+    }
+}
+
+void WalCmdDumpIndex::WriteAdv(char *&buf) const {
+    WriteBufAdv(buf, WalCommandType::DUMP_INDEX);
+    WriteBufAdv(buf, this->db_name_);
+    WriteBufAdv(buf, this->table_name_);
+    WriteBufAdv(buf, this->index_name_);
+    WriteBufAdv(buf, this->segment_id_);
+    WriteBufAdv(buf, static_cast<i32>(this->chunk_infos_.size()));
+    for (const auto &chunk_info : this->chunk_infos_) {
+        chunk_info.WriteBufferAdv(buf);
     }
 }
 
@@ -887,6 +967,9 @@ String WalCmd::WalCommandTypeToString(WalCommandType type) {
             break;
         case WalCommandType::OPTIMIZE:
             command = "OPTIMIZE";
+            break;
+        case WalCommandType::DUMP_INDEX:
+            command = "DUMP_INDEX";
             break;
         default: {
             String error_message = "Unknown command type";

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -856,10 +856,7 @@ void WalManager::WalCmdOptimizeReplay(WalCmdOptimize &cmd, TransactionID txn_id,
         UnrecoverableError(error_message);
     }
     auto fake_txn = Txn::NewReplayTxn(storage_->buffer_manager(), storage_->txn_manager(), storage_->catalog(), txn_id, commit_ts);
-    Vector<SegmentIndexEntry *> segment_index_entries = table_index_entry->OptimizeIndex(fake_txn.get(), std::move(cmd.params_), true /*replay*/);
-    TableEntry *table_entry = table_index_entry->table_index_meta()->table_entry();
-    auto *txn_table_store = fake_txn->GetTxnTableStore(table_entry);
-    txn_table_store->AddSegmentIndexesStore(table_index_entry, std::move(segment_index_entries));
+    table_index_entry->OptimizeIndex(fake_txn.get(), std::move(cmd.params_), true /*replay*/);
 }
 
 void WalManager::WalCmdAppendReplay(const WalCmdAppend &cmd, TransactionID txn_id, TxnTimeStamp commit_ts) {

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -98,6 +98,7 @@ private:
     // void WalCmdUpdateSegmentBloomFilterDataReplay(const WalCmdUpdateSegmentBloomFilterData &cmd, TransactionID txn_id, TxnTimeStamp commit_ts);
     void WalCmdCompactReplay(const WalCmdCompact &cmd, TransactionID txn_id, TxnTimeStamp commit_ts);
     void WalCmdOptimizeReplay(WalCmdOptimize &cmd, TransactionID txn_id, TxnTimeStamp commit_ts);
+    void WalCmdDumpIndexReplay(WalCmdDumpIndex &cmd, TransactionID txn_id, TxnTimeStamp commit_ts);
 
 public:
     u64 cfg_wal_size_threshold_{};

--- a/src/unit_test/storage/knnindex/merge_optimize/test_optimize.cpp
+++ b/src/unit_test/storage/knnindex/merge_optimize/test_optimize.cpp
@@ -187,7 +187,7 @@ TEST_F(OptimizeKnnTest, test1) {
 
             TxnTableStore *txn_table_store = txn->GetTxnTableStore(table_entry);
             TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry);
-            table_index_entry->MemIndexDump(txn_index_store, true);
+            table_index_entry->MemIndexDump(nullptr, txn_index_store, true);
 
             txn_mgr->CommitTxn(txn);
         }
@@ -291,7 +291,7 @@ TEST_F(OptimizeKnnTest, test_secondary_index_optimize) {
             ASSERT_TRUE(status.ok());
             TxnTableStore *txn_table_store = txn->GetTxnTableStore(table_entry);
             TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry);
-            table_index_entry->MemIndexDump(txn_index_store, true);
+            table_index_entry->MemIndexDump(nullptr, txn_index_store, true);
             txn_mgr->CommitTxn(txn);
         }
     }

--- a/test/sql/dql/knn/embedding/test_knn_hnsw_l2_lvq2.slt
+++ b/test/sql/dql/knn/embedding/test_knn_hnsw_l2_lvq2.slt
@@ -5,18 +5,27 @@ statement ok
 CREATE TABLE test_knn_hnsw_l2(c1 INT, c2 EMBEDDING(FLOAT, 4));
 
 statement ok
-COPY test_knn_hnsw_l2 FROM '/var/infinity/test_data/embedding_float_dim4.csv' WITH (DELIMITER ',');
-
-query I
-SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3);
-----
-8
-6
-4
-
-statement ok
 CREATE INDEX idx1 ON test_knn_hnsw_l2 (c2) USING Hnsw WITH (M = 16, ef_construction = 200, metric = l2);
 
+statement ok
+INSERT INTO test_knn_hnsw_l2 VALUES (2, [0.1, 0.2, 0.3, -0.2]);
+
+statement ok
+INSERT INTO test_knn_hnsw_l2 VALUES (4, [0.2, 0.1, 0.3, 0.4]);
+
+statement ok
+INSERT INTO test_knn_hnsw_l2 VALUES (6, [0.3, 0.2, 0.1, 0.4]), (8, [0.4, 0.3, 0.2, 0.1]);
+
+query I
+SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3) WITH (ef = 4);
+----
+8
+6
+4
+
+statement ok
+OPTIMIZE idx1 ON test_knn_hnsw_l2 WITH (compress_to_lvq);
+
 query I
 SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3) WITH (ef = 4, rerank);
 ----
@@ -25,24 +34,30 @@ SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], '
 4
 
 statement ok
-OPTIMIZE idx1 ON test_knn_hnsw_l2;
+INSERT INTO test_knn_hnsw_l2 VALUES (2, [0.1, 0.2, 0.3, -0.2]);
+
+statement ok
+INSERT INTO test_knn_hnsw_l2 VALUES (4, [0.2, 0.1, 0.3, 0.4]);
+
+statement ok
+INSERT INTO test_knn_hnsw_l2 VALUES (6, [0.3, 0.2, 0.1, 0.4]), (8, [0.4, 0.3, 0.2, 0.1]);
 
 query I
-SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3) WITH (ef = 4, rerank);
+SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3) WITH (ef = 8, rerank);
 ----
 8
+8
 6
-4
 
 statement ok
 COPY test_knn_hnsw_l2 FROM '/var/infinity/test_data/embedding_float_dim4.csv' WITH (DELIMITER ',');
 
 query I
-SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3) WITH (ef = 6, rerank);
+SELECT c1 FROM test_knn_hnsw_l2 SEARCH MATCH VECTOR (c2, [0.3, 0.3, 0.2, 0.2], 'float', 'l2', 3) WITH (ef = 12, rerank);
 ----
 8
 8
-6
+8
 
 statement ok
 DROP TABLE test_knn_hnsw_l2;


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: bug in python sdk.
2. Fix: bug of optimize command. Now, when optimize, the index will be dumped. And when dumped, wal will record the info of meta data. So mem index recover will not happen in replay stage after memory index dump.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Performance Improvement
