### PR TITLE
Add test cases for given index name and ignore index

### DIFF
--- a/python/infinity/local_infinity/query_builder.py
+++ b/python/infinity/local_infinity/query_builder.py
@@ -157,7 +157,10 @@ class InfinityLocalQueryBuilder(ABC):
             for k, v in knn_params.items():
                 key = k.lower()
                 value = v.lower()
-                knn_opt_params.append(InitParameter(key, value))
+                tmp_param = InitParameter()
+                tmp_param.param_name = key
+                tmp_param.param_value = value
+                knn_opt_params.append(tmp_param)
 
         knn_expr = WrapKnnExpr()
         knn_expr.column_expr = column_expr

--- a/python/test_pysdk/http_adapter.py
+++ b/python/test_pysdk/http_adapter.py
@@ -544,13 +544,16 @@ class http_adapter:
         self._filter = filter
         return self
 
-    def knn(self, fields, query_vector, element_type, metric_type, top_k):
+    def knn(self, fields, query_vector, element_type, metric_type, top_k, opt_params : {} = None):
         self._knn = {}
         self._knn["fields"] = [fields]
         self._knn["query_vector"] = query_vector
         self._knn["element_type"] = type_transfrom[element_type]
         self._knn["metric_type"] = metric_type
         self._knn["top_k"] = top_k
+        if opt_params is not None:
+            for key in opt_params:
+                self._knn[key] = opt_params[key]
         return self
 
     def fusion(self, method="", option="", optional_match_tensor: CommonMatchTensorExpr = None):

--- a/src/embedded_infinity/wrap_infinity.cpp
+++ b/src/embedded_infinity/wrap_infinity.cpp
@@ -311,6 +311,13 @@ ParsedExpr *WrapKnnExpr::GetParsedExpr(Status &status) {
 
     knn_expr->opt_params_ = new Vector<InitParameter *>();
     for (auto &param : opt_params) {
+        if(param.param_name_ == "index_name") {
+            knn_expr->index_name_ = param.param_value_;
+        }
+        if(param.param_name_ == "ignore_index" && param.param_value_ == "true") {
+            knn_expr->ignore_index_ = true;
+        }
+
         auto init_parameter = new InitParameter();
         init_parameter->param_name_ = param.param_name_;
         init_parameter->param_value_ = param.param_value_;

--- a/src/network/http/http_search.cpp
+++ b/src/network/http/http_search.cpp
@@ -455,6 +455,13 @@ KnnExpr *HTTPSearch::ParseKnn(const nlohmann::json &knn_json_object, HTTPStatus 
             if (knn_expr->opt_params_ == nullptr) {
                 knn_expr->opt_params_ = new Vector<InitParameter *>();
             }
+            if(key  == "index_name") {
+                knn_expr->index_name_ = field_json_obj.value();
+            }
+            if(key == "ignore_index" && field_json_obj.value() == "true") {
+                knn_expr->ignore_index_ = true;
+            }
+
             auto parameter = MakeUnique<InitParameter>();
             parameter->param_name_ = key;
             parameter->param_value_ = field_json_obj.value();


### PR DESCRIPTION
### What problem does this PR solve?
- add test cases for given index name and ignore index when searching dense vector
- enable http api to use given index name or ignore index when searching dense vector
- enable local  infinity pysdk to use given index name or ignore index when searching dense vector
### Type of change
- [x] New Feature (non-breaking change which adds functionality)
- [x] Test cases
- [x] Python SDK impacted, Need to update PyPI

