### PR TITLE
Adjust latin tokenizer within RAG analyzer

### DIFF
--- a/src/common/analyzer/rag_analyzer.cpp
+++ b/src/common/analyzer/rag_analyzer.cpp
@@ -19,7 +19,6 @@ module;
 #include <cmath>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <openccxx.h>
 #include <pcre2.h>
 #include <re2/re2.h>
@@ -971,7 +970,6 @@ String RAGAnalyzer::Tokenize(const String &line) {
             ToLower(t.c_str(), t.size(), lowercase_term, term_string_buffer_limit_);
             String stem_term;
             stemmer_->Stem(lowercase_term, stem_term);
-            std::cout << lowercase_term << " " << stem_term << std::endl;
             res.push_back(stem_term);
         }
         String ret = Join(res, 0);

--- a/src/common/analyzer/rag_analyzer.cppm
+++ b/src/common/analyzer/rag_analyzer.cppm
@@ -32,7 +32,7 @@ namespace infinity {
 // C++ reimplementation of
 // https://github.com/infiniflow/ragflow/blob/main/rag/nlp/rag_tokenizer.py
 
-class RegexTokenizer;
+class NLTKWordTokenizer;
 export class RAGAnalyzer : public Analyzer {
 public:
     RAGAnalyzer(const String &path);
@@ -110,7 +110,7 @@ public:
 
     bool fine_grained_{false};
 
-    UniquePtr<RegexTokenizer> regex_tokenizer_;
+    UniquePtr<NLTKWordTokenizer> nltk_tokenizer_;
 
     RE2 pattern1_{"[a-zA-Z_-]+$"};
 


### PR DESCRIPTION
### What problem does this PR solve?

- Previous regex tokenizer is not the same with NLTK word tokenizer, which will lead to inconsistent results for some Latin tokens. Such as `images.` at the end of some sentences will not have correct stem output: still `images` instead of `imag`. Current NLTK word tokenizer is still not totally the same with the python NLTK version due to the sentence splitter: current sentence splitter is a naive solution based on regex, while python one(`PunktSentenceTokenizer`) is a training based solution.
- Integrate latest performance improvements from python rag tokenizer, but disable right now due to different tokenization results.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
