### PR TITLE
Fix: unordered_map memory not release

### DIFF
--- a/src/bin/compilation_config.cppm.in
+++ b/src/bin/compilation_config.cppm.in
@@ -29,6 +29,8 @@ export module compilation_config;
 #define CSV_DATA_PATH "@CSV_DATA_PATH@"
 #define TMP_DATA_PATH "@TMP_DATA_PATH@"
 
+#define ENABLE_JEMALLOC "@ENABLE_JEMALLOC@"
+
 namespace infinity {
 
 export int version_major() {

--- a/src/main/variables.cpp
+++ b/src/main/variables.cpp
@@ -42,6 +42,7 @@ void VarUtil::InitVariablesMap() {
     global_name_map_[SYSTEM_MEMORY_USAGE_VAR_NAME.data()] = GlobalVariable::kSystemMemoryUsage;
     global_name_map_[OPEN_FILE_COUNT_VAR_NAME.data()] = GlobalVariable::kOpenFileCount;
     global_name_map_[CPU_USAGE_VAR_NAME.data()] = GlobalVariable::kCPUUsage;
+    global_name_map_["jeprof"] = GlobalVariable::kJeProf;
 
     session_name_map_[QUERY_COUNT_VAR_NAME.data()] = SessionVariable::kQueryCount;
     session_name_map_[TOTAL_COMMIT_COUNT_VAR_NAME.data()] = SessionVariable::kTotalCommitCount;

--- a/src/main/variables.cppm
+++ b/src/main/variables.cppm
@@ -43,6 +43,7 @@ export enum class GlobalVariable {
     kSystemMemoryUsage,         // global
     kOpenFileCount,             // global
     kCPUUsage,                  // global
+    kJeProf,                    // global
     kInvalid,
 };
 

--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -180,6 +180,7 @@ void BufferManager::RemoveClean() {
                 UnrecoverableError(error_message);
             }
         }
+        buffer_map_.rehash(buffer_map_.size());
     }
 }
 

--- a/src/storage/meta/meta_map.cppm
+++ b/src/storage/meta/meta_map.cppm
@@ -201,6 +201,7 @@ void MetaMap<Meta>::PickCleanup(CleanupScanner *scanner) {
                 ++iter;
             }
         }
+        meta_map_.rehash(meta_map_.size());
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: Rehash unordered_map in buffer_manager and meta_map when cleanup to release memory.
2. Add sql command `set global jeprof on;` to dump jeprof.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
