### PR TITLE
Fix: flush log when unrecoverable error

### DIFF
--- a/src/main/logger.cpp
+++ b/src/main/logger.cpp
@@ -89,6 +89,10 @@ void Logger::Initialize(const LoggerConfig &config) {
     SetLogLevel(config.log_level_);
 }
 
+void Logger::Flush() {
+    infinity_logger->flush();
+}
+
 void Logger::Shutdown() {
     if (stdout_sinker.get() != nullptr or rotating_file_sinker.get() != nullptr) {
         spdlog::shutdown();

--- a/src/main/logger.cppm
+++ b/src/main/logger.cppm
@@ -38,6 +38,7 @@ public:
     Initialize(Config* config_ptr);
 
     static void Initialize(const LoggerConfig &config);
+    static void Flush();
 
     static void
     Shutdown();


### PR DESCRIPTION
### What problem does this PR solve?

spdlog might not flush the data when unrecoverable error raised. This PR is to fix it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

