### PR TITLE
Fix error reporting in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (CLANG_VERSION_STRING VERSION_GREATER 16)
 
 else ()
 
-    message(FATAL_ERROR, "Please use clang version 17.0 and above, current version: ", ${CLANG_VERSION_STRING})
+    message(FATAL_ERROR "Please use clang version 17.0 and above, current version: ${CLANG_VERSION_STRING}")
 
 endif ()
 


### PR DESCRIPTION
### What problem does this PR solve?

There was an error in handling unsupported compiler in CMake. 

Error message before this change:
```
CMake Warning (dev) at CMakeLists.txt:51:
  Syntax Warning in cmake code at column 86

  Argument not separated from preceding token by whitespace.
```

Sample error message after this change:
```
CMake Error at CMakeLists.txt:51 (message):
  Please use clang version 17.0 and above, current version: g++.exe (GCC)
  13.1.0
```

Issue link: (no issue)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

