### PR TITLE
Add check heartbeat to leader.

### DIFF
--- a/src/main/cluster_manager.cppm
+++ b/src/main/cluster_manager.cppm
@@ -40,8 +40,10 @@ public:
 public:
     Status RegisterToLeader();
     void HeartBeatToLeader();
+    void CheckHeartBeat();
 
 private:
+    void CheckHeartBeatInner();
     Status RegisterToLeaderNoLock();
     Status UnregisterFromLeaderNoLock();
     Tuple<SharedPtr<PeerClient>, Status> ConnectToServerNoLock(const String &server_ip, i64 server_port);

--- a/src/main/infinity_context.cpp
+++ b/src/main/infinity_context.cpp
@@ -286,6 +286,8 @@ Status InfinityContext::ChangeRole(NodeRole target_role, const String &node_name
     Status status = Status::OK();
     if(target_role == NodeRole::kFollower or target_role == NodeRole::kLearner) {
         status = cluster_manager_->RegisterToLeader();
+    } else if (target_role == NodeRole::kLeader) {
+        cluster_manager_->CheckHeartBeat();
     }
     return status;
 }

--- a/src/network/peer_server_thrift_service.cpp
+++ b/src/network/peer_server_thrift_service.cpp
@@ -137,7 +137,7 @@ void PeerServerThriftService::HeartBeat(infinity_peer_server::HeartBeatResponse 
         }
     } else {
         response.error_code = static_cast<i64>(ErrorCode::kInvalidNodeRole);
-        response.error_message = fmt::format("Attempt to unregister from a non-leader node: {}", ToString(leader_node->node_role_));
+        response.error_message = fmt::format("Attempt to heatbeat from a non-leader node: {}", ToString(leader_node->node_role_));
     }
     return;
 }


### PR DESCRIPTION
### What problem does this PR solve?

When change role to leader, check heartbeat from follower and learner. If difference between last update ts and current ts is larger than 2 * heartbeat ts, the follower/learner is set as timeout.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
