### PR TITLE
Fix: fulltext optimize bug.

### DIFF
--- a/src/storage/meta/entry/chunk_index_entry.cppm
+++ b/src/storage/meta/entry/chunk_index_entry.cppm
@@ -44,7 +44,7 @@ export class ChunkIndexEntry : public BaseEntry, public EntryInterface {
 public:
     static Vector<std::string_view> DecodeIndex(std::string_view encode);
 
-    static String EncodeIndex(const ChunkID chunk_id, const SegmentIndexEntry *segment_index_entry);
+    static String EncodeIndex(const ChunkID chunk_id, const String &base_name, const SegmentIndexEntry *segment_index_entry);
 
     ChunkIndexEntry(ChunkID chunk_id, SegmentIndexEntry *segment_index_entry, const String &base_name, RowID base_rowid, u32 row_count);
 
@@ -129,6 +129,7 @@ public:
     void DeprecateChunk(TxnTimeStamp commit_ts) {
         assert(commit_ts_.load() < commit_ts);
         deprecate_ts_.store(commit_ts);
+        ResetOptimizing();
     }
 
     bool CheckVisible(Txn *txn) const override;
@@ -139,6 +140,10 @@ public:
     }
 
     void Save();
+
+    bool TrySetOptimizing();
+
+    void ResetOptimizing();
 
 public:
     ChunkID chunk_id_;
@@ -152,6 +157,7 @@ public:
 private:
     BufferObj *buffer_obj_{};
     Vector<BufferObj *> part_buffer_objs_;
+    Atomic<bool> optimizing_{false};
 };
 
 } // namespace infinity

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -923,7 +923,7 @@ ChunkIndexEntry *SegmentIndexEntry::RebuildChunkIndexEntries(TxnTableStore *txn_
     {
         std::shared_lock lock(rw_locker_);
         for (const auto &chunk_index_entry : chunk_index_entries_) {
-            if (chunk_index_entry->CheckVisible(txn)) {
+            if (chunk_index_entry->CheckVisible(txn) && chunk_index_entry->TrySetOptimizing()) {
                 row_count += chunk_index_entry->row_count_;
                 old_chunks.push_back(chunk_index_entry.get());
                 old_ids.push_back(chunk_index_entry->chunk_id_);

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -66,11 +66,13 @@ public:
 
     void Commit(TransactionID txn_id, TxnTimeStamp commit_ts);
 
+    void Rollback();
+
 public:
     TableIndexEntry *const table_index_entry_{};
 
     HashMap<SegmentID, SegmentIndexEntry *> index_entry_map_{};
-    Vector<ChunkIndexEntry *> chunk_index_entries_{};
+    HashMap<String, ChunkIndexEntry *> chunk_index_entries_{};
 
     Vector<Tuple<SegmentIndexEntry *, ChunkIndexEntry *, Vector<ChunkIndexEntry *>>> optimize_data_;
 };

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -936,7 +936,10 @@ void AddSegmentIndexEntryOp::Merge(CatalogDeltaOperation &other) {
         String error_message = fmt::format("Merge failed, other type: {}", other.GetTypeStr());
         UnrecoverableError(error_message);
     }
-    *this = std::move(static_cast<AddSegmentIndexEntryOp &>(other));
+    auto &add_segment_index_op = static_cast<AddSegmentIndexEntryOp &>(other);
+    MergeFlag flag = this->NextDeleteFlag(add_segment_index_op.merge_flag_);
+    *this = std::move(add_segment_index_op);
+    this->merge_flag_ = flag;
 }
 
 void AddChunkIndexEntryOp::Merge(CatalogDeltaOperation &other) {


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: ft_chunk_entry has same encode.
2. Fix: not optimizing a chunk when it is optimized but not committed
3. Fix: add duplicate chunk to txn store bug.
4. Fix: segment index entry mergeflag bug.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
