### PR TITLE
Enable jemalloc for release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,10 @@ set(CSV_DATA_PATH ${CMAKE_SOURCE_DIR}/third_party/zsv/data)
 set(TMP_DATA_PATH ${CMAKE_SOURCE_DIR}/tmp)
 
 # You can disable jemalloc by passing the `-DENABLE_JEMALLOC=OFF` option to CMake.
-option(ENABLE_JEMALLOC "Enable jemalloc support" OFF)
+option(ENABLE_JEMALLOC "Enable jemalloc support" ON)
 if(ENABLE_JEMALLOC)
     find_package(jemalloc REQUIRED)
-    set(JEMALLOC_STATIC_LIB "jemalloc.a")
+    set(JEMALLOC_STATIC_LIB "jemalloc_pic.a")
     if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DENABLE_JEMALLOC_PROF")
         set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DENABLE_JEMALLOC_PROF")
@@ -115,18 +115,18 @@ message(STATUS "Build type = ${CMAKE_BUILD_TYPE}")
 
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
 
-    set(CMAKE_CXX_FLAGS "-Ofast -DNDEBUG")
-    set(CMAKE_C_FLAGS  "-Ofast -DNDEBUG")
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Ofast -DNDEBUG")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Ofast -DNDEBUG")
 
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 
-    set(CMAKE_CXX_FLAGS "-O2 -g -DNDEBUG")
-    set(CMAKE_C_FLAGS  "-O2 -g -DNDEBUG")
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -O2 -g -DNDEBUG")
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -O2 -g -DNDEBUG")
 
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 
-    set(CMAKE_CXX_FLAGS "-O0 -g")
-    set(CMAKE_C_FLAGS "-O0 -g")
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -O0 -g")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g")
 
     if ("${CODE_COVERAGE}" STREQUAL "ON")
         add_compile_options(--coverage)

--- a/benchmark/local_infinity/fulltext/fulltext_benchmark.cpp
+++ b/benchmark/local_infinity/fulltext/fulltext_benchmark.cpp
@@ -133,7 +133,17 @@ void BenchmarkImport(SharedPtr<Infinity> infinity,
 
     profiler.Begin();
     ImportOptions import_options;
-    import_options.copy_file_type_ = CopyFileType::kJSONL;
+    String extension = Path(import_from).filename().extension().string();
+    if (extension == ".jsonl") {
+        import_options.copy_file_type_ = CopyFileType::kJSONL;
+    } else if (extension == ".json") {
+        import_options.copy_file_type_ = CopyFileType::kJSON;
+    } else if (extension == ".csv") {
+        import_options.copy_file_type_ = CopyFileType::kCSV;
+    } else {
+        LOG_ERROR(fmt::format("Unsupported file extension: {}", extension));
+        return;
+    }
     infinity->Import(db_name, table_name, import_from, std::move(import_options));
     LOG_INFO(fmt::format("Import data cost: {}", profiler.ElapsedToString()));
     profiler.End();
@@ -328,11 +338,10 @@ int main(int argc, char *argv[]) {
     String index_name = "ft_dbpedia_index";
     String srcfile = test_data_path();
     srcfile += "/benchmark/dbpedia-entity/corpus.jsonl";
+    // srcfile += "/benchmark/enwiki.33332620.csv";
 
-//#define DEL_LOCAL_DATA
-#ifdef DEL_LOCAL_DATA
-    system("rm -rf /var/infinity/data /var/infinity/wal /var/infinity/log /var/infinity/tmp");
-#endif
+    printf("Cleanup /var/infinity\n");
+    system("rm -rf /var/infinity/data /var/infinity/log /var/infinity/persistence /var/infinity/tmp /var/infinity/wal");
 
     SharedPtr<Infinity> infinity = CreateDbAndTable(db_name, table_name);
 

--- a/scripts/Dockerfile_infinity_builder_centos7
+++ b/scripts/Dockerfile_infinity_builder_centos7
@@ -128,7 +128,7 @@ RUN --mount=type=bind,source=v1.1.0.tar.gz,target=/root/v1.1.0.tar.gz  \
 # Refers to https://github.com/jemalloc/jemalloc/issues/2454
 RUN --mount=type=bind,source=jemalloc-5.3.0.tar.bz2,target=/root/jemalloc-5.3.0.tar.bz2  \
     cd /root && tar xjf jemalloc-5.3.0.tar.bz2 \
-    && cd jemalloc-5.3.0 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --enable-static --disable-libdl --enable-prof --enable-prof-libunwind && make -j install \
+    && cd jemalloc-5.3.0 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --enable-static --disable-libdl --enable-prof --enable-prof-libunwind --disable-initial-exec-tls && make -j install \
     && ldconfig && cd /root && rm -rf jemalloc-5.3.0
 
 # Install gperftools-2.15

--- a/scripts/Dockerfile_infinity_builder_centos7
+++ b/scripts/Dockerfile_infinity_builder_centos7
@@ -128,7 +128,7 @@ RUN --mount=type=bind,source=v1.1.0.tar.gz,target=/root/v1.1.0.tar.gz  \
 # Refers to https://github.com/jemalloc/jemalloc/issues/2454
 RUN --mount=type=bind,source=jemalloc-5.3.0.tar.bz2,target=/root/jemalloc-5.3.0.tar.bz2  \
     cd /root && tar xjf jemalloc-5.3.0.tar.bz2 \
-    && cd jemalloc-5.3.0 && CFLAGS="-fPIE" CXXFLAGS="-fPIE" ./configure --enable-static --disable-libdl --enable-prof --enable-prof-libunwind && make -j install \
+    && cd jemalloc-5.3.0 && CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --enable-static --disable-libdl --enable-prof --enable-prof-libunwind && make -j install \
     && ldconfig && cd /root && rm -rf jemalloc-5.3.0
 
 # Install gperftools-2.15

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -383,6 +383,7 @@ target_link_libraries(embedded_infinity_ext PRIVATE
         thrift.a
         thriftnb.a
         snappy.a
+        ${JEMALLOC_STATIC_LIB}
 )
 
 # WARN: python modules shall not link to static libstdc++!!!

--- a/test/sql/dql/fulltext/fulltext.slt
+++ b/test/sql/dql/fulltext/fulltext.slt
@@ -6,7 +6,7 @@ statement ok
 DROP TABLE IF EXISTS sqllogic_test_enwiki;
 
 statement ok
-CREATE TABLE sqllogic_test_enwiki(doctitle varchar, docdate varchar, body varchar);
+CREATE TABLE sqllogic_test_enwiki(doctitle varchar DEFAULT '', docdate varchar DEFAULT '', body varchar DEFAULT '');
 
 # copy data from csv file
 query I


### PR DESCRIPTION
Enable jemalloc for release to reduce MemIndexer memory usage.

### Type of change

- [x] Performance Improvement
- [x] Python SDK impacted, Need to update PyPI
