### PR TITLE
Refactor conflictcheck

### DIFF
--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -148,6 +148,8 @@ public:
 
     bool CheckRowVisible(BlockOffset block_offset, TxnTimeStamp check_ts, bool check_append) const;
 
+    bool CheckDeleteConflict(const Vector<BlockOffset> &block_offsets) const;
+
     void SetDeleteBitmask(TxnTimeStamp query_ts, Bitmask &bitmask) const;
 
     i32 GetAvailableCapacity();

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -247,6 +247,15 @@ public:
 
     Map<SegmentID, SharedPtr<SegmentEntry>> &segment_map() { return segment_map_; }
 
+    SegmentEntry *GetSegmentEntry(SegmentID seg_id) const {
+        std::shared_lock lock(rw_locker_);
+        auto iter = segment_map_.find(seg_id);
+        if (iter == segment_map_.end()) {
+            return nullptr;
+        }
+        return iter->second.get();
+    }
+
     const Vector<SharedPtr<ColumnDef>> &column_defs() const { return columns_; }
 
     IndexReader GetFullTextIndexReader(Txn *txn);

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -469,9 +469,11 @@ TxnTimeStamp Txn::Commit() {
     return commit_ts;
 }
 
-bool Txn::CheckConflict(Txn *other_txn) {
-    LOG_TRACE(fmt::format("Txn {} check conflict with {}.", txn_id_, other_txn->txn_id_));
+bool Txn::CheckConflict(Catalog *catalog) {
+    return txn_store_.CheckConflict(catalog);
+}
 
+bool Txn::CheckConflict(Txn *other_txn) {
     return txn_store_.CheckConflict(other_txn->txn_store_);
 }
 

--- a/src/storage/txn/txn.cppm
+++ b/src/storage/txn/txn.cppm
@@ -93,6 +93,8 @@ public:
 
     TxnTimeStamp Commit();
 
+    bool CheckConflict(Catalog *catalog);
+
     bool CheckConflict(Txn *txn);
 
     void CommitBottom();
@@ -213,6 +215,8 @@ public:
     WalEntry *GetWALEntry() const;
 
     const SharedPtr<String> GetTxnText() const { return txn_text_; }
+
+    const String &db_name() const { return db_name_; }
 
 private:
     void CheckTxnStatus();

--- a/src/storage/txn/txn_context.cppm
+++ b/src/storage/txn/txn_context.cppm
@@ -65,6 +65,7 @@ public:
         //     UnrecoverableError(fmt::format("Transaction isn't in ROLLBACKING status. {}", ToString(state_)));
         // }
         state_ = TxnState::kRollbacked;
+        committed_ts_ = commit_ts_;
     }
 
     inline void SetTxnCommitted(TxnTimeStamp committed_ts) {

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -121,6 +121,8 @@ public:
 
     void Rollback(TransactionID txn_id, TxnTimeStamp abort_ts);
 
+    bool CheckConflict(Catalog *catalog, Txn *txn) const;
+
     bool CheckConflict(const TxnTableStore *txn_table_store) const;
 
     void PrepareCommit1() const;
@@ -212,6 +214,8 @@ public:
     void AddDeltaOp(CatalogDeltaEntry *local_delta_opsm, TxnManager *txn_mgr) const;
 
     void MaintainCompactionAlg() const;
+
+    bool CheckConflict(Catalog *catalog);
 
     bool CheckConflict(const TxnStore &txn_store);
 


### PR DESCRIPTION
### What problem does this PR solve?

Refactor: conflict check, keeped less txn in memory now.

When checking conflict:
 1. txn manager will get all txns whose commit ts is less that current txn  AND in committing process. Those txn's store will be checked 
 2. the catalog will be checked using current txn's commit_ts as visit ts.

### Type of change

- [x] Refactoring
