### PR TITLE
Check hnsw column data type

### DIFF
--- a/python/test_pysdk/common/common_data.py
+++ b/python/test_pysdk/common/common_data.py
@@ -156,7 +156,7 @@ def str2sparse(str_input):
     return sparce_vec
 
 index_type_transfrom = {
-    1:"IVFFlat",
+    1:"IVFFLAT",
     2:"HNSW",
     3:"FULLTEXT",
     4:"SECONDARY",

--- a/src/parser/statement/extra/create_index_info.cpp
+++ b/src/parser/statement/extra/create_index_info.cpp
@@ -22,7 +22,7 @@ namespace infinity {
 std::string IndexInfo::IndexTypeToString(IndexType index_type) {
     switch (index_type) {
         case IndexType::kIVFFlat: {
-            return "IVFFlat";
+            return "IVFFLAT";
         }
         case IndexType::kHnsw: {
             return "HNSW";

--- a/src/storage/definition/index_hnsw.cpp
+++ b/src/storage/definition/index_hnsw.cpp
@@ -173,11 +173,26 @@ void IndexHnsw::ValidateColumnDataType(const SharedPtr<BaseTableRef> &base_table
         if (param->param_name_ == "encode" && StringToHnswEncodeType(param->param_value_) == HnswEncodeType::kLVQ) {
             // TODO: now only support float?
             if (embedding_data_type != EmbeddingDataType::kElemFloat) {
-                RecoverableError(
-                    Status::InvalidIndexDefinition(fmt::format("Attempt to create HNSW index with LVQ encoding on column: {}, data type: {}.",
-                                                               column_name,
-                                                               data_type_ptr->ToString())));
+                RecoverableError(Status::InvalidIndexDefinition(
+                    fmt::format("Attempt to create HNSW index with LVQ encoding on column: {}, data type: {}. now only support float element type.",
+                                column_name,
+                                data_type_ptr->ToString())));
             }
+        }
+    }
+    // TODO: now only support float, int8, uint8?
+    switch (embedding_data_type) {
+        case EmbeddingDataType::kElemFloat:
+        case EmbeddingDataType::kElemInt8:
+        case EmbeddingDataType::kElemUInt8: {
+            // supported
+            break;
+        }
+        default: {
+            RecoverableError(Status::InvalidIndexDefinition(
+                fmt::format("Attempt to create HNSW index on column: {}, data type: {}. now only support float, int8, uint8 element type.",
+                            column_name,
+                            data_type_ptr->ToString())));
         }
     }
 }

--- a/src/unit_test/parser/sql_parser.cpp
+++ b/src/unit_test/parser/sql_parser.cpp
@@ -572,7 +572,7 @@ TEST_F(SQLParserTest, good_create_index_1) {
         EXPECT_EQ(index_info->index_type_, IndexType::kIVFFlat);
         EXPECT_EQ(index_info->column_name_, "a");
         EXPECT_TRUE(index_info->index_param_list_->empty());
-        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFlat");
+        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFLAT");
         EXPECT_EQ(IndexInfo::StringToIndexType("IVFFLAT"), IndexType::kIVFFlat);
 
         result->Reset();
@@ -599,7 +599,7 @@ TEST_F(SQLParserTest, good_create_index_1) {
         EXPECT_EQ(index_info->index_type_, IndexType::kIVFFlat);
         EXPECT_EQ(index_info->column_name_, "a");
         EXPECT_TRUE(index_info->index_param_list_->empty());
-        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFlat");
+        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFLAT");
         EXPECT_EQ(IndexInfo::StringToIndexType("IVFFLAT"), IndexType::kIVFFlat);
 
         result->Reset();
@@ -626,7 +626,7 @@ TEST_F(SQLParserTest, good_create_index_1) {
         EXPECT_EQ(index_info->index_type_, IndexType::kIVFFlat);
         EXPECT_EQ(index_info->column_name_, "a");
         EXPECT_TRUE(index_info->index_param_list_->empty());
-        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFlat");
+        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFLAT");
         EXPECT_EQ(IndexInfo::StringToIndexType("IVFFLAT"), IndexType::kIVFFlat);
 
         result->Reset();
@@ -656,7 +656,7 @@ TEST_F(SQLParserTest, good_create_index_1) {
         EXPECT_EQ((*index_info->index_param_list_)[0]->param_name_, "metric");
         EXPECT_EQ((*index_info->index_param_list_)[0]->param_value_, "l2");
 
-        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFlat");
+        EXPECT_EQ(IndexInfo::IndexTypeToString(index_info->index_type_), "IVFFLAT");
         EXPECT_EQ(IndexInfo::StringToIndexType("IVFFLAT"), IndexType::kIVFFlat);
 
         result->Reset();


### PR DESCRIPTION
### What problem does this PR solve?
Only allow creating hnsw index on embedding / multi-vector column with float, int8 or uint8 element type

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring