### PR TITLE
Enable stemmer for more languages

### DIFF
--- a/docs/references/http_api_reference.mdx
+++ b/docs/references/http_api_reference.mdx
@@ -922,7 +922,7 @@ curl --request POST \
   - Parameter settings for a full-text index:  
     - `"type"`: `"fulltext"`
     - `"ANALYZER"`: *Optional*
-      - `"standard"`: (Default) Standard analyzer, segmented by tokens, lowercase processing, provides stemming outputs.
+      - `"standard"`: (Default) Standard analyzer, segmented by tokens, lowercase processing, provides stemming outputs. Use `-` to specify stemmer for languages, `English` is the default stemmer: `"standard-english"` and `"standard"` have the same stemmer setting. Supported language stemmer includes: `Danish`, `Dutch`, `English`, `Finnish`, `French`, `German`, `Hungarian`, `Italian`, `Norwegian`, `Porter`, `Portuguese`, `Romanian`,`Russian`,`Spanish`,`Swedish`,`Turkish`.
       - `"chinese"`: Simplified Chinese
       - `"tradition"`: Traditional Chinese
       - `"japanese"`: Japanese

--- a/docs/references/pysdk_api_reference.md
+++ b/docs/references/pysdk_api_reference.md
@@ -716,7 +716,7 @@ An `IndexInfo` structure contains three fields,`column_name`, `index_type`, and 
       - `"lvq"`: Locally-adaptive vector quantization. Works with float vector element only.  
   - Parameter settings for a full-text index:
     - `"ANALYZER"`: *Optional*
-      - `"standard"`: (Default) Standard analyzer, segmented by tokens, lowercase processing, provides stemming outputs.
+      - `"standard"`: (Default) Standard analyzer, segmented by tokens, lowercase processing, provides stemming outputs. Use `-` to specify stemmer for languages, `English` is the default stemmer: `"standard-english"` and `"standard"` have the same stemmer setting. Supported language stemmer includes: `Danish`, `Dutch`, `English`, `Finnish`, `French`, `German`, `Hungarian`, `Italian`, `Norwegian`, `Porter`, `Portuguese`, `Romanian`,`Russian`,`Spanish`,`Swedish`,`Turkish`.
       - `"chinese"`: Simplified Chinese
       - `"tradition"`: Traditional Chinese
       - `"japanese"`: Japanese

--- a/src/common/analyzer/analyzer_pool.cpp
+++ b/src/common/analyzer/analyzer_pool.cpp
@@ -15,7 +15,7 @@
 module;
 
 #include <cstring>
-
+#include <iostream>
 module analyzer_pool;
 
 import stl;
@@ -23,11 +23,13 @@ import third_party;
 import config;
 import infinity_context;
 import analyzer;
+import stemmer;
 import chinese_analyzer;
 import traditional_chinese_analyzer;
 import japanese_analyzer;
 import standard_analyzer;
 import ngram_analyzer;
