### PR TITLE
Fix default value for http api

### DIFF
--- a/python/infinity/common.py
+++ b/python/infinity/common.py
@@ -34,11 +34,19 @@ class SparseVector:
     def __post_init__(self):
         assert (self.values is None) or (len(self.indices) == len(self.values))
 
-    def to_dict(self):
+    def to_dict_old(self):
         d = {"indices": self.indices}
         if self.values is not None:
             d["values"] = self.values
         return d
+
+    def to_dict(self):
+        if self.values is None:
+            raise ValueError("SparseVector.values is None")
+        result = {}
+        for i, v in zip(self.indices, self.values):
+            result[str(i)] = v
+        return result
 
     @staticmethod
     def from_dict(d):

--- a/python/infinity/common.py
+++ b/python/infinity/common.py
@@ -61,7 +61,7 @@ class SparseVector:
 
 URI = Union[NetworkAddress, Path]
 VEC = Union[list, np.ndarray]
-INSERT_DATA = dict[str, Union[str, int, float, list[Union[int, float]]], SparseVector]
+INSERT_DATA = dict[str, Union[str, int, float, list[Union[int, float]]], SparseVector, dict]
 
 LOCAL_HOST = NetworkAddress("127.0.0.1", 23817)
 

--- a/python/infinity/local_infinity/table.py
+++ b/python/infinity/local_infinity/table.py
@@ -315,7 +315,7 @@ class LocalTable(Table, ABC):
         deprecated_api("knn is deprecated, please use match_dense instead")
         return self.match_dense(*args, **kwargs)
 
-    def match_sparse(self, vector_column_name: str, sparse_data: SparseVector, distance_type: str, topn: int,
+    def match_sparse(self, vector_column_name: str, sparse_data: SparseVector | dict, distance_type: str, topn: int,
                      opt_params: {} = None):
         self.query_builder.match_sparse(vector_column_name, sparse_data, distance_type, topn, opt_params)
         return self

--- a/python/infinity/local_infinity/utils.py
+++ b/python/infinity/local_infinity/utils.py
@@ -203,6 +203,21 @@ def get_local_constant_expr_from_python_value(value) -> WrapConstantExpr:
             constant_expression.literal_type = LiteralType.kDoubleSparseArray
             constant_expression.i64_array_idx = indices
             constant_expression.f64_array_value = values
+        case dict():
+            if len(value) == 0:
+                raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
+            match next(iter(value.values())):
+                case int():
+                    constant_expression.literal_type = LiteralType.kLongSparseArray
+                    constant_expression.i64_array_idx = [int(k) for k in value.keys()]
+                    constant_expression.i64_array_value = [int(v) for v in value.values()]
+                case float():
+                    constant_expression.literal_type = LiteralType.kDoubleSparseArray
+                    constant_expression.i64_array_idx = [int(k) for k in value.keys()]
+                    constant_expression.f64_array_value = [float(v) for v in value.values()]
+                case _:
+                    raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                            f"Invalid sparse vector value type: {type(next(iter(value.values())))}")
         case _:
             raise InfinityException(ErrorCode.INVALID_EXPRESSION, f"Invalid constant type: {type(value)}")
     return constant_expression

