### PR TITLE
Add multiple datatype support and enable match tensor array for http api

### DIFF
--- a/python/test_pysdk/http_adapter.py
+++ b/python/test_pysdk/http_adapter.py
@@ -479,7 +479,7 @@ class http_adapter:
             tmp.update({"match_sparse":self._match_sparse})
         if len(self._output):
             tmp.update({"output":self._output})
-        print(tmp)
+        #print(tmp)
         d = self.set_up_data([], tmp)
         r = self.request(url, "get", h, d)
         self.raise_exception(r)

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -667,7 +667,6 @@ class TestInfinity:
         res = db_obj.drop_table("test_with_index_after", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("check_data", [{"file_name": "enwiki_99.csv", "data_dir": common_values.TEST_TMP_DIR}],
                              indirect=True)
     def test_fulltext_operator_option(self, check_data):
@@ -701,7 +700,6 @@ class TestInfinity:
         res = db_obj.drop_table("test_fulltext_operator_option", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("match_param_1", ["doctitle,num,body^5"])
     @pytest.mark.parametrize("check_data", [{"file_name": "enwiki_embedding_99_commas.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
@@ -743,7 +741,6 @@ class TestInfinity:
             "test_with_fulltext_match_with_valid_columns", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("match_param_1", [pytest.param(1),
                                                pytest.param(1.1),
                                                pytest.param([]),
@@ -791,7 +788,6 @@ class TestInfinity:
             "test_with_fulltext_match_with_invalid_columns", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("match_param_2", ["a word a segment",
                                                "body=Greek"])
     @pytest.mark.parametrize("check_data", [{"file_name": "enwiki_embedding_99_commas.csv",
@@ -834,7 +830,6 @@ class TestInfinity:
             "test_with_fulltext_match_with_valid_words", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("match_param_2", [pytest.param(1),
                                                pytest.param(1.1),
                                                pytest.param([]),
@@ -883,7 +878,6 @@ class TestInfinity:
             "test_with_fulltext_match_with_invalid_words", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("match_param_3", [pytest.param("@#$!#@$SDa^sdf3!@#$"),
                                                "topn=1",
                                                "1"])
@@ -927,7 +921,6 @@ class TestInfinity:
             "test_with_fulltext_match_with_options", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("match_param_3", [pytest.param(1),
                                                pytest.param(1.1),
                                                pytest.param([]),
@@ -1222,7 +1215,6 @@ class TestInfinity:
 
     # "^5" indicates the point that column "body" get multipy by 5, default is multipy by 1
     # refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("fields_and_matching_text", [
         ["body", "black"],
         ["doctitle,num,body", "black"],
@@ -1422,7 +1414,6 @@ class TestInfinity:
         res = db_obj.drop_table("test_tensor_scan", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("table_params", [
         "vector,100,float,int8",
         "sparse,0,float,int8",

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -94,7 +94,6 @@ class TestInfinity:
         res = db_obj.drop_table("fix_tmp_20240116", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("check_data", [{"file_name": "embedding_int_dim3.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     def test_knn_u8(self, check_data):
@@ -145,7 +144,6 @@ class TestInfinity:
         res = db_obj.drop_table("test_knn_u8", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("check_data", [{"file_name": "embedding_int_dim3.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     @pytest.mark.parametrize("save_elem_type", ["float", "float16", "bfloat16"])
@@ -968,7 +966,6 @@ class TestInfinity:
             "test_with_fulltext_match_with_invalid_options", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("check_data", [{"file_name": "tensor_maxsim.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     @pytest.mark.parametrize("save_elem_t", ["float32", "float16", "bfloat16"])
@@ -1391,7 +1388,6 @@ class TestInfinity:
         res = db_obj.drop_table("test_tensor_scan", ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    @pytest.mark.usefixtures("skip_if_http")
     @pytest.mark.parametrize("dim", [1, 10, 100])  # 1^3, 10^3, 100^3
     def test_big_dimension_tensor_scan(self, dim):
         db_obj = self.infinity_obj.get_database("default_db")

--- a/src/network/http/http_search.cpp
+++ b/src/network/http/http_search.cpp
@@ -456,12 +456,14 @@ KnnExpr *HTTPSearch::ParseKnn(const nlohmann::json &knn_json_object, HTTPStatus 
                 knn_expr->embedding_data_type_ = EmbeddingDataType::kElemFloat;
             } else if(IsEqual(element_type, "float16")) {
                 knn_expr->embedding_data_type_ = EmbeddingDataType::kElemFloat16;
-            } else if(IsEqual(element_type, "float16")) {
+            } else if(IsEqual(element_type, "bfloat16")) {
                 knn_expr->embedding_data_type_ = EmbeddingDataType::kElemBFloat16;
             } else if(IsEqual(element_type, "double")) {
                 knn_expr->embedding_data_type_ = EmbeddingDataType::kElemDouble;
             } else if(IsEqual(element_type, "integer")) {
                 knn_expr->embedding_data_type_ = EmbeddingDataType::kElemInt32;
+            } else if(IsEqual(element_type, "int8")) {
+                knn_expr->embedding_data_type_ = EmbeddingDataType::kElemInt8;
             } else if(IsEqual(element_type, "uint8")) {
                 knn_expr->embedding_data_type_ = EmbeddingDataType::kElemUInt8;
             } else {
@@ -680,12 +682,9 @@ HTTPSearch::ParseVector(const nlohmann::json &json_object, EmbeddingDataType ele
                 const auto &value_ref = json_object[idx];
                 const auto &value_type = value_ref.type();
                 switch (value_type) {
-                    case nlohmann::json::value_t::number_integer: {
-                        embedding_data_ptr[idx] = value_ref.template get<int>();
-                        break;
-                    }
+                    case nlohmann::json::value_t::number_integer:
                     case nlohmann::json::value_t::number_unsigned: {
-                        embedding_data_ptr[idx] = value_ref.template get<unsigned>();
+                        embedding_data_ptr[idx] = value_ref.template get<i64>();
                         break;
                     }
                     default: {
@@ -697,6 +696,35 @@ HTTPSearch::ParseVector(const nlohmann::json &json_object, EmbeddingDataType ele
             }
 
             i32 *res = embedding_data_ptr;
+            embedding_data_ptr = nullptr;
+            return {dimension, res};
+        }
+        case EmbeddingDataType::kElemInt8: {
+            i8 *embedding_data_ptr = new i8[dimension];
+            DeferFn defer_free_embedding([&]() {
+                if (embedding_data_ptr != nullptr) {
+                    delete[] embedding_data_ptr;
+                    embedding_data_ptr = nullptr;
+                }
+            });
+            for (SizeT idx = 0; idx < dimension; ++idx) {
+                const auto &value_ref = json_object[idx];
+                const auto &value_type = value_ref.type();
+                switch (value_type) {
+                    case nlohmann::json::value_t::number_integer:
+                    case nlohmann::json::value_t::number_unsigned: {
+                        embedding_data_ptr[idx] = value_ref.template get<i64>();
+                        break;
+                    }
+                    default: {
+                        response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                        response["error_message"] = fmt::format("Embedding element type should be integer");
+                        return {0, nullptr};
+                    }
+                }
+            }
+
+            i8 *res = embedding_data_ptr;
             embedding_data_ptr = nullptr;
             return {dimension, res};
         }
@@ -712,12 +740,9 @@ HTTPSearch::ParseVector(const nlohmann::json &json_object, EmbeddingDataType ele
                 const auto &value_ref = json_object[idx];
                 const auto &value_type = value_ref.type();
                 switch (value_type) {
-                    case nlohmann::json::value_t::number_integer: {
-                        embedding_data_ptr[idx] = value_ref.template get<int>();
-                        break;
-                    }
+                    case nlohmann::json::value_t::number_integer:
                     case nlohmann::json::value_t::number_unsigned: {
-                        embedding_data_ptr[idx] = value_ref.template get<unsigned>();
+                        embedding_data_ptr[idx] = value_ref.template get<i64>();
                         break;
                     }
                     default: {
@@ -748,12 +773,9 @@ HTTPSearch::ParseVector(const nlohmann::json &json_object, EmbeddingDataType ele
                         embedding_data_ptr[idx] = value_ref.template get<double>();
                         break;
                     }
-                    case nlohmann::json::value_t::number_integer: {
-                        embedding_data_ptr[idx] = value_ref.template get<int>();
-                        break;
-                    }
+                    case nlohmann::json::value_t::number_integer:
                     case nlohmann::json::value_t::number_unsigned: {
-                        embedding_data_ptr[idx] = value_ref.template get<unsigned>();
+                        embedding_data_ptr[idx] = value_ref.template get<i64>();
                         break;
                     }
                     default: {
@@ -768,8 +790,72 @@ HTTPSearch::ParseVector(const nlohmann::json &json_object, EmbeddingDataType ele
             embedding_data_ptr = nullptr;
             return {dimension, res};
         }
-        case EmbeddingDataType::kElemFloat16:
-        case EmbeddingDataType::kElemBFloat16:
+        case EmbeddingDataType::kElemFloat16: {
+            float16_t *embedding_data_ptr = new float16_t[dimension];
+            DeferFn defer_free_embedding([&]() {
+                if (embedding_data_ptr != nullptr) {
+                    delete[] embedding_data_ptr;
+                    embedding_data_ptr = nullptr;
+                }
+            });
+            for (SizeT idx = 0; idx < dimension; ++idx) {
+                const auto &value_ref = json_object[idx];
+                const auto &value_type = value_ref.type();
+                switch (value_type) {
+                    case nlohmann::json::value_t::number_float: {
+                        embedding_data_ptr[idx] = value_ref.template get<double>();
+                        break;
+                    }
+                    case nlohmann::json::value_t::number_integer:
+                    case nlohmann::json::value_t::number_unsigned: {
+                        embedding_data_ptr[idx] = value_ref.template get<i64>();
+                        break;
+                    }
+                    default: {
+                        response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                        response["error_message"] = fmt::format("Embedding element type should be float");
+                        return {0, nullptr};
+                    }
+                }
+            }
+
+            float16_t *res = embedding_data_ptr;
+            embedding_data_ptr = nullptr;
+            return {dimension, res};
+        }
+        case EmbeddingDataType::kElemBFloat16: {
+            bfloat16_t *embedding_data_ptr = new bfloat16_t[dimension];
+            DeferFn defer_free_embedding([&]() {
+                if (embedding_data_ptr != nullptr) {
+                    delete[] embedding_data_ptr;
+                    embedding_data_ptr = nullptr;
+                }
+            });
+            for (SizeT idx = 0; idx < dimension; ++idx) {
+                const auto &value_ref = json_object[idx];
+                const auto &value_type = value_ref.type();
+                switch (value_type) {
+                    case nlohmann::json::value_t::number_float: {
+                        embedding_data_ptr[idx] = value_ref.template get<double>();
+                        break;
+                    }
+                    case nlohmann::json::value_t::number_integer:
+                    case nlohmann::json::value_t::number_unsigned: {
+                        embedding_data_ptr[idx] = value_ref.template get<i64>();
+                        break;
+                    }
+                    default: {
+                        response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                        response["error_message"] = fmt::format("Embedding element type should be float");
+                        return {0, nullptr};
+                    }
+                }
+            }
+
+            bfloat16_t *res = embedding_data_ptr;
+            embedding_data_ptr = nullptr;
+            return {dimension, res};
+        }
         default: {
             response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
             response["error_message"] = fmt::format("Only support float as the embedding data type");

--- a/src/network/http_server.cpp
+++ b/src/network/http_server.cpp
@@ -325,6 +325,8 @@ public:
                 EmbeddingDataType e_data_type;
                 if (etype == "integer") {
                     e_data_type = EmbeddingDataType::kElemInt32;
+                } else if (etype == "uint8") {
+                    e_data_type = EmbeddingDataType::kElemUInt8;
                 } else if (etype == "float") {
                     e_data_type = EmbeddingDataType::kElemFloat;
                 } else if (etype == "double") {

--- a/src/network/http_server.cpp
+++ b/src/network/http_server.cpp
@@ -327,6 +327,8 @@ public:
                     e_data_type = EmbeddingDataType::kElemInt32;
                 } else if (etype == "uint8") {
                     e_data_type = EmbeddingDataType::kElemUInt8;
+                } else if (etype == "int8") {
+                    e_data_type = EmbeddingDataType::kElemInt8;
                 } else if (etype == "float") {
                     e_data_type = EmbeddingDataType::kElemFloat;
                 } else if (etype == "double") {
@@ -394,6 +396,10 @@ public:
                     e_data_type = EmbeddingDataType::kElemFloat;
                 } else if (etype == "double") {
                     e_data_type = EmbeddingDataType::kElemDouble;
+                } else if (etype == "float16") {
+                    e_data_type = EmbeddingDataType::kElemFloat16;
+                } else if (etype == "bfloat16") {
+                    e_data_type = EmbeddingDataType::kElemBFloat16;
                 } else {
                     infinity::Status status = infinity::Status::InvalidEmbeddingDataType(etype);
                     json_response["error_code"] = status.code();
@@ -1710,7 +1716,7 @@ public:
                                             const_expr->sub_array_array_.emplace_back(std::move(const_expr_2));
                                             const_expr_2 = nullptr;
                                         }
-                                        values_row->emplace_back(const_expr);
+                                        (*values_row)[column_id] = const_expr;
                                         const_expr = nullptr;
                                     } else if(first_elem_first_elem_type == nlohmann::json::value_t::number_float) {
                                         infinity::ConstantExpr *const_expr = new ConstantExpr(LiteralType::kSubArrayArray);
@@ -1755,7 +1761,7 @@ public:
                                             const_expr->sub_array_array_.emplace_back(std::move(const_expr_2));
                                             const_expr_2 = nullptr;
                                         }
-                                        values_row->emplace_back(const_expr);
+                                        (*values_row)[column_id] = const_expr;
                                         const_expr = nullptr;
                                     }  else if(first_elem_first_elem_type == nlohmann::json::value_t::array) {
                                         //std::cout<<"tensorarray"<<std::endl;
@@ -1828,7 +1834,7 @@ public:
                                                 const_expr->sub_array_array_.emplace_back(std::move(const_expr_2));
                                                 const_expr_2 = nullptr;
                                             }
-                                            values_row->emplace_back(const_expr);
+                                            (*values_row)[column_id] = const_expr;
                                             const_expr = nullptr;
                                         } else if(first_elem_first_elem_first_elem_type == nlohmann::json::value_t::number_float) {
                                             infinity::ConstantExpr *const_expr = new ConstantExpr(LiteralType::kSubArrayArray);
@@ -1892,7 +1898,7 @@ public:
                                                 const_expr->sub_array_array_.emplace_back(std::move(const_expr_2));
                                                 const_expr_2 = nullptr;
                                             }
-                                            values_row->emplace_back(const_expr);
+                                            (*values_row)[column_id] = const_expr;
                                             const_expr = nullptr;
                                         } else {
                                             json_response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;


### PR DESCRIPTION
### What problem does this PR solve?
- Add uint8, float16, bfloat16 datatype support for http api knn
- enable match tensor array for http api
- fix http api bug that can not insert multiple tensorarray at once

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Test cases

