### PR TITLE
Binary vector hamming distance APIs

### DIFF
--- a/python/infinity_embedded/local_infinity/query_builder.py
+++ b/python/infinity_embedded/local_infinity/query_builder.py
@@ -101,6 +101,22 @@ class InfinityLocalQueryBuilder(ABC):
                 ErrorCode.INVALID_TOPK_TYPE, f"Invalid topn, type should be embedded, but get {type(topn)}"
             )
 
+        if embedding_data_type == "bit":
+            if len(embedding_data) % 8 != 0:
+                raise InfinityException(
+                    ErrorCode.INVALID_EMBEDDING_DATA_TYPE, f"Embeddings with data bit must have dimension of times of 8!"
+                )
+            else:
+                new_embedding_data = []
+                dimesions = int(len(embedding_data) / 8)
+                for i in range(dimesions):
+                    bitunit = 0
+                    for bit_idx in range(8):
+                        if embedding_data[i * 8 + bit_idx] > 0:
+                            bitunit |= (1 << bit_idx)
+                    new_embedding_data.append(bitunit)
+                embedding_data = new_embedding_data
+
         # type casting
         if isinstance(embedding_data, list):
             embedding_data = embedding_data
@@ -125,7 +141,7 @@ class InfinityLocalQueryBuilder(ABC):
         elem_type = EmbeddingDataType.kElemFloat
         if embedding_data_type == "bit":
             elem_type = EmbeddingDataType.kElemBit
-            raise Exception(f"Invalid embedding {embedding_data[0]} type")
+            data.u8_array_value = embedding_data
         elif embedding_data_type in ["unsigned tinyint", "uint8"]:
             elem_type = EmbeddingDataType.kElemUInt8
             data.u8_array_value = embedding_data

--- a/python/infinity_http.py
+++ b/python/infinity_http.py
@@ -661,15 +661,13 @@ class infinity_http:
 
         for res in self.output_res:
             for k in res:
-                print(res[k])
+                # print(res[k])
                 if k not in df_dict:
                     df_dict[k] = ()
                 tup = df_dict[k]
                 if res[k].isdigit() or is_float(res[k]):
-                    print('number')
                     new_tup = tup + (eval(res[k]),)
                 elif is_list(res[k]):
-                    print('list')
                     new_tup = tup + (ast.literal_eval(res[k]),)
                 elif is_date(res[k]):
                     new_tup = tup + (res[k],)
@@ -678,11 +676,9 @@ class infinity_http:
                 elif is_datetime(res[k]):
                     new_tup = tup + (res[k],)
                 elif is_sparse(res[k]):  # sparse vector
-                    print('sparse')
                     sparse_vec = str2sparse(res[k])
                     new_tup = tup + (sparse_vec,)
                 else:
-                    print('str')
                     if res[k].lower() == 'true':
                         res[k] = True
                     elif res[k].lower() == 'false':

--- a/python/infinity_http.py
+++ b/python/infinity_http.py
@@ -661,13 +661,15 @@ class infinity_http:
 
         for res in self.output_res:
             for k in res:
-                #print(res[k])
+                print(res[k])
                 if k not in df_dict:
                     df_dict[k] = ()
                 tup = df_dict[k]
                 if res[k].isdigit() or is_float(res[k]):
+                    print('number')
                     new_tup = tup + (eval(res[k]),)
                 elif is_list(res[k]):
+                    print('list')
                     new_tup = tup + (ast.literal_eval(res[k]),)
                 elif is_date(res[k]):
                     new_tup = tup + (res[k],)
@@ -676,9 +678,11 @@ class infinity_http:
                 elif is_datetime(res[k]):
                     new_tup = tup + (res[k],)
                 elif is_sparse(res[k]):  # sparse vector
+                    print('sparse')
                     sparse_vec = str2sparse(res[k])
                     new_tup = tup + (sparse_vec,)
                 else:
+                    print('str')
                     if res[k].lower() == 'true':
                         res[k] = True
                     elif res[k].lower() == 'false':

--- a/python/infinity_sdk/infinity/remote_thrift/query_builder.py
+++ b/python/infinity_sdk/infinity/remote_thrift/query_builder.py
@@ -131,6 +131,22 @@ class InfinityThriftQueryBuilder(ABC):
                 f"Invalid embedding data, type should be embedded, but get {type(embedding_data)}",
             )
 
