### PR TITLE
Add symbolic links to large files in vfs

### DIFF
--- a/src/storage/invertedindex/memory_indexer.cpp
+++ b/src/storage/invertedindex/memory_indexer.cpp
@@ -62,6 +62,8 @@ import buf_writer;
 import profiler;
 import third_party;
 import infinity_context;
+import persistence_manager;
+import defer_op;
 
 namespace infinity {
 constexpr int MAX_TUPLE_LENGTH = 1024; // we assume that analyzed term, together with docid/offset info, will never exceed such length
@@ -371,9 +373,16 @@ void MemoryIndexer::TupleListToIndexFile(UniquePtr<SortMergerTermTuple<TermTuple
     Path path = Path(index_dir_) / base_name_;
     String index_prefix = path.string();
     LocalFileSystem fs;
+
+    bool use_object_cache = InfinityContext::instance().persistence_manager() != nullptr;
     String posting_file = index_prefix + POSTING_SUFFIX;
-    SharedPtr<FileWriter> posting_file_writer = MakeShared<FileWriter>(fs, posting_file, 128000);
     String dict_file = index_prefix + DICT_SUFFIX;
+    Vector<ObjAddr> obj_addrs;
+    if (use_object_cache) {
+        obj_addrs.emplace_back(InfinityContext::instance().persistence_manager()->ObjCreateRefCount(posting_file));
+        obj_addrs.emplace_back(InfinityContext::instance().persistence_manager()->ObjCreateRefCount(dict_file));
+    }
+    SharedPtr<FileWriter> posting_file_writer = MakeShared<FileWriter>(fs, posting_file, 128000);
     SharedPtr<FileWriter> dict_file_writer = MakeShared<FileWriter>(fs, dict_file, 128000);
     TermMetaDumper term_meta_dumpler((PostingFormatOption(flag_)));
     String fst_file = index_prefix + DICT_SUFFIX + ".fst";
@@ -453,6 +462,22 @@ void MemoryIndexer::TupleListToIndexFile(UniquePtr<SortMergerTermTuple<TermTuple
     fs.DeleteFile(fst_file);
 
     String column_length_file = index_prefix + LENGTH_SUFFIX;
+
+    if (use_object_cache) {
+        obj_addrs.emplace_back(InfinityContext::instance().persistence_manager()->ObjCreateRefCount(column_length_file));
+    }
+    DeferFn defer_fn([&]() {
+        if (!use_object_cache) {
+            return;
+        }
+        for (auto &obj_addr : obj_addrs) {
+            InfinityContext::instance().persistence_manager()->PutObjCache(obj_addr);
+        }
+        std::filesystem::remove(posting_file);
+        std::filesystem::remove(dict_file);
+        std::filesystem::remove(column_length_file);
+    });
+
     auto [file_handler, status] = fs.OpenFile(column_length_file, FileFlags::WRITE_FLAG | FileFlags::TRUNCATE_CREATE, FileLockType::kNoLock);
     if(!status.ok()) {
         UnrecoverableError(status.message());

--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -92,7 +92,7 @@ ObjAddr PersistenceManager::Persist(const char *data, SizeT src_size, bool allow
         if (current_object_size_ >= object_size_limit_) {
             objects_.emplace(current_object_key_, ObjStat(src_size, 0));
             current_object_key_ = ObjCreate();
-            current_object_size_ = src_size;
+            current_object_size_ = 0;
         }
         return obj_addr;
     }
@@ -148,7 +148,6 @@ ObjAddr PersistenceManager::ObjCreateRefCount(const String &file_path) {
     fs::path src_fp = workspace_;
     fs::path dst_fp = file_path;
     src_fp.append(obj_key);
-    fmt::print("src_fp: {}, dst_fp: {}\n", src_fp.string(), dst_fp.string());
     try {
         if (fs::exists(dst_fp)) {
             fs::remove(dst_fp);

--- a/src/storage/persistence/persistence_manager.cppm
+++ b/src/storage/persistence/persistence_manager.cppm
@@ -40,10 +40,7 @@ public:
         current_object_key_ = ObjCreate();
         current_object_size_ = 0;
     }
-    ~PersistenceManager() {
-        current_object_key_ = ObjCreate();
-        current_object_size_ = 0;
-    }
+    ~PersistenceManager() {}
 
     // Create new object or append to current object, and returns the location.
     ObjAddr Persist(const String &file_path, bool allow_compose = true);

--- a/src/storage/persistence/persistence_manager.cppm
+++ b/src/storage/persistence/persistence_manager.cppm
@@ -36,8 +36,14 @@ export struct ObjStat {
 export class PersistenceManager {
 public:
     // TODO: build cache from existing files under workspace
-    PersistenceManager(const String workspace, SizeT object_size_limit) : workspace_(workspace), object_size_limit_(object_size_limit) {}
-    ~PersistenceManager() {}
+    PersistenceManager(const String workspace, SizeT object_size_limit) : workspace_(workspace), object_size_limit_(object_size_limit) {
+        current_object_key_ = ObjCreate();
+        current_object_size_ = 0;
+    }
+    ~PersistenceManager() {
+        current_object_key_ = ObjCreate();
+        current_object_size_ = 0;
+    }
 
     // Create new object or append to current object, and returns the location.
     ObjAddr Persist(const String &file_path, bool allow_compose = true);
@@ -54,6 +60,7 @@ public:
     // Decrease refcount
     void PutObjCache(const ObjAddr &object_addr);
 
+    ObjAddr ObjCreateRefCount(const String &file_path);
 private:
     String ObjCreate();
 


### PR DESCRIPTION
### What problem does this PR solve?
* add symbolic links to large files in vfs
* fix vfs initialization file object is empty
* using vfs in fulltext index offline dump

### Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring
