### PR TITLE
Add Hash() and Eq() support for InExpression

### DIFF
--- a/src/expression/in_expression.cpp
+++ b/src/expression/in_expression.cpp
@@ -61,4 +61,37 @@ String InExpression::ToString() const {
     return op.str();
 }
 
+u64 InExpression::Hash() const {
+    auto h = left_operand_ptr_->Hash();
+    for (const auto &arg : arguments_) {
+        h ^= arg->Hash();
+    }
+    if (in_type_ != InType::kIn) {
+        h ^= 0x1;
+    }
+    return h;
+}
+
+bool InExpression::Eq(const BaseExpression &other_base) const {
+    if (other_base.type() != ExpressionType::kIn) {
+        return false;
+    }
+    const auto &other = static_cast<const InExpression &>(other_base);
+    if (in_type_ != other.in_type_) {
+        return false;
+    }
+    if (!left_operand_ptr_->Eq(*other.left_operand_ptr_)) {
+        return false;
+    }
+    if (arguments_.size() != other.arguments_.size()) {
+        return false;
+    }
+    for (SizeT i = 0; i < arguments_.size(); ++i) {
+        if (!arguments_[i]->Eq(*other.arguments_[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace infinity

--- a/src/expression/in_expression.cppm
+++ b/src/expression/in_expression.cppm
@@ -146,6 +146,10 @@ public:
 
     inline DataType TypeOfArguments() const { return set_.Type(); }
 
+    u64 Hash() const override;
+
+    bool Eq(const BaseExpression &other) const override;
+
 private:
     SharedPtr<BaseExpression> left_operand_ptr_;
     InType in_type_;


### PR DESCRIPTION
### What problem does this PR solve?

Add Hash() and Eq() support for InExpression
Support result cache for filter with InExpression

Fix: #2295

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
