### PR TITLE
Fix fullckp

### DIFF
--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -144,7 +144,7 @@ QueryResult QueryContext::QueryStatement(const BaseStatement *statement) {
             }
         }
 
-        this->BeginTxn();
+        this->BeginTxn(statement);
 //        LOG_INFO(fmt::format("created transaction, txn_id: {}, begin_ts: {}, statement: {}",
 //                        session_ptr_->GetTxn()->TxnID(),
 //                        session_ptr_->GetTxn()->BeginTS(),
@@ -316,9 +316,10 @@ bool QueryContext::JoinBGStatement(BGQueryState &state, TxnTimeStamp &commit_ts,
     return true;
 }
 
-void QueryContext::BeginTxn() {
+void QueryContext::BeginTxn(const BaseStatement *statement) {
     if (session_ptr_->GetTxn() == nullptr) {
-        Txn* new_txn = storage_->txn_manager()->BeginTxn(nullptr);
+        bool is_checkpoint = statement != nullptr && statement->type_ == StatementType::kFlush;
+        Txn* new_txn = storage_->txn_manager()->BeginTxn(nullptr, is_checkpoint);
         session_ptr_->SetTxn(new_txn);
     }
 }

--- a/src/main/query_context.cppm
+++ b/src/main/query_context.cppm
@@ -88,7 +88,7 @@ public:
 
     inline u64 GetNextNodeID() { return ++current_max_node_id_; }
 
-    void BeginTxn();
+    void BeginTxn(const BaseStatement *statement = nullptr);
 
     TxnTimeStamp CommitTxn();
 

--- a/src/storage/background_process.cpp
+++ b/src/storage/background_process.cpp
@@ -71,12 +71,11 @@ void BGTaskProcessor::Process() {
                 case BGTaskType::kForceCheckpoint: {
                     LOG_DEBUG("Force checkpoint in background");
                     ForceCheckpointTask *force_ckp_task = static_cast<ForceCheckpointTask *>(bg_task.get());
-                    auto [max_commit_ts, wal_size] = catalog_->GetCheckpointState();
                     {
                         std::unique_lock<std::mutex> locker(task_mutex_);
                         task_text_ = force_ckp_task->ToString();
                     }
-                    wal_manager_->Checkpoint(force_ckp_task, max_commit_ts, wal_size);
+                    wal_manager_->Checkpoint(force_ckp_task);
                     LOG_DEBUG("Force checkpoint in background done");
                     break;
                 }
@@ -86,19 +85,18 @@ void BGTaskProcessor::Process() {
                         std::unique_lock<std::mutex> locker(task_mutex_);
                         task_text_ = task->ToString();
                     }
-                    catalog_->AddDeltaEntry(std::move(task->delta_entry_), task->wal_size_);
+                    catalog_->AddDeltaEntry(std::move(task->delta_entry_));
                     break;
                 }
                 case BGTaskType::kCheckpoint: {
                     LOG_DEBUG("Checkpoint in background");
                     auto *task = static_cast<CheckpointTask *>(bg_task.get());
                     bool is_full_checkpoint = task->is_full_checkpoint_;
-                    auto [max_commit_ts, wal_size] = catalog_->GetCheckpointState();
                     {
                         std::unique_lock<std::mutex> locker(task_mutex_);
                         task_text_ = task->ToString();
                     }
-                    wal_manager_->Checkpoint(is_full_checkpoint, max_commit_ts, wal_size);
+                    wal_manager_->Checkpoint(is_full_checkpoint);
                     LOG_DEBUG("Checkpoint in background done");
                     break;
                 }

--- a/src/storage/background_process.cppm
+++ b/src/storage/background_process.cppm
@@ -41,7 +41,6 @@ public:
 
 private:
     void Process();
-    void CompactProcess();
 
 private:
     BlockingQueue<SharedPtr<BGTask>> task_queue_;

--- a/src/storage/bg_task/bg_task.cppm
+++ b/src/storage/bg_task/bg_task.cppm
@@ -79,13 +79,12 @@ export struct StopProcessorTask final : public BGTask {
 };
 
 export struct AddDeltaEntryTask final : public BGTask {
-    AddDeltaEntryTask(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size)
-        : BGTask(BGTaskType::kAddDeltaEntry, false), delta_entry_(std::move(delta_entry)), wal_size_(wal_size) {}
+    AddDeltaEntryTask(UniquePtr<CatalogDeltaEntry> delta_entry)
+        : BGTask(BGTaskType::kAddDeltaEntry, false), delta_entry_(std::move(delta_entry)) {}
 
     String ToString() const final { return fmt::format("DeltaLog: {}", delta_entry_->ToString()); }
 
     UniquePtr<CatalogDeltaEntry> delta_entry_{};
-    i64 wal_size_{};
 };
 
 export struct CheckpointTaskBase : public BGTask {

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -1042,8 +1042,8 @@ bool Catalog::SaveDeltaCatalog(TxnTimeStamp max_commit_ts, String &delta_catalog
     return false;
 }
 
-void Catalog::AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size) {
-    global_catalog_delta_entry_->AddDeltaEntry(std::move(delta_entry), wal_size);
+void Catalog::AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry) {
+    global_catalog_delta_entry_->AddDeltaEntry(std::move(delta_entry));
 }
 
 void Catalog::ReplayDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry) { global_catalog_delta_entry_->ReplayDeltaEntry(std::move(delta_entry)); }