+        if embedding_data_type == "bit":
+            if len(embedding_data) % 8 != 0:
+                raise InfinityException(
+                    ErrorCode.INVALID_EMBEDDING_DATA_TYPE, f"Embeddings with data bit must have dimension of times of 8!"
+                )
+            else:
+                new_embedding_data = []
+                dimesions = int(len(embedding_data) / 8)
+                for i in range(dimesions):
+                    bitunit = 0
+                    for bit_idx in range(8):
+                        if embedding_data[i * 8 + bit_idx] > 0:
+                            bitunit |= (1 << bit_idx)
+                    new_embedding_data.append(bitunit)
+                embedding_data = new_embedding_data
+
         if embedding_data_type in ["uint8", "int8", "int16", "int32", "int", "int64"]:
             embedding_data = [int(x) for x in embedding_data]
 
@@ -141,7 +157,7 @@ class InfinityThriftQueryBuilder(ABC):
         elem_type = ElementType.ElementFloat32
         if embedding_data_type == "bit":
             elem_type = ElementType.ElementBit
-            raise InfinityException(ErrorCode.INVALID_EMBEDDING_DATA_TYPE, f"Invalid embedding {embedding_data[0]} type")
+            data.u8_array_value = embedding_data
         elif embedding_data_type == "uint8":
             elem_type = ElementType.ElementUInt8
             data.u8_array_value = embedding_data

--- a/python/test_pysdk/common/common_data.py
+++ b/python/test_pysdk/common/common_data.py
@@ -160,6 +160,8 @@ def is_sparse(str_input):
     pairs = tmp.split(",")
     for pair in pairs:
         t = pair.split(":")
+        if(len(t) != 2):
+            return False
         if not (t[0].isdigit() or is_float(t[0])):
             return False
         if not (t[1].isdigit() or is_float(t[1])):

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -1743,7 +1743,7 @@ class TestInfinity:
     @pytest.mark.parametrize("knn_distance_type", ["hamming"])
     def test_binary_embedding_hamming_distance(self, check_data, knn_distance_type, suffix):
         db_obj = self.infinity_obj.get_database("default_db")
-        db_obj.drop_table("test_binary_knn_hamming_distance" + suffix)
+        db_obj.drop_table("test_binary_knn_hamming_distance" + suffix, ConflictType.Ignore)
         table_obj = db_obj.create_table("test_binary_knn_hamming_distance" + suffix, {
             "c1" : {"type" : "int"},
             "c2" : {"type" : "vector, 16, bit"}

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -1749,7 +1749,7 @@ class TestInfinity:
             "c2" : {"type" : "vector, 16, bit"}
         }, ConflictType.Error)
 
-        table_obj.insert([{"c1" : 0, "c2" : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}])
+        table_obj.insert([{"c1" : 0, "c2" : [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}])
         table_obj.insert([{"c1" : 1, "c2" : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]}])
         table_obj.insert([{"c1" : 2, "c2" : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2]}])
         table_obj.insert([{"c1" : 3, "c2" : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3]}])
@@ -1757,6 +1757,10 @@ class TestInfinity:
         table_obj.insert([{"c1" : 5, "c2" : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5]}])
 
         res = table_obj.output(["*", "_distance"]).match_dense("c2", [0] * 16, "bit", "hamming", 3).to_df()
-        pd.testing.assert_frame_equal(res, pd.DataFrame(
-            {'c1' : (0, 1, 2), 'c2' : (['0000000000000000'], ['0000000000000001'], ['0000000000000011']), 'DISTANCE' : (0.0, 1.0, 2.0)}
-        ).astype({'c1': dtype('int32'), 'DISTANCE' : dtype('float32')})) 
+        if suffix == "_http":
+            pd.testing.assert_frame_equal(res, pd.DataFrame(
+                {'c1' : (0, 1, 2), 'c2' : ('[0100000000000000]', '[0000000000000001]', '[0000000000000011]'), 'DISTANCE' : (1.0, 1.0, 2.0)}).astype({'c1': dtype('int32'), 'DISTANCE' : dtype('float32')})) 
+        else:
+            pd.testing.assert_frame_equal(res, pd.DataFrame(
+                {'c1' : (0, 1, 2), 'c2' : (['0100000000000000'], ['0000000000000001'], ['0000000000000011']), 'DISTANCE' : (1.0, 1.0, 2.0)}
+            ).astype({'c1': dtype('int32'), 'DISTANCE' : dtype('float32')})) 

