### PR TITLE
Fix: cleanup block when import/compact fail.

### DIFF
--- a/src/executor/operator/physical_compact.cpp
+++ b/src/executor/operator/physical_compact.cpp
@@ -196,6 +196,8 @@ bool PhysicalCompact::Execute(QueryContext *query_context, OperatorState *operat
     }
     if (new_block->row_count() > 0) {
         new_segment->AppendBlockEntry(std::move(new_block));
+    } else {
+        std::move(*new_block).Cleanup();
     }
     if (new_segment->actual_row_count() > new_segment->row_capacity()) {
         UnrecoverableError(fmt::format("Compact segment {} error because of row count overflow.", new_segment_id));

--- a/src/storage/txn/txn_store.cpp
+++ b/src/storage/txn/txn_store.cpp
@@ -275,6 +275,9 @@ void TxnTableStore::Rollback(TransactionID txn_id, TxnTimeStamp abort_ts) {
     //     Catalog::RollbackPopulateIndex(txn_index_store.get(), txn_);
     // }
     Catalog::RollbackCompact(table_entry_, txn_id, abort_ts, compact_state_);
+    for (const auto &[new_segment_store, old_segments] : compact_state_.compact_data_) {
+        std::move(*new_segment_store.segment_entry_).Cleanup();
+    }
     blocks_.clear();
 
     for (auto &[table_index_entry, ptr_seq_n] : txn_indexes_) {


### PR DESCRIPTION
### What problem does this PR solve?

Add: error handle when import error format or in compact rollback so that the new block can be cleaned up.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
