### PR TITLE
Enable vfs by default

### DIFF
--- a/.github/workflows/slow_test.yml
+++ b/.github/workflows/slow_test.yml
@@ -5,7 +5,8 @@ on:
   create:
     tags:
       - "v*.*.*"                  # normal release
-      - "nightly"                 # the only one mutable tag
+      - "nightly"                 # mutable tag
+      - "slow-test"               # mutable tag
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,11 +110,11 @@ jobs:
         # GitHub Actions interprets output lines starting with "Error" as error messages, and it automatically sets the step status to failed when such lines are detected.
         run: cat debug.log 2>/dev/null || true
 
-      - name: Start infinity debug version with vfs on
+      - name: Start infinity debug version with vfs off
         if: ${{ !cancelled() && !failure() }}
         run: |
           # Run a command in the background
-          sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && rm -fr /var/infinity && cmake-build-debug/src/infinity --config=conf/pytest_parallel_infinity_vfs_conf.toml > vfs_debug.log 2>&1" &
+          sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && rm -fr /var/infinity && cmake-build-debug/src/infinity --config=conf/pytest_parallel_infinity_vfs_off.toml > vfs_debug.log 2>&1" &
 
       - name: Run pysdk remote infinity & parallel & http_api & sqllogic test debug version
         if: ${{ !cancelled() && !failure() }}
@@ -245,11 +245,11 @@ jobs:
         # GitHub Actions interprets output lines starting with "Error" as error messages, and it automatically sets the step status to failed when such lines are detected. 
         run: cat release.log 2>/dev/null || true
 
-      - name: Start infinity release version with vfs on
+      - name: Start infinity release version with vfs off
         if: ${{ !cancelled() && !failure() }}
         run: |
           # Run a command in the background
-          sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && rm -fr /var/infinity && cmake-build-release/src/infinity --config=conf/pytest_parallel_infinity_vfs_conf.toml > vfs_release.log 2>&1" &
+          sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && rm -fr /var/infinity && cmake-build-release/src/infinity --config=conf/pytest_parallel_infinity_vfs_off.toml > vfs_release.log 2>&1" &
 
       - name: Run pysdk remote infinity & parallel & http_api & sqllogic test release version
         if: ${{ !cancelled() && !failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Test embedded infinity for Python 3.10
         if: ${{ !cancelled() && !failure() }}
-        run: sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && source /usr/local/venv310/bin/activate && python3 tools/run_pysdk_local_infinity_test.py"
+        run: sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && rm -fr /var/infinity/* && cp test/data/config/infinity_conf.toml /var/infinity && source /usr/local/venv310/bin/activate && python3 tools/run_pysdk_local_infinity_test.py"
 
       - name: Start infinity release version
         if: ${{ !cancelled() && !failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,6 +219,10 @@ jobs:
         if: ${{ !cancelled() && !failure() }}
         run: sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && rm -fr /var/infinity/* && cp test/data/config/infinity_conf.toml /var/infinity && source /usr/local/venv310/bin/activate && python3 tools/run_pysdk_local_infinity_test.py"
 
+      - name: Collect embedded infinity log
+        if: ${{ !cancelled() && failure()}} # run this step if previous steps failed
+        run: sudo docker exec ${BUILDER_CONTAINER} bash -c "cat /var/infinity/log/infinity.log"
+
       - name: Start infinity release version
         if: ${{ !cancelled() && !failure() }}
         run: |

--- a/conf/infinity_conf.toml
+++ b/conf/infinity_conf.toml
@@ -20,8 +20,8 @@ log_file_rotate_count    = 10
 log_level               = "info"
 
 [storage]
-data_dir                 = "/var/infinity/data"
-
+persistence_dir         = "/var/infinity/persistence"
+data_dir                = "/var/infinity/data"
 # periodically activates garbage collection:
 # 0 means real-time,
 # s means seconds, for example "60s", 60 seconds
@@ -55,5 +55,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]

--- a/conf/pytest_parallel_infinity_vfs_off.toml
+++ b/conf/pytest_parallel_infinity_vfs_off.toml
@@ -21,6 +21,3 @@ wal_dir                  = "/var/infinity/wal"
 
 [resource]
 resource_dir             = "/var/infinity/resource"
-
-[persistence]
-persistence_dir          = "/var/infinity/persistence"

--- a/docs/references/configurations.md
+++ b/docs/references/configurations.md
@@ -69,8 +69,9 @@ log_level               = "info"
 
 # storage-related configuration
 [storage]
-# The directory of data files
-data_dir                 = "/var/infinity/data"
+# The working directory of the persistence manager.
+# The persistence manager maps block and index files to remote stored objects and manage the local cache.
+persistence_dir          = "/var/infinity/persistence"
 
 # periodically activates garbage collection:
 # use "number + unit of time" to specify intervals
@@ -134,14 +135,4 @@ wal_flush                     = "only_write"
 [resource]
 # The resource files used by Infinity (such as the dictionary files used by the analyzer)
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-# Persistent File Storage Path
-# When set to "" or not provided, persistent manager is diabled, and files are stored directly on the local file system.
-# When not empty, persistent manager is enabled. The generated files will be stored by the persistence manager on the path specified by persistence_dir.
-# For example, if the user adds three files: A, B, and C.
-# When persistence manager is disabled, the three files are stored on the local file system in their specified raw paths: A, B, C.
-# When persistence manager is enabled, the persistence manager determines how to store these files on the specified persistent path.
-# toggle persistence on to reduce possible file fragments in your local filesystem
-persistence_dir          = "/var/infinity/persistence"
 ```

--- a/python/restart_test/test_memidx.py
+++ b/python/restart_test/test_memidx.py
@@ -93,3 +93,28 @@ class TestMemIdx:
 
         infinity_obj.disconnect()
         infinity_runner.uninit()
+
+# create table test_memidx1(c1 int, c2 embedding(float, 4));
+# create index idx1 on test_memidx1(c2) using hnsw with(m=16, ef_construction=200, metric=l2,block_size=1);
+# insert into test_memidx1 values(2, [0.1,0.2,0.3,-0.2]),(2, [0.1,0.2,0.3,-0.2]),(2, [0.1,0.2,0.3,-0.2]),(2, [0.1,0.2,0.3,-0.2]),(2, [0.1,0.2,0.3,-0.2]);
+# insert into test_memidx1 values(4,[0.2,0.1,0.3,0.4]);
+# # wait 5s
+# insert into test_memidx1 values(4,[0.2,0.1,0.3,0.4]),(4,[0.2,0.1,0.3,0.4]),(4,[0.2,0.1,0.3,0.4]),(4,[0.2,0.1,0.3,0.4]);
+
+# select c1 from test_memidx1 search match vector(c2, [0.3,0.3,0.2,0.2],'float','l2',6);
+# # result: 4, 4, 4, 4, 4, 2
+# select count(*) from test_memidx1;
+# # result: 10
+# insert into test_memidx1 values(6,[0.3,0.2,0.1,0.4]),(6,[0.3,0.2,0.1,0.4]);
+# # wait 5s
+# insert into test_memidx1 values(8,[0.4,0.3,0.2,0.1]);
+
+# select c1 from test_memidx1 search match vector(c2, [0.3,0.3,0.2,0.2],'float','l2',6);
+# # result: 8, 6, 6, 4, 4, 4
+# select count(*) from test_memidx1;
+# # result: 13
+# # wait 3s
+# select c1 from test_memidx1 search match vector(c2, [0.3,0.3,0.2,0.2],'float','l2',6);
+# # result: 8, 6, 6, 4, 4, 4
+# select count(*) from test_memidx1;
+# # result: 13

--- a/src/common/default_values.cppm
+++ b/src/common/default_values.cppm
@@ -187,7 +187,7 @@ export {
     constexpr SizeT INSERT_BATCH_ROW_LIMIT = 8192;
 
     // default persistence parameter
-    constexpr std::string_view DEFAULT_PERSISTENCE_DIR = "";                        // Empty means disabled
+    constexpr std::string_view DEFAULT_PERSISTENCE_DIR = "/var/infinity/persistence"; // Empty means disabled
     constexpr std::string_view DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT_STR = "100MB"; // 100MB
     constexpr SizeT DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT = 100 * 1024lu * 1024lu;  // 100MB
 

--- a/src/executor/operator/physical_export.cpp
+++ b/src/executor/operator/physical_export.cpp
@@ -356,7 +356,7 @@ SizeT PhysicalExport::ExportToJSONL(QueryContext *query_context, ExportOperatorS
                     file_handler = std::move(result.first);
                 }
 
-                LOG_DEBUG(line_json.dump());
+                // LOG_DEBUG(line_json.dump());
                 String to_write = line_json.dump() + "\n";
                 fs.Write(*file_handler, to_write.c_str(), to_write.size());
                 ++row_count;

--- a/src/executor/operator/physical_show.cpp
+++ b/src/executor/operator/physical_show.cpp
@@ -5304,7 +5304,7 @@ void PhysicalShow::ExecuteShowPersistenceObjects(QueryContext *query_context, Sh
         MakeShared<ColumnDef>(1, bigint_type, "reference_count", std::set<ConstraintType>()),
         MakeShared<ColumnDef>(2, bigint_type, "size", std::set<ConstraintType>()),
         MakeShared<ColumnDef>(2, bigint_type, "parts", std::set<ConstraintType>()),
-        MakeShared<ColumnDef>(3, bigint_type, "deleted_size", std::set<ConstraintType>()),
+        MakeShared<ColumnDef>(3, varchar_type, "deleted_ranges", std::set<ConstraintType>()),
     };
 
     SharedPtr<TableDef> table_def = TableDef::Make(MakeShared<String>("default_db"), MakeShared<String>("show_persistence_objects"), column_defs);
@@ -5315,7 +5315,7 @@ void PhysicalShow::ExecuteShowPersistenceObjects(QueryContext *query_context, Sh
         bigint_type,
         bigint_type,
         bigint_type,
-        bigint_type,
+        varchar_type,
     };
 
     UniquePtr<DataBlock> output_block_ptr = DataBlock::MakeUniquePtr();
@@ -5360,8 +5360,12 @@ void PhysicalShow::ExecuteShowPersistenceObjects(QueryContext *query_context, Sh
             value_expr.AppendToChunk(output_block_ptr->column_vectors[3]);
         }
         {
-            // delete size
-            Value value = Value::MakeBigInt(object_pair.second.deleted_size_);
+            // deleted ranges
+            OStringStream oss;
+            for (const auto &range : object_pair.second.deleted_ranges_) {
+                oss << "[" << range.start_ << ", " << range.end_ << ") ";
+            }
+            Value value = Value::MakeVarchar(oss.str());
             ValueExpression value_expr(value);
             value_expr.AppendToChunk(output_block_ptr->column_vectors[4]);
         }

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -300,6 +300,17 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
             UnrecoverableError(status.message());
         }
 
+        // Persistence Dir
+        String persistence_dir = DEFAULT_PERSISTENCE_DIR.data();
+        UniquePtr<StringOption> persistence_dir_option = MakeUnique<StringOption>(PERSISTENCE_DIR_OPTION_NAME, persistence_dir);
+        global_options_.AddOption(std::move(persistence_dir_option));
+
+        // Persistence Object Size Limit
+        i64 persistence_object_size_limit = DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT;
+        UniquePtr<IntegerOption> persistence_object_size_limit_option =
+            MakeUnique<IntegerOption>(PERSISTENCE_OBJECT_SIZE_LIMIT_OPTION_NAME, persistence_object_size_limit, std::numeric_limits<i64>::max(), 0);
+        global_options_.AddOption(std::move(persistence_object_size_limit_option));
+
         // Cleanup Interval
         i64 cleanup_interval = DEFAULT_CLEANUP_INTERVAL_SEC;
         UniquePtr<IntegerOption> cleanup_interval_option =
@@ -454,17 +465,6 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
         if(!status.ok()) {
             UnrecoverableError(status.message());
         }
-
-        // Persistence Dir
-        String persistence_dir = DEFAULT_PERSISTENCE_DIR.data();
-        UniquePtr<StringOption> persistence_dir_option = MakeUnique<StringOption>(PERSISTENCE_DIR_OPTION_NAME, persistence_dir);
-        global_options_.AddOption(std::move(persistence_dir_option));
-
-        // Persistence Object Size Limit
-        i64 persistence_object_size_limit = DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT;
-        UniquePtr<IntegerOption> persistence_object_size_limit_option =
-            MakeUnique<IntegerOption>(PERSISTENCE_OBJECT_SIZE_LIMIT_OPTION_NAME, persistence_object_size_limit, std::numeric_limits<i64>::max(), 0);
-        global_options_.AddOption(std::move(persistence_object_size_limit_option));
     } else {
         config_toml = toml::parse_file(*config_path);
 
@@ -1066,6 +1066,39 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
                             }
                             break;
                         }
+                        case GlobalOptionIndex::kPersistenceDir: {
+                            String persistence_dir;
+                            if (elem.second.is_string()) {
+                                persistence_dir = elem.second.value_or(DEFAULT_PERSISTENCE_DIR.data());
+                            } else {
+                                return Status::InvalidConfig("'persistence_dir' field isn't string, such as \"persistence\"");
+                            }
+                            UniquePtr<StringOption> persistence_dir_option = MakeUnique<StringOption>(PERSISTENCE_DIR_OPTION_NAME, persistence_dir);
+                            global_options_.AddOption(std::move(persistence_dir_option));
+                            break;
+                        }
+                        case GlobalOptionIndex::kPersistenceObjectSizeLimit: {
+                            i64 persistence_object_size_limit;
+                            if (elem.second.is_string()) {
+                                String persistence_object_size_limit_str = elem.second.value_or(DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT_STR.data());
+                                auto res = ParseByteSize(persistence_object_size_limit_str, persistence_object_size_limit);
+                                if (!res.ok()) {
+                                    return res;
+                                }
+                            } else {
+                                return Status::InvalidConfig("'persistence_object_size_limit' field isn't string, such as \"100MB\"");
+                            }
+                            UniquePtr<IntegerOption> persistence_object_size_limit_option =
+                                MakeUnique<IntegerOption>(PERSISTENCE_OBJECT_SIZE_LIMIT_OPTION_NAME,
+                                                          persistence_object_size_limit,
+                                                          std::numeric_limits<i64>::max(),
+                                                          0);
+                            if (!persistence_object_size_limit_option->Validate()) {
+                                return Status::InvalidConfig(fmt::format("Invalid persistence_object_size_limit: {}", persistence_object_size_limit));
+                            }
+                            global_options_.AddOption(std::move(persistence_object_size_limit_option));
+                            break;
+                        }
                         case GlobalOptionIndex::kCleanupInterval: {
                             // Cleanup Interval
                             i64 cleanup_interval = DEFAULT_CLEANUP_INTERVAL_SEC;
@@ -1164,6 +1197,21 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
                     }
                 }
 
+                if (global_options_.GetOptionByIndex(GlobalOptionIndex::kPersistenceDir) == nullptr) {
+                    String persistence_dir =
+                        (global_options_.GetOptionByIndex(GlobalOptionIndex::kDataDir) == nullptr) ? DEFAULT_PERSISTENCE_DIR.data() : "";
+                    UniquePtr<StringOption> persistence_dir_option = MakeUnique<StringOption>(PERSISTENCE_DIR_OPTION_NAME, persistence_dir);
+                    global_options_.AddOption(std::move(persistence_dir_option));
+                }
+                if (global_options_.GetOptionByIndex(GlobalOptionIndex::kPersistenceObjectSizeLimit) == nullptr) {
+                    i64 persistence_object_size_limit = DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT;
+                    UniquePtr<IntegerOption> persistence_object_size_limit_option =
+                        MakeUnique<IntegerOption>(PERSISTENCE_OBJECT_SIZE_LIMIT_OPTION_NAME,
+                                                  persistence_object_size_limit,
+                                                  std::numeric_limits<i64>::max(),
+                                                  0);
+                    global_options_.AddOption(std::move(persistence_object_size_limit_option));
+                }
                 if(global_options_.GetOptionByIndex(GlobalOptionIndex::kDataDir) == nullptr) {
                     // Data Dir
                     String data_dir = "/var/infinity/data";
@@ -1220,73 +1268,6 @@ Status Config::Init(const SharedPtr<String> &config_path, DefaultConfig* default
 
             } else {
                 return Status::InvalidConfig("No 'storage' section in configure file.");
-            }
-        }
-
-        // Persistence
-        {
-            if (config_toml.contains("persistence")) {
-                auto persistence_config = config_toml["persistence"];
-                auto persistence_config_table = persistence_config.as_table();
-                for (auto &elem : *persistence_config_table) {
-                    String var_name = String(elem.first);
-                    GlobalOptionIndex option_index = global_options_.GetOptionIndex(var_name);
-                    switch (option_index) {
-                        case GlobalOptionIndex::kPersistenceDir: {
-                            String persistence_dir;
-                            if (elem.second.is_string()) {
-                                persistence_dir = elem.second.value_or(DEFAULT_PERSISTENCE_DIR.data());
-                            } else {
-                                return Status::InvalidConfig("'persistence_dir' field isn't string, such as \"persistence\"");
-                            }
-                            UniquePtr<StringOption> persistence_dir_option = MakeUnique<StringOption>(PERSISTENCE_DIR_OPTION_NAME, persistence_dir);
-                            global_options_.AddOption(std::move(persistence_dir_option));
-                            break;
-                        }
-                        case GlobalOptionIndex::kPersistenceObjectSizeLimit: {
-                            i64 persistence_object_size_limit;
-                            if (elem.second.is_string()) {
-                                String persistence_object_size_limit_str = elem.second.value_or(DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT_STR.data());
-                                auto res = ParseByteSize(persistence_object_size_limit_str, persistence_object_size_limit);
-                                if (!res.ok()) {
-                                    return res;
-                                }
-                            } else {
-                                return Status::InvalidConfig("'persistence_object_size_limit' field isn't string, such as \"100MB\"");
-                            }
-                            UniquePtr<IntegerOption> persistence_object_size_limit_option =
-                                MakeUnique<IntegerOption>(PERSISTENCE_OBJECT_SIZE_LIMIT_OPTION_NAME,
-                                                          persistence_object_size_limit,
-                                                          std::numeric_limits<i64>::max(),
-                                                          0);
-                            if (!persistence_object_size_limit_option->Validate()) {
-                                return Status::InvalidConfig(fmt::format("Invalid persistence_object_size_limit: {}", persistence_object_size_limit));
-                            }
-                            global_options_.AddOption(std::move(persistence_object_size_limit_option));
-                            break;
-                        }
-                        case GlobalOptionIndex::kInvalid:
-                        default: {
-                            return Status::InvalidConfig(fmt::format("Unrecognized config parameter: {} in 'persistence' field", var_name));
-                        }
-                    }
-                }
-                if (global_options_.GetOptionByIndex(GlobalOptionIndex::kPersistenceDir) == nullptr) {
-                    String persistence_dir = DEFAULT_PERSISTENCE_DIR.data();
-                    UniquePtr<StringOption> persistence_dir_option = MakeUnique<StringOption>(PERSISTENCE_DIR_OPTION_NAME, persistence_dir);
-                    global_options_.AddOption(std::move(persistence_dir_option));
-                }
-                if (global_options_.GetOptionByIndex(GlobalOptionIndex::kPersistenceObjectSizeLimit) == nullptr) {
-                    i64 persistence_object_size_limit = DEFAULT_PERSISTENCE_OBJECT_SIZE_LIMIT;
-                    UniquePtr<IntegerOption> persistence_object_size_limit_option =
-                        MakeUnique<IntegerOption>(PERSISTENCE_OBJECT_SIZE_LIMIT_OPTION_NAME,
-                                                  persistence_object_size_limit,
-                                                  std::numeric_limits<i64>::max(),
-                                                  0);
-                    global_options_.AddOption(std::move(persistence_object_size_limit_option));
-                }
-            } else {
-                return Status::InvalidConfig("No 'persistence' section in configure file.");
             }
         }
 

--- a/src/main/logger.cpp
+++ b/src/main/logger.cpp
@@ -48,11 +48,13 @@ void Logger::Initialize(Config *config_ptr) {
 
         infinity_logger = MakeShared<spdlog::logger>("infinity", sinks.begin(), sinks.end()); // NOLINT
         infinity_logger->set_pattern("[%H:%M:%S.%e] [%t] [%^%l%$] %v");
+        infinity_logger->flush_on(spdlog::level::warn);
         spdlog::details::registry::instance().register_logger(infinity_logger);
     } else {
         Vector<spdlog::sink_ptr> sinks{rotating_file_sinker};
         infinity_logger = MakeShared<spdlog::logger>("infinity", sinks.begin(), sinks.end()); // NOLINT
         infinity_logger->set_pattern("[%H:%M:%S.%e] [%t] [%^%l%$] %v");
+        infinity_logger->flush_on(spdlog::level::warn);
         spdlog::details::registry::instance().register_logger(infinity_logger);
     }
 

--- a/src/storage/background_process.cpp
+++ b/src/storage/background_process.cpp
@@ -72,7 +72,7 @@ void BGTaskProcessor::Process() {
                 case BGTaskType::kForceCheckpoint: {
                     LOG_DEBUG("Force checkpoint in background");
                     if (cleanup_trigger_.get() != nullptr) {
-                        LOG_DEBUG("Do cleanup before force checkpoint");
+                        LOG_INFO("Do cleanup before force checkpoint");
                         auto cleanup_task = cleanup_trigger_->CreateCleanupTask();
                         if (cleanup_task.get() != nullptr) {
                             cleanup_task->Execute();

--- a/src/storage/buffer/file_worker/bmp_index_file_worker.cpp
+++ b/src/storage/buffer/file_worker/bmp_index_file_worker.cpp
@@ -40,10 +40,10 @@ BMPIndexFileWorker::BMPIndexFileWorker(SharedPtr<String> file_dir,
 
         String index_path = GetFilePath();
         auto [file_handler, status] = fs.OpenFile(index_path, FileFlags::READ_FLAG, FileLockType::kNoLock);
-        if (!status.ok()) {
-            UnrecoverableError(status.message());
+        if (status.ok()) {
+            // When replay by full checkpoint, the data is deleted, but catalog is recovered. Do not read file in recovery.
+            index_size = fs.GetFileSize(*file_handler);
         }
-        index_size = fs.GetFileSize(*file_handler);
     }
     index_size_ = index_size;
 }

--- a/src/storage/buffer/file_worker/file_worker.cpp
+++ b/src/storage/buffer/file_worker/file_worker.cpp
@@ -89,9 +89,11 @@ void FileWorker::ReadFromFile(bool from_spill) {
     read_path = fmt::format("{}/{}", ChooseFileDir(from_spill), *file_name_);
     if (use_object_cache) {
         obj_addr_ = pm->GetObjFromLocalPath(read_path);
-        if (obj_addr_.Valid()) {
-            read_path = pm->GetObjCache(read_path);
+        if (!obj_addr_.Valid()) {
+            String error_message = fmt::format("Failed to find object for local path {}", read_path);
+            UnrecoverableError(error_message);
         }
+        read_path = pm->GetObjCache(read_path);
     }
     SizeT file_size = 0;
     u8 flags = FileFlags::READ_FLAG;

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cpp
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cpp
@@ -47,7 +47,8 @@ HnswFileWorker::HnswFileWorker(SharedPtr<String> file_dir,
 
         String index_path = GetFilePath();
         auto [file_handler, status] = fs.OpenFile(index_path, FileFlags::READ_FLAG, FileLockType::kNoLock);
-        if (status.ok()) { // file may deleted if cleaned up happens
+        if (status.ok()) {
+            // When replay by full checkpoint, the data is deleted, but catalog is recovered. Do not read file in recovery.
             index_size = fs.GetFileSize(*file_handler);
         }
     }

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -511,6 +511,9 @@ nlohmann::json Catalog::Serialize(TxnTimeStamp max_commit_ts) {
 
     PersistenceManager *pm = InfinityContext::instance().persistence_manager();
     if (pm != nullptr) {
+        // Finalize current object to ensure PersistenceManager be in a consistent state
+        pm->CurrentObjFinalize(true);
+
         json_res["obj_addr_map"] = pm->Serialize();
     }
     return json_res;
@@ -1062,6 +1065,12 @@ bool Catalog::SaveDeltaCatalog(TxnTimeStamp last_ckp_ts, TxnTimeStamp &max_commi
                 break;
         }
         op->InitializeAddrSerializer();
+    }
+
+    // Finalize current object to ensure PersistenceManager be in a consistent state
+    PersistenceManager *pm = InfinityContext::instance().persistence_manager();
+    if (pm != nullptr) {
+        pm->CurrentObjFinalize(true);
     }
 
     // Save the global catalog delta entry to disk.

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -1064,13 +1064,15 @@ bool Catalog::SaveDeltaCatalog(TxnTimeStamp last_ckp_ts, TxnTimeStamp &max_commi
                 LOG_TRACE(fmt::format("Ignore delta op: {}", op->ToString()));
                 break;
         }
-        op->InitializeAddrSerializer();
     }
 
     // Finalize current object to ensure PersistenceManager be in a consistent state
     PersistenceManager *pm = InfinityContext::instance().persistence_manager();
     if (pm != nullptr) {
         pm->CurrentObjFinalize(true);
+        for (auto &op : flush_delta_entry->operations()) {
+            op->InitializeAddrSerializer();
+        }
     }
 
     // Save the global catalog delta entry to disk.

--- a/src/storage/meta/entry/block_entry.cpp
+++ b/src/storage/meta/entry/block_entry.cpp
@@ -38,6 +38,7 @@ import cleanup_scanner;
 import buffer_manager;
 import buffer_obj;
 import logical_type;
+import infinity_context;
 
 namespace infinity {
 
@@ -306,13 +307,15 @@ SizeT BlockEntry::DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const
     return delete_row_n;
 }
 
-void BlockEntry::CommitFlushed(TxnTimeStamp commit_ts) {
+void BlockEntry::CommitFlushed(TxnTimeStamp commit_ts, WalBlockInfo *block_info) {
     std::unique_lock w_lock(rw_locker_);
     auto block_version_handle = version_buffer_object_->Load();
     auto *block_version = reinterpret_cast<BlockVersion *>(block_version_handle.GetDataMut());
     block_version->Append(commit_ts, this->block_row_count_);
 
     FlushVersionNoLock(commit_ts);
+    auto *pm = InfinityContext::instance().persistence_manager();
+    block_info->addr_serializer_.InitializeValid(pm);
 }
 
 void BlockEntry::CommitBlock(TransactionID txn_id, TxnTimeStamp commit_ts) {

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -33,6 +33,7 @@ import fast_rough_filter;
 import value;
 import buffer_obj;
 import bitmask;
+import wal_entry;
 
 namespace infinity {
 
@@ -100,7 +101,7 @@ protected:
 
     SizeT DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const Vector<BlockOffset> &rows);
 
-    void CommitFlushed(TxnTimeStamp commit_ts);
+    void CommitFlushed(TxnTimeStamp commit_ts, WalBlockInfo *block_info);
 
     void CommitBlock(TransactionID txn_id, TxnTimeStamp commit_ts);
 

--- a/src/storage/meta/entry/segment_entry.cpp
+++ b/src/storage/meta/entry/segment_entry.cpp
@@ -414,10 +414,17 @@ SizeT SegmentEntry::DeleteData(TransactionID txn_id,
     return delete_row_n;
 }
 
-void SegmentEntry::CommitFlushed(TxnTimeStamp commit_ts) {
+void SegmentEntry::CommitFlushed(TxnTimeStamp commit_ts, WalSegmentInfo *segment_info) {
     std::shared_lock w_lock(rw_locker_);
     for (auto &block_entry : block_entries_) {
-        block_entry->CommitFlushed(commit_ts);
+        WalBlockInfo *block_info_ptr = nullptr;
+        for (auto &block_info : segment_info->block_infos_) {
+            if (block_info.block_id_ == block_entry->block_id()) {
+                block_info_ptr = &block_info;
+                break;
+            }
+        }
+        block_entry->CommitFlushed(commit_ts, block_info_ptr);
     }
 }
 

--- a/src/storage/meta/entry/segment_entry.cppm
+++ b/src/storage/meta/entry/segment_entry.cppm
@@ -32,6 +32,7 @@ import meta_entry_interface;
 import cleanup_scanner;
 import logger;
 import bitmask;
+import wal_entry;
 
 namespace infinity {
 
@@ -209,7 +210,7 @@ public:
 
     SizeT DeleteData(TransactionID txn_id, TxnTimeStamp commit_ts, const HashMap<BlockID, Vector<BlockOffset>> &block_row_hashmap, Txn *txn);
 
-    void CommitFlushed(TxnTimeStamp commit_ts);
+    void CommitFlushed(TxnTimeStamp commit_ts, WalSegmentInfo *segment_info);
 
     void CommitSegment(TransactionID txn_id, TxnTimeStamp commit_ts, const TxnSegmentStore &segment_store, const DeleteState *delete_state);
 

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -1012,6 +1012,7 @@ ChunkIndexEntry *SegmentIndexEntry::RebuildChunkIndexEntries(TxnTableStore *txn_
         }
     }
     ReplaceChunkIndexEntries(txn_table_store, merged_chunk_index_entry, std::move(old_chunks));
+    merged_chunk_index_entry->SaveIndexFile();
     AddWalIndexDump(merged_chunk_index_entry.get(), txn, std::move(old_ids));
     return merged_chunk_index_entry.get();
 }

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -926,10 +926,7 @@ void TableEntry::OptimizeIndex(Txn *txn) {
                 for (auto &[segment_id, segment_index_entry] : segment_index_guard.index_by_segment_) {
                     SegmentEntry *segment_entry = GetSegmentByID(segment_id, begin_ts).get();
                     if (segment_entry != nullptr) {
-                        auto *merged_chunk_entry = segment_index_entry->RebuildChunkIndexEntries(txn_table_store, segment_entry);
-                        if (merged_chunk_entry != nullptr) {
-                            merged_chunk_entry->SaveIndexFile();
-                        }
+                        [[maybe_unused]] auto *merged_chunk_entry = segment_index_entry->RebuildChunkIndexEntries(txn_table_store, segment_entry);
                     }
                 }
                 break;

--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -399,7 +399,7 @@ ObjAddr PersistenceManager::ObjCreateRefCount(const String &file_path) {
     {
         std::lock_guard<std::mutex> lock(mtx_);
         objects_.emplace(obj_key, ObjStat(0, 1, 1));
-        LOG_TRACE(fmt::format("ObjCreateRefCount added dedicated {}", obj_key));
+        LOG_TRACE(fmt::format("ObjCreateRefCount added dedicated {}, path: {}", obj_key, file_path));
     }
 
     fs::path src_fp = workspace_;

--- a/src/storage/persistence/persistence_manager.cppm
+++ b/src/storage/persistence/persistence_manager.cppm
@@ -161,6 +161,8 @@ private:
 export struct AddrSerializer {
     void Initialize(PersistenceManager *pm, const Vector<String> &path);
 
+    void InitializeValid(PersistenceManager *pm);
+
     SizeT GetSizeInBytes() const;
  
     void WriteBufAdv(char *&buf) const;

--- a/src/storage/persistence/persistence_manager.cppm
+++ b/src/storage/persistence/persistence_manager.cppm
@@ -88,7 +88,7 @@ public:
     ObjAddr Persist(const char *data, SizeT len);
 
     // Force finalize current object. Subsequent append on the finalized object is forbidden.
-    void CurrentObjFinalize();
+    void CurrentObjFinalize(bool validate = false);
 
     /**
      * For dedicated objects

--- a/src/storage/persistence/persistence_manager.cppm
+++ b/src/storage/persistence/persistence_manager.cppm
@@ -42,22 +42,18 @@ export struct ObjAddr {
 };
 
 export struct Range {
-    SizeT start_{};
-    SizeT end_{};
+    SizeT start_{}; // inclusive
+    SizeT end_{};   // exclusive
     bool operator<(const Range &rhs) const { return start_ < rhs.start_; }
-
-    bool HasIntersection(const Range &rhs) const {
-        SizeT max_start = std::max(start_, rhs.start_);
-        SizeT min_end = std::min(end_, rhs.end_);
-        return max_start < min_end;
-    }
+    bool operator==(const Range &rhs) const { return start_ == rhs.start_ && end_ == rhs.end_; }
+    bool Cover(const Range &rhs) const { return start_ <= rhs.start_ && rhs.end_ <= end_; }
+    bool Intersect(const Range &rhs) const { return start_ < rhs.end_ && rhs.start_ < end_; }
 };
 
 export struct ObjStat {
     SizeT obj_size_{}; // footer (if present) is excluded
     SizeT parts_{};    // an object attribute
     SizeT ref_count_{}; // the number of user (R and W) of some part of this object
-    SizeT deleted_size_{};
     Set<Range> deleted_ranges_{};
 
     ObjStat() = default;

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -547,7 +547,7 @@ bool Txn::DeltaCheckpoint(TxnTimeStamp last_ckp_ts, TxnTimeStamp &max_commit_ts)
     // Finalize current object to ensure PersistenceManager be in a consistent state
     PersistenceManager *pm = InfinityContext::instance().persistence_manager();
     if (pm != nullptr) {
-        pm->CurrentObjFinalize();
+        pm->CurrentObjFinalize(true);
     }
 
     return true;
@@ -563,7 +563,7 @@ void Txn::FullCheckpoint(const TxnTimeStamp max_commit_ts) {
     // Finalize current object to ensure PersistenceManager be in a consistent state
     PersistenceManager *pm = InfinityContext::instance().persistence_manager();
     if (pm != nullptr) {
-        pm->CurrentObjFinalize();
+        pm->CurrentObjFinalize(true);
     }
 }
 

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -544,12 +544,6 @@ bool Txn::DeltaCheckpoint(TxnTimeStamp last_ckp_ts, TxnTimeStamp &max_commit_ts)
     }
     wal_entry_->cmds_.push_back(MakeShared<WalCmdCheckpoint>(max_commit_ts, false, delta_path, delta_name));
 
-    // Finalize current object to ensure PersistenceManager be in a consistent state
-    PersistenceManager *pm = InfinityContext::instance().persistence_manager();
-    if (pm != nullptr) {
-        pm->CurrentObjFinalize(true);
-    }
-
     return true;
 }
 
@@ -559,12 +553,6 @@ void Txn::FullCheckpoint(const TxnTimeStamp max_commit_ts) {
 
     catalog_->SaveFullCatalog(max_commit_ts, full_path, full_name);
     wal_entry_->cmds_.push_back(MakeShared<WalCmdCheckpoint>(max_commit_ts, true, full_path, full_name));
-
-    // Finalize current object to ensure PersistenceManager be in a consistent state
-    PersistenceManager *pm = InfinityContext::instance().persistence_manager();
-    if (pm != nullptr) {
-        pm->CurrentObjFinalize(true);
-    }
 }
 
 } // namespace infinity

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -23,6 +23,7 @@ import status;
 import internal_types;
 import index_base;
 import extra_ddl_info;
+import wal_entry;
 
 namespace infinity {
 
@@ -125,7 +126,7 @@ public:
 
     bool CheckConflict(const TxnTableStore *txn_table_store) const;
 
-    void PrepareCommit1() const;
+    void PrepareCommit1(const Vector<WalSegmentInfo *> &segment_infos) const;
 
     void PrepareCommit(TransactionID txn_id, TxnTimeStamp commit_ts, BufferManager *buffer_mgr);
 

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -407,9 +407,9 @@ AddChunkIndexEntryOp::AddChunkIndexEntryOp(ChunkIndexEntry *chunk_index_entry, T
     switch (index_type) {
         case IndexType::kFullText: {
             String full_path = fmt::format("{}/{}", *chunk_index_entry->base_dir_, *(segment_index_entry->index_dir()));
-            local_paths_.push_back(full_path + chunk_index_entry->base_name_ + POSTING_SUFFIX);
-            local_paths_.push_back(full_path + chunk_index_entry->base_name_ + DICT_SUFFIX);
-            local_paths_.push_back(full_path + chunk_index_entry->base_name_ + LENGTH_SUFFIX);
+            local_paths_.push_back(full_path + "/" + chunk_index_entry->base_name_ + POSTING_SUFFIX);
+            local_paths_.push_back(full_path + "/" + chunk_index_entry->base_name_ + DICT_SUFFIX);
+            local_paths_.push_back(full_path + "/" + chunk_index_entry->base_name_ + LENGTH_SUFFIX);
             break;
         }
         case IndexType::kHnsw:

--- a/src/storage/wal/wal_entry.cpp
+++ b/src/storage/wal/wal_entry.cpp
@@ -923,6 +923,7 @@ String WalCmdOptimize::ToString() const {
     for (auto &param_ptr : params_) {
         ss << param_ptr->ToString() << " | ";
     }
+    ss << std::endl;
     return ss.str();
 }
 
@@ -940,6 +941,7 @@ String WalCmdDumpIndex::ToString() const {
     for (auto &chunk_id : deprecate_ids_) {
         ss << chunk_id << " | ";
     }
+    ss << std::endl;
     return ss.str();
 }
 

--- a/src/storage/wal/wal_entry.cpp
+++ b/src/storage/wal/wal_entry.cpp
@@ -202,10 +202,10 @@ WalChunkIndexInfo::WalChunkIndexInfo(ChunkIndexEntry *chunk_index_entry)
     IndexType index_type = segment_index_entry->table_index_entry()->index_base()->index_type_;
     switch (index_type) {
         case IndexType::kFullText: {
-            String full_path = fmt::format("{}/{}", *chunk_index_entry->base_dir_, *(segment_index_entry->index_dir()));
-            paths_.push_back(full_path + chunk_index_entry->base_name_ + POSTING_SUFFIX);
-            paths_.push_back(full_path + chunk_index_entry->base_name_ + DICT_SUFFIX);
-            paths_.push_back(full_path + chunk_index_entry->base_name_ + LENGTH_SUFFIX);
+            String full_dir = fmt::format("{}/{}", *chunk_index_entry->base_dir_, *(segment_index_entry->index_dir()));
+            paths_.push_back(full_dir + "/" + chunk_index_entry->base_name_ + POSTING_SUFFIX);
+            paths_.push_back(full_dir + "/" + chunk_index_entry->base_name_ + DICT_SUFFIX);
+            paths_.push_back(full_dir + "/" + chunk_index_entry->base_name_ + LENGTH_SUFFIX);
             break;
         }
         case IndexType::kHnsw:

--- a/src/storage/wal/wal_entry.cppm
+++ b/src/storage/wal/wal_entry.cppm
@@ -399,7 +399,7 @@ export struct WalCmdCompact final : public WalCmd {
 
     const String db_name_{};
     const String table_name_{};
-    const Vector<WalSegmentInfo> new_segment_infos_{};
+    Vector<WalSegmentInfo> new_segment_infos_{};
     const Vector<SegmentID> deprecated_segment_ids_{};
 };
 

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -580,7 +580,7 @@ i64 WalManager::ReplayWalFile() {
         last_commit_ts = replay_entries[replay_count]->commit_ts_;
         last_txn_id = replay_entries[replay_count]->txn_id_;
 
-        LOG_INFO(replay_entries[replay_count]->ToString());
+        LOG_DEBUG(replay_entries[replay_count]->ToString());
         ReplayWalEntry(*replay_entries[replay_count]);
     }
 

--- a/src/unit_test/base_test.h
+++ b/src/unit_test/base_test.h
@@ -47,10 +47,9 @@ public:
 public:
     static constexpr const char* NULL_CONFIG_PATH = "";
 
-    static constexpr const char* CONFIG_PATH = "/config/test_vfs.toml";
+    static constexpr const char *CONFIG_PATH = "/config/test.toml";
 
-    static constexpr const char* VFS_CONFIG_PATH = "test/data/config/test_vfs.toml";
-
+    static constexpr const char *VFS_OFF_CONFIG_PATH = "test/data/config/test_vfs_off.toml";
 
 protected:
     const char *GetHomeDir() { return "/var/infinity"; }

--- a/src/unit_test/main/config.cpp
+++ b/src/unit_test/main/config.cpp
@@ -76,7 +76,7 @@ TEST_F(ConfigTest, test2) {
 
     EXPECT_EQ(config.Version(), "0.3.0");
     EXPECT_EQ(config.TimeZone(), "UTC");
-    EXPECT_EQ(config.TimeZoneBias(), -9);
+    EXPECT_EQ(config.TimeZoneBias(), -8);
 
     EXPECT_EQ(config.CPULimit(), 2u);
 
@@ -85,9 +85,9 @@ TEST_F(ConfigTest, test2) {
     EXPECT_EQ(config.HTTPPort(), 24821);
     EXPECT_EQ(config.ClientPort(), 24817);
 
-    EXPECT_EQ(config.LogFileName(), "info.log");
+    EXPECT_EQ(config.LogFileName(), "infinity.log");
     EXPECT_EQ(config.LogDir(), "/var/infinity/log");
-    EXPECT_EQ(config.LogFilePath(), "/var/infinity/log/info.log");
+    EXPECT_EQ(config.LogFilePath(), "/var/infinity/log/infinity.log");
     EXPECT_EQ(config.LogToStdout(), true);
     EXPECT_EQ(config.LogFileMaxSize(), 2 * 1024l * 1024l * 1024l);
     EXPECT_EQ(config.LogFileRotateCount(), 3l);
@@ -99,7 +99,7 @@ TEST_F(ConfigTest, test2) {
     // buffer
     EXPECT_EQ(config.BufferManagerSize(), 3 * 1024l * 1024l * 1024l);
     EXPECT_EQ(config.LRUNum(), 8);
-    EXPECT_EQ(config.TempDir(), "/tmp");
+    EXPECT_EQ(config.TempDir(), "/var/infinity/tmp");
     EXPECT_EQ(config.MemIndexMemoryQuota(), 2 * 1024l * 1024l * 1024l);
 }
 

--- a/src/unit_test/storage/bg_task/background_process.cpp
+++ b/src/unit_test/storage/bg_task/background_process.cpp
@@ -62,7 +62,7 @@ class BGProcessTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          BGProcessTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(BGProcessTest, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/bg_task/cleanup_task.cpp
+++ b/src/unit_test/storage/bg_task/cleanup_task.cpp
@@ -80,7 +80,7 @@ protected:
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          CleanupTaskTest,
                          ::testing::Values((std::string(test_data_path()) + "/config/test_close_bgtask.toml").c_str(),
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                                           (std::string(test_data_path()) + "/config/test_close_bgtask_vfs_off.toml").c_str()));
 
 TEST_P(CleanupTaskTest, test_delete_db_simple) {
     // close auto cleanup task

--- a/src/unit_test/storage/bg_task/compact_segments_task.cpp
+++ b/src/unit_test/storage/bg_task/compact_segments_task.cpp
@@ -110,8 +110,7 @@ protected:
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          CompactTaskTest,
                          ::testing::Values((std::string(test_data_path()) + "/config/test_close_bgtask.toml").c_str(),
-                                           (std::string(test_data_path()) + "/config/test_close_bgtask_vfs.toml").c_str()));
-
+                                           (std::string(test_data_path()) + "/config/test_close_bgtask_vfs_off.toml").c_str()));
 
 class SilentLogTestCompactTaskTest : public CompactTaskTest {
     void SetUp() override {
@@ -134,7 +133,7 @@ class SilentLogTestCompactTaskTest : public CompactTaskTest {
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          SilentLogTestCompactTaskTest,
                          ::testing::Values((std::string(test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                                           (std::string(test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_P(CompactTaskTest, compact_to_single_segment) {
     {

--- a/src/unit_test/storage/binary_fuse_filter/segment_sealing.cpp
+++ b/src/unit_test/storage/binary_fuse_filter/segment_sealing.cpp
@@ -106,9 +106,7 @@ protected:
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          SealingTaskTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
-
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(SealingTaskTest, append_unsealed_segment_sealed) {
     GTEST_SKIP() << "Skipping slow test.";

--- a/src/unit_test/storage/buffer/buffer_handle.cpp
+++ b/src/unit_test/storage/buffer/buffer_handle.cpp
@@ -54,9 +54,7 @@ class BufferHandleTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          BufferHandleTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
-
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(BufferHandleTest, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/bitmask.cpp
+++ b/src/unit_test/storage/column_vector/bitmask.cpp
@@ -53,7 +53,7 @@ class BitmaskTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          BitmaskTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(BitmaskTest, bitmask_a) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/bitmask_buffer.cpp
+++ b/src/unit_test/storage/column_vector/bitmask_buffer.cpp
@@ -55,8 +55,7 @@ class BitmaskBufferTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          BitmaskBufferTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(BitmaskBufferTest, bitmask_buffer_a) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_bool.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_bool.cpp
@@ -70,7 +70,7 @@ class ColumnVectorBoolTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorBoolTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorBoolTest, flat_boolean) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_date_time.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_date_time.cpp
@@ -71,8 +71,7 @@ class ColumnVectorDateTimeTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorDateTimeTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
-
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorDateTimeTest, flat_date) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_decimal.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_decimal.cpp
@@ -72,7 +72,7 @@ class ColumnVectorDecimalTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorDecimalTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorDecimalTest, flat_decimal) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_embedding.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_embedding.cpp
@@ -73,7 +73,7 @@ class ColumnVectorEmbeddingTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorEmbeddingTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorEmbeddingTest, flat_embedding) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_float.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_float.cpp
@@ -71,7 +71,7 @@ class ColumnVectorFloatTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorFloatTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorFloatTest, flat_float) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_geo.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_geo.cpp
@@ -64,7 +64,7 @@ class ColumnVectorGeoTest : public BaseTestParamStr {
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          ColumnVectorGeoTest,
                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                                           (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_P(ColumnVectorGeoTest, flat_point) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_integer.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_integer.cpp
@@ -70,7 +70,7 @@ class ColumnVectorIntegerTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorIntegerTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorIntegerTest, flat_tinyint) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_row.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_row.cpp
@@ -71,7 +71,7 @@ class ColumnVectorRowTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorRowTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorRowTest, flat_row) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_uuid.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_uuid.cpp
@@ -71,7 +71,7 @@ class ColumnVectorUuidTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorUuidTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorUuidTest, flat_uuid) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/column_vector_varchar.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_varchar.cpp
@@ -71,7 +71,7 @@ class ColumnVectorVarcharTest : public BaseTestParamStr {
 // INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 //                          ColumnVectorVarcharTest,
 //                          ::testing::Values((std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent.toml").c_str(),
-//                                            BaseTestParamStr::VFS_CONFIG_PATH));
+//                                            (std::string(infinity::test_data_path()) + "/config/test_close_bgtask_silent_vfs_off.toml").c_str()));
 
 TEST_F(ColumnVectorVarcharTest, flat_inline_varchar) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/selection.cpp
+++ b/src/unit_test/storage/column_vector/selection.cpp
@@ -54,7 +54,7 @@ class SelectionTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          SelectionTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(SelectionTest, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/column_vector/string_chunk.cpp
+++ b/src/unit_test/storage/column_vector/string_chunk.cpp
@@ -53,7 +53,7 @@ class StringChunkTest : public BaseTestParamStr {
 };
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          StringChunkTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 //
 //

--- a/src/unit_test/storage/definition/data_block.cpp
+++ b/src/unit_test/storage/definition/data_block.cpp
@@ -63,14 +63,9 @@ class DataBlockTest : public BaseTestParamStr {
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    DataBlockTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         DataBlockTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(DataBlockTest, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/invertedindex/column_index_merger.cpp
+++ b/src/unit_test/storage/invertedindex/column_index_merger.cpp
@@ -107,14 +107,9 @@ protected:
     String config_path_{};
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    ColumnIndexMergerTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         ColumnIndexMergerTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 void ColumnIndexMergerTest::CreateIndex(const Vector<String>& paragraphs,
                                         const String& index_dir,

--- a/src/unit_test/storage/invertedindex/memory_indexer.cpp
+++ b/src/unit_test/storage/invertedindex/memory_indexer.cpp
@@ -121,14 +121,9 @@ public:
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    MemoryIndexerTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         MemoryIndexerTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(MemoryIndexerTest, Insert) {
     // prepare fake segment index entry

--- a/src/unit_test/storage/invertedindex/posting_merger.cpp
+++ b/src/unit_test/storage/invertedindex/posting_merger.cpp
@@ -65,15 +65,9 @@ protected:
     String config_path_{};
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    PostingMergerTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
-
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         PostingMergerTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 void PostingMergerTest::CreateIndex() {
 

--- a/src/unit_test/storage/invertedindex/posting_writer.cpp
+++ b/src/unit_test/storage/invertedindex/posting_writer.cpp
@@ -53,14 +53,9 @@ protected:
     String config_path_{};
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    PostingWriterTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         PostingWriterTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(PostingWriterTest, test1) {
     Vector<docid_t> expected = {1, 3, 5, 7, 9};

--- a/src/unit_test/storage/invertedindex/search/query_builder.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_builder.cpp
@@ -175,14 +175,9 @@ class QueryBuilderTest : public BaseTestParamStr {
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    QueryBuilderTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         QueryBuilderTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 union FakeQueryBuilder {
     char empty_space[2 * sizeof(QueryBuilder)];

--- a/src/unit_test/storage/invertedindex/search/query_match.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_match.cpp
@@ -99,14 +99,9 @@ public:
     Vector<Vector<String>> datas_;
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    TestWithDifferentParams,
-    QueryMatchTest,
-    ::testing::Values(
-        BaseTestParamStr::NULL_CONFIG_PATH,
-        BaseTestParamStr::VFS_CONFIG_PATH
-    )
-);
+INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
+                         QueryMatchTest,
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 void QueryMatchTest::InitData() {
     datas_ = {

--- a/src/unit_test/storage/invertedindex/search/query_parser_and_optimizer.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_parser_and_optimizer.cpp
@@ -61,7 +61,7 @@ public:
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          QueryParserAndOptimizerTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 struct LogHelper {
     void Reset() {

--- a/src/unit_test/storage/knnindex/ann_ivf/ann_ivf_flat_l2.cpp
+++ b/src/unit_test/storage/knnindex/ann_ivf/ann_ivf_flat_l2.cpp
@@ -55,7 +55,7 @@ class AnnIVFFlatL2Test : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          AnnIVFFlatL2Test,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(AnnIVFFlatL2Test, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/knnindex/merge_optimize/test_optimize.cpp
+++ b/src/unit_test/storage/knnindex/merge_optimize/test_optimize.cpp
@@ -92,7 +92,7 @@ protected:
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          OptimizeKnnTest,
                          ::testing::Values((std::string(test_data_path()) + "/config/test_optimize.toml").c_str(),
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                                           (std::string(test_data_path()) + "/config/test_optimize_vfs_off.toml").c_str()));
 
 TEST_P(OptimizeKnnTest, test1) {
     Storage *storage = InfinityContext::instance().storage();

--- a/src/unit_test/storage/meta/catalog.cpp
+++ b/src/unit_test/storage/meta/catalog.cpp
@@ -77,8 +77,7 @@ class CatalogTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          CatalogTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 // txn1: create db1, get db1, delete db1, get db1, commit
 // txn2:             get db1,             get db1, commit

--- a/src/unit_test/storage/meta/cleanup_scanner.cpp
+++ b/src/unit_test/storage/meta/cleanup_scanner.cpp
@@ -48,7 +48,7 @@ class CleanUpScannerTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          CleanUpScannerTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(CleanUpScannerTest, nonexist_dir_test) {
     String dir = "/nonexist_dir";

--- a/src/unit_test/storage/meta/db_meta.cpp
+++ b/src/unit_test/storage/meta/db_meta.cpp
@@ -52,7 +52,7 @@ class DBMetaTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          DBMetaTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(DBMetaTest, to_string_test) {
     TxnManager *txn_mgr = infinity::InfinityContext::instance().storage()->txn_manager();

--- a/src/unit_test/storage/meta/entry/block_entry.cpp
+++ b/src/unit_test/storage/meta/entry/block_entry.cpp
@@ -52,7 +52,7 @@ protected:
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          BlockVersionTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(BlockVersionTest, SaveAndLoad) {
     BlockVersion block_version(8192);

--- a/src/unit_test/storage/meta/entry/db_entry.cpp
+++ b/src/unit_test/storage/meta/entry/db_entry.cpp
@@ -65,8 +65,7 @@ class DBEntryTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          DBEntryTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(DBEntryTest, decode_index_test){
     String db_name = "untitled_db";

--- a/src/unit_test/storage/meta/entry/segment_entry.cpp
+++ b/src/unit_test/storage/meta/entry/segment_entry.cpp
@@ -74,8 +74,7 @@ class SegmentEntryTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          SegmentEntryTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 void CreateTable();
 void CreateIndex();

--- a/src/unit_test/storage/meta/entry/table_collection_entry.cpp
+++ b/src/unit_test/storage/meta/entry/table_collection_entry.cpp
@@ -74,9 +74,7 @@ class TableEntryTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          TableEntryTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
-
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(TableEntryTest, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/meta/entry/table_entry.cpp
+++ b/src/unit_test/storage/meta/entry/table_entry.cpp
@@ -118,8 +118,7 @@ void InsertData(const String& db_name, const String& table_name) {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          TableEntryTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(TableEntryTest, decode_index_test){
     TxnManager *txn_mgr = infinity::InfinityContext::instance().storage()->txn_manager();

--- a/src/unit_test/storage/meta/entry/table_index_entry.cpp
+++ b/src/unit_test/storage/meta/entry/table_index_entry.cpp
@@ -73,8 +73,7 @@ class TableIndexEntryTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          TableIndexEntryTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 void InsertData(const String& db_name, const String& table_name);
 

--- a/src/unit_test/storage/meta/table_index_meta.cpp
+++ b/src/unit_test/storage/meta/table_index_meta.cpp
@@ -63,8 +63,7 @@ class TableIndexMetaTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          TableIndexMetaTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(TableIndexMetaTest, get_all_entries_test) {
     using namespace infinity;

--- a/src/unit_test/storage/meta/table_meta.cpp
+++ b/src/unit_test/storage/meta/table_meta.cpp
@@ -62,8 +62,7 @@ class TableMetaTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          TableMetaTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(TableMetaTest, to_string_test) {
     using namespace infinity;

--- a/src/unit_test/storage/txn/database_txn.cpp
+++ b/src/unit_test/storage/txn/database_txn.cpp
@@ -61,8 +61,7 @@ class DBTxnTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          DBTxnTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 TEST_P(DBTxnTest, test1) {
     using namespace infinity;

--- a/src/unit_test/storage/txn/table_txn.cpp
+++ b/src/unit_test/storage/txn/table_txn.cpp
@@ -65,8 +65,7 @@ class TableTxnTest : public BaseTestParamStr {
 
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
                          TableTxnTest,
-                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH,
-                                           BaseTestParamStr::VFS_CONFIG_PATH));
+                         ::testing::Values(BaseTestParamStr::NULL_CONFIG_PATH, BaseTestParamStr::VFS_OFF_CONFIG_PATH));
 
 using namespace infinity;
 

--- a/src/unit_test/storage/wal/catalog_delta_replay.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_replay.cpp
@@ -63,7 +63,7 @@ public:
         system(("mkdir -p " + String(GetFullTmpDir())).c_str());
         config_path = GetParam() == BaseTestParamStr::NULL_CONFIG_PATH
                           ? MakeShared<String>(std::string(test_data_path()) + "/config/test_close_bgtask.toml")
-                          : MakeShared<String>(std::string(test_data_path()) + "/config/test_close_bgtask_vfs.toml");
+                          : MakeShared<String>(std::string(test_data_path()) + "/config/test_close_bgtask_vfs_off.toml");
     }
 
     SharedPtr<String> config_path{};

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -60,7 +60,7 @@ protected:
     static std::shared_ptr<std::string> config_path() {
         return GetParam() == BaseTestParamStr::NULL_CONFIG_PATH
                    ? std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_bgtask.toml")
-                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_bgtask_vfs.toml");
+                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_bgtask_vfs_off.toml");
     }
 
     void SetUp() override {

--- a/src/unit_test/storage/wal/recycle_log.cpp
+++ b/src/unit_test/storage/wal/recycle_log.cpp
@@ -38,7 +38,7 @@ protected:
     static std::shared_ptr<std::string> test_ckp_recycle_config() {
         return GetParam() == BaseTestParamStr::NULL_CONFIG_PATH
                    ? std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp.toml")
-                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp_vfs.toml");
+                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp_vfs_off.toml");
     }
 
     void SetUp() override {

--- a/src/unit_test/storage/wal/repeat_replay.cpp
+++ b/src/unit_test/storage/wal/repeat_replay.cpp
@@ -52,7 +52,7 @@ protected:
     static std::shared_ptr<std::string> close_ckp_config() {
         return GetParam() == BaseTestParamStr::NULL_CONFIG_PATH
                    ? std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp.toml")
-                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp_vfs.toml");
+                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp_vfs_off.toml");
     }
 
     void SetUp() override {

--- a/src/unit_test/storage/wal/wal_entry.cpp
+++ b/src/unit_test/storage/wal/wal_entry.cpp
@@ -277,8 +277,10 @@ TEST_F(WalEntryTest, ReadWriteVFS) {
     String data_dir = "data_dir";
     SizeT object_size_limit = 100;
     PersistenceManager pm(workspace, data_dir, object_size_limit);
-    ObjAddr obj_addr1{.obj_key_ = "key1", .part_offset_ = 0, .part_size_ = 10};
-    pm.SaveLocalPath(paths[0], obj_addr1);
+    ObjAddr obj_addr0{.obj_key_ = "key1", .part_offset_ = 0, .part_size_ = 10};
+    ObjAddr obj_addr1{.obj_key_ = "key1", .part_offset_ = 10, .part_size_ = 20};
+    pm.SaveLocalPath(paths[0], obj_addr0);
+    pm.SaveLocalPath(paths[1], obj_addr1);
 
     AddrSerializer addr_serializer;
     addr_serializer.Initialize(&pm, paths);

--- a/src/unit_test/storage/wal/wal_replay.cpp
+++ b/src/unit_test/storage/wal/wal_replay.cpp
@@ -67,7 +67,7 @@ protected:
     static std::shared_ptr<std::string> config_path() {
         return GetParam() == BaseTestParamStr::NULL_CONFIG_PATH
                    ? std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp.toml")
-                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp_vfs.toml");
+                   : std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_ckp_vfs_off.toml");
     }
 
     void SetUp() override {

--- a/test/data/config/infinity_conf.toml
+++ b/test/data/config/infinity_conf.toml
@@ -1,6 +1,6 @@
 [general]
 version                 = "0.3.0"
-time_zone                = "utc-9"
+time_zone               = "utc-8"
 cpu_limit               = 2
 
 [network]
@@ -11,10 +11,10 @@ client_port             = 24817
 connection_pool_size    = 128
 
 [log]
-log_filename            = "info.log"
+log_filename            = "infinity.log"
 log_dir                 = "/var/infinity/log"
 log_to_stdout           = true
-log_file_max_size            = "2GB"
+log_file_max_size       = "2GB"
 log_file_rotate_count   = 3
 
 # trace/debug/info/warning/error/critical 6 log levels, default: info
@@ -24,9 +24,9 @@ log_level               = "trace"
 persistence_dir         = "/var/infinity/persistence"
 
 [buffer]
-buffer_manager_size        = "3GB"
-lru_num                  = 8
-temp_dir                = "/tmp"
+buffer_manager_size     = "3GB"
+lru_num                 = 8
+temp_dir                = "/var/infinity/tmp"
 memindex_memory_quota   = "2GB"
 
 [wal]

--- a/test/data/config/infinity_conf.toml
+++ b/test/data/config/infinity_conf.toml
@@ -21,7 +21,7 @@ log_file_rotate_count   = 3
 log_level               = "trace"
 
 [storage]
-data_dir                = "/var/infinity/data"
+persistence_dir         = "/var/infinity/persistence"
 
 [buffer]
 buffer_manager_size        = "3GB"
@@ -34,5 +34,3 @@ wal_dir                 = "/var/infinity/wal"
 
 [resource]
 resource_dir          = "/var/infinity/resource"
-
-[persistence]

--- a/test/data/config/restart_test/test_fulltext/1.toml
+++ b/test/data/config/restart_test/test_fulltext/1.toml
@@ -13,5 +13,3 @@ mem_index_capacity = 1048576
 [wal]
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_fulltext/2.toml
+++ b/test/data/config/restart_test/test_fulltext/2.toml
@@ -14,5 +14,3 @@ optimize_interval = "0s"
 mem_index_capacity = 10000
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_fulltext/3.toml
+++ b/test/data/config/restart_test/test_fulltext/3.toml
@@ -14,5 +14,3 @@ optimize_interval = "1s"
 mem_index_capacity = 10000
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_insert/1.toml
+++ b/test/data/config/restart_test/test_insert/1.toml
@@ -14,5 +14,3 @@ delta_checkpoint_interval = "0s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_insert/2.toml
+++ b/test/data/config/restart_test/test_insert/2.toml
@@ -14,5 +14,3 @@ delta_checkpoint_interval = "1s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_memidx/1.toml
+++ b/test/data/config/restart_test/test_memidx/1.toml
@@ -18,5 +18,3 @@ delta_checkpoint_interval = "0s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_memidx/2.toml
+++ b/test/data/config/restart_test/test_memidx/2.toml
@@ -18,5 +18,3 @@ delta_checkpoint_interval = "3s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/restart_test/test_memidx/3.toml
+++ b/test/data/config/restart_test/test_memidx/3.toml
@@ -18,5 +18,3 @@ delta_checkpoint_interval = "0s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/test.toml
+++ b/test/data/config/test.toml
@@ -10,7 +10,6 @@ log_filename             = "infinity.log"
 log_dir                  = "/var/infinity/log"
 
 [storage]
-data_dir                 = "/var/infinity/data"
 
 [buffer]
 buffer_manager_size      = "8GB"
@@ -21,6 +20,3 @@ wal_dir                  = "/var/infinity/wal"
 
 [resource]
 resource_dir             = "/var/infinity/resource"
-
-[persistence]
-persistence_dir          = "/var/infinity/persistence"

--- a/test/data/config/test_buffer_obj.toml
+++ b/test/data/config/test_buffer_obj.toml
@@ -22,5 +22,3 @@ buffer_manager_size = "512kb"
 temp_dir         = "/var/infinity/tmp"
 
 [resource]
-
-[persistence]

--- a/test/data/config/test_buffer_obj_2.toml
+++ b/test/data/config/test_buffer_obj_2.toml
@@ -22,5 +22,3 @@ buffer_manager_size = "32mb"
 temp_dir         = "/var/infinity/tmp"
 
 [resource]
-
-[persistence]

--- a/test/data/config/test_cleanup_task_silent_vfs_off.toml
+++ b/test/data/config/test_cleanup_task_silent_vfs_off.toml
@@ -4,23 +4,19 @@ time_zone = "utc-8"
 
 [network]
 [log]
+log_level = "critical"
 
 [storage]
-# close auto optimize
-optimize_interval = "0s"
+data_dir = "/var/infinity/data"
 # close auto cleanup task
 cleanup_interval = "0s"
-# close auto compaction
+# close auto compact
 compact_interval = "0s"
 
 [buffer]
 [wal]
-# close delta checkpoint
-delta_checkpoint_interval = "0s"
 # close full checkpoint
 full_checkpoint_interval = "0s"
-
+#short checkpoint interval to allow quick cleanup
+delta_checkpoint_interval = "1s"
 [resource]
-
-[persistence]
-persistence_dir           = "/var/infinity/persistence"

--- a/test/data/config/test_close_bgtask.toml
+++ b/test/data/config/test_close_bgtask.toml
@@ -21,5 +21,3 @@ delta_checkpoint_interval = "0s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/test_close_bgtask_vfs_off.toml
+++ b/test/data/config/test_close_bgtask_vfs_off.toml
@@ -4,9 +4,9 @@ time_zone = "utc-8"
 
 [network]
 [log]
-log_level = "critical"
 
 [storage]
+data_dir = "/var/infinity/data"
 # close auto optimize
 optimize_interval = "0s"
 # close auto cleanup task

--- a/test/data/config/test_close_ckp.toml
+++ b/test/data/config/test_close_ckp.toml
@@ -14,4 +14,3 @@ wal_compact_threshold            = "10KB"
 [storage]
 [buffer]
 [resource]
-[persistence]

--- a/test/data/config/test_close_ckp_vfs_off.toml
+++ b/test/data/config/test_close_ckp_vfs_off.toml
@@ -12,7 +12,7 @@ full_checkpoint_interval = "0s"
 wal_compact_threshold            = "10KB"
 
 [storage]
+data_dir          = "/var/infinity/persistence"
+
 [buffer]
 [resource]
-[persistence]
-persistence_dir          = "/var/infinity/persistence"

--- a/test/data/config/test_conf_invalid_bytesize.toml
+++ b/test/data/config/test_conf_invalid_bytesize.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_invalid_log_level.toml
+++ b/test/data/config/test_conf_invalid_log_level.toml
@@ -20,6 +20,7 @@ log_level                = "invalid_level"  # Changed to "invalid_level"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_invalid_param.toml
+++ b/test/data/config/test_conf_invalid_param.toml
@@ -24,6 +24,7 @@ log_1evel               = "tracewrong"
 
 [st0rage]
 data_dir                = "/var/infinity/datawrong"
+persistence_dirrr       = "/var/infinity/persistencewrong"
 
 [bufferrrr]
 buffer_mAnager_size        = "50GB"
@@ -36,6 +37,3 @@ wa1_dir                 = "/var/infinity/wawrong"
 
 [resourCEEe]
 resource_dffir          = "/var/infinity/resourcewrong"
-
-[persistence]
-persistence_dirrr       = "/var/infinity/persistencewrong"

--- a/test/data/config/test_conf_invalid_server_address.toml
+++ b/test/data/config/test_conf_invalid_server_address.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_invalid_timeinfo.toml
+++ b/test/data/config/test_conf_invalid_timeinfo.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "1day"  # Changed to "1day"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_invalid_timezone.toml
+++ b/test/data/config/test_conf_invalid_timezone.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_invalid_version.toml
+++ b/test/data/config/test_conf_invalid_version.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_out_of_bound_bytesize.toml
+++ b/test/data/config/test_conf_out_of_bound_bytesize.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_out_of_bound_number.toml
+++ b/test/data/config/test_conf_out_of_bound_number.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_out_of_bound_timeinfo.toml
+++ b/test/data/config/test_conf_out_of_bound_timeinfo.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "721h"  # Changed to "721h"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_out_of_bound_timezone.toml
+++ b/test/data/config/test_conf_out_of_bound_timezone.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_out_of_bound_walflush.toml
+++ b/test/data/config/test_conf_out_of_bound_walflush.toml
@@ -20,6 +20,7 @@ log_level                = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "invalid"  # Changed to "invalid"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir               = "/var/infinity/persistence"

--- a/test/data/config/test_conf_valid_value.toml
+++ b/test/data/config/test_conf_valid_value.toml
@@ -21,6 +21,7 @@ log_level               = "info"
 
 [storage]
 data_dir                 = "/var/infinity/data"
+persistence_dir          = "/var/infinity/persistence"
 
 optimize_interval        = "10s"
 cleanup_interval         = "60s"
@@ -44,6 +45,3 @@ wal_flush                     = "only_write"
 
 [resource]
 resource_dir                  = "/var/infinity/resource"
-
-[persistence]
-persistence_dir       = "/var/infinity/persistence"

--- a/test/data/config/test_optimize.toml
+++ b/test/data/config/test_optimize.toml
@@ -14,4 +14,3 @@ compact_interval = "0s"
 [wal]
 [buffer]
 [resource]
-[persistence]

--- a/test/data/config/test_optimize_vfs_off.toml
+++ b/test/data/config/test_optimize_vfs_off.toml
@@ -4,16 +4,14 @@ time_zone = "utc-8"
 
 [network]
 [log]
-log_to_stdout = true
 
 [storage]
+data_dir = "/var/infinity/data"
+# close auto optimize
 optimize_interval = "0s"
-cleanup_interval = "1s"
+# close auto compaction
 compact_interval = "0s"
 
-[buffer]
 [wal]
-delta_checkpoint_interval = "1s"
-full_checkpoint_interval = "0s"
-
+[buffer]
 [resource]

--- a/test/data/config/test_tracer.toml
+++ b/test/data/config/test_tracer.toml
@@ -26,5 +26,3 @@ delta_checkpoint_interval = "0s"
 full_checkpoint_interval = "0s"
 
 [resource]
-
-[persistence]

--- a/test/data/config/test_vfs_off.toml
+++ b/test/data/config/test_vfs_off.toml
@@ -10,7 +10,7 @@ log_filename             = "infinity.log"
 log_dir                  = "/var/infinity/log"
 
 [storage]
-persistence_dir          = "/var/infinity/persistence"
+data_dir                 = "/var/infinity/data"
 
 [buffer]
 buffer_manager_size      = "8GB"

--- a/tools/run_http_api.py
+++ b/tools/run_http_api.py
@@ -12,20 +12,23 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     print("python test path is {}".format(python_test_dir))
     # run test
     print(f"start pysdk test with {pytest_mark}")
+    args = [
+        python_executable,
+        "-m",
+        "pytest",
+        # "--capture=tee-sys",
+        "--tb=short",
+        "-x",
+        "-m",
+        pytest_mark,
+        f"{python_test_dir}/test_pysdk",
+        "--http",
+    ]
+    quoted_args = ['"' + arg + '"' if " " in arg else arg for arg in args]
+    print(" ".join(quoted_args))
 
     process = subprocess.Popen(
-        # ["python", "-m", "pytest", "--tb=short", '-s', '-x', '-m', pytest_mark, f'{python_test_dir}/test'],
-        [
-            python_executable,
-            "-m",
-            "pytest",
-            "--tb=short",
-            "-x",
-            "-m",
-            pytest_mark,
-            f"{python_test_dir}/test_pysdk",
-            "--http",
-        ],
+        args,
         stdout=sys.stdout,
         stderr=sys.stderr,
         universal_newlines=True,

--- a/tools/run_parallel_test.py
+++ b/tools/run_parallel_test.py
@@ -9,9 +9,22 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     print("python test path is {}".format(python_test_dir))
     # run test
     print(f"start pysdk test with {pytest_mark}")
+    args = [
+        "python",
+        "-m",
+        "pytest",
+        # "--capture=tee-sys",
+        "--tb=short",
+        "-x",
+        "-m",
+        pytest_mark,
+        f"{python_test_dir}/parallel_test",
+    ]
+    quoted_args = ['"' + arg + '"' if " " in arg else arg for arg in args]
+    print(" ".join(quoted_args))
+
     process = subprocess.Popen(
-        # ["python", "-m", "pytest", "--tb=short", '-s', '-x', '-m', pytest_mark, f'{python_test_dir}/test'],
-        ["python", "-m", "pytest", "--tb=short", '-x', '-m', pytest_mark, f'{python_test_dir}/parallel_test'],
+        args,
         stdout=sys.stdout,
         stderr=sys.stderr,
         universal_newlines=True,
@@ -23,7 +36,6 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     print("pysdk test finished.")
 
 
-
 if __name__ == "__main__":
     print("Note: this script must be run under root directory of the project.")
     current_path = os.getcwd()
@@ -33,7 +45,7 @@ if __name__ == "__main__":
         "-m",
         "--pytest_mark",
         type=str,
-        default='not complex and not slow',
+        default="not complex and not slow",
         dest="pytest_mark",
     )
     args = parser.parse_args()

--- a/tools/run_parallel_test_continuous.py
+++ b/tools/run_parallel_test_continuous.py
@@ -17,11 +17,11 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     begin_time = time.time()
     while time.time() - begin_time < 8 * 3600:
         process = subprocess.Popen(
-            # ["python", "-m", "pytest", "--tb=short", '-s', '-x', '-m', pytest_mark, f'{python_test_dir}/test'],
             [
                 python_executable,
                 "-m",
                 "pytest",
+                "--capture=tee-sys",
                 "--tb=short",
                 "-x",
                 "-m",

--- a/tools/run_pysdk_local_infinity_test.py
+++ b/tools/run_pysdk_local_infinity_test.py
@@ -12,20 +12,23 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     print("python test path is {}".format(python_test_dir))
     # run test
     print(f"start pysdk test with {pytest_mark}")
+    args = [
+        python_executable,
+        "-m",
+        "pytest",
+        # "--capture=tee-sys",
+        "--tb=short",
+        "-x",
+        "-m",
+        pytest_mark,
+        f"{python_test_dir}/test_pysdk",
+        "--local-infinity",
+    ]
+    quoted_args = ['"' + arg + '"' if " " in arg else arg for arg in args]
+    print(" ".join(quoted_args))
 
     process = subprocess.Popen(
-        # ["python", "-m", "pytest", "--tb=short", '-s', '-x', '-m', pytest_mark, f'{python_test_dir}/test'],
-        [
-            python_executable,
-            "-m",
-            "pytest",
-            "--tb=short",
-            "-x",
-            "-m",
-            pytest_mark,
-            f"{python_test_dir}/test_pysdk",
-            "--local-infinity",
-        ],
+        args,
         stdout=sys.stdout,
         stderr=sys.stderr,
         universal_newlines=True,

--- a/tools/run_pysdk_remote_infinity_test.py
+++ b/tools/run_pysdk_remote_infinity_test.py
@@ -12,18 +12,22 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     print("python test path is {}".format(python_test_dir))
     # run test
     print(f"start pysdk test with {pytest_mark}")
+    args = [
+        python_executable,
+        "-m",
+        "pytest",
+        # "--capture=tee-sys",
+        "--tb=short",
+        "-x",
+        "-m",
+        pytest_mark,
+        f"{python_test_dir}/test_pysdk",
+    ]
+    quoted_args = ['"' + arg + '"' if " " in arg else arg for arg in args]
+    print(" ".join(quoted_args))
+
     process = subprocess.Popen(
-        # ["python", "-m", "pytest", "--tb=short", '-s', '-x', '-m', pytest_mark, f'{python_test_dir}/test'],
-        [
-            python_executable,
-            "-m",
-            "pytest",
-            "--tb=short",
-            "-x",
-            "-m",
-            pytest_mark,
-            f"{python_test_dir}/test_pysdk",
-        ],
+        args,
         stdout=sys.stdout,
         stderr=sys.stderr,
         universal_newlines=True,

--- a/tools/run_restart_test.py
+++ b/tools/run_restart_test.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
             python_executable,
             "-m",
             "pytest",
+            # "--capture=tee-sys",
             f"{python_test_dir}/restart_test",
             f"--infinity_path={infinity_path}",
             "-m",

--- a/tools/run_slow_test.py
+++ b/tools/run_slow_test.py
@@ -12,18 +12,21 @@ def python_sdk_test(python_test_dir: str, pytest_mark: str):
     print("python test path is {}".format(python_test_dir))
     # run test
     print(f"start pysdk test with {pytest_mark}")
+    args = [
+        python_executable,
+        "-m",
+        "pytest",
+        "--tb=short",
+        "-x",
+        "-m",
+        pytest_mark,
+        f"{python_test_dir}",
+    ]
+    quoted_args = ['"' + arg + '"' if " " in arg else arg for arg in args]
+    print(" ".join(quoted_args))
+
     process = subprocess.Popen(
-        # ["python", "-m", "pytest", "--tb=short", '-s', '-x', '-m', pytest_mark, f'{python_test_dir}/test'],
-        [
-            python_executable,
-            "-m",
-            "pytest",
-            "--tb=short",
-            "-x",
-            "-m",
-            pytest_mark,
-            f"{python_test_dir}",
-        ],
+        args,
         stdout=sys.stdout,
         stderr=sys.stderr,
         universal_newlines=True,


### PR DESCRIPTION
Enable vfs by default.
Disable vfs only if `data_dir` is not empty and `persistence_dir` is empty.

### Type of change

- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Documentation Update
- [x] Test cases
