### PR TITLE
Start network server before storage is started

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/infinity_thrift_rpc/ttypes.py
+++ b/python/infinity_sdk/infinity/remote_thrift/infinity_thrift_rpc/ttypes.py
@@ -8611,14 +8611,16 @@ class ShowCurrentNodeResponse(object):
      - error_code
      - error_msg
      - node_role
+     - server_status
 
     """
 
 
-    def __init__(self, error_code=None, error_msg=None, node_role=None,):
+    def __init__(self, error_code=None, error_msg=None, node_role=None, server_status=None,):
         self.error_code = error_code
         self.error_msg = error_msg
         self.node_role = node_role
+        self.server_status = server_status
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -8644,6 +8646,11 @@ class ShowCurrentNodeResponse(object):
                     self.node_role = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 4:
+                if ftype == TType.STRING:
+                    self.server_status = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -8665,6 +8672,10 @@ class ShowCurrentNodeResponse(object):
         if self.node_role is not None:
             oprot.writeFieldBegin('node_role', TType.STRING, 3)
             oprot.writeString(self.node_role.encode('utf-8') if sys.version_info[0] == 2 else self.node_role)
+            oprot.writeFieldEnd()
+        if self.server_status is not None:
+            oprot.writeFieldBegin('server_status', TType.STRING, 4)
+            oprot.writeString(self.server_status.encode('utf-8') if sys.version_info[0] == 2 else self.server_status)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -9533,6 +9544,7 @@ ShowCurrentNodeResponse.thrift_spec = (
     (1, TType.I64, 'error_code', None, None, ),  # 1
     (2, TType.STRING, 'error_msg', 'UTF8', None, ),  # 2
     (3, TType.STRING, 'node_role', 'UTF8', None, ),  # 3
+    (4, TType.STRING, 'server_status', 'UTF8', None, ),  # 4
 )
 all_structs.append(CommandRequest)
 CommandRequest.thrift_spec = (

--- a/python/restart_test/test_memidx.py
+++ b/python/restart_test/test_memidx.py
@@ -49,12 +49,13 @@ class TestMemIdx:
 
         part1()
 
-        # config1 can held 6 rows of hnsw mem index before dump
+        # config1 can hold 6 rows of hnsw mem index before dump
         # 1. recover by dumpindex wal & memindex recovery
         decorator2 = infinity_runner_decorator_factory(config2, uri, infinity_runner)
 
         @decorator2
         def part2(infinity_obj):
+            time.sleep(5)
             db_obj = infinity_obj.get_database("default_db")
             table_obj = db_obj.get_table("test_memidx1")
             data_dict, data_type_dict = (
@@ -81,6 +82,7 @@ class TestMemIdx:
 
         @decorator3
         def part3(infinity_obj):
+            time.sleep(5)
             db_obj = infinity_obj.get_database("default_db")
             table_obj = db_obj.get_table("test_memidx1")
 

--- a/src/admin/admin_executor.cpp
+++ b/src/admin/admin_executor.cpp
@@ -4126,6 +4126,27 @@ QueryResult AdminExecutor::ShowCurrentNode(QueryContext *query_context, const Ad
                 value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
             }
         }
+
+        {
+            SizeT column_id = 0;
+            {
+                Value value = Value::MakeVarchar("status");
+                ValueExpression value_expr(value);
+                value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
+            }
+
+            ++column_id;
+            {
+                bool infinity_started = InfinityContext::instance().InfinityContextStarted();
+                String infinity_status("started");
+                if (!infinity_started) {
+                    infinity_status = "starting";
+                }
+                Value value = Value::MakeVarchar(infinity_status);
+                ValueExpression value_expr(value);
+                value_expr.AppendToChunk(output_block_ptr->column_vectors[column_id]);
+            }
+        }
     }
 
     output_block_ptr->Finalize();

--- a/src/bin/infinity_main.cpp
+++ b/src/bin/infinity_main.cpp
@@ -231,7 +231,7 @@ auto main(int argc, char **argv) -> int {
         return app.exit(e);
     }
 
-    InfinityContext::instance().Init(config_path, m_flag, nullptr);
+    InfinityContext::instance().InitPhase1(config_path, m_flag, nullptr);
 
     auto start_thrift_servers = [&]() {
         StartThriftServer();
@@ -253,6 +253,8 @@ auto main(int argc, char **argv) -> int {
     shutdown_thread = infinity::Thread([&]() { ShutdownServer(); });
 
     RegisterSignal();
+
+    InfinityContext::instance().InitPhase2();
 
     shutdown_thread.join();
 

--- a/src/common/status.cpp
+++ b/src/common/status.cpp
@@ -131,6 +131,8 @@ Status Status::NotSupportInMaintenanceMode() {
     return Status(ErrorCode::kAdminOnlySupportInMaintenanceMode, MakeUnique<String>("Not support in maintenance mode"));
 }
 
+Status Status::InfinityIsStarting() { return Status(ErrorCode::kInfinityIsStarting, MakeUnique<String>("Infinity is starting")); }
+
 // 3. Syntax error or access rule violation
 Status Status::InvalidUserName(const String &user_name) {
     return Status(ErrorCode::kInvalidUsername, MakeUnique<String>(fmt::format("{} is a invalid user name", user_name)));

--- a/src/common/status.cppm
+++ b/src/common/status.cppm
@@ -43,6 +43,7 @@ export enum class ErrorCode : long {
     kClientVersionMismatch = 2004,
     kAdminOnlySupportInMaintenanceMode = 2005,
     kNotSupportInMaintenanceMode = 2006,
+    kInfinityIsStarting = 2007,
 
     // 3. syntax error or access rule violation
     kInvalidUsername = 3001,
@@ -218,6 +219,7 @@ public:
     static Status ClientVersionMismatch(const char *expected_version, const char *given_version);
     static Status AdminOnlySupportInMaintenanceMode();
     static Status NotSupportInMaintenanceMode();
+    static Status InfinityIsStarting();
 
     // 3. Syntax error or access rule violation`
     static Status InvalidUserName(const String &user_name);

--- a/src/main/infinity.cpp
+++ b/src/main/infinity.cpp
@@ -85,7 +85,7 @@ void Infinity::Hello() { fmt::print("hello infinity\n"); }
 void Infinity::LocalInit(const String &path, const String &config_path) {
     if (!config_path.empty() && VirtualStore::Exists(config_path)) {
         SharedPtr<String> config_path_ptr = MakeShared<String>(config_path);
-        InfinityContext::instance().Init(config_path_ptr);
+        InfinityContext::instance().InitPhase1(config_path_ptr);
     } else {
         LOG_WARN(fmt::format("Infinity::LocalInit cannot find config: {}", config_path));
         UniquePtr<DefaultConfig> default_config = MakeUnique<DefaultConfig>();
@@ -97,8 +97,9 @@ void Infinity::LocalInit(const String &path, const String &config_path) {
 
         default_config->default_log_level_ = LogLevel::kInfo;
         default_config->default_log_to_stdout_ = false;
-        InfinityContext::instance().Init(nullptr, false, default_config.get());
+        InfinityContext::instance().InitPhase1(nullptr, false, default_config.get());
     }
+    InfinityContext::instance().InitPhase2();
 }
 
 void Infinity::LocalUnInit() { InfinityContext::instance().UnInit(); }

--- a/src/main/infinity_context.cpp
+++ b/src/main/infinity_context.cpp
@@ -130,6 +130,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
             cluster_manager_ = MakeUnique<ClusterManager>();
             cluster_manager_->InitAsAdmin();
             storage_->SetStorageMode(StorageMode::kAdmin);
+            infinity_context_started_ = false;
             StartThriftServers();
             break;
         }
@@ -143,6 +144,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         cluster_manager_->InitAsAdmin();
                         return set_storage_status;
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 case NodeRole::kLeader: {
@@ -157,6 +159,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         cluster_manager_->InitAsAdmin();
                         return set_storage_status;
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 case NodeRole::kFollower: {
@@ -175,6 +178,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         cluster_manager_->InitAsAdmin();
                         return init_status;
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 case NodeRole::kLearner: {
@@ -193,6 +197,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         cluster_manager_->InitAsAdmin();
                         return init_status;
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 case NodeRole::kUnInitialized: {
@@ -233,6 +238,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         task_scheduler_->UnInit();
                         task_scheduler_.reset();
                     }
+                    infinity_context_started_ = false;
                     break;
                 }
                 case NodeRole::kUnInitialized: {
@@ -242,6 +248,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                     if (!set_storage_status.ok()) {
                         UnrecoverableError("Failed to set node storage to un-init.");
                     }
+                    infinity_context_started_ = false;
                     return set_storage_status;
                 }
                 default: {
@@ -271,6 +278,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         task_scheduler_->UnInit();
                         task_scheduler_.reset();
                     }
+                    infinity_context_started_ = false;
                     break;
                 }
                 case NodeRole::kFollower: {
@@ -292,6 +300,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         cluster_manager_.reset();
                         return init_status;
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 case NodeRole::kLearner: {
@@ -313,6 +322,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         cluster_manager_.reset();
                         return init_status;
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 case NodeRole::kStandalone: {
@@ -325,6 +335,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                     if (!set_storage_status.ok()) {
                         UnrecoverableError("Failed to set node storage to un-init.");
                     }
+                    infinity_context_started_ = false;
                     return set_storage_status;
                 }
                 default: {
@@ -356,7 +367,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                         task_scheduler_->UnInit();
                         task_scheduler_.reset();
                     }
-
+                    infinity_context_started_ = false;
                     break;
                 }
                 case NodeRole::kStandalone: {
@@ -371,6 +382,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                     if (!set_storage_status.ok()) {
                         UnrecoverableError("Failed to set node storage to un-init.");
                     }
+                    infinity_context_started_ = false;
                     return set_storage_status;
                 }
                 case NodeRole::kLeader: {
@@ -399,6 +411,7 @@ Status InfinityContext::ChangeServerRole(NodeRole target_role, bool from_leader,
                     if (!set_storage_status.ok()) {
                         UnrecoverableError("Failed to set node storage to leader.");
                     }
+                    infinity_context_started_ = true;
                     break;
                 }
                 default: {

--- a/src/main/infinity_context.cppm
+++ b/src/main/infinity_context.cppm
@@ -54,7 +54,8 @@ public:
 
     NodeRole GetServerRole() const;
 
-    void Init(const SharedPtr<String> &config_path, bool admin_flag = false, DefaultConfig *default_config = nullptr);
+    void InitPhase1(const SharedPtr<String> &config_path, bool admin_flag = false, DefaultConfig *default_config = nullptr);
+    void InitPhase2();
     //    void InitAdminMode(const SharedPtr<String> &config_path, bool m_flag = false, DefaultConfig *default_config = nullptr);
     Status
     ChangeServerRole(NodeRole target_role, bool from_leader = false, const String &node_name = {}, String leader_ip = {}, u16 leader_port = {});
@@ -70,6 +71,8 @@ public:
     void StartThriftServers();
     void StopThriftServers();
 
+    bool InfinityContextStarted() const { return infinity_context_started_; }
+
 private:
     friend class Singleton;
 
@@ -82,6 +85,7 @@ private:
     UniquePtr<Storage> storage_{};
     UniquePtr<SessionManager> session_mgr_{};
     UniquePtr<ClusterManager> cluster_manager_{};
+    atomic_bool infinity_context_started_{false};
 
     // For fulltext index
     ThreadPool inverting_thread_pool_{4};

--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -128,18 +128,21 @@ QueryResult QueryContext::Query(const String &query) {
 QueryResult QueryContext::QueryStatement(const BaseStatement *base_statement) {
     QueryResult query_result;
 
-    if (InfinityContext::instance().IsAdminRole()) {
-        if (base_statement->Type() == StatementType::kAdmin) {
+    if (base_statement->Type() == StatementType::kAdmin) {
+        if (InfinityContext::instance().IsAdminRole()) {
             const AdminStatement *admin_statement = static_cast<const AdminStatement *>(base_statement);
             return HandleAdminStatement(admin_statement);
         } else {
-            query_result.result_table_ = nullptr;
-            query_result.status_ = Status::NotSupportInMaintenanceMode();
-            return query_result;
-        }
-    } else {
-        if (base_statement->Type() == StatementType::kAdmin) {
             const AdminStatement *admin_statement = static_cast<const AdminStatement *>(base_statement);
+            if (admin_statement->admin_type_ == AdminStmtType::kShowNode) {
+                return HandleAdminStatement(admin_statement);
+            }
+
+            if (!InfinityContext::instance().InfinityContextStarted()) {
+                query_result.result_table_ = nullptr;
+                query_result.status_ = Status::InfinityIsStarting();
+                return query_result;
+            }
 
             switch (admin_statement->admin_type_) {
                 case AdminStmtType::kShowVariable: {
@@ -164,6 +167,12 @@ QueryResult QueryContext::QueryStatement(const BaseStatement *base_statement) {
 
             query_result.result_table_ = nullptr;
             query_result.status_ = Status::AdminOnlySupportInMaintenanceMode();
+            return query_result;
+        }
+    } else {
+        if (!InfinityContext::instance().InfinityContextStarted()) {
+            query_result.result_table_ = nullptr;
+            query_result.status_ = Status::InfinityIsStarting();
             return query_result;
         }
     }

--- a/src/network/infinity_thrift/infinity_types.cpp
+++ b/src/network/infinity_thrift/infinity_types.cpp
@@ -14761,6 +14761,10 @@ void ShowCurrentNodeResponse::__set_error_msg(const std::string& val) {
 void ShowCurrentNodeResponse::__set_node_role(const std::string& val) {
   this->node_role = val;
 }
+
+void ShowCurrentNodeResponse::__set_server_status(const std::string& val) {
+  this->server_status = val;
+}
 std::ostream& operator<<(std::ostream& out, const ShowCurrentNodeResponse& obj)
 {
   obj.printTo(out);
@@ -14813,6 +14817,14 @@ uint32_t ShowCurrentNodeResponse::read(::apache::thrift::protocol::TProtocol* ip
           xfer += iprot->skip(ftype);
         }
         break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->server_status);
+          this->__isset.server_status = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -14842,6 +14854,10 @@ uint32_t ShowCurrentNodeResponse::write(::apache::thrift::protocol::TProtocol* o
   xfer += oprot->writeString(this->node_role);
   xfer += oprot->writeFieldEnd();
 
+  xfer += oprot->writeFieldBegin("server_status", ::apache::thrift::protocol::T_STRING, 4);
+  xfer += oprot->writeString(this->server_status);
+  xfer += oprot->writeFieldEnd();
+
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -14852,6 +14868,7 @@ void swap(ShowCurrentNodeResponse &a, ShowCurrentNodeResponse &b) {
   swap(a.error_code, b.error_code);
   swap(a.error_msg, b.error_msg);
   swap(a.node_role, b.node_role);
+  swap(a.server_status, b.server_status);
   swap(a.__isset, b.__isset);
 }
 
@@ -14859,12 +14876,14 @@ ShowCurrentNodeResponse::ShowCurrentNodeResponse(const ShowCurrentNodeResponse& 
   error_code = other538.error_code;
   error_msg = other538.error_msg;
   node_role = other538.node_role;
+  server_status = other538.server_status;
   __isset = other538.__isset;
 }
 ShowCurrentNodeResponse& ShowCurrentNodeResponse::operator=(const ShowCurrentNodeResponse& other539) {
   error_code = other539.error_code;
   error_msg = other539.error_msg;
   node_role = other539.node_role;
+  server_status = other539.server_status;
   __isset = other539.__isset;
   return *this;
 }
@@ -14874,6 +14893,7 @@ void ShowCurrentNodeResponse::printTo(std::ostream& out) const {
   out << "error_code=" << to_string(error_code);
   out << ", " << "error_msg=" << to_string(error_msg);
   out << ", " << "node_role=" << to_string(node_role);
+  out << ", " << "server_status=" << to_string(server_status);
   out << ")";
 }
 

--- a/src/network/infinity_thrift/infinity_types.h
+++ b/src/network/infinity_thrift/infinity_types.h
@@ -5834,10 +5834,11 @@ void swap(ShowCurrentNodeRequest &a, ShowCurrentNodeRequest &b);
 std::ostream& operator<<(std::ostream& out, const ShowCurrentNodeRequest& obj);
 
 typedef struct _ShowCurrentNodeResponse__isset {
-  _ShowCurrentNodeResponse__isset() : error_code(false), error_msg(false), node_role(false) {}
+  _ShowCurrentNodeResponse__isset() : error_code(false), error_msg(false), node_role(false), server_status(false) {}
   bool error_code :1;
   bool error_msg :1;
   bool node_role :1;
+  bool server_status :1;
 } _ShowCurrentNodeResponse__isset;
 
 class ShowCurrentNodeResponse : public virtual ::apache::thrift::TBase {
@@ -5848,13 +5849,15 @@ class ShowCurrentNodeResponse : public virtual ::apache::thrift::TBase {
   ShowCurrentNodeResponse() noexcept
                           : error_code(0),
                             error_msg(),
-                            node_role() {
+                            node_role(),
+                            server_status() {
   }
 
   virtual ~ShowCurrentNodeResponse() noexcept;
   int64_t error_code;
   std::string error_msg;
   std::string node_role;
+  std::string server_status;
 
   _ShowCurrentNodeResponse__isset __isset;
 
@@ -5864,6 +5867,8 @@ class ShowCurrentNodeResponse : public virtual ::apache::thrift::TBase {
 
   void __set_node_role(const std::string& val);
 
+  void __set_server_status(const std::string& val);
+
   bool operator == (const ShowCurrentNodeResponse & rhs) const
   {
     if (!(error_code == rhs.error_code))
@@ -5871,6 +5876,8 @@ class ShowCurrentNodeResponse : public virtual ::apache::thrift::TBase {
     if (!(error_msg == rhs.error_msg))
       return false;
     if (!(node_role == rhs.node_role))
+      return false;
+    if (!(server_status == rhs.server_status))
       return false;
     return true;
   }

--- a/src/network/infinity_thrift_service.cpp
+++ b/src/network/infinity_thrift_service.cpp
@@ -1720,6 +1720,11 @@ void InfinityThriftService::ShowCurrentNode(infinity_thrift_rpc::ShowCurrentNode
             response.node_role = value.GetVarchar();
         }
 
+        {
+            Value value = data_block->GetValue(1, 1);
+            response.server_status = value.GetVarchar();
+        }
+
         response.__set_error_code((i64)(result.ErrorCode()));
     } else {
         ProcessQueryResult(response, result);

--- a/src/unit_test/base_test.cppm
+++ b/src/unit_test/base_test.cppm
@@ -166,7 +166,8 @@ public:
         if (config_path_str != BaseTestParamStr::NULL_CONFIG_PATH) {
             config_path = std::make_shared<std::string>(std::filesystem::absolute(config_path_str));
         }
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
     }
 
     void TearDown() override {

--- a/src/unit_test/executor/pipeline/fragment.cpp
+++ b/src/unit_test/executor/pipeline/fragment.cpp
@@ -34,7 +34,8 @@ class FragmentTest : public BaseTest {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = nullptr;
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
     }
 
     void TearDown() override {

--- a/src/unit_test/main/query_profiler.cpp
+++ b/src/unit_test/main/query_profiler.cpp
@@ -29,7 +29,8 @@ class QueryProfilerTest : public BaseTest {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = nullptr;
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
     }
 
     void TearDown() override {

--- a/src/unit_test/storage/bg_task/compact_segments_task.cpp
+++ b/src/unit_test/storage/bg_task/compact_segments_task.cpp
@@ -104,7 +104,8 @@ class SilentLogTestCompactTaskTest : public CompactTaskTest {
         if (config_path_str != BaseTestParamStr::NULL_CONFIG_PATH) {
             config_path = infinity::MakeShared<std::string>(config_path_str);
         }
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
     }
 };
 

--- a/src/unit_test/storage/binary_fuse_filter/segment_sealing.cpp
+++ b/src/unit_test/storage/binary_fuse_filter/segment_sealing.cpp
@@ -144,7 +144,8 @@ TEST_P(SealingTaskTest, append_unsealed_segment_sealed) {
         infinity::GlobalResourceUsage::Init();
         std::shared_ptr<std::string> config_path = nullptr;
         RemoveDbDirs();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         // BufferManager *buffer_manager = storage->buffer_manager();
         TxnManager *txn_mgr = storage->txn_manager();

--- a/src/unit_test/storage/buffer/buffer_obj.cpp
+++ b/src/unit_test/storage/buffer/buffer_obj.cpp
@@ -88,7 +88,8 @@ TEST_F(BufferObjTest, test1) {
     RemoveDbDirs();
     std::shared_ptr<std::string> config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_buffer_obj.toml");
     //    RemoveDbDirs();
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
 
     SizeT memory_limit = 1024;
     String data_dir(GetFullDataDir());
@@ -492,7 +493,8 @@ TEST_F(BufferObjTest, test_hnsw_index_buffer_obj_shutdown) {
 #endif
     std::shared_ptr<std::string> config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_buffer_obj_2.toml");
     //    RemoveDbDirs();
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
 
     constexpr u64 kInsertN = 2;
     constexpr u64 kImportSize = 8192;
@@ -660,7 +662,8 @@ TEST_F(BufferObjTest, test_hnsw_index_buffer_obj_shutdown) {
 TEST_F(BufferObjTest, test_big_with_gc_and_cleanup) {
     std::shared_ptr<std::string> config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_buffer_obj.toml");
     RemoveDbDirs();
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
 
     constexpr u64 kInsertN = 256;
     constexpr u64 kImportSize = 8192;
@@ -753,7 +756,8 @@ TEST_F(BufferObjTest, test_big_with_gc_and_cleanup) {
 TEST_F(BufferObjTest, test_multiple_threads_read) {
     std::shared_ptr<std::string> config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_buffer_obj.toml");
     RemoveDbDirs();
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
 
     constexpr u64 kInsertN = 256;
     constexpr u64 kImportSize = 8192;

--- a/src/unit_test/storage/io/virtual_store.cpp
+++ b/src/unit_test/storage/io/virtual_store.cpp
@@ -275,7 +275,8 @@ TEST_F(VirtualStoreTest, TestCleanDir) {
 TEST_F(VirtualStoreTest, minio_upload) {
     using namespace infinity;
     auto config_path = MakeShared<String>(std::string(test_data_path())+"/config/test_minio_s3_storage.toml");
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
     VirtualStore::InitRemoteStore(StorageType::kMinio, "192.168.200.165:9000", false, "minioadmin", "minioadmin", "infinity");
 
     if(VirtualStore::BucketExists()){
@@ -311,7 +312,8 @@ TEST_F(VirtualStoreTest, minio_upload) {
 TEST_F(VirtualStoreTest, minio_download) {
     using namespace infinity;
     auto config_path = MakeShared<String>(std::string(test_data_path())+"/config/test_minio_s3_storage.toml");
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
     VirtualStore::InitRemoteStore(StorageType::kMinio, "192.168.200.165:9000", false, "minioadmin", "minioadmin", "infinity");
 
     if(VirtualStore::BucketExists()){

--- a/src/unit_test/storage/txn/conflict_check.cpp
+++ b/src/unit_test/storage/txn/conflict_check.cpp
@@ -42,7 +42,8 @@ protected:
         RemoveDbDirs();
 
         auto config_path = std::make_shared<std::string>(std::string(test_data_path()) + "/config/test_close_bgtask.toml");
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         storage_ = InfinityContext::instance().storage();
         txn_mgr_ = storage_->txn_manager();

--- a/src/unit_test/storage/wal/catalog_delta_replay.cpp
+++ b/src/unit_test/storage/wal/catalog_delta_replay.cpp
@@ -120,7 +120,8 @@ TEST_P(CatalogDeltaReplayTest, replay_db_entry) {
 
     std::shared_ptr<std::string> db_entry_dir1;
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -148,7 +149,8 @@ TEST_P(CatalogDeltaReplayTest, replay_db_entry) {
         infinity::InfinityContext::instance().UnInit();
     }
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -190,7 +192,8 @@ TEST_P(CatalogDeltaReplayTest, replay_table_entry) {
 
     std::shared_ptr<std::string> table_entry_dir1;
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -219,7 +222,8 @@ TEST_P(CatalogDeltaReplayTest, replay_table_entry) {
         infinity::InfinityContext::instance().UnInit();
     }
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -256,7 +260,8 @@ TEST_P(CatalogDeltaReplayTest, replay_import) {
     auto table_def = TableDef::Make(db_name, table_name, MakeShared<String>(), {column_def1, column_def2});
 
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -311,7 +316,8 @@ TEST_P(CatalogDeltaReplayTest, replay_import) {
         infinity::InfinityContext::instance().UnInit();
     }
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -355,7 +361,8 @@ TEST_P(CatalogDeltaReplayTest, replay_append) {
     auto table_name = std::make_shared<std::string>("tb1");
     auto table_def = TableDef::Make(db_name, table_name, MakeShared<String>(), {column_def1, column_def2});
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -393,7 +400,8 @@ TEST_P(CatalogDeltaReplayTest, replay_append) {
         infinity::InfinityContext::instance().UnInit();
     }
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -436,7 +444,8 @@ TEST_P(CatalogDeltaReplayTest, replay_delete) {
 
     std::shared_ptr<std::string> table_entry_dir1;
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -506,7 +515,8 @@ TEST_P(CatalogDeltaReplayTest, replay_with_full_checkpoint) {
     auto table_def_uncommitted = TableDef::Make(db_name, table_name_uncommitted, MakeShared<String>(), {column_def1, column_def2});
 
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -638,7 +648,8 @@ TEST_P(CatalogDeltaReplayTest, replay_with_full_checkpoint) {
 
     // now restart and the table `tb_uncommitted` should exist
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -682,7 +693,8 @@ TEST_P(CatalogDeltaReplayTest, replay_compact_to_single_rollback) {
     String table_name = "tb1";
     config_path = nullptr;
     RemoveDbDirs();
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
 
     Storage *storage = infinity::InfinityContext::instance().storage();
     BufferManager *buffer_manager = storage->buffer_manager();
@@ -751,7 +763,8 @@ TEST_P(CatalogDeltaReplayTest, replay_table_single_index) {
     auto table_def = TableDef::Make(db_name, table_name, MakeShared<String>(), {column_def1, column_def2});
 
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -905,7 +918,8 @@ TEST_P(CatalogDeltaReplayTest, replay_table_single_index_named_db) {
     auto table_def = TableDef::Make(db_name, table_name, MakeShared<String>(), {column_def1, column_def2});
 
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -1071,7 +1085,8 @@ TEST_P(CatalogDeltaReplayTest, replay_table_single_index_and_compact) {
     auto table_def = TableDef::Make(db_name, table_name, MakeShared<String>(), {column_def1});
 
     {
-        InfinityContext::instance().Init(config_path);
+        InfinityContext::instance().InitPhase1(config_path);
+        InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
         BufferManager *buffer_manager = storage->buffer_manager();
         CompactionProcessor *compaction_processor = storage->compaction_processor();

--- a/src/unit_test/storage/wal/checkpoint.cpp
+++ b/src/unit_test/storage/wal/checkpoint.cpp
@@ -140,7 +140,8 @@ TEST_P(CheckpointTest, test_cleanup_and_checkpoint) {
     infinity::GlobalResourceUsage::Init();
 #endif
     std::shared_ptr<std::string> config_path = CheckpointTest::config_path();
-    infinity::InfinityContext::instance().Init(config_path);
+    infinity::InfinityContext::instance().InitPhase1(config_path);
+    infinity::InfinityContext::instance().InitPhase2();
 
     Storage *storage = infinity::InfinityContext::instance().storage();
     BufferManager *buffer_manager = storage->buffer_manager();
@@ -218,7 +219,8 @@ TEST_P(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
 
     // create table and shutdown
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
         {
@@ -241,7 +243,8 @@ TEST_P(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
     }
     // create index and shutdown
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
 
@@ -264,7 +267,8 @@ TEST_P(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
     }
     // drop index and shutdown
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
 
@@ -283,7 +287,8 @@ TEST_P(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint1) {
     }
     // now restart and recreate index should be ok
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
 
@@ -331,7 +336,8 @@ TEST_P(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
     // create table
     // create index, insert data and shutdown
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
         BGTaskProcessor *bg_processor = storage->bg_processor();
@@ -407,7 +413,8 @@ TEST_P(CheckpointTest, test_index_replay_with_full_and_delta_checkpoint2) {
     }
     // now restart and recreate index should be ok
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
 
@@ -447,7 +454,8 @@ TEST_P(CheckpointTest, test_fullcheckpoint_withsmallest_walfile) {
     String wal_dir;
     int insert_n = 100;
     {
-        infinity::InfinityContext::instance().Init(nullptr /*config_path*/);
+        infinity::InfinityContext::instance().InitPhase1(nullptr /*config_path*/);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
 
@@ -493,7 +501,8 @@ TEST_P(CheckpointTest, test_fullcheckpoint_withsmallest_walfile) {
     }
     RemoveOldWal(wal_dir);
     {
-        infinity::InfinityContext::instance().Init(nullptr /*config_path*/);
+        infinity::InfinityContext::instance().InitPhase1(nullptr /*config_path*/);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = infinity::InfinityContext::instance().storage();
         auto *txn_mgr = storage->txn_manager();
 

--- a/src/unit_test/storage/wal/recycle_log.cpp
+++ b/src/unit_test/storage/wal/recycle_log.cpp
@@ -56,7 +56,8 @@ TEST_P(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         Config *config = storage->config();
@@ -124,7 +125,8 @@ TEST_P(RecycleLogTest, recycle_wal_after_delta_checkpoint) {
         infinity::GlobalResourceUsage::Init(); // test replay
 #endif
         std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -150,7 +152,8 @@ TEST_P(RecycleLogTest, recycle_wal_after_full_checkpoint) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         Config *config = storage->config();
@@ -226,7 +229,8 @@ TEST_P(RecycleLogTest, recycle_wal_after_full_checkpoint) {
         infinity::GlobalResourceUsage::Init(); // test replay
 #endif
         std::shared_ptr<std::string> config_path = RecycleLogTest::test_ckp_recycle_config();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();

--- a/src/unit_test/storage/wal/repeat_replay.cpp
+++ b/src/unit_test/storage/wal/repeat_replay.cpp
@@ -127,7 +127,8 @@ TEST_P(RepeatReplayTest, append) {
     };
 
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -145,7 +146,8 @@ TEST_P(RepeatReplayTest, append) {
         infinity::InfinityContext::instance().UnInit();
     }
     {                                                            // replay with no checkpoint, only replay wal
-        infinity::InfinityContext::instance().Init(config_path); // auto full checkpoint when initialize
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2(); // auto full checkpoint when initialize
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -155,7 +157,8 @@ TEST_P(RepeatReplayTest, append) {
         infinity::InfinityContext::instance().UnInit();
     }
     {                                                            // replay with full checkpoint + wal
-        infinity::InfinityContext::instance().Init(config_path); // auto full checkpoint when initialize
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2(); // auto full checkpoint when initialize
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -172,7 +175,8 @@ TEST_P(RepeatReplayTest, append) {
         infinity::InfinityContext::instance().UnInit();
     }
     for (int i = 0; i < 2; ++i) {                                // replay with full checkpoint + delta checkpoint + wal
-        infinity::InfinityContext::instance().Init(config_path); // auto full checkpoint when initialize
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2(); // auto full checkpoint when initialize
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -245,7 +249,8 @@ TEST_P(RepeatReplayTest, import) {
     };
 
     {
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -265,7 +270,8 @@ TEST_P(RepeatReplayTest, import) {
         infinity::InfinityContext::instance().UnInit();
     }
     {                                                            // replay with no checkpoint, only replay wal
-        infinity::InfinityContext::instance().Init(config_path); // auto full checkpoint when initialize
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2(); // auto full checkpoint when initialize
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -276,7 +282,8 @@ TEST_P(RepeatReplayTest, import) {
         infinity::InfinityContext::instance().UnInit();
     }
     {                                                            // replay with full checkpoint + wal
-        infinity::InfinityContext::instance().Init(config_path); // auto full checkpoint when initialize
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2(); // auto full checkpoint when initialize
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();
@@ -294,7 +301,8 @@ TEST_P(RepeatReplayTest, import) {
         infinity::InfinityContext::instance().UnInit();
     }
     for (int i = 0; i < 2; ++i) {                                // replay with full checkpoint + delta checkpoint + wal
-        infinity::InfinityContext::instance().Init(config_path); // auto full checkpoint when initialize
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2(); // auto full checkpoint when initialize
         Storage *storage = InfinityContext::instance().storage();
 
         TxnManager *txn_mgr = storage->txn_manager();

--- a/src/unit_test/storage/wal/wal_entry.cpp
+++ b/src/unit_test/storage/wal/wal_entry.cpp
@@ -198,7 +198,8 @@ void MockWalFile(const String &wal_file_path, const String &ckp_file_path, const
 
 TEST_F(WalEntryTest, ReadWrite) {
     RemoveDbDirs();
-    infinity::InfinityContext::instance().Init(nullptr);
+    infinity::InfinityContext::instance().InitPhase1(nullptr);
+    infinity::InfinityContext::instance().InitPhase2();
     SharedPtr<WalEntry> entry = MakeShared<WalEntry>();
     entry->cmds_.push_back(MakeShared<WalCmdCreateDatabase>("db1", "default2_comment", "AAA_db1"));
     entry->cmds_.push_back(MakeShared<WalCmdDropDatabase>("db1"));
@@ -253,7 +254,9 @@ TEST_F(WalEntryTest, ReadWrite) {
         Vector<ChunkID> deprecate_ids{0, 1};
         entry->cmds_.push_back(MakeShared<WalCmdDumpIndex>("db1", "tbl1", "idx1", 0 /*segment_id*/, chunk_infos, deprecate_ids));
     }
-    { entry->cmds_.push_back(MakeShared<WalCmdRenameTable>("db1", "tbl1", "tbl2")); }
+    {
+        entry->cmds_.push_back(MakeShared<WalCmdRenameTable>("db1", "tbl1", "tbl2"));
+    }
     {
         Vector<SharedPtr<ColumnDef>> column_defs;
         std::set<ConstraintType> constraints;

--- a/src/unit_test/storage/wal/wal_replay.cpp
+++ b/src/unit_test/storage/wal/wal_replay.cpp
@@ -94,7 +94,8 @@ TEST_P(WalReplayTest, wal_replay_database) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -151,7 +152,8 @@ TEST_P(WalReplayTest, wal_replay_database) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -210,7 +212,8 @@ TEST_P(WalReplayTest, wal_replay_tables) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -263,7 +266,8 @@ TEST_P(WalReplayTest, wal_replay_tables) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -298,7 +302,8 @@ TEST_P(WalReplayTest, wal_replay_append) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -401,7 +406,8 @@ TEST_P(WalReplayTest, wal_replay_append) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -474,7 +480,8 @@ TEST_P(WalReplayTest, wal_replay_import) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -618,7 +625,8 @@ TEST_P(WalReplayTest, wal_replay_import) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -675,7 +683,8 @@ TEST_F(WalReplayTest, wal_replay_compact) {
 #ifdef INFINITY_DEBUG
         infinity::GlobalResourceUsage::Init();
 #endif
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         BufferManager *buffer_manager = storage->buffer_manager();
@@ -754,7 +763,8 @@ TEST_F(WalReplayTest, wal_replay_compact) {
 #ifdef INFINITY_DEBUG
         infinity::GlobalResourceUsage::Init();
 #endif
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -793,7 +803,8 @@ TEST_P(WalReplayTest, wal_replay_create_index_IvfFlat) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -866,7 +877,8 @@ TEST_P(WalReplayTest, wal_replay_create_index_IvfFlat) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -897,7 +909,8 @@ TEST_P(WalReplayTest, wal_replay_create_index_hnsw) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();
@@ -972,7 +985,8 @@ TEST_P(WalReplayTest, wal_replay_create_index_hnsw) {
         infinity::GlobalResourceUsage::Init();
 #endif
         std::shared_ptr<std::string> config_path = WalReplayTest::config_path();
-        infinity::InfinityContext::instance().Init(config_path);
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         Storage *storage = infinity::InfinityContext::instance().storage();
         TxnManager *txn_mgr = storage->txn_manager();

--- a/thrift/infinity.thrift
+++ b/thrift/infinity.thrift
@@ -730,7 +730,8 @@ struct ShowCurrentNodeRequest {
 struct ShowCurrentNodeResponse {
 1: i64 error_code,
 2: string error_msg,
-3: string node_role
+3: string node_role,
+4: string server_status
 }
 
 struct CommandRequest {


### PR DESCRIPTION
### What problem does this PR solve?

1. start network server firstly, before finish infinity context initializing.
2. update python sdk to response server status.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
