### PR TITLE
Fix corruption for offline index building for empty data

### DIFF
--- a/python/test_pysdk/test_index.py
+++ b/python/test_pysdk/test_index.py
@@ -656,6 +656,63 @@ class TestInfinity:
             "test_insert_data_fulltext_index_search" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
+    @pytest.mark.parametrize("file_format", ["csv"])
+    def test_empty_fulltext_index(self, file_format, suffix):
+        # prepare data for insert
+        column_names = ["doctitle", "docdate", "body"]
+        df = pandas.read_csv(os.getcwd() + TEST_DATA_DIR + file_format + "/enwiki_99." + file_format,
+                             delimiter="\t",
+                             header=None,
+                             names=column_names)
+        data = {key: list(value.values())
+                for key, value in df.to_dict().items()}
+
+        db_obj = self.infinity_obj.get_database("default_db")
+        res = db_obj.drop_table(
+            "test_empty_fulltext_index" + suffix, ConflictType.Ignore)
+        assert res.error_code == ErrorCode.OK
+        table_obj = db_obj.create_table("test_empty_fulltext_index" + suffix, {
+            "doctitle": {"type": "varchar"}, "docdate": {"type": "varchar"}, "body": {"type": "varchar"}, "body2": {"type": "varchar", "default":""}
+        }, ConflictType.Error)
+
+        # Create 99*300/8192 = 3.6 BlockEntry to test MemIndexRecover and OptimizeIndex
+        for it in range(300):
+            value = []
+            for i in range(len(data["doctitle"])):
+                value.append({"doctitle": data["doctitle"][i],
+                              "docdate": data["docdate"][i], "body": data["body"][i]})
+            table_obj.insert(value)
+        for it in range(10):
+            value = []
+            for i in range(len(data["doctitle"])):
+                value.append({"doctitle": data["doctitle"][i],
+                              "docdate": data["docdate"][i], "body": ""})
+            table_obj.insert(value)
+        time.sleep(5)
+
+        res = table_obj.create_index("body_index",
+                                     index.IndexInfo("body",
+                                                     index.IndexType.FullText))
+        assert res.error_code == ErrorCode.OK
+        res = table_obj.create_index("body2_index",
+                                     index.IndexInfo("body2",
+                                                     index.IndexType.FullText))
+        assert res.error_code == ErrorCode.OK
+
+        res = table_obj.output(["doctitle", "docdate", "_row_id", "_score"]).match_text(
+            "body^5", "harmful chemical", 3).to_pl()
+        assert not res.is_empty()
+        print(res)
+
+        res = table_obj.output(["doctitle", "docdate", "body2", "_row_id", "_score"]).match_text(
+            "body2^5", "harmful chemical", 3).to_pl()
+        assert res.is_empty()
+        print(res)
+
+        res = db_obj.drop_table(
+            "test_empty_fulltext_index" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
     @pytest.mark.parametrize("check_data", [{"file_name": "enwiki_9.csv", "data_dir": common_values.TEST_TMP_DIR, }],
                              indirect=True)
     def test_fulltext_match_with_invalid_analyzer(self, check_data, suffix):

--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -260,9 +260,9 @@ void ColumnInverter::SortForOfflineDump() {
 
 void ColumnInverter::SpillSortResults(FILE *spill_file, u64 &tuple_count, UniquePtr<BufWriter>& buf_writer) {
     // spill sort results for external merge sort
-    if (positions_.empty()) {
-        return;
-    }
+    // if (positions_.empty()) {
+    //    return;
+    //}
     SizeT spill_file_tell = ftell(spill_file);
     // size of this Run in bytes
     u32 data_size = 0;

--- a/src/storage/invertedindex/common/external_sort_merger.cpp
+++ b/src/storage/invertedindex/common/external_sort_merger.cpp
@@ -153,6 +153,8 @@ void SortMerger<KeyType, LenType>::Init(DirectIO &io_stream) {
         u32 s = size_run_[i] > PRE_BUF_SIZE_ ? PRE_BUF_SIZE_ : size_run_[i];
         size_t ret = io_stream.Read(micro_buf_[i], s);
         size_micro_run_[i] = ret;
+        if (s == 0)
+            continue;
 
         /// it is not needed for compression, validation will be made within IOStream in that case
         // if a record can fit in microrun buffer

--- a/src/storage/invertedindex/common/loser_tree.cppm
+++ b/src/storage/invertedindex/common/loser_tree.cppm
@@ -47,10 +47,15 @@ public:
                            const Comparator& cmp = Comparator())
          : ik_(k), k_(round_up_to_power_of_two(k)),
           losers_(2 * k_), cmp_(cmp), first_insert_(true) {
-
+        /*
         for (Source i = ik_ - 1; i < k_; i++) {
             losers_[i + k_].sup = true;
             losers_[i + k_].source = invalid_;
+        }
+        */
+        for (Source i = 0; i < 2 * k_; i++) {
+            losers_[i].sup = true;
+            losers_[i].source = invalid_;
         }
     }
 

--- a/src/storage/io/virtual_store.cpp
+++ b/src/storage/io/virtual_store.cpp
@@ -272,6 +272,9 @@ Status VirtualStore::Truncate(const String &file_name, SizeT new_length) {
         UnrecoverableError(error_message);
     }
     std::error_code error_code;
+    if (!std::filesystem::exists(file_name)) {
+        std::ofstream file(file_name, std::ios::out | std::ios::binary | std::ios::trunc);
+    }
     std::filesystem::resize_file(file_name, new_length, error_code);
     if (error_code.value() != 0) {
         String error_message = fmt::format("Failed to truncate {} to size {}", file_name, strerror(errno));

--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -79,6 +79,8 @@ PersistenceManager::PersistenceManager(const String &workspace, const String &da
     if (!VirtualStore::Exists(workspace_)) {
         VirtualStore::MakeDirectory(workspace_);
     }
+    String read_path_empty = GetObjPath(ObjAddr::KeyEmpty);
+    VirtualStore::Truncate(read_path_empty, 0);
 }
 
 PersistenceManager::~PersistenceManager() = default;
@@ -114,10 +116,18 @@ PersistWriteResult PersistenceManager::Persist(const String &file_path, const St
         UnrecoverableError(error_message);
     }
     if (src_size == 0) {
-        String error_message = fmt::format("Persist skipped empty local path {}.", file_path);
+        String error_message = fmt::format("Persist empty local path {}.", file_path);
         LOG_WARN(error_message);
+        ObjAddr obj_addr(ObjAddr::KeyEmpty, 0, 0);
+        fs::remove(tmp_file_path, ec);
+        if (ec) {
+            String error_message = fmt::format("Failed to remove {}.", tmp_file_path);
+            UnrecoverableError(error_message);
+        }
         std::lock_guard<std::mutex> lock(mtx_);
-        local_path_obj_.erase(local_path);
+        local_path_obj_[local_path] = obj_addr;
+        result.persist_keys_.push_back(ObjAddr::KeyEmpty);
+        result.obj_addr_ = obj_addr;
         return result;
     } else if (!try_compose || src_size >= object_size_limit_) {
         String obj_key = ObjCreate();
@@ -235,7 +245,14 @@ PersistReadResult PersistenceManager::GetObjCache(const String &file_path) {
         return result;
     }
     result.obj_addr_ = it->second;
-    if (ObjStat *obj_stat = objects_->Get(it->second.obj_key_); obj_stat != nullptr) {
+    if (it->second.part_size_ == 0) {
+        LOG_TRACE(fmt::format("GetObjCache empty object {} for local path {}", it->second.obj_key_, local_path));
+        if (it->second.obj_key_ != ObjAddr::KeyEmpty) {
+            String error_message = fmt::format("GetObjCache object {} is empty", it->second.obj_key_);
+            UnrecoverableError(error_message);
+        }
+        result.cached_ = true;
+    } else if (ObjStat *obj_stat = objects_->Get(it->second.obj_key_); obj_stat != nullptr) {
         LOG_TRACE(fmt::format("GetObjCache object {} ref count {}", it->second.obj_key_, obj_stat->ref_count_));
         if(!obj_stat->cached_){
             String read_path = GetObjPath(result.obj_addr_.obj_key_);
@@ -308,7 +325,8 @@ PersistWriteResult PersistenceManager::PutObjCache(const String &file_path) {
         UnrecoverableError(error_message);
     }
     if (it->second.part_size_ == 0) {
-        UnrecoverableError(fmt::format("PutObjCache object {} part size is 0", it->second.obj_key_));
+        LOG_TRACE(fmt::format("PutObjCache empty object {} for local path {}", it->second.obj_key_, local_path));
+        return result;
     }
     ObjStat *obj_stat = objects_->Release(it->second.obj_key_, result.drop_keys_);
     if (obj_stat == nullptr) {
@@ -365,7 +383,10 @@ void PersistenceManager::CleanupNoLock(const ObjAddr &object_addr,
                                        bool check_ref_count) {
     ObjStat *obj_stat = objects_->GetNoCount(object_addr.obj_key_);
     if (obj_stat == nullptr) {
-        if (object_addr.obj_key_ == current_object_key_) {
+        if (object_addr.obj_key_ == ObjAddr::KeyEmpty) {
+            assert(object_addr.part_size_ == 0);
+            return;
+        } else if (object_addr.obj_key_ == current_object_key_) {
             CurrentObjFinalizeNoLock(persist_keys, drop_keys);
             obj_stat = objects_->GetNoCount(object_addr.obj_key_);
             assert(obj_stat != nullptr);

--- a/src/storage/persistence/persistence_manager.cppm
+++ b/src/storage/persistence/persistence_manager.cppm
@@ -42,6 +42,7 @@ export struct ObjAddr {
     void WriteBufAdv(char *&buf) const;
 
     static ObjAddr ReadBufAdv(const char *&buf);
+    static constexpr String KeyEmpty = "KEY_EMPTY";
 };
 
 export struct PersistWriteResult {

--- a/src/unit_test/storage/invertedindex/memory_indexer.cpp
+++ b/src/unit_test/storage/invertedindex/memory_indexer.cpp
@@ -183,8 +183,8 @@ TEST_P(MemoryIndexerTest, test3) {
 TEST_P(MemoryIndexerTest, test4) {
     auto fake_segment_index_entry_1 = SegmentIndexEntry::CreateFakeEntry(GetFullDataDir());
     MemoryIndexer indexer1(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
-    indexer1.Insert(empty_column_, 0, 10, true);
-    indexer1.Insert(column_, 0, 10, true);
+    indexer1.Insert(empty_column_, 0, 5, true);
+    indexer1.Insert(column_, 0, 5, true);
     indexer1.Dump(true);
     fake_segment_index_entry_1->AddFtChunkIndexEntry("chunk1", RowID(0U, 0U).ToUint64(), 5U);
     fake_segment_index_entry_1->UpdateFulltextColumnLenInfo(indexer1.GetColumnLengthSum(), indexer1.GetDocCount());
@@ -195,8 +195,8 @@ TEST_P(MemoryIndexerTest, test4) {
     reader.Open(flag_, GetFullDataDir(), std::move(index_by_segment), nullptr);
     Pair<u64, float> res = reader.GetTotalDfAndAvgColumnLength();
 
-    ASSERT_EQ(res.first, 20U);
-    ASSERT_EQ(res.second, 22.65f);
+    ASSERT_EQ(res.first, 10U);
+    ASSERT_EQ(res.second, 45.3f);
 }
 
 TEST_P(MemoryIndexerTest, SpillLoadTest) {

--- a/src/unit_test/storage/invertedindex/memory_indexer.cpp
+++ b/src/unit_test/storage/invertedindex/memory_indexer.cpp
@@ -169,14 +169,34 @@ TEST_P(MemoryIndexerTest, test3) {
     indexer1.Insert(empty_column_, 0, 10, true);
     indexer1.Dump(true);
     fake_segment_index_entry_1->AddFtChunkIndexEntry("chunk1", RowID(0U, 0U).ToUint64(), 5U);
+    fake_segment_index_entry_1->UpdateFulltextColumnLenInfo(indexer1.GetColumnLengthSum(), indexer1.GetDocCount());
 
     Map<SegmentID, SharedPtr<SegmentIndexEntry>> index_by_segment = {{1, fake_segment_index_entry_1}};
 
     ColumnIndexReader reader;
     reader.Open(flag_, GetFullDataDir(), std::move(index_by_segment), nullptr);
     Pair<u64, float> res = reader.GetTotalDfAndAvgColumnLength();
-    ASSERT_EQ(res.first, 0U);
+    ASSERT_EQ(res.first, 10U);
     ASSERT_EQ(res.second, 0.0f);
+}
+
+TEST_P(MemoryIndexerTest, test4) {
+    auto fake_segment_index_entry_1 = SegmentIndexEntry::CreateFakeEntry(GetFullDataDir());
+    MemoryIndexer indexer1(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    indexer1.Insert(empty_column_, 0, 10, true);
+    indexer1.Insert(column_, 0, 10, true);
+    indexer1.Dump(true);
+    fake_segment_index_entry_1->AddFtChunkIndexEntry("chunk1", RowID(0U, 0U).ToUint64(), 5U);
+    fake_segment_index_entry_1->UpdateFulltextColumnLenInfo(indexer1.GetColumnLengthSum(), indexer1.GetDocCount());
+
+    Map<SegmentID, SharedPtr<SegmentIndexEntry>> index_by_segment = {{1, fake_segment_index_entry_1}};
+
+    ColumnIndexReader reader;
+    reader.Open(flag_, GetFullDataDir(), std::move(index_by_segment), nullptr);
+    Pair<u64, float> res = reader.GetTotalDfAndAvgColumnLength();
+
+    ASSERT_EQ(res.first, 20U);
+    ASSERT_EQ(res.second, 22.65f);
 }
 
 TEST_P(MemoryIndexerTest, SpillLoadTest) {


### PR DESCRIPTION
### What problem does this PR solve?

Fix corruption for offline index building for empty data. Allowed persist empty file. Close #2028

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases
