### PR TITLE
Add: const column vector.

### DIFF
--- a/src/executor/operator/physical_compact.cpp
+++ b/src/executor/operator/physical_compact.cpp
@@ -154,7 +154,7 @@ bool PhysicalCompact::Execute(QueryContext *query_context, OperatorState *operat
             Vector<ColumnVector> input_column_vectors;
             for (ColumnID column_id = 0; column_id < column_count; ++column_id) {
                 auto *column_block_entry = block_entry->GetColumnBlockEntry(column_id);
-                input_column_vectors.emplace_back(column_block_entry->GetColumnVector(buffer_mgr));
+                input_column_vectors.emplace_back(column_block_entry->GetConstColumnVector(buffer_mgr));
             }
             SizeT read_offset = 0;
             while (true) {

--- a/src/executor/operator/physical_export.cpp
+++ b/src/executor/operator/physical_export.cpp
@@ -166,7 +166,7 @@ SizeT PhysicalExport::ExportToCSV(QueryContext *query_context, ExportOperatorSta
                         break;
                     }
                     default: {
-                        column_vectors.emplace_back(block_entry->GetColumnBlockEntry(select_column_idx)->GetColumnVector(buffer_manager));
+                        column_vectors.emplace_back(block_entry->GetColumnBlockEntry(select_column_idx)->GetConstColumnVector(buffer_manager));
                         if(column_vectors[block_column_idx].Size() != block_row_count) {
                             String error_message = "Unmatched row_count between block and block_column";
                             UnrecoverableError(error_message);
@@ -288,7 +288,7 @@ SizeT PhysicalExport::ExportToJSONL(QueryContext *query_context, ExportOperatorS
                         break;
                     }
                     default: {
-                        column_vectors.emplace_back(block_entry->GetColumnBlockEntry(select_column_idx)->GetColumnVector(buffer_manager));
+                        column_vectors.emplace_back(block_entry->GetColumnBlockEntry(select_column_idx)->GetConstColumnVector(buffer_manager));
                         if(column_vectors[block_column_idx].Size() != block_row_count) {
                             String error_message = "Unmatched row_count between block and block_column";
                             UnrecoverableError(error_message);
@@ -399,7 +399,7 @@ SizeT PhysicalExport::ExportToFVECS(QueryContext *query_context, ExportOperatorS
             BlockEntry *block_entry = segment_snapshot.block_map_[block_idx];
             SizeT block_row_count = block_entry->row_count();
 
-            ColumnVector exported_column_vector = block_entry->GetColumnBlockEntry(exported_column_idx)->GetColumnVector(buffer_manager);
+            ColumnVector exported_column_vector = block_entry->GetColumnBlockEntry(exported_column_idx)->GetConstColumnVector(buffer_manager);
             if(exported_column_vector.Size() != block_row_count) {
                 String error_message = "Unmatched row_count between block and block_column";
                 UnrecoverableError(error_message);

--- a/src/executor/operator/physical_match.cpp
+++ b/src/executor/operator/physical_match.cpp
@@ -875,7 +875,7 @@ bool PhysicalMatch::ExecuteInnerHomebrewed(QueryContext *query_context, Operator
             SizeT column_id = 0;
             for (; column_id < column_n; ++column_id) {
                 BlockColumnEntry *block_column_ptr = block_entry->GetColumnBlockEntry(column_ids[column_id]);
-                ColumnVector column_vector = block_column_ptr->GetColumnVector(query_context->storage()->buffer_manager());
+                ColumnVector column_vector = block_column_ptr->GetConstColumnVector(query_context->storage()->buffer_manager());
                 output_block_ptr->column_vectors[column_id]->AppendWith(column_vector, block_offset, 1);
             }
             Value v = Value::MakeFloat(score_result[output_id]);

--- a/src/executor/operator/physical_scan/physical_knn_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_knn_scan.cpp
@@ -75,7 +75,7 @@ void ReadDataBlock(DataBlock *output,
             u32 segment_offset = block_id * DEFAULT_BLOCK_CAPACITY;
             output->column_vectors[output_column_id++]->AppendWith(RowID(segment_id, segment_offset), row_count);
         } else {
-            ColumnVector column_vector = current_block_entry->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr);
+            ColumnVector column_vector = current_block_entry->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr);
             output->column_vectors[output_column_id++]->AppendWith(column_vector, 0, row_count);
         }
     }
@@ -306,7 +306,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                 //                       block_column_idx + 1,
                 //                       brute_task_n));
                 block_entry->SetDeleteBitmask(begin_ts, bitmask);
-                ColumnVector column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+                ColumnVector column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
                 auto data = reinterpret_cast<const DataType *>(column_vector.data());
                 merge_heap->Search(query, data, knn_scan_shared_data->dimension_, dist_func->dist_func_, row_count, segment_id, block_id, bitmask);
             }
@@ -501,7 +501,7 @@ void PhysicalKnnScan::ExecuteInternal(QueryContext *query_context, KnnScanOperat
                                         prev_block_id = block_id;
                                         BlockEntry *block_entry = block_index->GetBlockEntry(segment_id, block_id);
                                         BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(knn_column_id);
-                                        column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+                                        column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
                                     }
                                     const auto *data = reinterpret_cast<const DataType *>(column_vector.data());
                                     data += block_offset * knn_scan_shared_data->dimension_;

--- a/src/executor/operator/physical_scan/physical_match_sparse_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_match_sparse_scan.cpp
@@ -394,7 +394,7 @@ void PhysicalMatchSparseScan::ExecuteInnerT(DistFunc *dist_func,
         block_entry->SetDeleteBitmask(begin_ts, bitmask);
 
         auto *block_column_entry = block_entry->GetColumnBlockEntry(search_column_id_);
-        ColumnVector column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+        ColumnVector column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
 
         for (SizeT query_id = 0; query_id < query_n; ++query_id) {
             auto query_sparse = get_ele(query_vector, query_id);

--- a/src/executor/operator/physical_scan/physical_match_tensor_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_match_tensor_scan.cpp
@@ -288,7 +288,7 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
                                                 const BlockEntry *block_entry = block_guard.block_entries_[block_id].get();
                                                 block_entry->SetDeleteBitmask(begin_ts, block_bitmask);
                                                 BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(this->search_column_id_);
-                                                auto column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+                                                auto column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
                                                 // output score will always be float type
                                                 CalculateScoreOnColumnVector(column_vector,
                                                                              segment_id,
@@ -342,7 +342,7 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
         Bitmask bitmask;
         if (this->CalculateFilterBitmask(segment_id, block_id, row_count, bitmask)) {
             block_entry->SetDeleteBitmask(begin_ts, bitmask);
-            auto column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+            auto column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
             // output score will always be float type
             CalculateScoreOnColumnVector(column_vector, segment_id, block_id, 0, row_count, bitmask, *match_tensor_expr_, function_data);
         }
@@ -386,7 +386,7 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
             for (SizeT i = 0; i < column_n; ++i) {
                 const auto column_id = base_table_ref_->column_ids_[i];
                 auto *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
-                auto column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+                auto column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
                 output_block_ptr->column_vectors[i]->AppendWith(column_vector, block_offset, 1);
             }
             output_block_ptr->AppendValueByPtr(column_n, (ptr_t)&result_scores[top_idx]);
@@ -771,7 +771,7 @@ void GetRerankerScore(Vector<MatchTensorRerankDoc> &rerank_docs,
         const BlockOffset block_offset = segment_offset % DEFAULT_BLOCK_CAPACITY;
         BlockColumnEntry *block_column_entry =
             block_index->segment_block_index_.at(segment_id).block_map_.at(block_id)->GetColumnBlockEntry(column_id);
-        auto column_vec = block_column_entry->GetColumnVector(buffer_mgr);
+        auto column_vec = block_column_entry->GetConstColumnVector(buffer_mgr);
         doc.score_ = CalcutateScoreOfRowOp::Execute(column_vec, block_offset, query_tensor_ptr, query_embedding_num, basic_embedding_dimension);
     }
 }

--- a/src/executor/operator/physical_scan/physical_scan_base.cpp
+++ b/src/executor/operator/physical_scan/physical_scan_base.cpp
@@ -121,7 +121,7 @@ void PhysicalScanBase::SetOutput(const Vector<char *> &raw_result_dists_list,
             for (SizeT i = 0; i < column_n; ++i) {
                 SizeT column_id = base_table_ref_->column_ids_[i];
                 auto *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
-                ColumnVector &&column_vector = block_column_entry->GetColumnVector(buffer_mgr);
+                ColumnVector &&column_vector = block_column_entry->GetConstColumnVector(buffer_mgr);
 
                 output_block_ptr->column_vectors[i]->AppendWith(column_vector, block_offset, 1);
             }

--- a/src/executor/operator/physical_scan/physical_table_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_table_scan.cpp
@@ -180,7 +180,7 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
                     break;
                 }
                 default: {
-                    ColumnVector column_vector = current_block_entry->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr);
+                    ColumnVector column_vector = current_block_entry->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr);
                     output_ptr->column_vectors[output_column_id++]->AppendWith(column_vector, read_offset, write_size);
                 }
             }

--- a/src/executor/physical_operator.cpp
+++ b/src/executor/physical_operator.cpp
@@ -84,7 +84,7 @@ void PhysicalOperator::InputLoad(QueryContext *query_context, OperatorState *ope
                 auto binding = load_metas[k].binding_;
                 BlockColumnEntry *block_column_ptr = block_entry->GetColumnBlockEntry(binding.column_idx);
 
-                ColumnVector column_vector = block_column_ptr->GetColumnVector(query_context->storage()->buffer_manager());
+                ColumnVector column_vector = block_column_ptr->GetConstColumnVector(query_context->storage()->buffer_manager());
                 input_block->column_vectors[load_metas[k].index_]->AppendWith(column_vector, block_offset, 1);
             }
         }

--- a/src/storage/buffer/file_worker/bmp_index_file_worker.cpp
+++ b/src/storage/buffer/file_worker/bmp_index_file_worker.cpp
@@ -68,7 +68,17 @@ void BMPIndexFileWorker::FreeInMemory() {
         const auto error_message = "Data is not allocated.";
         UnrecoverableError(error_message);
     }
-    delete reinterpret_cast<AbstractBMP *>(data_);
+    auto *p = reinterpret_cast<AbstractBMP *>(data_);
+    std::visit(
+        [](auto &&arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (!std::is_same_v<T, std::nullptr_t>) {
+                if (arg != nullptr) {
+                    delete arg;
+                }
+            }
+        },
+        *p);
     data_ = nullptr;
 }
 

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cpp
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cpp
@@ -75,7 +75,18 @@ void HnswFileWorker::FreeInMemory() {
         String error_message = "FreeInMemory: Data is not allocated.";
         UnrecoverableError(error_message);
     }
-    delete reinterpret_cast<AbstractHnsw *>(data_);
+    auto *p = reinterpret_cast<AbstractHnsw *>(data_);
+    std::visit(
+        [&](auto &&index) {
+            using T = std::decay_t<decltype(index)>;
+            if constexpr (!std::is_same_v<T, std::nullptr_t>) {
+                if (index != nullptr) {
+                    delete index;
+                }
+            }
+        },
+        *p);
+    delete p;
     data_ = nullptr;
 }
 

--- a/src/storage/column_vector/column_vector.cpp
+++ b/src/storage/column_vector/column_vector.cpp
@@ -149,6 +149,7 @@ void ColumnVector::Initialize(ColumnVectorType vector_type, SizeT capacity) {
 void ColumnVector::Initialize(BufferManager *buffer_mgr,
                               BlockColumnEntry *block_column_entry,
                               SizeT current_row_count,
+                              ColumnVectorTipe vector_tipe,
                               ColumnVectorType vector_type,
                               SizeT capacity) {
     Pair<VectorBufferType, VectorBufferType> vector_buffer_types = InitializeHelper(vector_type, capacity);
@@ -165,7 +166,16 @@ void ColumnVector::Initialize(BufferManager *buffer_mgr,
         buffer_ = VectorBuffer::Make(buffer_mgr, block_column_entry, data_type_size_, capacity_, vector_buffer_types);
         nulls_ptr_ = Bitmask::Make(capacity_);
     }
-    data_ptr_ = buffer_->GetDataMut();
+    switch (vector_tipe) {
+        case ColumnVectorTipe::kReadWrite: {
+            data_ptr_ = buffer_->GetDataMut();
+            break;
+        }
+        case ColumnVectorTipe::kReadOnly: {
+            data_ptr_ = const_cast<ptr_t>(buffer_->GetData());
+            break;
+        }
+    }
     tail_index_ = current_row_count;
 }
 

--- a/src/storage/column_vector/column_vector.cppm
+++ b/src/storage/column_vector/column_vector.cppm
@@ -45,6 +45,11 @@ namespace infinity {
 class BufferManager;
 class BlockColumnEntry;
 
+export enum class ColumnVectorTipe: i8 {
+    kReadWrite,
+    kReadOnly,
+};
+
 export enum class ColumnVectorType : i8 {
     kInvalid,
     kFlat,          // Stand without any encode
@@ -200,6 +205,7 @@ public:
     void Initialize(BufferManager *buffer_mgr,
                     BlockColumnEntry *block_column_entry,
                     SizeT current_row_count,
+                    ColumnVectorTipe vector_tipe = ColumnVectorTipe::kReadWrite,
                     ColumnVectorType vector_type = ColumnVectorType::kFlat,
                     SizeT capacity = DEFAULT_VECTOR_SIZE);
 

--- a/src/storage/knn_index/emvb/emvb_index.cpp
+++ b/src/storage/knn_index/emvb/emvb_index.cpp
@@ -100,7 +100,7 @@ void EMVBIndex::BuildEMVBIndex(const RowID base_rowid,
         // read the segment to get total embedding count
         BlockID block_id = start_segment_offset / DEFAULT_BLOCK_CAPACITY;
         BlockOffset block_offset = start_segment_offset % DEFAULT_BLOCK_CAPACITY;
-        auto column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr));
+        auto column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr));
         const TensorT *tensor_ptr = reinterpret_cast<const TensorT *>(column_vector->data());
         for (u32 i = 0; i < row_count; ++i) {
             {
@@ -108,7 +108,7 @@ void EMVBIndex::BuildEMVBIndex(const RowID base_rowid,
                 block_offset = new_segment_offset % DEFAULT_BLOCK_CAPACITY;
                 if (const BlockID new_block_id = new_segment_offset / DEFAULT_BLOCK_CAPACITY; new_block_id != block_id) {
                     block_id = new_block_id;
-                    column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr));
+                    column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr));
                     tensor_ptr = reinterpret_cast<const TensorT *>(column_vector->data());
                 }
             }
@@ -163,7 +163,7 @@ void EMVBIndex::BuildEMVBIndex(const RowID base_rowid,
                 const SegmentOffset new_segment_offset = start_segment_offset + sample_row;
                 const BlockID block_id = new_segment_offset / DEFAULT_BLOCK_CAPACITY;
                 const BlockOffset block_offset = new_segment_offset % DEFAULT_BLOCK_CAPACITY;
-                auto column_vector = block_entries[block_id]->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr);
+                auto column_vector = block_entries[block_id]->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr);
                 const TensorT *tensor_ptr = reinterpret_cast<const TensorT *>(column_vector.data());
                 const auto [embedding_num, chunk_id, chunk_offset] = tensor_ptr[block_offset];
                 const auto embedding_ptr = column_vector.buffer_->fix_heap_mgr_->GetRawPtrFromChunk(chunk_id, chunk_offset);
@@ -194,7 +194,7 @@ void EMVBIndex::BuildEMVBIndex(const RowID base_rowid,
         const auto time_4 = std::chrono::high_resolution_clock::now();
         BlockID block_id = start_segment_offset / DEFAULT_BLOCK_CAPACITY;
         BlockOffset block_offset = start_segment_offset % DEFAULT_BLOCK_CAPACITY;
-        auto column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr));
+        auto column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr));
         const TensorT *tensor_ptr = reinterpret_cast<const TensorT *>(column_vector->data());
         for (u32 i = 0; i < row_count; ++i) {
             {
@@ -202,7 +202,7 @@ void EMVBIndex::BuildEMVBIndex(const RowID base_rowid,
                 block_offset = new_segment_offset % DEFAULT_BLOCK_CAPACITY;
                 if (const BlockID new_block_id = new_segment_offset / DEFAULT_BLOCK_CAPACITY; new_block_id != block_id) {
                     block_id = new_block_id;
-                    column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr));
+                    column_vector = MakeUnique<ColumnVector>(block_entries[block_id]->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr));
                     tensor_ptr = reinterpret_cast<const TensorT *>(column_vector->data());
                 }
             }

--- a/src/storage/knn_index/emvb/emvb_index_in_mem.cpp
+++ b/src/storage/knn_index/emvb/emvb_index_in_mem.cpp
@@ -68,7 +68,7 @@ u32 EMVBIndexInMem::GetRowCount() const {
 }
 
 void EMVBIndexInMem::Insert(u16 block_id, BlockColumnEntry *block_column_entry, BufferManager *buffer_manager, u32 row_offset, u32 row_count) {
-    const ColumnVector column_vector = block_column_entry->GetColumnVector(buffer_manager);
+    const ColumnVector column_vector = block_column_entry->GetConstColumnVector(buffer_manager);
     const auto tensor_ptr_start = reinterpret_cast<const TensorT *>(column_vector.data()) + row_offset;
     std::unique_lock lock(rw_mutex_);
     const auto income_segment_entry = block_column_entry->GetBlockEntry()->GetSegmentEntry();

--- a/src/storage/knn_index/knn_hnsw/abstract_hnsw.cppm
+++ b/src/storage/knn_index/knn_hnsw/abstract_hnsw.cppm
@@ -166,7 +166,7 @@ public:
 
     const AbstractHnsw &get() const { return hnsw_; }
 
-    AbstractHnsw &get_ref() { return hnsw_; }
+    AbstractHnsw *get_ptr() { return &hnsw_; }
 
 private:
     static constexpr SizeT kBuildBucketSize = 1024;

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -141,6 +141,14 @@ UniquePtr<BlockColumnEntry> BlockColumnEntry::NewReplayBlockColumnEntry(const Bl
 }
 
 ColumnVector BlockColumnEntry::GetColumnVector(BufferManager *buffer_mgr) {
+    return GetColumnVectorInner(buffer_mgr, ColumnVectorTipe::kReadWrite);
+}
+
+ColumnVector BlockColumnEntry::GetConstColumnVector(BufferManager *buffer_mgr) {
+    return GetColumnVectorInner(buffer_mgr, ColumnVectorTipe::kReadOnly);
+}
+
+ColumnVector BlockColumnEntry::GetColumnVectorInner(BufferManager *buffer_mgr, const ColumnVectorTipe tipe) {
     if (this->buffer_ == nullptr) {
         // Get buffer handle from buffer manager
         auto file_worker = MakeUnique<DataFileWorker>(this->base_dir_, this->file_name_, 0);
@@ -148,7 +156,7 @@ ColumnVector BlockColumnEntry::GetColumnVector(BufferManager *buffer_mgr) {
     }
 
     ColumnVector column_vector(column_type_);
-    column_vector.Initialize(buffer_mgr, this, block_entry_->row_count());
+    column_vector.Initialize(buffer_mgr, this, block_entry_->row_count(), tipe);
     return column_vector;
 }
 

--- a/src/storage/meta/entry/block_column_entry.cppm
+++ b/src/storage/meta/entry/block_column_entry.cppm
@@ -77,6 +77,12 @@ public:
 
     ColumnVector GetColumnVector(BufferManager *buffer_mgr);
 
+    ColumnVector GetConstColumnVector(BufferManager *buffer_mgr);
+
+private:
+    ColumnVector GetColumnVectorInner(BufferManager *buffer_mgr, const ColumnVectorTipe tipe);
+
+public:
     void AppendOutlineBuffer(u32 buffer_group_id, BufferObj *buffer);
 
     BufferObj *GetOutlineBuffer(u32 buffer_group_id, SizeT idx) const;

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -277,7 +277,7 @@ void SegmentIndexEntry::MemIndexInsert(SharedPtr<BlockEntry> block_entry,
                 }
             }
             BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(column_id);
-            SharedPtr<ColumnVector> column_vector = MakeShared<ColumnVector>(block_column_entry->GetColumnVector(buffer_manager));
+            SharedPtr<ColumnVector> column_vector = MakeShared<ColumnVector>(block_column_entry->GetConstColumnVector(buffer_manager));
             memory_indexer_->Insert(column_vector, row_offset, row_count, false);
             break;
         }
