### PR TITLE
Issue error message when no 'next_column_id' in table_entry

### DIFF
--- a/src/storage/meta/entry/table_entry.cpp
+++ b/src/storage/meta/entry/table_entry.cpp
@@ -1219,6 +1219,11 @@ UniquePtr<TableEntry> TableEntry::Deserialize(const nlohmann::json &table_entry_
     TxnTimeStamp begin_ts = table_entry_json["begin_ts"];
     SegmentID unsealed_id = table_entry_json["unsealed_id"];
     SegmentID next_segment_id = table_entry_json["next_segment_id"];
+
+    if(!table_entry_json.contains("next_column_id")) {
+        String error_message = "No 'next_column_id in table entry of catalog file, maybe your catalog is generated before 0.4.0.'";
+        UnrecoverableError(error_message);
+    }
     ColumnID next_column_id = table_entry_json["next_column_id"];
 
     UniquePtr<TableEntry> table_entry = MakeUnique<TableEntry>(deleted,


### PR DESCRIPTION
### What problem does this PR solve?

In 0.4.0-dev2, we introduce next_column_id in table entry, if user try to load the catalog file before 0.4.0-dev2. Infinity will exit without proper error message.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
