### PR TITLE
Fix corruption if no outputs from analyzer

### DIFF
--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -152,6 +152,8 @@ struct TermRefRadix {
 };
 
 void ColumnInverter::SortTerms() {
+    if (term_refs_.empty())
+        return;
     Vector<u64> first_four_bytes(term_refs_.size());
     for (u32 i = 0; i < term_refs_.size(); ++i) {
         u64 first_four = ntohl(*reinterpret_cast<const u32 *>(GetTermFromRef(term_refs_[i])));


### PR DESCRIPTION
### What problem does this PR solve?

Standard analyzer will output empty given pure non-ascii characters, it will lead to corruption for sorting.

Issue link:#1533

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
