### PR TITLE
Fix: can't connect other local directory

### DIFF
--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -235,6 +235,9 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
 
         // Log dir
         String log_dir = "/var/infinity/log";
+        if(default_config != nullptr) {
+            log_dir = default_config->default_log_dir_;
+        }
         UniquePtr<StringOption> log_dir_option = MakeUnique<StringOption>(LOG_DIR_OPTION_NAME, log_dir);
         status = global_options_.AddOption(std::move(log_dir_option));
         if(!status.ok()) {
@@ -287,6 +290,9 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
 
         // Data Dir
         String data_dir = "/var/infinity/data";
+        if(default_config != nullptr) {
+            data_dir = default_config->default_data_dir_;
+        }
         UniquePtr<StringOption> data_dir_option = MakeUnique<StringOption>(DATA_DIR_OPTION_NAME, data_dir);
         status = global_options_.AddOption(std::move(data_dir_option));
         if(!status.ok()) {
@@ -363,6 +369,9 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
 
         // Temp Dir
         String temp_dir = "/var/infinity/tmp";
+        if(default_config != nullptr) {
+            temp_dir = default_config->default_temp_dir_;
+        }
         UniquePtr<StringOption> temp_dir_option = MakeUnique<StringOption>(TEMP_DIR_OPTION_NAME, temp_dir);
         status = global_options_.AddOption(std::move(temp_dir_option));
         if(!status.ok()) {
@@ -372,6 +381,9 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
 
         // WAL Dir
         String wal_dir = "/var/infinity/wal";
+        if(default_config != nullptr) {
+            wal_dir = default_config->default_wal_dir_;
+        }
         UniquePtr<StringOption> wal_dir_option = MakeUnique<StringOption>(WAL_DIR_OPTION_NAME, wal_dir);
         status = global_options_.AddOption(std::move(wal_dir_option));
         if(!status.ok()) {
@@ -434,6 +446,9 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
 
         // Resource Dir
         String resource_dir = "/var/infinity/resource";
+        if(default_config != nullptr) {
+            resource_dir = default_config->default_resource_dir_;
+        }
         UniquePtr<StringOption> resource_dir_option = MakeUnique<StringOption>("resource_dir", resource_dir);
         status = global_options_.AddOption(std::move(resource_dir_option));
         if(!status.ok()) {

--- a/src/main/config.cppm
+++ b/src/main/config.cppm
@@ -31,6 +31,11 @@ export constexpr std::string_view log_level = "log_level";
 export struct DefaultConfig {
     LogLevel default_log_level_{LogLevel::kInfo};
     bool default_log_to_stdout_{false};
+    String default_log_dir_ = "/var/infinity/log";
+    String default_data_dir_ = "/var/infinity/data";
+    String default_wal_dir_ = "/var/infinity/wal";
+    String default_temp_dir_ = "/var/infinity/tmp";
+    String default_resource_dir_ = "/var/infinity/resource";
 };
 
 export struct Config {

--- a/src/main/infinity.cpp
+++ b/src/main/infinity.cpp
@@ -75,6 +75,12 @@ void Infinity::LocalInit(const String &path) {
         InfinityContext::instance().Init(config_path);
     } else {
         UniquePtr<DefaultConfig> default_config = MakeUnique<DefaultConfig>();
+        default_config->default_log_dir_ = fmt::format("{}/log", path);
+        default_config->default_data_dir_ = fmt::format("{}/data", path);
+        default_config->default_wal_dir_ = fmt::format("{}/wal", path);
+        default_config->default_temp_dir_ = fmt::format("{}/tmp", path);
+        default_config->default_resource_dir_ = fmt::format("{}/resource", path);
+
         default_config->default_log_level_ = LogLevel::kInfo;
         default_config->default_log_to_stdout_ = false;
         InfinityContext::instance().Init(nullptr, false, default_config.get());


### PR DESCRIPTION
### What problem does this PR solve?

Use infinity python SDK as Embedded mode, will always use /var/infinty to store the data/wal/log, etc. This PR is to fix it.
 
Issue link:#1607

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)