### PR TITLE
Fix: delta ckp commit ts.

### DIFF
--- a/src/storage/meta/catalog.cppm
+++ b/src/storage/meta/catalog.cppm
@@ -226,7 +226,7 @@ public:
 
     void SaveFullCatalog(TxnTimeStamp max_commit_ts, String &full_path, String &full_name);
 
-    bool SaveDeltaCatalog(TxnTimeStamp max_commit_ts, String &delta_path, String &delta_name);
+    bool SaveDeltaCatalog(TxnTimeStamp &max_commit_ts, String &delta_path, String &delta_name);
 
     void AddDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
 

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -525,20 +525,21 @@ void Txn::Rollback() {
 
 void Txn::AddWalCmd(const SharedPtr<WalCmd> &cmd) { wal_entry_->cmds_.push_back(cmd); }
 
-// those whose commit_ts is <= max_commit_ts will be checkpointed
+// max_commit_ts is only used for full checkpoint
 bool Txn::Checkpoint(const TxnTimeStamp max_commit_ts, bool is_full_checkpoint) {
     if (is_full_checkpoint) {
         FullCheckpoint(max_commit_ts);
         return true;
     } else {
-        return DeltaCheckpoint(max_commit_ts);
+        return DeltaCheckpoint();
     }
 }
 
 // Incremental checkpoint contains only the difference in status between the last checkpoint and this checkpoint (that is, "increment")
-bool Txn::DeltaCheckpoint(const TxnTimeStamp max_commit_ts) {
+bool Txn::DeltaCheckpoint() {
     String delta_path, delta_name;
     // only save the catalog delta entry
+    TxnTimeStamp max_commit_ts = 0; // the max_commit_ts is determined by the max commit ts of flushed delta entry
     bool skip = catalog_->SaveDeltaCatalog(max_commit_ts, delta_path, delta_name);
     if (skip) {
         LOG_INFO("No delta catalog file is written");
@@ -548,6 +549,7 @@ bool Txn::DeltaCheckpoint(const TxnTimeStamp max_commit_ts) {
     return true;
 }
 
+// those whose commit_ts is <= max_commit_ts will be checkpointed
 void Txn::FullCheckpoint(const TxnTimeStamp max_commit_ts) {
     String full_path, full_name;
 

--- a/src/storage/txn/txn.cppm
+++ b/src/storage/txn/txn.cppm
@@ -203,7 +203,7 @@ public:
 
     void FullCheckpoint(const TxnTimeStamp max_commit_ts);
 
-    bool DeltaCheckpoint(const TxnTimeStamp max_commit_ts);
+    bool DeltaCheckpoint();
 
     TxnManager *txn_mgr() const { return txn_mgr_; }
 

--- a/src/storage/txn/txn.cppm
+++ b/src/storage/txn/txn.cppm
@@ -199,11 +199,9 @@ public:
     // WAL and replay OPS
     void AddWalCmd(const SharedPtr<WalCmd> &cmd);
 
-    bool Checkpoint(const TxnTimeStamp max_commit_ts, bool is_full_checkpoint);
-
     void FullCheckpoint(const TxnTimeStamp max_commit_ts);
 
-    bool DeltaCheckpoint();
+    TxnTimeStamp DeltaCheckpoint();
 
     TxnManager *txn_mgr() const { return txn_mgr_; }
 

--- a/src/storage/wal/catalog_delta_entry.cppm
+++ b/src/storage/wal/catalog_delta_entry.cppm
@@ -382,7 +382,7 @@ public:
     void ReplayDeltaEntry(UniquePtr<CatalogDeltaEntry> delta_entry);
 
     // Pick and remove all operations that are committed before `max_commit_ts`, after `full_ckp_ts`
-    UniquePtr<CatalogDeltaEntry> PickFlushEntry(TxnTimeStamp max_commit_ts);
+    UniquePtr<CatalogDeltaEntry> PickFlushEntry(TxnTimeStamp &max_commit_ts);
 
     Vector<CatalogDeltaOpBrief> GetOperationBriefs() const;
 

--- a/src/unit_test/storage/wal/catalog_delta_entry.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_entry.cpp
@@ -473,7 +473,9 @@ TEST_F(CatalogDeltaEntryTest, ComplicateMergeEntries) {
             for (auto &entry : merged_entries) {
                 global_catalog_delta_entry->ReplayDeltaEntry(std::move(entry));
             }
-            auto merged_entry = global_catalog_delta_entry->PickFlushEntry(5);
+            TxnTimeStamp max_ts;
+            auto merged_entry = global_catalog_delta_entry->PickFlushEntry(max_ts);
+            EXPECT_EQ(max_ts, 4);
             EXPECT_EQ(merged_entry->operations().size(), 1u);
         }
     }
@@ -511,7 +513,9 @@ TEST_F(CatalogDeltaEntryTest, ComplicateMergeEntries) {
             for (auto &entry : merged_entries) {
                 global_catalog_delta_entry->ReplayDeltaEntry(std::move(entry));
             }
-            auto merged_entry = global_catalog_delta_entry->PickFlushEntry(7);
+            TxnTimeStamp max_ts;
+            auto merged_entry = global_catalog_delta_entry->PickFlushEntry(max_ts);
+            EXPECT_EQ(max_ts, 6);
             EXPECT_EQ(merged_entry->operations().size(), 1u);
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Fix: delta checkpoint choose the max commit ts when determine which entry to flush.
Because only those entry **HAS flushed** in wal can appear in delta op entry candidate list in ascending **ORDER**, so either a "op" will apper in wal or delta op when replaying.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