@@ -489,7 +489,7 @@ void SegmentIndexEntry::PopulateEntirely(const SegmentEntry *segment_entry, Txn 
                     memory_indexer_->InsertGap(begin_row_id - exp_begin_row_id);
                 }
 
-                SharedPtr<ColumnVector> column_vector = MakeShared<ColumnVector>(block_column_entry->GetColumnVector(buffer_mgr));
+                SharedPtr<ColumnVector> column_vector = MakeShared<ColumnVector>(block_column_entry->GetConstColumnVector(buffer_mgr));
                 memory_indexer_->Insert(column_vector, 0, block_entry->row_count(), true);
                 memory_indexer_->Commit(true);
             }

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -764,28 +764,30 @@ void SegmentIndexEntry::OptIndex(IndexBase *index_base,
             if (!params) {
                 break;
             }
-            auto optimize_index = [&](AbstractHnsw &abstract_hnsw) {
+            auto optimize_index = [&](AbstractHnsw *abstract_hnsw) {
                 std::visit(
                     [&](auto &&index) {
                         using T = std::decay_t<decltype(index)>;
                         if constexpr (std::is_same_v<T, std::nullptr_t>) {
                             UnrecoverableError("Invalid index type.");
                         } else {
-                            abstract_hnsw = std::move(*index).CompressToLVQ().release();
+                            auto *p = std::move(*index).CompressToLVQ().release();
+                            delete index;
+                            *abstract_hnsw = p;
                         }
                     },
-                    abstract_hnsw);
+                    *abstract_hnsw);
             };
 
             const auto [chunk_index_entries, memory_index_entry] = this->GetHnswIndexSnapshot();
             for (const auto &chunk_index_entry : chunk_index_entries) {
                 BufferHandle buffer_handle = chunk_index_entry->GetIndex();
                 auto *abstract_hnsw = reinterpret_cast<AbstractHnsw *>(buffer_handle.GetDataMut());
-                optimize_index(*abstract_hnsw);
+                optimize_index(abstract_hnsw);
                 chunk_index_entry->SaveIndexFile();
             }
             if (memory_index_entry.get() != nullptr) {
-                optimize_index(memory_index_entry->get_ref());
+                optimize_index(memory_index_entry->get_ptr());
                 dumped_memindex_entry = this->MemIndexDump(false /*spill*/);
             }
             break;

--- a/src/storage/meta/iter/block_column_iter.cppm
+++ b/src/storage/meta/iter/block_column_iter.cppm
@@ -36,7 +36,7 @@ export template <bool CheckTS = true>
 class BlockColumnIter {
 public:
     BlockColumnIter(BlockColumnEntry *entry, BufferManager *buffer_mgr, TxnTimeStamp iterate_ts)
-        : block_entry_(entry->GetBlockEntry()), column_vector_(MakeShared<ColumnVector>(entry->GetColumnVector(buffer_mgr))),
+        : block_entry_(entry->GetBlockEntry()), column_vector_(MakeShared<ColumnVector>(entry->GetConstColumnVector(buffer_mgr))),
           ele_size_(entry->column_type()->Size()), iterate_ts_(iterate_ts), offset_(0), read_end_(0) {}
     // TODO: Does `ColumnVector` implements the move constructor?
 
@@ -72,7 +72,7 @@ export template <>
 class BlockColumnIter<false> {
 public:
     BlockColumnIter(BlockColumnEntry *entry, BufferManager *buffer_mgr, TxnTimeStamp)
-        : block_entry_(entry->GetBlockEntry()), column_vector_(MakeShared<ColumnVector>(entry->GetColumnVector(buffer_mgr))),
+        : block_entry_(entry->GetBlockEntry()), column_vector_(MakeShared<ColumnVector>(entry->GetConstColumnVector(buffer_mgr))),
           ele_size_(entry->column_type()->Size()), size_(block_entry_->row_count()), offset_(0) {}
 
     Optional<Pair<const void *, BlockOffset>> Next() {
@@ -100,7 +100,7 @@ export template <typename DataType>
 class MemIndexInserterIter {
 public:
     MemIndexInserterIter(SegmentOffset block_offset, BlockColumnEntry *entry, BufferManager *buffer_mgr, SizeT offset, SizeT size)
-        : block_offset_(block_offset), column_vector_(MakeShared<ColumnVector>(entry->GetColumnVector(buffer_mgr))),
+        : block_offset_(block_offset), column_vector_(MakeShared<ColumnVector>(entry->GetConstColumnVector(buffer_mgr))),
           ele_size_(entry->column_type()->Size()), cur_(offset), end_(offset + size) {}
 
     Optional<Pair<const DataType *, SegmentOffset>> Next() {
@@ -126,7 +126,7 @@ export template <typename DataType, typename IdxType>
 class MemIndexInserterIter<SparseVecRef<DataType, IdxType>> {
 public:
     MemIndexInserterIter(SegmentOffset block_offset, BlockColumnEntry *entry, BufferManager *buffer_mgr, SizeT offset, SizeT size)
-        : block_offset_(block_offset), column_vector_(MakeShared<ColumnVector>(entry->GetColumnVector(buffer_mgr))),
+        : block_offset_(block_offset), column_vector_(MakeShared<ColumnVector>(entry->GetConstColumnVector(buffer_mgr))),
           ele_size_(entry->column_type()->Size()), cur_(offset), end_(offset + size) {}
 
     Optional<Pair<SparseVecRef<DataType, IdxType>, SegmentOffset>> Next() {

--- a/src/storage/secondary_index/common_query_filter.cpp
+++ b/src/storage/secondary_index/common_query_filter.cpp
@@ -61,7 +61,7 @@ void ReadDataBlock(DataBlock *output,
             u32 segment_offset = block_id * DEFAULT_BLOCK_CAPACITY;
             output->column_vectors[i]->AppendWith(RowID(segment_id, segment_offset), row_count);
         } else {
-            ColumnVector column_vector = current_block_entry->GetColumnBlockEntry(column_id)->GetColumnVector(buffer_mgr);
+            ColumnVector column_vector = current_block_entry->GetColumnBlockEntry(column_id)->GetConstColumnVector(buffer_mgr);
             output->column_vectors[i]->AppendWith(column_vector, 0, row_count);
         }
     }

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -659,7 +659,7 @@ TEST_F(BufferObjTest, test_hnsw_index_buffer_obj_shutdown) {
                 auto block_entry = segment_entry->GetBlockEntryByID(i);
                 EXPECT_EQ(block_entry->row_count(), kImportSize);
                 auto *col = block_entry->GetColumnBlockEntry(0);
-                auto column_vector = col->GetColumnVector(buffer_mgr);
+                auto column_vector = col->GetConstColumnVector(buffer_mgr);
                 for (u64 j = 0; j < kImportSize; ++j) {
                     Value v1 = column_vector.GetValue(j);
                 }
@@ -746,7 +746,7 @@ TEST_F(BufferObjTest, test_big_with_gc_and_cleanup) {
                 auto block_entry = segment_entry->GetBlockEntryByID(i);
                 EXPECT_EQ(block_entry->row_count(), kImportSize);
                 auto *col = block_entry->GetColumnBlockEntry(0);
-                auto column_vector = col->GetColumnVector(buffer_mgr);
+                auto column_vector = col->GetConstColumnVector(buffer_mgr);
                 for (u64 j = 0; j < kImportSize; ++j) {
                     Value v1 = column_vector.GetValue(j);
                     Value v2 = Value::MakeBigInt(i * 1000 + j);
@@ -829,7 +829,7 @@ TEST_F(BufferObjTest, test_multiple_threads_read) {
                     auto block_entry = segment_entry->GetBlockEntryByID(i);
                     EXPECT_EQ(block_entry->row_count(), kImportSize);
                     auto *col = block_entry->GetColumnBlockEntry(0);
-                    auto column_vector = col->GetColumnVector(buffer_mgr);
+                    auto column_vector = col->GetConstColumnVector(buffer_mgr);
                     for (u64 j = 0; j < kImportSize; ++j) {
                         Value v1 = column_vector.GetValue(j);
                         Value v2 = Value::MakeBigInt(i * 1000 + j);

--- a/src/unit_test/storage/wal/wal_replay.cpp
+++ b/src/unit_test/storage/wal/wal_replay.cpp
@@ -440,9 +440,9 @@ TEST_F(WalReplayTest, wal_replay_append) {
             BlockColumnEntry *column1 = block_entry->GetColumnBlockEntry(1);
             BlockColumnEntry *column2 = block_entry->GetColumnBlockEntry(2);
 
-            ColumnVector col0 = column0->GetColumnVector(storage->buffer_manager());
-            ColumnVector col1 = column1->GetColumnVector(storage->buffer_manager());
-            ColumnVector col2 = column2->GetColumnVector(storage->buffer_manager());
+            ColumnVector col0 = column0->GetConstColumnVector(storage->buffer_manager());
+            ColumnVector col1 = column1->GetConstColumnVector(storage->buffer_manager());
+            ColumnVector col2 = column2->GetConstColumnVector(storage->buffer_manager());
 
             for (SizeT i = 0; i < row_count; ++i) {
                 Value v0 = col0.GetValue(i);
@@ -640,15 +640,15 @@ TEST_F(WalReplayTest, wal_replay_import) {
             BlockColumnEntry *column1 = block_entry->GetColumnBlockEntry(1);
             BlockColumnEntry *column2 = block_entry->GetColumnBlockEntry(2);
 
-            ColumnVector col0 = column0->GetColumnVector(buffer_manager);
+            ColumnVector col0 = column0->GetConstColumnVector(buffer_manager);
             Value v0 = col0.GetValue(0);
             EXPECT_EQ(v0.GetValue<TinyIntT>(), 1);
 
-            ColumnVector col1 = column1->GetColumnVector(buffer_manager);
+            ColumnVector col1 = column1->GetConstColumnVector(buffer_manager);
             Value v1 = col1.GetValue(0);
             EXPECT_EQ(v1.GetValue<BigIntT>(), (i64)(22));
 
-            ColumnVector col2 = column2->GetColumnVector(buffer_manager);
+            ColumnVector col2 = column2->GetConstColumnVector(buffer_manager);
             Value v2 = col2.GetValue(0);
             DataType *col2_type = column2->column_type().get();
             EXPECT_EQ(col2_type->type(), LogicalType::kDouble);


### PR DESCRIPTION
### What problem does this PR solve?

Add: BlockColumnEntry::GetConstColumnVector interface that get column vector which will not be flushed when evicted.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Performance Improvement
