### PR TITLE
Fix mem tracer

### DIFF
--- a/src/executor/operator/physical_show.cpp
+++ b/src/executor/operator/physical_show.cpp
@@ -4605,7 +4605,8 @@ void PhysicalShow::ExecuteShowMemIndex(QueryContext *query_context, ShowOperator
     SizeT row_count = 0;
 
     BGMemIndexTracer *mem_index_tracer = query_context->storage()->memindex_tracer();
-    Vector<MemIndexTracerInfo> mem_index_tracer_info_array = mem_index_tracer->GetMemIndexTracerInfo();
+    Txn *txn = query_context->GetTxn();
+    Vector<MemIndexTracerInfo> mem_index_tracer_info_array = mem_index_tracer->GetMemIndexTracerInfo(txn);
     for (const auto &memindex_tracer_info : mem_index_tracer_info_array) {
         if (output_block_ptr.get() == nullptr) {
             output_block_ptr = DataBlock::MakeUniquePtr();

--- a/src/storage/bg_task/bg_task.cpp
+++ b/src/storage/bg_task/bg_task.cpp
@@ -14,27 +14,12 @@
 
 module;
 
-export module base_memindex;
+module bg_task;
 
-import stl;
-import memindex_tracer;
-import infinity_context;
+import base_memindex;
 
 namespace infinity {
 
-class TableIndexEntry;
-
-export class BaseMemIndex {
-public:
-    virtual MemIndexTracerInfo GetInfo() const = 0;
-
-    virtual TableIndexEntry *table_index_entry() const = 0;
-
-protected:
-    void AddMemUsed(SizeT mem) {
-        auto *memindex_tracer = InfinityContext::instance().storage()->memindex_tracer();
-        memindex_tracer->AddMemUsed(mem);
-    }
-};
+DumpIndexTask::DumpIndexTask(BaseMemIndex *mem_index, Txn *txn) : BGTask(BGTaskType::kDumpIndex, true), mem_index_(mem_index), txn_(txn) {}
 
 } // namespace infinity

--- a/src/storage/bg_task/bg_task.cppm
+++ b/src/storage/bg_task/bg_task.cppm
@@ -39,6 +39,8 @@ export enum class BGTaskType {
     kInvalid
 };
 
+class BaseMemIndex;
+
 export struct BGTask {
     BGTask(BGTaskType type, bool async) : type_(type), async_(async) {}
 
@@ -169,20 +171,15 @@ public:
 
 export class DumpIndexTask final : public BGTask {
 public:
-    DumpIndexTask(i64 id, SharedPtr<String> db_name, SharedPtr<String> table_name, SharedPtr<String> index_name)
-        : BGTask(BGTaskType::kDumpIndex, true), task_id_(id), db_name_(db_name), table_name_(table_name), index_name_(index_name) {}
+    DumpIndexTask(BaseMemIndex *mem_index, Txn *txn);
 
     ~DumpIndexTask() override = default;
 
-    String ToString() const override {
-        return fmt::format("DumpIndexTask, index: {}, table: {}, db: {}", index_name_->c_str(), table_name_->c_str(), db_name_->c_str());
-    }
+    String ToString() const override { return "DumpIndexTask"; }
 
 public:
-    i64 task_id_{};
-    SharedPtr<String> db_name_;
-    SharedPtr<String> table_name_;
-    SharedPtr<String> index_name_;
+    BaseMemIndex *mem_index_{};
+    Txn *txn_{};
 };
 
 } // namespace infinity

--- a/src/storage/knn_index/knn_hnsw/abstract_hnsw.cppm
+++ b/src/storage/knn_index/knn_hnsw/abstract_hnsw.cppm
@@ -41,6 +41,7 @@ import infinity_context;
 import logger;
 import base_memindex;
 import memindex_tracer;
+import table_index_entry;
 
 namespace infinity {
 
@@ -182,6 +183,8 @@ public:
     const AbstractHnsw &get() const { return hnsw_; }
 
     AbstractHnsw *get_ptr() { return &hnsw_; }
+
+    TableIndexEntry *table_index_entry() const override;
 
 protected:
     MemIndexTracerInfo GetInfo() const override;

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -1011,6 +1011,11 @@ ChunkIndexEntry *SegmentIndexEntry::RebuildChunkIndexEntries(TxnTableStore *txn_
     return merged_chunk_index_entry.get();
 }
 
+BaseMemIndex *SegmentIndexEntry::GetMemIndex() const {
+    // only support hnsw index now.
+    return static_cast<BaseMemIndex *>(memory_hnsw_index_.get());
+}
+
 void SegmentIndexEntry::SaveIndexFile() {
     String &index_name = *table_index_entry_->index_dir();
     u64 segment_id = this->segment_id_;

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -49,6 +49,7 @@ class HnswIndexInMem;
 class SecondaryIndexInMem;
 class EMVBIndexInMem;
 class BMPIndexInMem;
+class BaseMemIndex;
 
 export struct PopulateEntireConfig {
     bool prepare_;
@@ -177,6 +178,8 @@ public:
                                   Vector<ChunkIndexEntry *> old_chunks);
 
     ChunkIndexEntry *RebuildChunkIndexEntries(TxnTableStore *txn_table_store, SegmentEntry *segment_entry);
+
+    BaseMemIndex *GetMemIndex() const;
 
     Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<MemoryIndexer>> GetFullTextIndexSnapshot() {
         std::shared_lock lock(rw_locker_);

--- a/src/storage/meta/entry/table_entry.cppm
+++ b/src/storage/meta/entry/table_entry.cppm
@@ -136,6 +136,8 @@ public:
 
     TableIndexEntry *GetIndexReplay(const String &index_name, TransactionID txn_id, TxnTimeStamp begin_ts);
 
+    Vector<TableIndexEntry *> TableIndexes(TransactionID txn_id, TxnTimeStamp begin_ts);
+
     void AddSegmentReplayWalImport(SharedPtr<SegmentEntry> segment_entry);
 
     void AddSegmentReplayWalCompact(SharedPtr<SegmentEntry> segment_entry);

--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -258,6 +258,13 @@ SharedPtr<TableIndexEntry> TableIndexEntry::Deserialize(const nlohmann::json &in
     return table_index_entry;
 }
 
+BaseMemIndex *TableIndexEntry::GetMemIndex() const {
+    if (last_segment_.get() == nullptr) {
+        return nullptr;
+    }
+    return last_segment_->GetMemIndex();
+}
+
 void TableIndexEntry::MemIndexCommit() {
     if (last_segment_.get() != nullptr) {
         last_segment_->MemIndexCommit();

--- a/src/storage/meta/entry/table_index_entry.cppm
+++ b/src/storage/meta/entry/table_index_entry.cppm
@@ -45,6 +45,7 @@ struct TableEntry;
 struct SegmentEntry;
 class BaseTableRef;
 class AddTableIndexEntryOp;
+class BaseMemIndex;
 
 export struct SegmentIndexesGuard {
     const Map<SegmentID, SharedPtr<SegmentIndexEntry>> &index_by_segment_;
@@ -93,6 +94,8 @@ public:
 public:
     // Getter
     const SharedPtr<String> &GetIndexName() const { return index_base_->index_name_; }
+
+    BaseMemIndex *GetMemIndex() const;
 
     inline TableIndexMeta *table_index_meta() { return table_index_meta_; }
     inline const IndexBase *index_base() const { return index_base_.get(); }

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -59,7 +59,6 @@ void Storage::Init() {
                                             MakeShared<String>(config_ptr_->TempDir()),
                                             config_ptr_->LRUNum());
     buffer_mgr_->Start();
-    memory_index_tracer_ = MakeUnique<BGMemIndexTracer>(config_ptr_->MemIndexMemoryQuota());
 
     // Construct wal manager
     wal_mgr_ = MakeUnique<WalManager>(this,
@@ -126,6 +125,7 @@ void Storage::Init() {
 
         periodic_trigger_thread_->Start();
     }
+    memory_index_tracer_ = MakeUnique<BGMemIndexTracer>(config_ptr_->MemIndexMemoryQuota(), new_catalog_.get(), txn_mgr_.get());
 }
 
 void Storage::UnInit() {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -91,6 +91,8 @@ void Storage::Init() {
     // start WalManager after TxnManager since it depends on TxnManager.
     wal_mgr_->Start();
 
+    memory_index_tracer_ = MakeUnique<BGMemIndexTracer>(config_ptr_->MemIndexMemoryQuota(), new_catalog_.get(), txn_mgr_.get());
+
     new_catalog_->StartMemoryIndexCommit();
     new_catalog_->MemIndexRecover(buffer_mgr_.get(), system_start_ts);
 
@@ -125,7 +127,6 @@ void Storage::Init() {
 
         periodic_trigger_thread_->Start();
     }
-    memory_index_tracer_ = MakeUnique<BGMemIndexTracer>(config_ptr_->MemIndexMemoryQuota(), new_catalog_.get(), txn_mgr_.get());
 }
 
 void Storage::UnInit() {

--- a/src/unit_test/storage/tracer/test_tracer.cpp
+++ b/src/unit_test/storage/tracer/test_tracer.cpp
@@ -22,6 +22,8 @@ import bg_task;
 import blocking_queue;
 import third_party;
 import logger;
+import txn;
+import table_index_entry;
 
 using namespace infinity;
 
@@ -37,6 +39,8 @@ public:
         std::lock_guard lck(mtx_);
         return MemIndexTracerInfo(index_name_, table_name_, db_name_, mem_used_, row_count_);
     }
+
+    TableIndexEntry *table_index_entry() const override { return nullptr; }
 
     void AddMemUsed(SizeT usage, SizeT row_cnt);
 
@@ -71,6 +75,8 @@ private:
     TestMemIndex *GetMemIndexInner(const String &index_name);
 
 public:
+    Vector<BaseMemIndex *> GetMemIndexes();
+
     TestMemIndex *GetMemIndex(const String &index_name);
 
     void AppendMemIndex(const String &index_name, SizeT mem_used, SizeT row_cnt);
@@ -79,10 +85,7 @@ public:
 
     bool CleanupIndex(const String &index_name);
 
-    void reset() {
-        std::lock_guard lck(mtx_);
-        memindexes_.clear();
-    }
+    void reset() { memindexes_.clear(); }
 
 private:
     TestMemIndexTracer *tracer_;
@@ -90,6 +93,14 @@ private:
     std::mutex mtx_;
     HashMap<String, UniquePtr<TestMemIndex>> memindexes_;
 };
+
+Vector<BaseMemIndex *> TestCatalog::GetMemIndexes() {
+    Vector<BaseMemIndex *> ret;
+    for (auto &iter : memindexes_) {
+        ret.push_back(iter.second.get());
+    }
+    return ret;
+}
 
 TestMemIndex *TestCatalog::GetMemIndexInner(const String &index_name) {
     auto iter = memindexes_.find(index_name);
@@ -143,10 +154,15 @@ public:
     virtual ~TestMemIndexTracer() {
         task_queue_.Enqueue(nullptr);
         dump_thread_.join();
+        catalog_.reset();
         EXPECT_EQ(this->cur_index_memory(), 0ul);
     }
 
     void TriggerDump(UniquePtr<DumpIndexTask> task) override { task_queue_.Enqueue(std::move(task)); }
+
+    Txn *GetTxn() override { return nullptr; }
+
+    Vector<BaseMemIndex *> GetAllMemIndexes(Txn *txn) override { return catalog_.GetMemIndexes(); }
 
     void HandleDump(UniquePtr<DumpIndexTask> task);
 
@@ -165,14 +181,11 @@ TestMemIndex::TestMemIndex(SharedPtr<String> index_name, TestMemIndexTracer *tra
     db_name_ = MakeShared<String>("test_db");
     table_name_ = MakeShared<String>("test_table");
     index_name_ = index_name;
-    if (trace_) {
-        tracer_->RegisterMemIndex(this);
-    }
 }
 
 TestMemIndex::~TestMemIndex() {
     if (trace_) {
-        tracer_->UnregisterMemIndex(this, mem_used_);
+        tracer_->DecreaseMemUsed(mem_used_);
     }
 }
 
@@ -186,15 +199,17 @@ void TestMemIndex::AddMemUsed(SizeT usage, SizeT row_cnt) {
 }
 
 void TestMemIndexTracer::HandleDump(UniquePtr<DumpIndexTask> task) {
-    if (task->task_id_ % 4 != 0 || !may_fail_) { // success dump
+    auto *mem_index = static_cast<TestMemIndex *>(task->mem_index_);
+    static int dump_id = 0;
+    if ((dump_id++) % 4 != 0 || !may_fail_) { // success dump
         SizeT dumped_size = 0;
         SizeT row_cnt = 0;
-        bool res = catalog_.DumpMemIndex(*task->index_name_, dumped_size, row_cnt);
+        bool res = catalog_.DumpMemIndex(*mem_index->index_name_, dumped_size, row_cnt);
         if (res) {
-            this->DumpDone(dumped_size, task->task_id_);
+            this->DumpDone(dumped_size, mem_index);
         }
     } else { // fail dump
-        this->DumpFail(task->task_id_);
+        this->DumpFail(mem_index);
     }
 }
 
@@ -220,7 +235,6 @@ TEST_F(MemIndexTracerTest, test1) {
     catalog.AppendMemIndex("idx1", 10, 10);
     catalog.AppendMemIndex("idx2", 30, 30);
     catalog.AppendMemIndex("idx3", 20, 20);
-    catalog.reset();
 }
 
 TEST_F(MemIndexTracerTest, test2) {
@@ -251,7 +265,6 @@ TEST_F(MemIndexTracerTest, test2) {
         for (auto &th : threads) {
             th.join();
         }
-        catalog.reset();
     };
     Test(false);
     Test(true);


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix: memory index tracer bug.
memory index tracer now contains catalog ptr instead of hash map of memindex ptr. handle multi version of memory index.
2. Fix restart test.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
