### PR TITLE
Http cluster example

### DIFF
--- a/conf/learner.toml
+++ b/conf/learner.toml
@@ -24,7 +24,7 @@ log_level               = "debug"
 
 [storage]
 persistence_dir         = "/var/infinity/learner/persistence"
-data_dir                = "/var/infinity/leader/data"
+data_dir                = "/var/infinity/learner/data"
 # periodically activates garbage collection:
 # 0 means real-time,
 # s means seconds, for example "60s", 60 seconds

--- a/conf/learner.toml
+++ b/conf/learner.toml
@@ -24,7 +24,7 @@ log_level               = "debug"
 
 [storage]
 persistence_dir         = "/var/infinity/learner/persistence"
-data_dir                = "/var/infinity/learner/data"
+data_dir                = "/var/infinity/leader/data"
 # periodically activates garbage collection:
 # 0 means real-time,
 # s means seconds, for example "60s", 60 seconds

--- a/example/http/cluster_admin.sh
+++ b/example/http/cluster_admin.sh
@@ -1,3 +1,76 @@
+# This file shows how cluster in infinity work.
+# To run this script, you should first run these 3 commands to start 3 nodes seperately,
+# you can run these commands at the root directory of project after building the code:
+
+# ./cmake-build-debug/src/infinity --config conf/leader.toml
+# ./cmake-build-debug/src/infinity --config conf/follower.toml
+# ./cmake-build-debug/src/infinity --config conf/learner.toml
+
+# setting leader
+echo '--setting leader'
+curl --request POST \
+    --url http://localhost:23821/admin/node/current \
+    --header 'accept: application/json' \
+    --header 'content-type: application/json' \
+    --data ' 
+    {
+        "role" : "leader",
+        "name" : "boss"
+    } '
+
+# setting follower and register leader
+echo '\n\n--setting follower and register leader'
+curl --request POST \
+    --url http://localhost:23822/admin/node/current \
+    --header 'accept: application/json' \
+    --header 'content-type: application/json' \
+    --data ' 
+    {
+        "role" : "follower",
+        "name" : "following",
+        "address" : "0.0.0.0:23851"
+    } '
+
+# setting learner and register leader
+echo '\n\n--setting learner and register leader'
+curl --request POST \
+    --url http://localhost:23823/admin/node/current \
+    --header 'accept: application/json' \
+    --header 'content-type: application/json' \
+    --data ' 
+    {
+        "role" : "learner",
+        "name" : "learning",
+        "address" : "0.0.0.0:23851"
+    } '
+
+# check each nodes
+echo '\n\n--check leader node'
 curl --request GET \
-    --url http://localhost:23820/admin/node/current \
+    --url http://localhost:23821/admin/node/current \
+    --header 'accept: application/json'
+
+echo '\n\n--check follower node'
+curl --request GET \
+    --url http://localhost:23822/admin/node/current \
+    --header 'accept: application/json'
+
+echo '\n\n--check learner node'
+curl --request GET \
+    --url http://localhost:23823/admin/node/current \
+    --header 'accept: application/json'
+
+echo '\n\n--on leader, check the learner node in cluster'
+curl --request GET \
+    --url http://localhost:23821/admin/node/learning \
+    --header 'accept: application/json'
+
+echo '\n\n--on follower, check the leader in cluster'
+curl --request GET \
+    --url http://localhost:23822/admin/node/boss \
+    --header 'accept: application/json'
+
+echo '\n\n--on learner, list all nodes in cluster'
+curl --request GET \
+    --url http://localhost:23822/admin/nodes \
     --header 'accept: application/json'

--- a/src/network/http_server.cpp
+++ b/src/network/http_server.cpp
@@ -3992,16 +3992,26 @@ public:
         auto result = infinity->AdminShowCurrentNode();
 
         nlohmann::json json_response;