@@ -1086,10 +1086,6 @@ void Catalog::MemIndexRecover(BufferManager *buffer_manager) {
 void Catalog::StartMemoryIndexCommit() {
     mem_index_commit_thread_ = MakeUnique<Thread>([this] { MemIndexCommitLoop(); });
 }
-
-Tuple<TxnTimeStamp, i64> Catalog::GetCheckpointState() const { return global_catalog_delta_entry_->GetCheckpointState(); }
-
-void Catalog::InitDeltaEntry(TxnTimeStamp max_commit_ts) { global_catalog_delta_entry_->InitMaxCommitTS(max_commit_ts); }
 
 SizeT Catalog::GetDeltaLogCount() const { return global_catalog_delta_entry_->OpSize(); }
 

--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -226,7 +226,7 @@ public:
 
     bool SaveDeltaCatalog(TxnTimeStamp max_commit_ts, String &delta_path, String &delta_name);
 
-    void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size);
+    void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
 
     void ReplayDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
 
@@ -305,12 +305,6 @@ public:
     void MemIndexRecover(BufferManager *buffer_manager);
 
     void PickCleanup(CleanupScanner *scanner);
-
-    // delta checkpoint info
-public:
-    Tuple<TxnTimeStamp, i64> GetCheckpointState() const;
-
-    void InitDeltaEntry(TxnTimeStamp max_commit_ts);
 
 private:
     UniquePtr<GlobalCatalogDeltaEntry> global_catalog_delta_entry_{MakeUnique<GlobalCatalogDeltaEntry>()};