--- a/python/infinity/remote_thrift/query_builder.py
+++ b/python/infinity/remote_thrift/query_builder.py
@@ -191,7 +191,7 @@ class InfinityThriftQueryBuilder(ABC):
     def match_sparse(
         self,
         vector_column_name: str,
-        sparse_data: SparseVector,
+        sparse_data: SparseVector | dict,
         metric_type: str,
         topn: int,
         opt_params: Optional[dict] = None,

--- a/python/infinity/remote_thrift/table.py
+++ b/python/infinity/remote_thrift/table.py
@@ -345,7 +345,7 @@ class RemoteTable(Table, ABC):
         self.query_builder.match_tensor(column_name, query_data, query_data_type, topn, extra_option)
         return self
 
-    def match_sparse(self, vector_column_name: str, sparse_data: SparseVector, distance_type: str, topn: int,
+    def match_sparse(self, vector_column_name: str, sparse_data: SparseVector | dict, distance_type: str, topn: int,
                      opt_params: Optional[dict] = None):
         self.query_builder.match_sparse(vector_column_name, sparse_data, distance_type, topn, opt_params)
         return self

--- a/python/infinity/remote_thrift/utils.py
+++ b/python/infinity/remote_thrift/utils.py
@@ -231,6 +231,23 @@ def get_remote_constant_expr_from_python_value(value) -> ttypes.ConstantExpr:
                 literal_type=ttypes.LiteralType.SparseDoubleArray,
                 i64_array_idx=indices,
                 f64_array_value=values)
+        case dict():
+            if len(value) == 0:
+                raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
+            match next(iter(value.values())):
+                case int():
+                    constant_expression = ttypes.ConstantExpr(
+                        literal_type=ttypes.LiteralType.SparseIntegerArray,
+                        i64_array_idx=[int(k) for k in value.keys()],
+                        i64_array_value=[int(v) for v in value.values()])
+                case float():
+                    constant_expression = ttypes.ConstantExpr(
+                        literal_type=ttypes.LiteralType.SparseDoubleArray,
+                        i64_array_idx=[int(k) for k in value.keys()],
+                        f64_array_value=[float(v) for v in value.values()])
+                case _:
+                    raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                            f"Invalid sparse vector value type: {type(next(iter(value.values())))}")
         case _:
             raise InfinityException(ErrorCode.INVALID_EXPRESSION, f"Invalid constant type: {type(value)}")
     return constant_expression

--- a/python/infinity/table.py
+++ b/python/infinity/table.py
@@ -18,7 +18,7 @@ from typing import Optional, Union, Any
 
 import infinity.remote_thrift.infinity_thrift_rpc.ttypes as ttypes
 from infinity.index import IndexInfo
-from infinity.common import InfinityException
+from infinity.common import InfinityException, INSERT_DATA
 from infinity.embedded_infinity_ext import ExplainType as LocalExplainType
 from infinity.errors import ErrorCode
 
@@ -76,7 +76,7 @@ class Table(ABC):
         pass
 
     @abstractmethod
-    def insert(self, data: list[dict[str, Union[str, int, float, list[Union[int, float]]]]]):
+    def insert(self, data: Union[INSERT_DATA, list[INSERT_DATA]]):
         pass
 
     @abstractmethod

--- a/python/infinity_http.py
+++ b/python/infinity_http.py
@@ -185,40 +185,9 @@ class infinity_http:
         try:
             fields = []
             for col in columns_definition:
-                tmp = {}
-                tmp["name"] = col
+                tmp = {"name": col}
                 for param_name in columns_definition[col]:
-                    if param_name.lower() != "constraints" and param_name.lower() != "default": # not constraint and default, should be type
-                        tmp[param_name.lower()] = columns_definition[col][param_name]
-                    elif param_name.lower() == "default":
-                        type_tmp = {}
-                        params = tmp["type"].split(",")
-                        match params[0].strip().lower():
-                            case "vector" | "multivector" | "tensor" | "tensorarray":
-                                type_tmp["type"] = params[0].strip()
-                                type_tmp["dimension"] = int(params[1].strip())
-                                type_tmp["element_type"] = type_transfrom[params[2].strip()]
-                            case "sparse":
-                                type_tmp["type"] = params[0].strip()
-                                type_tmp["dimension"] = int(params[1].strip())
-                                type_tmp["data_type"] = type_transfrom[params[2].strip()]
-                                type_tmp["index_type"] = type_transfrom[params[3].strip()]
-                            case _:
-                                type_tmp["type"] = params[0].strip()
-
-                        default_field = {}
-                        if type_tmp["type"] == "vector":
-                            default_field["type"] = type_to_vector_literaltype[type_tmp["element_type"]]
-                        elif type_tmp["type"] == "tensor":
-                            pass
-                        elif type_tmp["type"] == "sparse":
-                            pass
-                        else:
-                            default_field["type"] = type_to_literaltype[type_tmp["type"]]
-                        default_field["value"] = columns_definition[col][param_name]
-                        tmp["default"] = default_field
-                    else:
-                        tmp[param_name.lower()] = columns_definition[col][param_name]
+                    tmp[param_name.lower()] = columns_definition[col][param_name]
                 fields.append(tmp)
         except:
             raise InfinityException(ErrorCode.SYNTAX_ERROR, "http adapter create table parse error")