--- a/src/expression/filter_fulltext_expression.cpp
+++ b/src/expression/filter_fulltext_expression.cpp
@@ -76,7 +76,8 @@ bool FilterFulltextExpression::Eq(const BaseExpression &other_base) const {
         return false;
     }
     const auto &other = static_cast<const FilterFulltextExpression &>(other_base);
-    return fields_ == other.fields_ && matching_text_ == other.matching_text_ && options_text_ == other.options_text_;
+    return std::strcmp(fields_.c_str(), other.fields_.c_str()) == 0 && std::strcmp(matching_text_.c_str(), other.matching_text_.c_str()) == 0 &&
+           std::strcmp(options_text_.c_str(), other.options_text_.c_str()) == 0;
 }
 
 } // namespace infinity

--- a/src/network/http_server.cpp
+++ b/src/network/http_server.cpp
@@ -108,6 +108,8 @@ infinity::Status ParseColumnDefs(const nlohmann::json &fields, Vector<ColumnDef 
                     e_data_type = EmbeddingDataType::kElemFloat16;
                 } else if (etype == "bfloat16") {
                     e_data_type = EmbeddingDataType::kElemBFloat16;
+                } else if (etype == "bit") {
+                    e_data_type = EmbeddingDataType::kElemBit;
                 } else {
                     return infinity::Status::InvalidEmbeddingDataType(etype);
                 }

--- a/src/network/infinity_thrift_service.cpp
+++ b/src/network/infinity_thrift_service.cpp
@@ -2082,7 +2082,11 @@ KnnExpr *InfinityThriftService::GetKnnExprFromProto(Status &status, const infini
 
     auto [embedding_data_ptr, dimension, status2] = GetEmbeddingDataTypeDataPtrFromProto(expr.embedding_data);
     knn_expr->embedding_data_ptr_ = embedding_data_ptr;
-    knn_expr->dimension_ = dimension;
+    if (knn_expr->embedding_data_type_ == EmbeddingDataType::kElemBit) {
+        knn_expr->dimension_ = dimension * 8;
+    } else {
+        knn_expr->dimension_ = dimension;
+    }
     if (!status2.ok()) {
         status = status2;
         return nullptr;

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -14,8 +14,6 @@
 
 module;
 
-#include <string>
-
 module expression_binder;
 
 import stl;
@@ -898,8 +896,8 @@ SharedPtr<BaseExpression> ExpressionBinder::BuildSearchExpr(const SearchExpr &ex
             }
             case ParsedExprType::kMatchSparse: {
                 auto &match_sparse = const_cast<MatchSparseExpr &>(*static_cast<const MatchSparseExpr *>(match_expr));
-                for(auto &param : match_sparse.opt_params_){
-                    if(param->param_name_ != "alpha" and param->param_name_ != "beta" and param->param_name_ != "tail"){
+                for (auto &param : match_sparse.opt_params_) {
+                    if (param->param_name_ != "alpha" and param->param_name_ != "beta" and param->param_name_ != "tail") {
                         RecoverableError(Status::SyntaxError(fmt::format("Unsupported optional parameter: {}", param->param_name_)));
                     }
                 }

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -14,6 +14,8 @@
 
 module;
 
+#include <string>
+
 module expression_binder;
 
 import stl;


### PR DESCRIPTION
### What problem does this PR solve?

Support matching binary vectors with hamming distance in infinity sdk(remote and embedded) and http.

SDK:
```python
res = table_obj.output(["*", "_distance"]).match_dense("c2", [0] * 16, "bit", "hamming", 3).to_df()
```

HTTP:
```bash
curl --request GET \
    --url http://localhost:23820/databases/default_db/tables/test_binary_hamming/docs \
    --header 'accept: application/json' \
    --header 'content-type: application/json' \
    --data ' 
    {
        "output":
        [
            "*",
            "_distance"
        ],
        "search":
        [
            {
                "match_method": "dense",
                "fields": "c2",
                "query_vector": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                "element_type": "bit",
                "metric_type": "hamming",
                "topn": 3
            }
        ]
    } '
```

Issue link: #2069 

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Python SDK impacted, Need to update PyPI