--- a/src/storage/meta/entry/entry_list.cppm
+++ b/src/storage/meta/entry/entry_list.cppm
@@ -510,6 +510,7 @@ bool EntryList<Entry>::PickCleanup(CleanupScanner *scanner) {
         SharedPtr<Entry> &entry = *iter;
         if (entry->commit_ts_ < visible_ts) {
             if (entry->deleted_) {
+                LOG_DEBUG(fmt::format("PickCleanup entry: {}, commit_ts: {}", entry->encode(), entry->commit_ts_));
                 iter = entry_list_.erase(iter);
             } else {
                 lock.unlock();

--- a/src/storage/meta/meta_map.cppm
+++ b/src/storage/meta/meta_map.cppm
@@ -195,7 +195,7 @@ void MetaMap<Meta>::PickCleanup(CleanupScanner *scanner) {
         std::unique_lock w_lock(rw_locker_);
         for (auto iter = meta_map_.begin(); iter != meta_map_.end();) {
             if (iter->second->Empty()) {
-                LOG_DEBUG(fmt::format("PickCleanup: all_delete: {}", iter->first));
+                LOG_DEBUG(fmt::format("PickCleanup meta: {}", iter->first));
                 iter = meta_map_.erase(iter);
             } else {
                 ++iter;

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -525,6 +525,7 @@ void Txn::Rollback() {
 
 void Txn::AddWalCmd(const SharedPtr<WalCmd> &cmd) { wal_entry_->cmds_.push_back(cmd); }
 
+// those whose commit_ts is <= max_commit_ts will be checkpointed
 bool Txn::Checkpoint(const TxnTimeStamp max_commit_ts, bool is_full_checkpoint) {
     if (is_full_checkpoint) {
         FullCheckpoint(max_commit_ts);

--- a/src/storage/txn/txn_manager.cpp
+++ b/src/storage/txn/txn_manager.cpp
@@ -45,7 +45,7 @@ TxnManager::TxnManager(Catalog *catalog,
     : catalog_(catalog), buffer_mgr_(buffer_mgr), bg_task_processor_(bg_task_processor), wal_mgr_(wal_mgr), start_ts_(start_ts), is_running_(false),
       enable_compaction_(enable_compaction) {}
 
-Txn *TxnManager::BeginTxn(UniquePtr<String> txn_text) {
+Txn *TxnManager::BeginTxn(UniquePtr<String> txn_text, bool ckp_txn) {
     // Check if the is_running_ is true
     if (is_running_.load() == false) {
         String error_message = "TxnManager is not running, cannot create txn";
@@ -59,6 +59,13 @@ Txn *TxnManager::BeginTxn(UniquePtr<String> txn_text) {
 
     // Record the start ts of the txn
     TxnTimeStamp ts = ++start_ts_;
+    if (ckp_txn) {
+        if (ckp_begin_ts_ != 0) {
+            UnrecoverableError(fmt::format("Checkpoint txn is already started in {}", ckp_begin_ts_));
+        }
+        LOG_DEBUG(fmt::format("Checkpoint txn is started in {}", ts));
+        ckp_begin_ts_ = ts;
+    }
 
     // Create txn instance
     auto new_txn = SharedPtr<Txn>(new Txn(this, buffer_mgr_, catalog_, bg_task_processor_, new_txn_id, ts, std::move(txn_text)));
@@ -192,8 +199,7 @@ void TxnManager::AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry) {
         String error_message = "TxnManager is not running, cannot add delta entry";
         UnrecoverableError(error_message);
     }
-    i64 wal_size = wal_mgr_->WalSize();
-    bg_task_processor_->Submit(MakeShared<AddDeltaEntryTask>(std::move(delta_entry), wal_size));
+    bg_task_processor_->Submit(MakeShared<AddDeltaEntryTask>(std::move(delta_entry)));
 }
 
 void TxnManager::Start() {
@@ -347,6 +353,16 @@ void TxnManager::FinishTxn(Txn *txn) {
             UnrecoverableError(error_message);
         }
     }
+}
+
+bool TxnManager::InCheckpointProcess(TxnTimeStamp commit_ts) {
+    std::lock_guard guard(locker_);
+    if (commit_ts > ckp_begin_ts_) {
+        LOG_TRACE(fmt::format("Full checkpoint begin in {}, cur txn commit_ts: {}, swap to new wal file", ckp_begin_ts_, commit_ts));
+        ckp_begin_ts_ = UNCOMMIT_TS;
+        return true;
+    }
+    return false;
 }
 
 } // namespace infinity

--- a/src/storage/txn/txn_manager.cppm
+++ b/src/storage/txn/txn_manager.cppm
@@ -21,6 +21,7 @@ import txn;
 import buffer_manager;
 import txn_state;
 import wal_entry;
+import default_values;
 
 namespace infinity {
 
@@ -46,7 +47,7 @@ public:
 
     ~TxnManager() = default;
 
-    Txn *BeginTxn(UniquePtr<String> txn_text);
+    Txn *BeginTxn(UniquePtr<String> txn_text, bool ckp_txn = false);
 
     Txn *GetTxn(TransactionID txn_id);
 
@@ -110,6 +111,8 @@ public:
 
     u64 NextSequence() { return ++sequence_; }
 
+    bool InCheckpointProcess(TxnTimeStamp commit_ts);
+
 private:
     Catalog *catalog_{};
     mutable std::mutex locker_{};
@@ -125,6 +128,7 @@ private:
     Map<TxnTimeStamp, WalEntry *> wait_conflict_ck_{}; // sorted by commit ts
 
     Atomic<TxnTimeStamp> start_ts_{}; // The next txn ts
+    TxnTimeStamp ckp_begin_ts_ = UNCOMMIT_TS;     // cur ckp begin ts, 0 if no ckp is happening
 
     // For stop the txn manager
     atomic_bool is_running_{false};

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -1021,7 +1021,7 @@ void CatalogDeltaEntry::AddOperation(UniquePtr<CatalogDeltaOperation> operation)
 
 void GlobalCatalogDeltaEntry::InitFullCheckpointTs(TxnTimeStamp last_full_ckp_ts) { last_full_ckp_ts_ = last_full_ckp_ts; }
 
-void GlobalCatalogDeltaEntry::AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size) {
+void GlobalCatalogDeltaEntry::AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry) {
     // {
     //     for (auto &delta_entry : delta_entries) {
     //         LOG_INFO(fmt::format("Add delta entry: {}", delta_entry->ToString()));
@@ -1037,7 +1037,6 @@ void GlobalCatalogDeltaEntry::AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_e
     } else {
         // Continuous
         do {
-            wal_size_ = std::max(wal_size_, wal_size);
             // LOG_INFO(fmt::format("Add delta entry: {} in to delta_ops_", entry_sequence));
             this->AddDeltaEntryInner(delta_entry.get());
 
@@ -1106,11 +1105,6 @@ void GlobalCatalogDeltaEntry::AddDeltaEntryInner(CatalogDeltaEntry *delta_entry)
         String error_message = "max_commit_ts == UNCOMMIT_TS";
         UnrecoverableError(error_message);
     }
-    if (max_commit_ts_ > max_commit_ts) {
-        String error_message = fmt::format("max_commit_ts_ {} > max_commit_ts {}", max_commit_ts_, max_commit_ts);
-        UnrecoverableError(error_message);
-    }
-    max_commit_ts_ = max_commit_ts;
 
     for (auto &new_op : delta_entry->operations()) {
         if (new_op->type_ == CatalogDeltaOpType::ADD_SEGMENT_ENTRY) {

--- a/src/storage/wal/catalog_delta_entry.cppm
+++ b/src/storage/wal/catalog_delta_entry.cppm
@@ -375,19 +375,14 @@ export class GlobalCatalogDeltaEntry {
 public:
     GlobalCatalogDeltaEntry() = default;
 
-    // Must be called before any checkpoint.
-    void InitMaxCommitTS(TxnTimeStamp max_commit_ts) { max_commit_ts_ = max_commit_ts; }
-
     void InitFullCheckpointTs(TxnTimeStamp last_full_ckp_ts);
 
-    void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry, i64 wal_size);
+    void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
 
     void ReplayDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
 
     // Pick and remove all operations that are committed before `max_commit_ts`, after `full_ckp_ts`
     UniquePtr<CatalogDeltaEntry> PickFlushEntry(TxnTimeStamp max_commit_ts);
-
-    Tuple<TxnTimeStamp, i64> GetCheckpointState() const { return {max_commit_ts_, wal_size_}; }
 
     Vector<CatalogDeltaOpBrief> GetOperationBriefs() const;
 
@@ -406,9 +401,7 @@ private:
     Map<String, UniquePtr<CatalogDeltaOperation>> delta_ops_;
     HashSet<TransactionID> txn_ids_;
     // update by add delta entry, read by bg_process::checkpoint
-    TxnTimeStamp max_commit_ts_{0};
     TxnTimeStamp last_full_ckp_ts_{0};
-    i64 wal_size_{};
 
     mutable std::mutex catalog_delta_locker_{};
 };

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -105,6 +105,8 @@ public:
     u64 cfg_wal_size_threshold_{};
     u64 cfg_delta_checkpoint_interval_wal_bytes_{};
 
+    const String &wal_dir() const { return wal_dir_; }
+
 private:
     // Concurrent writing WAL is disallowed. So put all WAL writing into a queue
     // and do serial writing.

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -146,6 +146,15 @@ protected:
             txn_mgr->CommitTxn(txn);
         }
     }
+
+    void RemoveOldWal(const String &wal_dir) {
+        for (const auto &entry : std::filesystem::directory_iterator(wal_dir)) {
+            if (entry.path().extension() == ".log") {
+                continue;
+            }
+            std::filesystem::remove(entry.path());
+        }
+    }
 };
 
 TEST_F(CheckpointTest, test_cleanup_and_checkpoint) {
@@ -435,6 +444,102 @@ TEST_F(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
 
         infinity::InfinityContext::instance().UnInit();
     }
+#ifdef INFINITY_DEBUG
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
+    EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);
+    infinity::GlobalResourceUsage::UnInit();
+#endif
+}
+
+TEST_F(CheckpointTest, test_fullcheckpoint_withsmallest_walfile) {
+#ifdef INFINITY_DEBUG
+    infinity::GlobalResourceUsage::Init();
+#endif
+
+    auto db_name = MakeShared<String>("default_db");
+    auto table_name = MakeShared<String>("tbl1");
+    Vector<SharedPtr<ColumnDef>> columns;
+    Vector<SharedPtr<DataType>> column_types;
+    {
+        std::set<ConstraintType> constraints;
+        auto column_def_ptr = MakeShared<ColumnDef>(0, MakeShared<DataType>(DataType(LogicalType::kInteger)), "col1", constraints);
+        columns.emplace_back(column_def_ptr);
+        column_types.emplace_back(column_def_ptr->type());
+    }
+
+    String wal_dir;
+    int insert_n = 100;
+    {
+        infinity::InfinityContext::instance().Init(nullptr /*config_path*/);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        TxnManager *txn_mgr = storage->txn_manager();
+
+        {
+
+            auto tbl_def = MakeUnique<TableDef>(db_name, table_name, columns);
+
+            auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("create table"));
+            auto status = txn->CreateTable(*db_name, std::move(tbl_def), ConflictType::kIgnore);
+            EXPECT_TRUE(status.ok());
+            txn_mgr->CommitTxn(txn);
+        }
+
+        auto append = [&] {
+            auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("insert table"));
+            auto [table_entry, get_status] = txn->GetTableByName(*db_name, *table_name);
+            EXPECT_TRUE(get_status.ok());
+
+            SharedPtr<DataBlock> input_block = MakeShared<DataBlock>();
+            input_block->Init(column_types);
+            for (int i = 0; i < insert_n; ++i) {
+                input_block->AppendValue(0 /*column_idx*/, Value::MakeInt(i));
+            }
+            input_block->Finalize();
+
+            auto append_status = txn->Append(table_entry, input_block);
+            EXPECT_TRUE(append_status.ok());
+            txn_mgr->CommitTxn(txn);
+        };
+        append();
+        {
+            auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("full ckp"), true);
+            SharedPtr<ForceCheckpointTask> force_ckp_task = MakeShared<ForceCheckpointTask>(txn, true /*full_check_point*/);
+            storage->bg_processor()->Submit(force_ckp_task);
+            append();
+            force_ckp_task->Wait();
+
+            txn_mgr->CommitTxn(txn);
+        }
+        wal_dir = storage->wal_manager()->wal_dir();
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+    RemoveOldWal(wal_dir);
+    {
+        infinity::InfinityContext::instance().Init(nullptr /*config_path*/);
+        Storage *storage = infinity::InfinityContext::instance().storage();
+        auto *txn_mgr = storage->txn_manager();
+
+        {
+            auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("get table"));
+            auto [table_entry, status] = txn->GetTableByName(*db_name, *table_name);
+            EXPECT_TRUE(status.ok());
+
+            EXPECT_EQ(table_entry->segment_map().size(), 1);
+            auto segment_entry = table_entry->GetSegmentByID(0, txn->BeginTS());
+            EXPECT_NE(segment_entry, nullptr);
+
+            EXPECT_EQ(segment_entry->block_entries().size(), 1);
+            auto block_entry = segment_entry->GetBlockEntryByID(0);
+            EXPECT_NE(block_entry, nullptr);
+
+            auto [start, end] = block_entry->GetVisibleRange(txn->BeginTS(), 0);
+            EXPECT_EQ(int(end - start), insert_n * 2);
+        }
+
+        infinity::InfinityContext::instance().UnInit();
+    }
+
 #ifdef INFINITY_DEBUG
     EXPECT_EQ(infinity::GlobalResourceUsage::GetObjectCount(), 0);
     EXPECT_EQ(infinity::GlobalResourceUsage::GetRawMemoryCount(), 0);


### PR DESCRIPTION
### What problem does this PR solve?

1. Truncate wal file to least as possible after full checkpoint.
    Now, if no other transaction is committed in checkpoint process, the wal file will only contains the checkpoint walentry, which makes full checkpoint more version compactible.
3. Refactor code in checkpoint timestamp.
4. Fix system_start_ts initialize after restart.

#1317

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
