### PR TITLE
Fix idxreplay

### DIFF
--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -97,7 +97,7 @@ BufferManager::~BufferManager() { RemoveClean(); }
 
 BufferObj *BufferManager::AllocateBufferObject(UniquePtr<FileWorker> file_worker) {
     String file_path = file_worker->GetFilePath();
-    auto buffer_obj = MakeUnique<BufferObj>(this, true, std::move(file_worker));
+    auto buffer_obj = MakeUnique<BufferObj>(this, true, std::move(file_worker), buffer_id_++);
 
     BufferObj *res = buffer_obj.get();
     {
@@ -121,7 +121,7 @@ BufferObj *BufferManager::GetBufferObject(UniquePtr<FileWorker> file_worker) {
         return iter1->second.get();
     }
 
-    auto buffer_obj = MakeUnique<BufferObj>(this, false, std::move(file_worker));
+    auto buffer_obj = MakeUnique<BufferObj>(this, false, std::move(file_worker), buffer_id_++);
 
     BufferObj *res = buffer_obj.get();
     buffer_map_.emplace(std::move(file_path), std::move(buffer_obj));
@@ -273,8 +273,8 @@ void BufferManager::MoveTemp(BufferObj *buffer_obj) {
 }
 
 SizeT BufferManager::LRUIdx(BufferObj *buffer_obj) const {
-    auto p = reinterpret_cast<u64>(buffer_obj);
-    return p % lru_caches_.size();
+    auto id = buffer_obj->id();
+    return id % lru_caches_.size();
 }
 
 } // namespace infinity

--- a/src/storage/buffer/buffer_manager.cppm
+++ b/src/storage/buffer/buffer_manager.cppm
@@ -110,6 +110,7 @@ private:
 
     std::mutex w_locker_{};
     HashMap<String, UniquePtr<BufferObj>> buffer_map_{};
+    u32 buffer_id_{};
 
     std::mutex gc_locker_{};
     Vector<LRUCache> lru_caches_{};

--- a/src/storage/buffer/buffer_obj.cpp
+++ b/src/storage/buffer/buffer_obj.cpp
@@ -28,8 +28,8 @@ module buffer_obj;
 
 namespace infinity {
 
-BufferObj::BufferObj(BufferManager *buffer_mgr, bool is_ephemeral, UniquePtr<FileWorker> file_worker)
-    : buffer_mgr_(buffer_mgr), file_worker_(std::move(file_worker)) {
+BufferObj::BufferObj(BufferManager *buffer_mgr, bool is_ephemeral, UniquePtr<FileWorker> file_worker, u32 id)
+    : buffer_mgr_(buffer_mgr), file_worker_(std::move(file_worker)), id_(id) {
     // Init other info
     file_worker_->SetBaseTempDir(buffer_mgr->GetDataDir(), buffer_mgr->GetTempDir());
 

--- a/src/storage/buffer/buffer_obj.cppm
+++ b/src/storage/buffer/buffer_obj.cppm
@@ -78,7 +78,7 @@ export String BufferTypeToString(BufferType buffer_type) {
 export class BufferObj {
 public:
     // called by BufferMgr::Get or BufferMgr::Allocate
-    explicit BufferObj(BufferManager *buffer_mgr, bool is_ephemeral, UniquePtr<FileWorker> file_worker);
+    explicit BufferObj(BufferManager *buffer_mgr, bool is_ephemeral, UniquePtr<FileWorker> file_worker, u32 id);
 
     virtual ~BufferObj();
 
@@ -129,6 +129,7 @@ public:
     }
     BufferType type() const { return type_; }
     u64 rc() const { return rc_; }
+    u32 id() const { return id_; }
 
     // check the invalid state, only used in tests.
     void CheckState() const;
@@ -142,6 +143,9 @@ protected:
     BufferType type_{BufferType::kTemp};
     u64 rc_{0};
     const UniquePtr<FileWorker> file_worker_;
+
+private:
+    u32 id_;
 };
 
 } // namespace infinity

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -96,8 +96,7 @@ public:
 
     void CommitOptimize(ChunkIndexEntry *new_chunk, const Vector<ChunkIndexEntry *> &old_chunks, TxnTimeStamp commit_ts);
 
-    SharedPtr<ChunkIndexEntry>
-    OptIndex(IndexBase *index_base, TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
+    void OptIndex(IndexBase *index_base, TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
 
     bool Flush(TxnTimeStamp checkpoint_ts);
 
@@ -123,6 +122,8 @@ public:
 
     // Dump or spill the memory indexer
     SharedPtr<ChunkIndexEntry> MemIndexDump(bool spill = false);
+
+    void AddWalIndexDump(ChunkIndexEntry *dumped_index_entry, Txn *txn);
 
     // Init the mem index from previously spilled one.
     void MemIndexLoad(const String &base_name, RowID base_row_id);
@@ -177,12 +178,12 @@ public:
 
     Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<ChunkIndexEntry>> GetHnswIndexSnapshot() {
         std::shared_lock lock(rw_locker_);
-        return {chunk_index_entries_, memory_hnsw_indexer_};
+        return {chunk_index_entries_, memory_chunk_indexer_};
     }
 
     Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<ChunkIndexEntry>> GetBMPIndexSnapshot() {
         std::shared_lock lock(rw_locker_);
-        return {chunk_index_entries_, memory_hnsw_indexer_};
+        return {chunk_index_entries_, memory_chunk_indexer_};
     }
 
     Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<SecondaryIndexInMem>> GetSecondaryIndexSnapshot() {
@@ -266,7 +267,7 @@ private:
     ChunkID next_chunk_id_{0};
 
     Vector<SharedPtr<ChunkIndexEntry>> chunk_index_entries_{};
-    SharedPtr<ChunkIndexEntry> memory_hnsw_indexer_{};
+    SharedPtr<ChunkIndexEntry> memory_chunk_indexer_{};
     SharedPtr<MemoryIndexer> memory_indexer_{};
     SharedPtr<SecondaryIndexInMem> memory_secondary_index_{};
     SharedPtr<EMVBIndexInMem> memory_emvb_index_{};

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -711,6 +711,8 @@ void TableEntry::MemIndexInsertInner(TableIndexEntry *table_index_entry, Txn *tx
                 chunk_index_entry->Commit(txn->CommitTS());
                 txn_table_store->AddChunkIndexStore(table_index_entry, chunk_index_entry.get());
 
+                segment_index_entry->AddWalIndexDump(chunk_index_entry.get(), txn);
+
                 if (index_base->index_type_ == IndexType::kFullText) {
                     table_index_entry->UpdateFulltextSegmentTs(txn->CommitTS());
                 }

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -395,9 +395,7 @@ void TableIndexEntry::UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin
     txn_id_ = txn_id;
 }
 
-Vector<SharedPtr<ChunkIndexEntry>>
-TableIndexEntry::OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay) {
-    Vector<SharedPtr<ChunkIndexEntry>> res;
+void TableIndexEntry::OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay) {
     switch (index_base_->index_type_) {
         case IndexType::kBMP: {
             if (replay) {
@@ -405,10 +403,7 @@ TableIndexEntry::OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr
             }
             std::unique_lock w_lock(rw_locker_);
             for (const auto &[segment_id, segment_index_entry] : index_by_segment_) {
-                auto p = segment_index_entry->OptIndex(index_base_.get(), txn_table_store, opt_params, false /*replay*/);
-                if (p.get() != nullptr) {
-                    res.push_back(p);
-                }
+                segment_index_entry->OptIndex(index_base_.get(), txn_table_store, opt_params, false /*replay*/);
             }
             break;
         }
@@ -430,11 +425,7 @@ TableIndexEntry::OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr
                 txn_table_store->AddIndexStore(this);
                 if (!replay) {
                     for (const auto &[segment_id, segment_index_entry] : index_by_segment_) {
-                        auto p =
-                            segment_index_entry->OptIndex(static_cast<IndexBase *>(&old_index_hnsw), txn_table_store, opt_params, false /*replay*/);
-                        if (p.get() != nullptr) {
-                            res.push_back(p);
-                        }
+                        segment_index_entry->OptIndex(static_cast<IndexBase *>(&old_index_hnsw), txn_table_store, opt_params, false /*replay*/);
                     }
                 }
             }
@@ -444,7 +435,6 @@ TableIndexEntry::OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr
             LOG_WARN("Not implemented");
         }
     }
-    return res;
 }
 
 } // namespace infinity

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -139,7 +139,7 @@ public:
     // replay
     void UpdateEntryReplay(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
 
-    Vector<SharedPtr<ChunkIndexEntry>> OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
+    void OptIndex(TxnTableStore *txn_table_store, const Vector<UniquePtr<InitParameter>> &opt_params, bool replay);
 
 private:
     static SharedPtr<String> DetermineIndexDir(const String &base_dir, const String &parent_dir, const String &index_name) {

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -275,6 +275,10 @@ Tuple<TableIndexEntry *, Status> Txn::CreateIndexDef(TableEntry *table_entry, co
     }
     auto *txn_table_store = txn_store_.GetTxnTableStore(table_entry);
     txn_table_store->AddIndexStore(table_index_entry);
+
+    String index_dir_tail = table_index_entry->GetPathNameTail();
+    wal_entry_->cmds_.push_back(
+        MakeShared<WalCmdCreateIndex>(*table_entry->GetDBName(), *table_entry->GetTableName(), std::move(index_dir_tail), index_base));
     return {table_index_entry, index_status};
 }
 
@@ -327,22 +331,22 @@ Status Txn::CreateIndexDo(BaseTableRef *table_ref, const String &index_name, Has
 }
 
 Status Txn::CreateIndexFinish(const TableEntry *table_entry, const TableIndexEntry *table_index_entry) {
-    String index_dir_tail = table_index_entry->GetPathNameTail();
-    auto index_base = table_index_entry->table_index_def();
-    wal_entry_->cmds_.push_back(
-        MakeShared<WalCmdCreateIndex>(*table_entry->GetDBName(), *table_entry->GetTableName(), std::move(index_dir_tail), index_base));
+    // String index_dir_tail = table_index_entry->GetPathNameTail();
+    // auto index_base = table_index_entry->table_index_def();
+    // wal_entry_->cmds_.push_back(
+    //     MakeShared<WalCmdCreateIndex>(*table_entry->GetDBName(), *table_entry->GetTableName(), std::move(index_dir_tail), index_base));
     return Status::OK();
 }
 
 Status Txn::CreateIndexFinish(const String &db_name, const String &table_name, const SharedPtr<IndexBase> &index_base) {
-    this->CheckTxn(db_name);
+    // this->CheckTxn(db_name);
 
-    auto [table_index_entry, status] = this->GetIndexByName(db_name, table_name, *index_base->index_name_);
-    if (!status.ok()) {
-        return status;
-    }
-    String index_dir_tail = table_index_entry->GetPathNameTail();
-    this->AddWalCmd(MakeShared<WalCmdCreateIndex>(db_name, table_name, std::move(index_dir_tail), index_base));
+    // auto [table_index_entry, status] = this->GetIndexByName(db_name, table_name, *index_base->index_name_);
+    // if (!status.ok()) {
+    //     return status;
+    // }
+    // String index_dir_tail = table_index_entry->GetPathNameTail();
+    // this->AddWalCmd(MakeShared<WalCmdCreateIndex>(db_name, table_name, std::move(index_dir_tail), index_base));
     return Status::OK();
 }
 

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -133,22 +133,9 @@ Status Txn::OptIndex(TableIndexEntry *table_index_entry, Vector<UniquePtr<InitPa
     TableEntry *table_entry = table_index_entry->table_index_meta()->table_entry();
     TxnTableStore *txn_table_store = this->GetTxnTableStore(table_entry);
 
-    Vector<SharedPtr<ChunkIndexEntry>> dumped_chunks = table_index_entry->OptIndex(txn_table_store, init_params, false /*replay*/);
-
-    String index_name = *table_index_entry->GetIndexName();
-    String table_name = *table_entry->GetTableName();
-
-    if (!dumped_chunks.empty()) {
-        Vector<WalChunkIndexInfo> chunk_infos;
-        SegmentID segment_id = dumped_chunks[0]->segment_index_entry_->segment_id();
-        for (const auto &dumped_chunk : dumped_chunks) {
-            if (segment_id != dumped_chunk->segment_index_entry_->segment_id()) {
-                UnrecoverableError("Not implemented");
-            }
-            chunk_infos.emplace_back(dumped_chunk.get());
-        }
-        wal_entry_->cmds_.push_back(MakeShared<WalCmdDumpIndex>(db_name_, table_name, index_name, segment_id, std::move(chunk_infos)));
-    }
+    const String &index_name = *table_index_entry->GetIndexName();
+    const String &table_name = *table_entry->GetTableName();
+    table_index_entry->OptIndex(txn_table_store, init_params, false /*replay*/);
 
     wal_entry_->cmds_.push_back(MakeShared<WalCmdOptimize>(db_name_, table_name, index_name, std::move(init_params)));
     return Status::OK();


### PR DESCRIPTION
### What problem does this PR solve?

Add index dump wal.
Now, when index is dumped/optimized/populate, chunk entry is recorded in wal, which fix idx replay slow.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
