### PR TITLE
Standard analyzer could output unicode tokens

### DIFF
--- a/src/common/analyzer/common_analyzer.cpp
+++ b/src/common/analyzer/common_analyzer.cpp
@@ -21,6 +21,7 @@ import stl;
 import term;
 import stemmer;
 import analyzer;
+import tokenizer;
 module common_analyzer;
 
 namespace infinity {
@@ -30,6 +31,12 @@ CommonLanguageAnalyzer::CommonLanguageAnalyzer()
     : Analyzer(), lowercase_string_buffer_(term_string_buffer_limit_), stemmer_(MakeUnique<Stemmer>()), case_sensitive_(false), contain_lower_(false),
       extract_eng_stem_(true), extract_synonym_(false), cjk_(false), remove_stopwords_(false) {
     stemmer_->Init(STEM_LANG_ENGLISH);
+    TokenizeConfig token_config;
+    String divide_str("@#$");
+    String unite_str("/");
+    token_config.AddDivides(divide_str);
+    token_config.AddUnites(unite_str);
+    tokenizer_.SetConfig(token_config);
 }
 
 CommonLanguageAnalyzer::~CommonLanguageAnalyzer() {}

--- a/src/common/analyzer/tokenizer.cpp
+++ b/src/common/analyzer/tokenizer.cpp
@@ -35,7 +35,7 @@ CharTypeTable::CharTypeTable(bool use_def_delim) {
         return;
     // set the lower 4 bit to record default char type
     for (u8 i = 0; i < BYTE_MAX; i++) {
-        if (std::isalnum(i))
+        if (std::isalnum(i) || i > 127)
             continue;
         else if (std::isspace(i))
             char_type_table_[i] = SPACE_CHR;

--- a/test/sql/dql/fulltext/fulltext.slt
+++ b/test/sql/dql/fulltext/fulltext.slt
@@ -25,20 +25,20 @@ CREATE INDEX ft_index ON sqllogic_test_enwiki(body) USING FULLTEXT;
 query TTI
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', 'harmful chemical', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 21.620300
+Anarchism 30-APR-2012 03:25:17.000 0 22.299635
 
 # only phrase
 query TTI rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 6 20.881144
+Anarchism 30-APR-2012 03:25:17.000 6 20.753590
 
 # phrase and term
 query TTI rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('doctitle,body^5', '"social customs" harmful', 'topn=3');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 21.620300
-Anarchism 30-APR-2012 03:25:17.000 6 20.881144
+Anarchism 30-APR-2012 03:25:17.000 0 22.299635
+Anarchism 30-APR-2012 03:25:17.000 6 20.753590
 
 # copy data from csv file
 query I
@@ -48,8 +48,8 @@ COPY sqllogic_test_enwiki FROM '/var/infinity/test_data/enwiki_99.csv' WITH ( DE
 query TTI rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', 'harmful chemical', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 22.533094
-Anarchism 30-APR-2012 03:25:17.000 4294967296 22.533094
+Anarchism 30-APR-2012 03:25:17.000 0 23.241112
+Anarchism 30-APR-2012 03:25:17.000 4294967296 23.241112
 
 # copy data from csv file
 query I
@@ -59,17 +59,17 @@ COPY sqllogic_test_enwiki FROM '/var/infinity/test_data/enwiki_99.csv' WITH ( DE
 query TTI rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', 'harmful chemical anarchism', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 25.498550
-Anarchism 30-APR-2012 03:25:17.000 4294967296 25.498550
-Anarchism 30-APR-2012 03:25:17.000 8589934592 25.498550
+Anarchism 30-APR-2012 03:25:17.000 0 26.370461
+Anarchism 30-APR-2012 03:25:17.000 4294967296 26.370461
+Anarchism 30-APR-2012 03:25:17.000 8589934592 26.370461
 
 
 query TTI rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('doctitle,body^5', 'harmful chemical anarchism', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 25.498550
-Anarchism 30-APR-2012 03:25:17.000 4294967296 25.498550
-Anarchism 30-APR-2012 03:25:17.000 8589934592 25.498550
+Anarchism 30-APR-2012 03:25:17.000 0 26.370461
+Anarchism 30-APR-2012 03:25:17.000 4294967296 26.370461
+Anarchism 30-APR-2012 03:25:17.000 8589934592 26.370461
 
 
 statement ok
@@ -78,9 +78,9 @@ CREATE INDEX ft_index2 ON sqllogic_test_enwiki(doctitle) USING FULLTEXT;
 query TTI rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('doctitle,body^5', 'harmful chemical anarchism', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 25.500229
-Anarchism 30-APR-2012 03:25:17.000 4294967296 25.500231
-Anarchism 30-APR-2012 03:25:17.000 8589934592 25.500231
+Anarchism 30-APR-2012 03:25:17.000 0 26.372139
+Anarchism 30-APR-2012 03:25:17.000 4294967296 26.372139
+Anarchism 30-APR-2012 03:25:17.000 8589934592 26.372139
 
 
 # Clean up

--- a/test/sql/dql/fusion.slt
+++ b/test/sql/dql/fusion.slt
@@ -85,9 +85,9 @@ SELECT num FROM enwiki_embedding SEARCH MATCH TEXT ('body^5', 'harmful chemical'
 query II
 SELECT num, SCORE() FROM enwiki_embedding SEARCH MATCH TEXT ('body^5', 'harmful chemical', 'topn=3'), MATCH VECTOR (vec, [0.0, 0.0, 0.0, 0.0], 'float', 'l2', 3), FUSION('weighted_sum');
 ----
-6989 0.994939
-9893 0.993580
-2123 0.991929
+6989 0.995004
+9893 0.993591
+2123 0.992094
 0 0.500000
 1 0.077979
 2 0.019869
@@ -97,9 +97,9 @@ query II
 SELECT num, SCORE() FROM enwiki_embedding SEARCH MATCH TEXT ('body^5', 'harmful chemical', 'topn=3'), MATCH VECTOR (vec, [0.0, 0.0, 0.0, 0.0], 'float', 'l2', 3), FUSION('weighted_sum', 'weights=1.0,2.0');
 ----
 0 1.000000
-6989 0.994939
-9893 0.993580
-2123 0.991929
+6989 0.995004
+9893 0.993591
+2123 0.992094
 1 0.155958
 2 0.039737
 
@@ -107,9 +107,9 @@ SELECT num, SCORE() FROM enwiki_embedding SEARCH MATCH TEXT ('body^5', 'harmful 
 query II
 SELECT num, SCORE() FROM enwiki_embedding SEARCH MATCH VECTOR (vec, [0.0, 0.0, 0.0, 0.0], 'float', 'l2', 3), MATCH TEXT ('body^5', 'harmful chemical', 'topn=3'), FUSION('weighted_sum', 'weights=1.0,2.0');
 ----
-6989 1.989878
-9893 1.987159
-2123 1.983859
+6989 1.990007
+9893 1.987183
+2123 1.984188
 0 0.500000
 1 0.077979
 2 0.019869


### PR DESCRIPTION
### What problem does this PR solve?

Previously, StandardAnalyzer will ignore unicode tokens

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