--- a/python/test_pysdk/common/common_data.py
+++ b/python/test_pysdk/common/common_data.py
@@ -131,8 +131,8 @@ def is_list(str):
 def is_bool(str):
     return str.lower() == "true" or str.lower() == "false"
 
-def is_sparse(str):
-    tmp = str.replace("[", "")
+def is_sparse(str_input):
+    tmp = str_input.replace("[", "")
     tmp = tmp.replace("]", "")
     pairs = tmp.split(",")
     for pair in pairs:
@@ -143,17 +143,14 @@ def is_sparse(str):
             return False
     return True
 
-def str2sparse(str):
+def str2sparse(str_input):
     sparce_vec = {}
-    sparce_vec["indices"] = []
-    sparce_vec["values"] = []
-    tmp = str.replace("[", "")
+    tmp = str_input.replace("[", "")
     tmp = tmp.replace("]", "")
     pairs = tmp.split(",")
     for pair in pairs:
         t = pair.split(":")
-        sparce_vec["indices"].append(eval(t[0]))
-        sparce_vec["values"].append(eval(t[1]))
+        sparce_vec[str(eval(t[0]))] = eval(t[1])
 
     return sparce_vec
 

--- a/python/test_pysdk/test_insert.py
+++ b/python/test_pysdk/test_insert.py
@@ -503,20 +503,20 @@ class TestInfinity:
         assert table_obj
         res = table_obj.insert([{"c1": SparseVector(**{"indices": [10, 20, 30], "values": [1.1, 2.2, 3.3]})}])
         assert res.error_code == ErrorCode.OK
-        res = table_obj.insert([{"c1": SparseVector(**{"indices": [40, 50, 60], "values": [4.4, 5.5, 6.6]})}])
+        res = table_obj.insert([{"c1": SparseVector([40, 50, 60], [4.4, 5.5, 6.6])}])
         assert res.error_code == ErrorCode.OK
