### PR TITLE
Handle object persist/cleanup/read outside persistence_manager.

### DIFF
--- a/src/storage/invertedindex/column_index_iterator.cpp
+++ b/src/storage/invertedindex/column_index_iterator.cpp
@@ -16,6 +16,7 @@ import local_file_system;
 import third_party;
 import infinity_context;
 import persistence_manager;
+import persist_result_handler;
 
 namespace infinity {
 
@@ -31,10 +32,15 @@ ColumnIndexIterator::ColumnIndexIterator(const String &index_dir, const String &
     posting_file.append(POSTING_SUFFIX);
 
     if (use_object_cache) {
+        PersistResultHandler handler(pm);
         dict_file_path_ = dict_file;
         posting_file_path_ = posting_file;
-        dict_file = pm->GetObjPath(pm->GetObjCache(dict_file).obj_key_);
-        posting_file = pm->GetObjPath(pm->GetObjCache(posting_file).obj_key_);
+        PersistReadResult result = pm->GetObjCache(dict_file);
+        const ObjAddr &obj_addr = handler.HandleReadResult(result);
+        dict_file = pm->GetObjPath(obj_addr.obj_key_);
+        PersistReadResult result2 = pm->GetObjCache(posting_file);
+        const ObjAddr &obj_addr2 = handler.HandleReadResult(result2);
+        posting_file = pm->GetObjPath(obj_addr2.obj_key_);
     }
 
     dict_reader_ = MakeShared<DictionaryReader>(dict_file, PostingFormatOption(flag));

--- a/src/storage/invertedindex/column_index_merger.cpp
+++ b/src/storage/invertedindex/column_index_merger.cpp
@@ -31,6 +31,7 @@ import persistence_manager;
 import infinity_context;
 import defer_op;
 import utility;
+import persist_result_handler;
 
 namespace infinity {
 ColumnIndexMerger::ColumnIndexMerger(const String &index_dir, optionflag_t flag) : index_dir_(index_dir), flag_(flag) {}
@@ -96,7 +97,10 @@ void ColumnIndexMerger::Merge(const Vector<String> &base_names, const Vector<Row
             u32 id_offset = base_row_id - merge_base_rowid;
 
             if (use_object_cache) {
-                column_len_file = pm->GetObjPath(pm->GetObjCache(column_len_file).obj_key_);
+                PersistResultHandler handler(pm);
+                PersistReadResult result = pm->GetObjCache(column_len_file);
+                const ObjAddr &obj_addr = handler.HandleReadResult(result);
+                column_len_file = pm->GetObjPath(obj_addr.obj_key_);
             }
 
             auto [file_handler, status] = fs_.OpenFile(column_len_file, FileFlags::READ_FLAG, FileLockType::kNoLock);
@@ -147,9 +151,13 @@ void ColumnIndexMerger::Merge(const Vector<String> &base_names, const Vector<Row
     fs_.AppendFile(tmp_dict_file, tmp_fst_file);
     fs_.DeleteFile(tmp_fst_file);
     if (use_object_cache) {
-        pm->Persist(dict_file, tmp_dict_file, false);
-        pm->Persist(posting_file, tmp_posting_file, false);
-        pm->Persist(column_length_file, tmp_column_length_file, false);
+        PersistResultHandler handler(pm);
+        PersistWriteResult result1 = pm->Persist(dict_file, tmp_dict_file, false);
+        PersistWriteResult result2 = pm->Persist(posting_file, tmp_posting_file, false);
+        PersistWriteResult result3 = pm->Persist(column_length_file, tmp_column_length_file, false);
+        handler.HandleWriteResult(result1);
+        handler.HandleWriteResult(result2);
+        handler.HandleWriteResult(result3);
     }
 }
 

--- a/src/storage/invertedindex/disk_segment_reader.cpp
+++ b/src/storage/invertedindex/disk_segment_reader.cpp
@@ -36,6 +36,7 @@ import status;
 import logger;
 import persistence_manager;
 import infinity_context;
+import persist_result_handler;
 
 namespace infinity {
 
@@ -49,7 +50,9 @@ DiskIndexSegmentReader::DiskIndexSegmentReader(const String &index_dir, const St
     posting_file_.append(POSTING_SUFFIX);
     String posting_file = posting_file_;
     if (nullptr != pm) {
-        ObjAddr obj_addr = pm->GetObjCache(posting_file);
+        PersistResultHandler handler(pm);
+        PersistReadResult result = pm->GetObjCache(posting_file);
+        const ObjAddr &obj_addr = handler.HandleReadResult(result);
         if (!obj_addr.Valid()) {
             // Empty posting
             return;
@@ -72,7 +75,10 @@ DiskIndexSegmentReader::DiskIndexSegmentReader(const String &index_dir, const St
     dict_file_.append(DICT_SUFFIX);
     String dict_file = dict_file_;
     if (nullptr != pm) {
-        dict_file = pm->GetObjPath(pm->GetObjCache(dict_file).obj_key_);
+        PersistResultHandler handler(pm);
+        PersistReadResult result = pm->GetObjCache(dict_file);
+        const ObjAddr &obj_addr = handler.HandleReadResult(result);
+        dict_file = pm->GetObjPath(obj_addr.obj_key_);
     }
     dict_reader_ = MakeShared<DictionaryReader>(dict_file, PostingFormatOption(flag));
 }

--- a/src/storage/invertedindex/memory_indexer.cpp
+++ b/src/storage/invertedindex/memory_indexer.cpp
@@ -66,6 +66,7 @@ import blocking_queue;
 import segment_index_entry;
 import persistence_manager;
 import utility;
+import persist_result_handler;
 
 namespace infinity {
 constexpr int MAX_TUPLE_LENGTH = 1024; // we assume that analyzed term, together with docid/offset info, will never exceed such length
@@ -318,9 +319,13 @@ void MemoryIndexer::Dump(bool offline, bool spill) {
     fs.Write(*file_handler, &column_length_array[0], sizeof(column_length_array[0]) * column_length_array.size());
     fs.Close(*file_handler);
     if (use_object_cache) {
-        pm->Persist(posting_file, tmp_posting_file, false);
-        pm->Persist(dict_file, tmp_dict_file, false);
-        pm->Persist(column_length_file, tmp_column_length_file, false);
+        PersistResultHandler handler(pm);
+        PersistWriteResult result1 = pm->Persist(posting_file, tmp_posting_file, false);
+        PersistWriteResult result2 = pm->Persist(dict_file, tmp_dict_file, false);
+        PersistWriteResult result3 = pm->Persist(column_length_file, tmp_column_length_file, false);
+        handler.HandleWriteResult(result1);
+        handler.HandleWriteResult(result2);
+        handler.HandleWriteResult(result3);
     }
 
     is_spilled_ = spill;
@@ -493,9 +498,13 @@ void MemoryIndexer::TupleListToIndexFile(UniquePtr<SortMergerTermTuple<TermTuple
     fs.Write(*file_handler, &unsafe_column_lengths[0], sizeof(unsafe_column_lengths[0]) * unsafe_column_lengths.size());
     fs.Close(*file_handler);
     if (use_object_cache) {
-        pm->Persist(posting_file, tmp_posting_file, false);
-        pm->Persist(dict_file, tmp_dict_file, false);
-        pm->Persist(column_length_file, tmp_column_length_file, false);
+        PersistResultHandler handler(pm);
+        PersistWriteResult result1 = pm->Persist(posting_file, tmp_posting_file, false);
+        PersistWriteResult result2 = pm->Persist(dict_file, tmp_dict_file, false);
+        PersistWriteResult result3 = pm->Persist(column_length_file, tmp_column_length_file, false);
+        handler.HandleWriteResult(result1);
+        handler.HandleWriteResult(result2);
+        handler.HandleWriteResult(result3);
     }
 }
 

--- a/src/storage/meta/entry/chunk_index_entry.cpp
+++ b/src/storage/meta/entry/chunk_index_entry.cpp
@@ -45,6 +45,7 @@ import column_def;
 import internal_types;
 import infinity_context;
 import persistence_manager;
+import persist_result_handler;
 
 namespace infinity {
 
@@ -399,8 +400,11 @@ void ChunkIndexEntry::Cleanup(CleanupInfoTracer *info_tracer, bool dropped) {
         String posting_file = index_prefix + POSTING_SUFFIX;
         String dict_file = index_prefix + DICT_SUFFIX;
         if (pm != nullptr) {
-            pm->Cleanup(posting_file);
-            pm->Cleanup(dict_file);
+            PersistResultHandler handler(pm);
+            PersistWriteResult result1 = pm->Cleanup(posting_file);
+            PersistWriteResult result2 = pm->Cleanup(dict_file);
+            handler.HandleWriteResult(result1);
+            handler.HandleWriteResult(result2);
             LOG_DEBUG(fmt::format("Cleaned chunk index entry {}, posting: {}, dictionary file: {}", index_prefix, posting_file, dict_file));
         } else {
             String absolute_posting_file = fmt::format("{}/{}", InfinityContext::instance().config()->DataDir(), posting_file);

--- a/src/storage/persistence/persist_result_handler.cpp
+++ b/src/storage/persistence/persist_result_handler.cpp
@@ -1,0 +1,46 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <vector>
+#include <filesystem>
+
+module persist_result_handler;
+
+import infinity_exception;
+import third_party;
+
+namespace fs = std::filesystem;
+
+namespace infinity {
+
+void PersistResultHandler::HandleWriteResult(const PersistWriteResult &result) {
+    for ([[maybe_unused]] const String &persist_key : result.persist_keys_) {
+        //
+    }
+    for (const String &drop_key : result.drop_keys_) {
+        String drop_path = pm_->GetObjPath(drop_key);
+        fs::remove(drop_path);
+    }
+}
+
+ObjAddr PersistResultHandler::HandleReadResult(const PersistReadResult &result) {
+    if (!result.cached_) {
+        UnrecoverableError(fmt::format("HandleReadResult: object {} is not cached", result.obj_addr_.obj_key_));
+    }
+    return result.obj_addr_;
+}
+
+}

--- a/src/storage/persistence/persist_result_handler.cppm
+++ b/src/storage/persistence/persist_result_handler.cppm
@@ -1,0 +1,36 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module persist_result_handler;
+
+import stl;
+import persistence_manager;
+
+namespace infinity {
+
+export class PersistResultHandler {
+public:
+    PersistResultHandler(PersistenceManager *pm) : pm_(pm) {}
+
+    void HandleWriteResult(const PersistWriteResult &result);
+
+    ObjAddr HandleReadResult(const PersistReadResult &result);
+
+private:
+    PersistenceManager *pm_;
+};
+
+}

--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -321,6 +321,7 @@ PersistReadResult PersistenceManager::GetObjCache(const String &file_path) {
     if (it == local_path_obj_.end()) {
         String error_message = fmt::format("GetObjCache Failed to find object for local path {}", local_path);
         LOG_WARN(error_message);
+        result.cached_ = true; // TODO
         return result;
     }
     auto oit = objects_.find(it->second.obj_key_);

--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -153,7 +153,9 @@ PersistenceManager::~PersistenceManager() {
     assert(sum_ref_count == 0);
 }
 
-ObjAddr PersistenceManager::Persist(const String &file_path, const String &tmp_file_path, bool try_compose) {
+PersistWriteResult PersistenceManager::Persist(const String &file_path, const String &tmp_file_path, bool try_compose) {
+    PersistWriteResult result;
+
     std::error_code ec;
     fs::path src_fp = tmp_file_path;
 
@@ -167,7 +169,7 @@ ObjAddr PersistenceManager::Persist(const String &file_path, const String &tmp_f
         std::lock_guard<std::mutex> lock(mtx_);
         auto it = local_path_obj_.find(local_path);
         if (it != local_path_obj_.end()) {
-            CleanupNoLock(it->second);
+            CleanupNoLock(it->second, result.persist_keys_, result.drop_keys_);
             LOG_TRACE(fmt::format("Persist deleted mapping from local path {} to ObjAddr({}, {}, {})",
                                   local_path,
                                   it->second.obj_key_,
@@ -186,7 +188,7 @@ ObjAddr PersistenceManager::Persist(const String &file_path, const String &tmp_f
         LOG_WARN(error_message);
         std::lock_guard<std::mutex> lock(mtx_);
         local_path_obj_.erase(local_path);
-        return ObjAddr();
+        return result;
     } else if (!try_compose || src_size >= object_size_limit_) {
         String obj_key = ObjCreate();
         fs::path dst_fp = workspace_;
@@ -207,11 +209,13 @@ ObjAddr PersistenceManager::Persist(const String &file_path, const String &tmp_f
                               obj_addr.obj_key_,
                               obj_addr.part_offset_,
                               obj_addr.part_size_));
-        return obj_addr;
+        result.persist_keys_.push_back(obj_key);
+        result.obj_addr_ = obj_addr;
+        return result;
     } else {
         std::lock_guard<std::mutex> lock(mtx_);
         if (int(src_size) > CurrentObjRoomNoLock()) {
-            CurrentObjFinalizeNoLock();
+            CurrentObjFinalizeNoLock(result.persist_keys_);
         }
         ObjAddr obj_addr(current_object_key_, current_object_size_, src_size);
         CurrentObjAppendNoLock(tmp_file_path, src_size);
@@ -227,18 +231,20 @@ ObjAddr PersistenceManager::Persist(const String &file_path, const String &tmp_f
                               obj_addr.obj_key_,
                               obj_addr.part_offset_,
                               obj_addr.part_size_));
-        return obj_addr;
+        result.obj_addr_ = obj_addr;
+        return result;
     }
 }
 
 // TODO:
 // - Upload the finalized object to object store in background.
-void PersistenceManager::CurrentObjFinalize(bool validate) {
+PersistWriteResult PersistenceManager::CurrentObjFinalize(bool validate) {
+    PersistWriteResult result;
     std::lock_guard<std::mutex> lock(mtx_);
-    CurrentObjFinalizeNoLock();
+    CurrentObjFinalizeNoLock(result.persist_keys_);
 
     if (!validate)
-        return;
+        return result;
     for (auto &[local_path, obj_addr] : local_path_obj_) {
         auto it = objects_.find(obj_addr.obj_key_);
         if (it == objects_.end()) {
@@ -272,9 +278,11 @@ void PersistenceManager::CurrentObjFinalize(bool validate) {
             }
         }
     }
+    return result;
 }
 
-void PersistenceManager::CurrentObjFinalizeNoLock() {
+void PersistenceManager::CurrentObjFinalizeNoLock(Vector<String> &persist_keys) {
+    persist_keys.push_back(current_object_key_);
     if (current_object_size_ > 0) {
         if (current_object_parts_ > 1) {
             // Add footer to composed object -- format version 1
@@ -299,7 +307,9 @@ void PersistenceManager::CurrentObjFinalizeNoLock() {
     }
 }
 
-ObjAddr PersistenceManager::GetObjCache(const String &file_path) {
+PersistReadResult PersistenceManager::GetObjCache(const String &file_path) {
+    PersistReadResult result;
+
     String local_path = RemovePrefix(file_path);
     if (local_path.empty()) {
         String error_message = fmt::format("Failed to find local path of {}", local_path);
@@ -311,7 +321,7 @@ ObjAddr PersistenceManager::GetObjCache(const String &file_path) {
     if (it == local_path_obj_.end()) {
         String error_message = fmt::format("GetObjCache Failed to find object for local path {}", local_path);
         LOG_WARN(error_message);
-        return ObjAddr();
+        return result;
     }
     auto oit = objects_.find(it->second.obj_key_);
     if (oit != objects_.end()) {
@@ -321,12 +331,13 @@ ObjAddr PersistenceManager::GetObjCache(const String &file_path) {
         if (it->second.obj_key_ != current_object_key_) {
             String error_message = fmt::format("GetObjCache object {} not found", it->second.obj_key_);
             UnrecoverableError(error_message);
-            return ObjAddr();
         }
         current_object_ref_count_++;
         LOG_TRACE(fmt::format("GetObjCache current object {} ref count {}", it->second.obj_key_, current_object_ref_count_));
     }
-    return it->second;
+    result.obj_addr_ = it->second;
+    result.cached_ = true; // TODO
+    return result;
 }
 
 ObjAddr PersistenceManager::GetObjCacheWithoutCnt(const String &local_path) {
@@ -416,11 +427,11 @@ void PersistenceManager::CurrentObjAppendNoLock(const String &tmp_file_path, Siz
     dstFile.close();
 }
 
-void PersistenceManager::CleanupNoLock(const ObjAddr &object_addr, bool check_ref_count) {
+void PersistenceManager::CleanupNoLock(const ObjAddr &object_addr, Vector<String> &persist_keys, Vector<String> &drop_keys, bool check_ref_count) {
     auto it = objects_.find(object_addr.obj_key_);
     if (it == objects_.end()) {
         if (object_addr.obj_key_ == current_object_key_) {
-            CurrentObjFinalizeNoLock();
+            CurrentObjFinalizeNoLock(persist_keys);
             it = objects_.find(object_addr.obj_key_);
             assert(it != objects_.end());
         } else {
@@ -493,15 +504,16 @@ void PersistenceManager::CleanupNoLock(const ObjAddr &object_addr, bool check_re
 
     LOG_TRACE(fmt::format("Deleted object {} range [{}, {})", object_addr.obj_key_, orig_range.start_, orig_range.end_));
     if (range.start_ == 0 && range.end_ == it->second.obj_size_ && object_addr.obj_key_ != current_object_key_) {
-        fs::path fp = workspace_;
+        // fs::path fp = workspace_;
         if (object_addr.obj_key_.empty()) {
             String error_message = fmt::format("Failed to find object key");
             UnrecoverableError(error_message);
         }
-        fp.append(object_addr.obj_key_);
-        fs::remove(fp);
+        drop_keys.emplace_back(object_addr.obj_key_);
+        // fp.append(object_addr.obj_key_);
+        // fs::remove(fp);
         objects_.erase(it);
-        LOG_TRACE(fmt::format("Deleted object {}", object_addr.obj_key_));
+        // LOG_TRACE(fmt::format("Deleted object {}", object_addr.obj_key_));
     }
 }
 
@@ -560,7 +572,9 @@ String PersistenceManager::RemovePrefix(const String &path) {
     return "";
 }
 
-void PersistenceManager::Cleanup(const String &file_path) {
+PersistWriteResult PersistenceManager::Cleanup(const String &file_path) {
+    PersistWriteResult result;
+
     String local_path = RemovePrefix(file_path);
     if (local_path.empty()) {
         String error_message = fmt::format("Failed to find local path of {}", local_path);
@@ -572,15 +586,16 @@ void PersistenceManager::Cleanup(const String &file_path) {
     if (it == local_path_obj_.end()) {
         String error_message = fmt::format("Failed to find object for local path {}", local_path);
         LOG_WARN(error_message);
-        return;
+        return result;
     }
-    CleanupNoLock(it->second, true);
+    CleanupNoLock(it->second, result.persist_keys_, result.drop_keys_, true);
     LOG_TRACE(fmt::format("Deleted mapping from local path {} to ObjAddr({}, {}, {})",
                           local_path,
                           it->second.obj_key_,
                           it->second.part_offset_,
                           it->second.part_size_));
     local_path_obj_.erase(it);
+    return result;
 }
 
 nlohmann::json PersistenceManager::Serialize() {

--- a/src/unit_test/storage/invertedindex/posting_merger.cpp
+++ b/src/unit_test/storage/invertedindex/posting_merger.cpp
@@ -31,6 +31,7 @@ import vector_with_lock;
 import logger;
 import infinity_context;
 import persistence_manager;
+import persist_result_handler;
 
 using namespace infinity;
 
@@ -151,7 +152,10 @@ TEST_P(PostingMergerTest, Basic) {
             String real_column_len_file = column_len_file;
             PersistenceManager *pm = InfinityContext::instance().persistence_manager();
             if (pm != nullptr) {
-                real_column_len_file = pm->GetObjPath(pm->GetObjCache(real_column_len_file).obj_key_);
+                PersistResultHandler handler(pm);
+                PersistReadResult result = pm->GetObjCache(real_column_len_file);
+                const ObjAddr &obj_addr = handler.HandleReadResult(result);
+                real_column_len_file = pm->GetObjPath(obj_addr.obj_key_);
             }
             RowID base_row_id = row_ids[i];
             u32 id_offset = base_row_id - merge_base_rowid;

--- a/src/unit_test/storage/persistence/persistence_manager.cpp
+++ b/src/unit_test/storage/persistence/persistence_manager.cpp
@@ -5,6 +5,7 @@ import persistence_manager;
 import local_file_system;
 import file_system_type;
 import third_party;
+import persist_result_handler;
 
 using namespace infinity;
 namespace fs = std::filesystem;
@@ -18,6 +19,7 @@ public:
         system(("mkdir -p " + workspace_).c_str());
         system(("mkdir -p " + file_dir_).c_str());
         pm_ = MakeUnique<PersistenceManager>(workspace_, file_dir_, ObjSizeLimit);
+        handler_ = MakeUnique<PersistResultHandler>(pm_.get());
     }
     void CheckObjData(const String& obj_addr, const String& data);
 
@@ -26,10 +28,12 @@ protected:
     String file_dir_{};
     UniquePtr<PersistenceManager> pm_{};
     static constexpr int ObjSizeLimit = 128;
+    UniquePtr<PersistResultHandler> handler_;
 };
 
 void PersistenceManagerTest::CheckObjData(const String& local_file_path, const String& data) {
-    auto obj_addr = pm_->GetObjCache(local_file_path);
+    PersistReadResult result = pm_->GetObjCache(local_file_path);
+    const ObjAddr &obj_addr = handler_->HandleReadResult(result);
     String obj_path = pm_->GetObjPath(obj_addr.obj_key_);
     fs::path obj_fp(obj_path);
     ASSERT_TRUE(fs::exists(obj_fp));
@@ -56,10 +60,13 @@ TEST_F(PersistenceManagerTest, PersistFileBasic) {
     String persist_str = "Persistence Manager Test";
     out_file << persist_str;
     out_file.close();
-    ObjAddr obj_addr = pm_->Persist(file_path, file_path);
+    PersistWriteResult result = pm_->Persist(file_path, file_path);
+    handler_->HandleWriteResult(result);
+    const ObjAddr &obj_addr = result.obj_addr_;
     ASSERT_TRUE(obj_addr.Valid());
     ASSERT_EQ(obj_addr.part_size_, persist_str.size());
-    pm_->CurrentObjFinalize();
+    PersistWriteResult result2 = pm_->CurrentObjFinalize();
+    handler_->HandleWriteResult(result2);
 
     CheckObjData(file_path, persist_str);
 }
@@ -78,14 +85,17 @@ TEST_F(PersistenceManagerTest, PersistMultiFile) {
         file_paths.push_back(file_path);
         persist_strs.push_back(persist_str);
 
-        ObjAddr obj_addr = pm_->Persist(file_path, file_path);
+        PersistWriteResult result = pm_->Persist(file_path, file_path);
+        handler_->HandleWriteResult(result);
+        const ObjAddr &obj_addr = result.obj_addr_;
         ASSERT_TRUE(obj_addr.Valid());
         ASSERT_EQ(obj_addr.part_size_, persist_str.size());
         obj_addrs.push_back(obj_addr);
     }
     ASSERT_EQ(file_paths.size(), persist_strs.size());
     ASSERT_EQ(file_paths.size(), obj_addrs.size());
-    pm_->CurrentObjFinalize();
+    PersistWriteResult result = pm_->CurrentObjFinalize();
+    handler_->HandleWriteResult(result);
 
     for (SizeT i = 0; i < file_paths.size(); ++i) {
         CheckObjData(file_paths[i], persist_strs[i]);
@@ -99,6 +109,7 @@ TEST_F(PersistenceManagerTest, PersistFileMultiThread) {
     HashMap<String, ObjAddr> obj_addrs;
     Vector<std::thread> threads;
     std::mutex obj_mutex;
+
     for (SizeT i = 0; i < 10; ++i) {
         String file_path = file_path_base + std::to_string(i);
         std::ofstream out_file(file_path);
@@ -109,7 +120,9 @@ TEST_F(PersistenceManagerTest, PersistFileMultiThread) {
         persist_strs.push_back(persist_str);
 
         threads.emplace_back([this, file_path, persist_str, &obj_addrs, &obj_mutex]() {
-            ObjAddr obj_addr = pm_->Persist(file_path, file_path);
+            PersistWriteResult result = pm_->Persist(file_path, file_path);
+            handler_->HandleWriteResult(result);
+            const ObjAddr &obj_addr = result.obj_addr_;
             ASSERT_TRUE(obj_addr.Valid());
             ASSERT_EQ(obj_addr.part_size_, persist_str.size());
             std::unique_lock<std::mutex> lock(obj_mutex);
@@ -121,7 +134,8 @@ TEST_F(PersistenceManagerTest, PersistFileMultiThread) {
     }
     ASSERT_EQ(file_paths.size(), persist_strs.size());
     ASSERT_EQ(file_paths.size(), obj_addrs.size());
-    pm_->CurrentObjFinalize();
+    PersistWriteResult result = pm_->CurrentObjFinalize();
+    handler_->HandleWriteResult(result);
 
     for (SizeT i = 0; i < file_paths.size(); ++i) {
         CheckObjData(file_paths[i], persist_strs[i]);
@@ -144,7 +158,9 @@ TEST_F(PersistenceManagerTest, CleanupBasic) {
         file_paths.push_back(file_path);
         persist_strs.push_back(persist_str);
 
-        ObjAddr obj_addr = pm_->Persist(file_path, file_path);
+        PersistWriteResult result = pm_->Persist(file_path, file_path);
+        handler_->HandleWriteResult(result);
+        const ObjAddr &obj_addr = result.obj_addr_;
         ASSERT_TRUE(obj_addr.Valid());
         ASSERT_EQ(obj_addr.part_size_, persist_str.size());
         obj_addrs.push_back(obj_addr);
@@ -152,7 +168,8 @@ TEST_F(PersistenceManagerTest, CleanupBasic) {
     }
     ASSERT_EQ(file_paths.size(), persist_strs.size());
     ASSERT_EQ(file_paths.size(), obj_addrs.size());
-    pm_->CurrentObjFinalize();
+    PersistWriteResult result = pm_->CurrentObjFinalize();
+    handler_->HandleWriteResult(result);
 
     for (SizeT i = 0; i < file_paths.size(); ++i) {
         CheckObjData(file_paths[i], persist_strs[i]);
@@ -167,7 +184,8 @@ TEST_F(PersistenceManagerTest, CleanupBasic) {
     std::shuffle(file_paths.begin(), file_paths.end(), g);
 
     for (auto& file_path : file_paths) {
-        pm_->Cleanup(file_path);
+        PersistWriteResult result = pm_->Cleanup(file_path);
+        handler_->HandleWriteResult(result);
     }
     for (const auto& obj_path : obj_paths) {
         ASSERT_FALSE(fs::exists(obj_path));


### PR DESCRIPTION
### What problem does this PR solve?

PersistenceManager::Persist, PersistenceManager::Finalize, PersistenceManager::Cleanup now return PersistWriteResult.
PersistenceManager::GetObj now return PersistReadResult.

PerisistResultHandler is used to handle the result.
If remote filesystem is supported. the envict and recover key is inside the PersistWriteResult. and PersistReadResult will contain whether cache is valid. Send request to remote fielsystem and update cache is job of PersistResultHandler.

### Type of change

- [x] Refactoring