+        nlohmann::json node_info;
         HTTPStatus http_status;
 
         if (result.IsOk()) {
-            json_response["error_code"] = 0;
-            DataBlock *data_block = result.result_table_->GetDataBlockById(0).get();
-            Value value = data_block->GetValue(1, 1);
-            const String &variable_value = value.ToString();
-            json_response["role"] = variable_value;
-
+            SizeT block_rows = result.result_table_->DataBlockCount();
+            for (SizeT block_id = 0; block_id < block_rows; ++block_id) {
+                DataBlock *data_block = result.result_table_->GetDataBlockById(block_id).get();
+                auto row_count = data_block->row_count();
+                for (int row = 0; row < row_count; ++row) {
+                    // variable name
+                    const String &attrib_name = data_block->GetValue(0, row).ToString();
+                    // variable value
+                    const String &attrib_value = data_block->GetValue(1, row).ToString();
+                    node_info[attrib_name] = attrib_value;
+                }
+            }
             http_status = HTTPStatus::CODE_200;
+            json_response["error_code"] = ErrorCode::kOk;
+            json_response["node"] = node_info;
+
         } else {
             json_response["error_code"] = result.ErrorCode();
             json_response["error_message"] = result.ErrorMsg();
@@ -4018,22 +4028,31 @@ public:
         DeferFn defer_fn([&]() { infinity->RemoteDisconnect(); });
 
         nlohmann::json json_response;
+        nlohmann::json node_info;
         HTTPStatus http_status;
 
         String node_name = request->getPathVariable("node_name");
         QueryResult result = infinity->AdminShowNode(node_name);
 
         if (result.IsOk()) {
-            DataBlock *data_block = result.result_table_->GetDataBlockById(0).get();
-            Value value = data_block->GetValue(1, 1);
-            const String &node_role = value.ToString();
-
-            json_response["error_code"] = ErrorCode::kOk;
-            json_response["role"] = node_role;
+            SizeT block_rows = result.result_table_->DataBlockCount();
+            for (SizeT block_id = 0; block_id < block_rows; ++block_id) {
+                DataBlock *data_block = result.result_table_->GetDataBlockById(block_id).get();
+                auto row_count = data_block->row_count();
+                for (int row = 0; row < row_count; ++row) {
+                    // variable name
+                    const String &attrib_name = data_block->GetValue(0, row).ToString();
+                    // variable value
+                    const String &attrib_value = data_block->GetValue(1, row).ToString();
+                    node_info[attrib_name] = attrib_value;
+                }
+            }
             http_status = HTTPStatus::CODE_200;
+            json_response["node"] = node_info;
+            json_response["error_code"] = ErrorCode::kOk;
         } else {
             json_response["error_code"] = result.ErrorCode();
-            json_response["error_msg"] = result.ErrorMsg();
+            json_response["error_message"] = result.ErrorMsg();
             http_status = HTTPStatus::CODE_500;
         }
 
@@ -4058,9 +4077,32 @@ public:
                 DataBlock *data_block = result.result_table_->GetDataBlockById(block_id).get();
                 auto row_count = data_block->row_count();
                 for (int row = 0; row < row_count; ++row) {
-                    String node_name = data_block->GetValue(0, row).ToString();
-                    String node_role = data_block->GetValue(1, row).ToString();
-                    nodes_json.push_back({node_name, node_role});
+                    nlohmann::json node_json;
+                    {
+                        String node_name = data_block->GetValue(0, row).ToString();
+                        node_json["name"] = node_name;
+                    }
+                    {
+                        String node_role = data_block->GetValue(1, row).ToString();
+                        node_json["role"] = node_role;
+                    }
+                    {
+                        String node_status = data_block->GetValue(2, row).ToString();
+                        node_json["status"] = node_status;
+                    }
+                    {
+                        String node_address = data_block->GetValue(3, row).ToString();
+                        node_json["address"] = node_address;
+                    }
+                    {
+                        String last_update = data_block->GetValue(4, row).ToString();
+                        node_json["last_update"] = last_update;
+                    }
+                    {
+                        String heartbeat = data_block->GetValue(5, row).ToString();
+                        node_json["heartbeat"] = heartbeat;
+                    }
+                    nodes_json.push_back(node_json);
                 }
             }
             http_status = HTTPStatus::CODE_200;


### PR DESCRIPTION
### What problem does this PR solve?

- Modified HTTP APIs for more comprehensice outputs.
- New HTTP examples for cluster admins, commands include:
    - Setting roles for each nodes.
    - For each node, list its own information.
    - On one node, list all nodes in cluster.
    - On one node, list some node in cluster by its name.

### Type of change

- [x] Other (please describe): New example