-        res = table_obj.insert([{"c1": SparseVector(**{"indices": [70, 80, 90], "values": [7.7, 8.8, 9.9]})},
-                                {"c1": SparseVector(**{"indices": [70, 80, 90], "values": [-7.7, -8.8, -9.9]})}])
+        res = table_obj.insert([{"c1": {"70": 7.7, "80": 8.8, "90": 9.9}},
+                                {"c1": {"70": -7.7, "80": -8.8, "90": -9.9}}])
         assert res.error_code == ErrorCode.OK
         print(table_obj.output(["*"]).to_pl())
         res = table_obj.output(["*"]).to_df()
         print(res)
         pd.testing.assert_frame_equal(res, pd.DataFrame(
             {'c1': (
-                {"indices": [10, 20, 30], "values": [1.1, 2.2, 3.3]},
-                {"indices": [40, 50, 60], "values": [4.4, 5.5, 6.6]},
-                {"indices": [70, 80, 90], "values": [7.7, 8.8, 9.9]},
-                {"indices": [70, 80, 90], "values": [-7.7, -8.8, -9.9]})}))
+                {"10": 1.1, "20": 2.2, "30": 3.3},
+                {"40": 4.4, "50": 5.5, "60": 6.6},
+                {"70": 7.7, "80": 8.8, "90": 9.9},
+                {"70": -7.7, "80": -8.8, "90": -9.9})}))
 
         res = db_obj.drop_table("test_insert_sparse"+suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK

--- a/src/executor/operator/physical_import.cpp
+++ b/src/executor/operator/physical_import.cpp
@@ -848,8 +848,8 @@ SharedPtr<ConstantExpr> BuildConstantExprFromJson(const nlohmann::json &json_obj
         }
         case nlohmann::json::value_t::string: {
             auto res = MakeShared<ConstantExpr>(LiteralType::kString);
-            auto str = json_object.get<String>();
-            res->str_value_ = strdup(json_object.get<String>().c_str());
+            const auto str = json_object.get<String>();
+            res->str_value_ = strdup(str.c_str());
             return res;
         }
         case nlohmann::json::value_t::array: {
@@ -999,147 +999,6 @@ SharedPtr<ConstantExpr> BuildConstantSparseExprFromJson(const nlohmann::json &js
             RecoverableError(Status::ImportFileFormatError(error_info));
             return nullptr;
         }
-    }
-}
-
-ConstantExpr * BuildConstantSparseExprFromJson(const nlohmann::json &json_object) {
-    //SharedPtr<ConstantExpr> res = nullptr;
-    //auto res = new ConstantExpr(LiteralType::kDoubleSparseArray);
-    //res->double_sparse_array_.first.emplace_back(0);
-    //res->double_sparse_array_.first.emplace_back(20);
-    //res->double_sparse_array_.first.emplace_back(80);
-    //res->double_sparse_array_.second.emplace_back(1.0);
-    //res->double_sparse_array_.second.emplace_back(2.0);
-    //res->double_sparse_array_.second.emplace_back(3.0);
-    //return res;
-
-    auto it = json_object.items().begin();
-    auto index_itr = it;
-    ++it;
-    auto value_itr = it;
-    auto first_value_elem = value_itr.value()[0];
-    auto first_value_elem_type = first_value_elem.type();
-    if(first_value_elem_type == nlohmann::json::value_t::number_float) {
-        auto res = new ConstantExpr(LiteralType::kDoubleSparseArray);
-        res->double_sparse_array_.first.reserve(json_object.items().begin().value().size());
-        res->double_sparse_array_.second.reserve(json_object.items().begin().value().size());
-        for(auto &pairs : json_object.items()) {
-            if(pairs.key() == "indices") {
-                if(pairs.value().type() == nlohmann::json::value_t::array) {
-                    for (size_t idx = 0; idx < pairs.value().size(); ++idx) {
-                        const auto &value_ref = pairs.value()[idx];
-                        const auto &value_type = value_ref.type();
-                        switch (value_type) {
-                            case nlohmann::json::value_t::number_integer: {
-                                res->double_sparse_array_.first.emplace_back(value_ref.template get<int64_t>());
-                                break;
-                            }
-                            case nlohmann::json::value_t::number_unsigned: {
-                                res->double_sparse_array_.first.emplace_back(value_ref.template get<uint64_t>());
-                                break;
-                            }
-                            default: {
-                                const auto error_info = fmt::format("Unrecognized json object type: {}", json_object.type_name());
-                                RecoverableError(Status::ImportFileFormatError(error_info));
-                                delete res;
-                                res = nullptr;
-                                return nullptr;
-                            }
-                        }
-                    }
-                }
-            } else if(pairs.key() == "values") {
-                if(pairs.value().type() == nlohmann::json::value_t::array) {
-                    for (size_t idx = 0; idx < pairs.value().size(); ++idx) {
-                        const auto &value_ref = pairs.value()[idx];
-                        const auto &value_type = value_ref.type();
-
-                        switch (value_type) {
-                            case nlohmann::json::value_t::number_integer: {
-                                res->double_sparse_array_.second.emplace_back(value_ref.template get<int64_t>());
-                                break;
-                            }
-                            case nlohmann::json::value_t::number_unsigned: {
-                                res->double_sparse_array_.second.emplace_back(value_ref.template get<uint64_t>());
-                                break;
-                            }
-                            case nlohmann::json::value_t::number_float: {
-                                res->double_sparse_array_.second.emplace_back(value_ref.template get<double>());
-                                break;
-                            }
-                            default: {
-                                const auto error_info = fmt::format("Unrecognized json object type: {}", json_object.type_name());
-                                RecoverableError(Status::ImportFileFormatError(error_info));
-                                delete res;
-                                res = nullptr;
-                                return nullptr;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return res;
-    } else if(first_value_elem_type == nlohmann::json::value_t::number_integer or first_value_elem_type == nlohmann::json::value_t::number_unsigned) {
-        auto res = new ConstantExpr(LiteralType::kLongSparseArray);
-        res->long_sparse_array_.first.reserve(json_object.items().begin().value().size());
-        res->long_sparse_array_.second.reserve(json_object.items().begin().value().size());
-        for(auto &pairs : json_object.items()) {
-            if(pairs.key() == "indices") {
-                if(pairs.value().type() == nlohmann::json::value_t::array) {
-                    for (size_t idx = 0; idx < pairs.value().size(); ++idx) {
-                        const auto &value_ref = pairs.value()[idx];
-                        const auto &value_type = value_ref.type();
-                        switch (value_type) {
-                            case nlohmann::json::value_t::number_integer: {
-                                res->long_sparse_array_.first.emplace_back(value_ref.template get<int64_t>());
-                                break;
-                            }
-                            case nlohmann::json::value_t::number_unsigned: {
-                                res->long_sparse_array_.first.emplace_back(value_ref.template get<uint64_t>());
-                                break;
-                            }
-                            default: {
-                                const auto error_info = fmt::format("Unrecognized json object type: {}", json_object.type_name());
-                                RecoverableError(Status::ImportFileFormatError(error_info));
-                                delete res;
-                                res = nullptr;
-                                return nullptr;
-                            }
-                        }
-                    }
-                }
-            } else if(pairs.key() == "values") {
-                if(pairs.value().type() == nlohmann::json::value_t::array) {
-                    for (size_t idx = 0; idx < pairs.value().size(); ++idx) {
-                        const auto &value_ref = pairs.value()[idx];
-                        const auto &value_type = value_ref.type();
-                        switch (value_type) {
-                            case nlohmann::json::value_t::number_integer: {
-                                res->long_sparse_array_.second.emplace_back(value_ref.template get<int64_t>());
-                                break;
-                            }
-                            case nlohmann::json::value_t::number_unsigned: {
-                                res->long_sparse_array_.second.emplace_back(value_ref.template get<uint64_t>());
-                                break;
-                            }
-                            default: {
-                                const auto error_info = fmt::format("Unrecognized json object type: {}", json_object.type_name());
-                                RecoverableError(Status::ImportFileFormatError(error_info));
-                                delete res;
-                                res = nullptr;
-                                return nullptr;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return res;
-    } else {
-        const auto error_info = fmt::format("Unrecognized json object type: {}", json_object.type_name());
-        RecoverableError(Status::ImportFileFormatError(error_info));
-        return nullptr;
     }
 }
 

--- a/src/executor/operator/physical_import.cppm
+++ b/src/executor/operator/physical_import.cppm
@@ -37,6 +37,7 @@ import internal_types;
 import statement_common;
 import data_type;
 import logger;
+import sparse_info;
 
 namespace infinity {
 
@@ -140,6 +141,6 @@ private:
 };
 
 export SharedPtr<ConstantExpr> BuildConstantExprFromJson(const nlohmann::json &json_object);
-export  ConstantExpr * BuildConstantSparseExprFromJson(const nlohmann::json &json_object);
+export SharedPtr<ConstantExpr> BuildConstantSparseExprFromJson(const nlohmann::json &json_object, const SparseInfo *sparse_info);
 
 } // namespace infinity

--- a/src/network/http/http_search.cpp
+++ b/src/network/http/http_search.cpp
@@ -767,7 +767,7 @@ MatchTensorExpr *HTTPSearch::ParseMatchTensor(const nlohmann::json &json_object,
                 response["error_message"] = "Missing element_type for query_tensor";
                 return nullptr;
             }
-            const String element_type = json_object["element_type"];
+            String element_type = json_object["element_type"];
             const auto tensor_expr = BuildConstantExprFromJson(field_json_obj.value());
             match_tensor_expr->SetQueryTensorStr(std::move(element_type), tensor_expr.get());
         } else if (IsEqual(key, "options")) {
@@ -818,8 +818,74 @@ MatchSparseExpr *HTTPSearch::ParseMatchSparse(const nlohmann::json &json_object,
             }
             match_sparse_expr->column_expr_ = std::move(column_expr);
         } else if (IsEqual(key, "query_sparse")) {
-            const auto sparse_expr = BuildConstantSparseExprFromJson(field_json_obj.value());
-            match_sparse_expr->SetQuerySparse(sparse_expr);
+            ConstantExpr *const_sparse_expr = nullptr;
+            DeferFn defer_free_sparse([&]() {
+                if (const_sparse_expr != nullptr) {
+                    delete const_sparse_expr;
+                    const_sparse_expr = nullptr;
+                }
+            });
+            auto &value = field_json_obj.value();
+            if (value.size() == 0) {
+                response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                response["error_message"] = fmt::format("Empty sparse vector, cannot decide type");
+                return nullptr;
+            }
+            switch (value.begin().value().type()) {
+                case nlohmann::json::value_t::number_unsigned:
+                case nlohmann::json::value_t::number_integer: {
+                    const_sparse_expr = new ConstantExpr(LiteralType::kLongSparseArray);
+                    break;
+                }
+                case nlohmann::json::value_t::number_float: {
+                    const_sparse_expr = new ConstantExpr(LiteralType::kDoubleSparseArray);
+                    break;
+                }
+                default: {
+                    response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                    response["error_message"] = fmt::format("Sparse value element type error");
+                    return nullptr;
+                }
+            }
+            HashSet<i64> key_set;
+            for (const auto &[sparse_k, sparse_v] : value.items()) {
+                i64 key_val = std::stoll(sparse_k);
+                if (const auto [_, insert_ok] = key_set.insert(key_val); !insert_ok) {
+                    response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                    response["error_message"] = fmt::format("Duplicate key {} in sparse array!", key);
+                    return nullptr;
+                }
+                bool good_v = false;
+                switch (sparse_v.type()) {
+                    case nlohmann::json::value_t::number_unsigned:
+                    case nlohmann::json::value_t::number_integer: {
+                        if (const_sparse_expr->literal_type_ == LiteralType::kLongSparseArray) {
+                            const_sparse_expr->long_sparse_array_.first.push_back(key_val);
+                            const_sparse_expr->long_sparse_array_.second.push_back(sparse_v.get<i64>());
+                            good_v = true;
+                        }
+                        break;
+                    }
+                    case nlohmann::json::value_t::number_float: {
+                        if (const_sparse_expr->literal_type_ == LiteralType::kDoubleSparseArray) {
+                            const_sparse_expr->double_sparse_array_.first.push_back(key_val);
+                            const_sparse_expr->double_sparse_array_.second.push_back(sparse_v.get<double>());
+                            good_v = true;
+                        }
+                        break;
+                    }
+                    default: {
+                        break;
+                    }
+                }
+                if (!good_v) {
+                    response["error_code"] = ErrorCode::kInvalidEmbeddingDataType;
+                    response["error_message"] = fmt::format("Sparse value element type error");
+                    return nullptr;
+                }
+            }
+            match_sparse_expr->SetQuerySparse(const_sparse_expr);
+            assert(const_sparse_expr == nullptr);
         } else if (IsEqual(key, "topn")) {
             topn = field_json_obj.value().get<i64>();
         } else if (IsEqual(key, "opt_params")) {

--- a/src/parser/expr/match_sparse_expr.cpp
+++ b/src/parser/expr/match_sparse_expr.cpp
@@ -23,7 +23,7 @@ void MatchSparseExpr::SetSearchColumn(ParsedExpr *&column_expr) {
     column_expr = nullptr;
 }
 
-void MatchSparseExpr::SetQuerySparse(ConstantExpr *raw_sparse_expr) {
+void MatchSparseExpr::SetQuerySparse(ConstantExpr *&raw_sparse_expr) {
     query_sparse_expr_.reset(raw_sparse_expr);
     query_sparse_expr_->TrySortSparseVec(nullptr);
     raw_sparse_expr = nullptr;

--- a/src/parser/expr/match_sparse_expr.h
+++ b/src/parser/expr/match_sparse_expr.h
@@ -31,7 +31,7 @@ public:
 
     void SetSearchColumn(ParsedExpr *&column_expr);
 
-    void SetQuerySparse(ConstantExpr *raw_sparse_expr);
+    void SetQuerySparse(ConstantExpr *&raw_sparse_expr);
 
     void SetMetricType(char *&raw_metric_type);
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix default value for http api

Update pysdk SparseVector support: now also accept python dict like `{"1": 0.33, "22": 4.56}`

Issue link:#1738

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Refactoring