### PR TITLE
Fix restart

### DIFF
--- a/.github/workflows/slow_test.yml
+++ b/.github/workflows/slow_test.yml
@@ -66,7 +66,7 @@ jobs:
         run : |
           sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && pip3 install -r python/restart_test/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host tuna.tsinghua.edu.cn
           sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && pytest python/restart_test/test_insert.py -k "test_data[infinity_runner0-columns5-gen-test/data/config/restart_test/test_insert/1.toml]" -s --infinity_path=cmake-build-release/src/infinity"
-          sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && pytest python/restart_test/test_insert.py -k "test_index[infinity_runner0-columns2-indexes2-gen-test/data/config/restart_test/test_insert/1.toml]" -s --infinity_path=cmake-build-release/src/infinity"
+          sudo docker exec ${BUILDER_CONTAINER} bash -c "cd /infinity/ && pytest python/restart_test/test_insert.py -k "test_index[infinity_runner0-columns2-indexes2-gen-1000000-test/data/config/restart_test/test_insert/1.toml]" -s --infinity_path=cmake-build-release/src/infinity"
 
       - name: Collect restart test output
         if: ${{ !cancelled() }} # always run this step even if previous steps failed

--- a/python/restart_test/restart_util.py
+++ b/python/restart_test/restart_util.py
@@ -174,6 +174,7 @@ class LChYDataGenerato:
                 "dense_vec",
                 index.IndexType.Hnsw,
                 {
+                    "encode": "lvq",
                     "m": "16",
                     "ef_construction": "200",
                     "metric": "l2",

--- a/python/restart_test/test_insert.py
+++ b/python/restart_test/test_insert.py
@@ -1,11 +1,9 @@
-import functools
 import pytest
 from common import common_values
 from infinity.common import ConflictType
 from infinity_runner import InfinityRunner
 import time
 import threading
-import itertools
 from restart_util import *
 
 
@@ -13,14 +11,13 @@ from restart_util import *
 class TestInsert:
     def insert_inner(
         self,
+        insert_n: int,
         infinity_runner: InfinityRunner,
         config: str,
         columns: dict,
         data_gen_factory,
     ):
         uri = common_values.TEST_LOCAL_HOST
-
-        insert_n = 1000000
         data_gen = data_gen_factory(insert_n)
 
         stop_n = 10
@@ -89,10 +86,10 @@ class TestInsert:
             t1.join()
 
     @pytest.mark.parametrize(
-        "config",
+        "insert_n, config",
         [
-            "test/data/config/restart_test/test_insert/1.toml",
-            "test/data/config/restart_test/test_insert/2.toml",
+            (100000, "test/data/config/restart_test/test_insert/1.toml"),
+            (1000000, "test/data/config/restart_test/test_insert/1.toml"),
         ],
     )
     @pytest.mark.parametrize(
@@ -129,6 +126,7 @@ class TestInsert:
     def test_data(
         self,
         infinity_runner: InfinityRunner,
+        insert_n: int,
         config: str,
         columns: dict,
         data_gen_factory,
@@ -144,7 +142,7 @@ class TestInsert:
         infinity_obj.disconnect()
         infinity_runner.uninit()
 
-        self.insert_inner(infinity_runner, config, columns, data_gen_factory)
+        self.insert_inner(insert_n, infinity_runner, config, columns, data_gen_factory)
 
         infinity_runner.init(config)
         infinity_obj = InfinityRunner.connect(uri)
@@ -154,10 +152,10 @@ class TestInsert:
         infinity_runner.uninit()
 
     @pytest.mark.parametrize(
-        "config",
+        "insert_n,config",
         [
-            "test/data/config/restart_test/test_insert/1.toml",
-            "test/data/config/restart_test/test_insert/3.toml",
+            (100000, "test/data/config/restart_test/test_insert/1.toml"),
+            (1000000, "test/data/config/restart_test/test_insert/1.toml"),
         ],
     )
     @pytest.mark.parametrize(
@@ -185,6 +183,7 @@ class TestInsert:
     def test_index(
         self,
         infinity_runner: InfinityRunner,
+        insert_n: int,
         config: str,
         columns: dict,
         indexes: list[index.IndexInfo],
@@ -203,7 +202,7 @@ class TestInsert:
         infinity_obj.disconnect()
         infinity_runner.uninit()
 
-        self.insert_inner(infinity_runner, config, columns, data_gen_factory)
+        self.insert_inner(insert_n, infinity_runner, config, columns, data_gen_factory)
 
         infinity_runner.init(config)
         infinity_obj = InfinityRunner.connect(uri)

--- a/src/storage/compaction_process.cpp
+++ b/src/storage/compaction_process.cpp
@@ -143,6 +143,7 @@ Vector<Pair<UniquePtr<BaseStatement>, Txn *>> CompactionProcessor::ScanForCompac
 
 void CompactionProcessor::ScanAndOptimize() {
     Txn *opt_txn = txn_mgr_->BeginTxn(MakeUnique<String>("ScanAndOptimize"));
+    LOG_INFO(fmt::format("ScanAndOptimize opt begin ts: {}", opt_txn->BeginTS()));
     TransactionID txn_id = opt_txn->TxnID();
     TxnTimeStamp begin_ts = opt_txn->BeginTS();
 

--- a/src/storage/meta/entry/chunk_index_entry.cpp
+++ b/src/storage/meta/entry/chunk_index_entry.cpp
@@ -99,11 +99,12 @@ SharedPtr<ChunkIndexEntry> ChunkIndexEntry::NewHnswIndexChunkIndexEntry(ChunkID 
 }
 
 SharedPtr<ChunkIndexEntry> ChunkIndexEntry::NewFtChunkIndexEntry(SegmentIndexEntry *segment_index_entry,
+                                                                 ChunkID chunk_id,
                                                                  const String &base_name,
                                                                  RowID base_rowid,
                                                                  u32 row_count,
                                                                  BufferManager *buffer_mgr) {
-    auto chunk_index_entry = SharedPtr<ChunkIndexEntry>(new ChunkIndexEntry(0, segment_index_entry, base_name, base_rowid, row_count));
+    auto chunk_index_entry = SharedPtr<ChunkIndexEntry>(new ChunkIndexEntry(chunk_id, segment_index_entry, base_name, base_rowid, row_count));
     const auto &index_dir = segment_index_entry->index_dir();
     assert(index_dir.get() != nullptr);
     if (buffer_mgr != nullptr) {

--- a/src/storage/meta/entry/chunk_index_entry.cpp
+++ b/src/storage/meta/entry/chunk_index_entry.cpp
@@ -427,7 +427,7 @@ void ChunkIndexEntry::LoadPartsReader(BufferManager *buffer_mgr) {
 void ChunkIndexEntry::DeprecateChunk(TxnTimeStamp commit_ts) {
     assert(commit_ts_.load() < commit_ts);
     deprecate_ts_.store(commit_ts);
-    LOG_INFO(fmt::format("Deprecate chunk {}.", encode()));
+    LOG_INFO(fmt::format("Deprecate chunk {}, ts: {}", encode(), commit_ts));
     ResetOptimizing();
 }
 

--- a/src/storage/meta/entry/chunk_index_entry.cppm
+++ b/src/storage/meta/entry/chunk_index_entry.cppm
@@ -60,7 +60,7 @@ public:
                                                                   SizeT index_size);
 
     static SharedPtr<ChunkIndexEntry>
-    NewFtChunkIndexEntry(SegmentIndexEntry *segment_index_entry, const String &base_name, RowID base_rowid, u32 row_count, BufferManager *buffer_mgr);
+    NewFtChunkIndexEntry(SegmentIndexEntry *segment_index_entry, ChunkID chunk_id, const String &base_name, RowID base_rowid, u32 row_count, BufferManager *buffer_mgr);
 
     static SharedPtr<ChunkIndexEntry> NewSecondaryIndexChunkIndexEntry(ChunkID chunk_id,
                                                                        SegmentIndexEntry *segment_index_entry,

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -235,7 +235,9 @@ SegmentIndexEntry::LoadIndexEntry(TableIndexEntry *table_index_entry, u32 segmen
     for (u32 i = 0; i < vector_file_worker.size(); ++i) {
         vector_buffer[i] = buffer_manager->GetBufferObject(std::move(vector_file_worker[i]));
     }
-    return UniquePtr<SegmentIndexEntry>(new SegmentIndexEntry(table_index_entry, segment_id, std::move(vector_buffer)));
+    auto res = UniquePtr<SegmentIndexEntry>(new SegmentIndexEntry(table_index_entry, segment_id, std::move(vector_buffer)));
+    res->buffer_manager_ = buffer_manager;
+    return res;
 }
 
 BufferHandle SegmentIndexEntry::GetIndex() { return vector_buffer_[0]->Load(); }

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -1091,12 +1091,16 @@ SharedPtr<ChunkIndexEntry> SegmentIndexEntry::AddChunkIndexEntryReplay(ChunkID c
 
     SharedPtr<ChunkIndexEntry> chunk_index_entry =
         ChunkIndexEntry::NewReplayChunkIndexEntry(chunk_id, this, param.get(), base_name, base_rowid, row_count, commit_ts, deprecate_ts, buffer_mgr);
-    if (chunk_id == chunk_index_entries_.size()) {
+    bool add = false;
+    for (auto &chunk : chunk_index_entries_) {
+        if (chunk->chunk_id_ == chunk_id) {
+            chunk = chunk_index_entry;
+            add = true;
+            break;
+        }
+    }
+    if (!add) {
         chunk_index_entries_.push_back(chunk_index_entry);
-    } else if (chunk_id < chunk_index_entries_.size()) {
-        chunk_index_entries_[chunk_id] = chunk_index_entry;
-    } else {
-        UnrecoverableError(fmt::format("Chunk id: {} is larger than chunk index entries size: {}", chunk_id, chunk_index_entries_.size()));
     }
     if (table_index_entry_->table_index_def()->index_type_ == IndexType::kFullText) {
         try {

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -1054,8 +1054,9 @@ void SegmentIndexEntry::AddChunkIndexEntry(SharedPtr<ChunkIndexEntry> chunk_inde
 
 SharedPtr<ChunkIndexEntry> SegmentIndexEntry::AddFtChunkIndexEntry(const String &base_name, RowID base_rowid, u32 row_count) {
     std::shared_lock lock(rw_locker_);
+    ChunkID chunk_id = this->GetNextChunkID();
     // row range of chunk_index_entries_ may overlop and misorder due to deprecated ones.
-    SharedPtr<ChunkIndexEntry> chunk_index_entry = ChunkIndexEntry::NewFtChunkIndexEntry(this, base_name, base_rowid, row_count, buffer_manager_);
+    SharedPtr<ChunkIndexEntry> chunk_index_entry = ChunkIndexEntry::NewFtChunkIndexEntry(this, chunk_id, base_name, base_rowid, row_count, buffer_manager_);
     chunk_index_entries_.push_back(chunk_index_entry);
     return chunk_index_entry;
 }

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -1093,8 +1093,16 @@ SharedPtr<ChunkIndexEntry> SegmentIndexEntry::AddChunkIndexEntryReplay(ChunkID c
         ChunkIndexEntry::NewReplayChunkIndexEntry(chunk_id, this, param.get(), base_name, base_rowid, row_count, commit_ts, deprecate_ts, buffer_mgr);
     chunk_index_entries_.push_back(chunk_index_entry); // replay not need lock
     if (table_index_entry_->table_index_def()->index_type_ == IndexType::kFullText) {
-        u64 column_length_sum = chunk_index_entry->GetColumnLengthSum();
-        UpdateFulltextColumnLenInfo(column_length_sum, row_count);
+        try {
+            u64 column_length_sum = chunk_index_entry->GetColumnLengthSum();
+            UpdateFulltextColumnLenInfo(column_length_sum, row_count);
+        } catch (const UnrecoverableException &e) {
+            String msg(e.what());
+            if (!msg.find("No such file or directory")) {
+                throw e;
+            }
+            LOG_WARN("Fulltext index file not found, skip update column length info");
+        }
     };
     return chunk_index_entry;
 }

--- a/src/storage/meta/entry/segment_index_entry.cppm
+++ b/src/storage/meta/entry/segment_index_entry.cppm
@@ -257,13 +257,13 @@ public:
     void SetMemoryIndexer(UniquePtr<MemoryIndexer> &&memory_indexer) { memory_indexer_ = std::move(memory_indexer); }
     static SharedPtr<SegmentIndexEntry> CreateFakeEntry(const String &index_dir);
 
+    ChunkID GetNextChunkID() { return next_chunk_id_++; }
+
 private:
     explicit SegmentIndexEntry(TableIndexEntry *table_index_entry, SegmentID segment_id, Vector<BufferObj *> vector_buffer);
     // Load from disk. Is called by SegmentIndexEntry::Deserialize.
     static UniquePtr<SegmentIndexEntry>
     LoadIndexEntry(TableIndexEntry *table_index_entry, u32 segment_id, BufferManager *buffer_manager, CreateIndexParam *create_index_param);
-
-    ChunkID GetNextChunkID() { return next_chunk_id_++; }
 
 private:
     BufferManager *buffer_manager_{};

--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -909,7 +909,9 @@ void TableEntry::OptimizeIndex(Txn *txn) {
                         auto &chunk_index_entry = chunk_index_entries[i];
                         old_chunks.push_back(chunk_index_entry.get());
                     }
+                    ChunkID chunk_id = segment_index_entry->GetNextChunkID();
                     SharedPtr<ChunkIndexEntry> merged_chunk_index_entry = ChunkIndexEntry::NewFtChunkIndexEntry(segment_index_entry.get(),
+                                                                                                                chunk_id, /*chunk_id*/
                                                                                                                 dst_base_name,
                                                                                                                 base_rowid,
                                                                                                                 total_row_count,

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -440,7 +440,7 @@ TxnTimeStamp Txn::Commit() {
 
     // register commit ts in wal manager here, define the commit sequence
     TxnTimeStamp commit_ts = txn_mgr_->GetCommitTimeStampW(this);
-    LOG_TRACE(fmt::format("Txn: {} is committing, committing ts: {}", txn_id_, commit_ts));
+    LOG_TRACE(fmt::format("Txn: {} is committing, begin_ts:{} committing ts: {}", txn_id_, BeginTS(), commit_ts));
 
     this->SetTxnCommitting(commit_ts);
 

--- a/src/storage/txn/txn.cpp
+++ b/src/storage/txn/txn.cpp
@@ -531,6 +531,11 @@ void Txn::Rollback() {
 
 void Txn::AddWalCmd(const SharedPtr<WalCmd> &cmd) { 
     std::lock_guard guard(txn_store_.mtx_);
+    auto state = txn_context_.GetTxnState();
+    if (state != TxnState::kStarted) {
+        auto begin_ts = BeginTS();
+        UnrecoverableError(fmt::format("Should add wal cmd in started state, begin_ts: {}", begin_ts));
+    }
     wal_entry_->cmds_.push_back(cmd);
 }
 

--- a/src/storage/wal/catalog_delta_entry.cpp
+++ b/src/storage/wal/catalog_delta_entry.cpp
@@ -1206,7 +1206,7 @@ void GlobalCatalogDeltaEntry::AddDeltaEntryInner(CatalogDeltaEntry *delta_entry)
             auto *add_chunk_index_op = static_cast<AddChunkIndexEntryOp *>(new_op.get());
             if (add_chunk_index_op->deprecate_ts_ != UNCOMMIT_TS) {
                 add_chunk_index_op->merge_flag_ = MergeFlag::kDelete;
-                LOG_DEBUG(fmt::format("Delete chunk: {}", *new_op->encode_));
+                LOG_DEBUG(fmt::format("Delete chunk: {} at {}", *new_op->encode_, add_chunk_index_op->deprecate_ts_));
             }
         }
         const String &encode = *new_op->encode_;

--- a/src/storage/wal/wal_entry.cpp
+++ b/src/storage/wal/wal_entry.cpp
@@ -16,6 +16,7 @@ module;
 
 #include <cassert>
 #include <vector>
+#include <sstream>
 
 module wal_entry;
 

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -516,7 +516,7 @@ i64 WalManager::ReplayWalFile() {
                 String error_message = "Found unexpected bad wal entry";
                 UnrecoverableError(error_message);
             }
-            LOG_TRACE(wal_entry->ToString());
+            // LOG_TRACE(wal_entry->ToString());
 
             WalCmdCheckpoint *checkpoint_cmd = nullptr;
             if (wal_entry->IsCheckPoint(checkpoint_cmd)) {

--- a/test/data/config/restart_test/test_insert/1.toml
+++ b/test/data/config/restart_test/test_insert/1.toml
@@ -8,7 +8,7 @@ log_to_stdout = true
 log_level               = "trace"
 
 [storage]
-mem_index_capacity       = 8192
+mem_index_capacity       = 10000
 
 [buffer]
 [wal]


### PR DESCRIPTION
### What problem does this PR solve?

1. Fix buffer manager == nullptr when replay segment_index_entry
2. Update chunk id when add fulltext chunk index entry.
3. Add assert to prevent add wal cmd after wal is written.
4. Fix: fulltext chunk index entry reading file in replay process.
5. Fix: chunk index update replay
6. Fix: dump index and optimize index conflict.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
