### PR TITLE
Fix: compact with delete bug.

### DIFF
--- a/src/executor/operator/physical_compact.cpp
+++ b/src/executor/operator/physical_compact.cpp
@@ -139,6 +139,7 @@ bool PhysicalCompact::Execute(QueryContext *query_context, OperatorState *operat
     auto *txn_mgr = txn->txn_mgr();
     auto *buffer_mgr = query_context->storage()->buffer_manager();
     TxnTimeStamp scan_ts = txn_mgr->GetNewTimeStamp();
+    compact_state_data->scan_ts_ = scan_ts;
 
     TableEntry *table_entry = base_table_ref_->table_entry_ptr_;
     BlockIndex *block_index = base_table_ref_->block_index_.get();

--- a/src/executor/operator/physical_compact_finish.cpp
+++ b/src/executor/operator/physical_compact_finish.cpp
@@ -86,7 +86,7 @@ bool PhysicalCompactFinish::ApplyDeletes(QueryContext *query_context, const Comp
             }
         }
     }
-    const HashMap<SegmentID, Vector<SegmentOffset>> &to_delete = compact_state_data->GetToDelete();
+    const Vector<Pair<SegmentID, Vector<SegmentOffset>>> &to_delete = compact_state_data->GetToDelete();
     Vector<RowID> row_ids;
     for (const auto &[segment_id, delete_offsets] : to_delete) {
         for (SegmentOffset offset : delete_offsets) {

--- a/src/function/table/compact_state_data.cppm
+++ b/src/function/table/compact_state_data.cppm
@@ -63,9 +63,9 @@ export class CompactStateData {
 public:
     CompactStateData(TableEntry *table_entry) : new_table_ref_(MakeShared<BaseTableRef>(table_entry, MakeShared<BlockIndex>())){};
 
-    void AddToDelete(SegmentID segment_id, const Vector<SegmentOffset> &delete_offsets);
+    void AddToDelete(TxnTimeStamp commit_ts, SegmentID segment_id, Vector<SegmentOffset> delete_offsets);
 
-    const HashMap<SegmentID, Vector<SegmentOffset>> &GetToDelete() const { return to_delete_; }
+    Vector<Pair<SegmentID, Vector<SegmentOffset>>> GetToDelete() const;
 
     void AddNewSegment(SharedPtr<SegmentEntry> new_segment, Vector<SegmentEntry *> compacted_segments, Txn *txn);
 
@@ -78,10 +78,11 @@ public:
 public:
     Vector<CompactSegmentData> segment_data_list_;
     RowIDRemap remapper_{};
+    TxnTimeStamp scan_ts_ = UNCOMMIT_TS; // ts when compact get the visible range
 
 private:
     std::mutex mutex_;
-    HashMap<SegmentID, Vector<SegmentOffset>> to_delete_;
+    Vector<Tuple<TxnTimeStamp, SegmentID, Vector<SegmentOffset>>> to_delete_;
 
     std::mutex mutex2_;
     SharedPtr<BaseTableRef> new_table_ref_{}; // table ref after compact

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -417,8 +417,8 @@ void SegmentEntry::CommitSegment(TransactionID txn_id,
                         segment_offsets.push_back(block_id * DEFAULT_BLOCK_CAPACITY + block_offset);
                     }
                 }
-                compact_state_data_->AddToDelete(segment_id_, segment_offsets);
                 LOG_INFO(fmt::format("Append {} rows to to_delete_list in compact list", segment_offsets.size()));
+                compact_state_data_->AddToDelete(commit_ts, segment_id_, std::move(segment_offsets));
             }
         }
     }

--- a/src/unit_test/storage/bg_task/compact_segments_task.cpp
+++ b/src/unit_test/storage/bg_task/compact_segments_task.cpp
@@ -435,8 +435,6 @@ TEST_F(SilentLogTestCompactTaskTest, delete_in_compact_process) {
     }
 }
 
-// Cannot compile the test. So annotate it.
-
 TEST_F(CompactTaskTest, uncommit_delete_in_compact_process) {
     for (int task_i = 0; task_i < 10; ++task_i) {
         LOG_INFO(fmt::format("Test {}", task_i));


### PR DESCRIPTION
### What problem does this PR solve?

Bug:
In compact process, when segments are set as kCompacting, but not scanned, some delete txns commit, and add to_delete entry in compact shared data. When compact process proceed scaning the segment, it will skip the deleted lines, and when applying to_delete entries, it will delete those lines again, which cause UnrecoverableError (delete one line twice).
Fix:
After set kCompacting state and get scan ts, compact process save that scan ts in compact shared data. And when appling to_delete entry, only those commit_ts > scan_ts is applied. Because previous delete has been skipped in scan.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