+import logger;
 
 namespace infinity {
 
@@ -38,6 +40,27 @@ constexpr u64 prime = 0x100000001B3ull;
 constexpr u64 Str2Int(const char *str, u64 last_value = basis) {
     return (*str != '\0' && *str != '-') ? Str2Int(str + 1, (*str ^ last_value) * prime) : last_value;
 }
+
+bool IcharEquals(char a, char b) { return ToLower(static_cast<int>(a)) == ToLower(static_cast<int>(b)); }
+
+bool IEquals(std::string_view lhs, std::string_view rhs) { return std::ranges::equal(lhs, rhs, IcharEquals); }
+
+constexpr std::string_view DANISH = "-danish";
+constexpr std::string_view DUTCH = "-dutch";
+constexpr std::string_view ENGLISH = "-english";
+constexpr std::string_view FINNISH = "-finnish";
+constexpr std::string_view FRENCH = "-french";
+constexpr std::string_view GERMAN = "-german";
+constexpr std::string_view HUNGARIAN = "-hungarian";
+constexpr std::string_view ITALIAN = "-italian";
+constexpr std::string_view NORWEGIAN = "-norwegian";
+constexpr std::string_view PORTER = "-porter";
+constexpr std::string_view PORTUGUESE = "-portuguese";
+constexpr std::string_view ROMANIAN = "-romanian";
+constexpr std::string_view RUSSIAN = "-russian";
+constexpr std::string_view SPANISH = "-spanish";
+constexpr std::string_view SWEDISH = "-swedish";
+constexpr std::string_view TURKISH = "-turkish";
 
 Tuple<UniquePtr<Analyzer>, Status> AnalyzerPool::GetAnalyzer(const std::string_view &name) {
     switch (Str2Int(name.data())) {
@@ -128,7 +151,48 @@ Tuple<UniquePtr<Analyzer>, Status> AnalyzerPool::GetAnalyzer(const std::string_v
             return {MakeUnique<JapaneseAnalyzer>(*reinterpret_cast<JapaneseAnalyzer *>(prototype)), Status::OK()};
         }
         case Str2Int(STANDARD.data()): {
-            return {MakeUnique<StandardAnalyzer>(), Status::OK()};
+            UniquePtr<StandardAnalyzer> analyzer = MakeUnique<StandardAnalyzer>();
+            Language lang = STEM_LANG_ENGLISH;
+            const char *str = name.data();
+            while (*str != '\0' && *str != '-') {
+                str++;
+            }
+
+            if (IEquals(std::string_view(str), DANISH)) {
+                lang = STEM_LANG_DANISH;
+            } else if (IEquals(std::string_view(str), DUTCH)) {
+                lang = STEM_LANG_DUTCH;
+            } else if (IEquals(std::string_view(str), ENGLISH)) {
+                lang = STEM_LANG_ENGLISH;
+            } else if (IEquals(std::string_view(str), FINNISH)) {
+                lang = STEM_LANG_FINNISH;
+            } else if (IEquals(std::string_view(str), FRENCH)) {
+                lang = STEM_LANG_FRENCH;
+            } else if (IEquals(std::string_view(str), GERMAN)) {
+                lang = STEM_LANG_GERMAN;
+            } else if (IEquals(std::string_view(str), HUNGARIAN)) {
+                lang = STEM_LANG_HUNGARIAN;
+            } else if (IEquals(std::string_view(str), ITALIAN)) {
+                lang = STEM_LANG_ITALIAN;
+            } else if (IEquals(std::string_view(str), NORWEGIAN)) {
+                lang = STEM_LANG_NORWEGIAN;
+            } else if (IEquals(std::string_view(str), PORTER)) {
+                lang = STEM_LANG_PORT;
+            } else if (IEquals(std::string_view(str), PORTUGUESE)) {
+                lang = STEM_LANG_PORTUGUESE;
+            } else if (IEquals(std::string_view(str), ROMANIAN)) {
+                lang = STEM_LANG_ROMANIAN;
+            } else if (IEquals(std::string_view(str), RUSSIAN)) {
+                lang = STEM_LANG_RUSSIAN;
+            } else if (IEquals(std::string_view(str), SPANISH)) {
+                lang = STEM_LANG_SPANISH;
+            } else if (IEquals(std::string_view(str), SWEDISH)) {
+                lang = STEM_LANG_SWEDISH;
+            } else if (IEquals(std::string_view(str), TURKISH)) {
+                lang = STEM_LANG_TURKISH;
+            }
+            analyzer->InitStemmer(lang);
+            return {std::move(analyzer), Status::OK()};
         }
         case Str2Int(NGRAM.data()): {
             // ngram-{number}

--- a/src/common/analyzer/common_analyzer.cpp
+++ b/src/common/analyzer/common_analyzer.cpp
@@ -30,7 +30,6 @@ constexpr int MAX_TUPLE_LENGTH = 1024;
 CommonLanguageAnalyzer::CommonLanguageAnalyzer()
     : Analyzer(), lowercase_string_buffer_(term_string_buffer_limit_), stemmer_(MakeUnique<Stemmer>()), case_sensitive_(false), contain_lower_(false),
       extract_eng_stem_(true), extract_synonym_(false), cjk_(false), remove_stopwords_(false) {
-    stemmer_->Init(STEM_LANG_ENGLISH);
     TokenizeConfig token_config;
     String divide_str("@#$");
     String unite_str("/");
@@ -40,6 +39,8 @@ CommonLanguageAnalyzer::CommonLanguageAnalyzer()
 }
 
 CommonLanguageAnalyzer::~CommonLanguageAnalyzer() {}
+
+void CommonLanguageAnalyzer::InitStemmer(Language language) { stemmer_->Init(language); }
 
 int CommonLanguageAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
     Parse(input.text_);

--- a/src/common/analyzer/common_analyzer.cppm
+++ b/src/common/analyzer/common_analyzer.cppm
@@ -27,6 +27,8 @@ public:
     CommonLanguageAnalyzer(const CommonLanguageAnalyzer &) = delete;
     virtual ~CommonLanguageAnalyzer();
 
+    void InitStemmer(Language language);
+
     void SetCaseSensitive(bool case_sensitive = true, bool contain_lower = true) {
         case_sensitive_ = case_sensitive;
         contain_lower_ = contain_lower;

--- a/src/common/analyzer/standard_analyzer.cppm
+++ b/src/common/analyzer/standard_analyzer.cppm
@@ -30,6 +30,8 @@ public:
 
     ~StandardAnalyzer() {}
 
+    void InitStemmer(Language language) { CommonLanguageAnalyzer::InitStemmer(language); }
+
 protected:
     inline void Parse(const String &input) override {
         tokenizer_.Tokenize(input);


### PR DESCRIPTION
### What problem does this PR solve?
Enable stemmer for these languages:

`Danish`, `Dutch`, `English`, `Finnish`, `French`, `German`, `Hungarian`, `Italian`, `Norwegian`, `Porter`, `Portuguese`, `Romanian`,`Russian`,`Spanish`,`Swedish`,`Turkish`.
      

Issue link:#1827

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
