### PR TITLE
ivf index dump by memory usage

### DIFF
--- a/src/storage/compaction_process.cpp
+++ b/src/storage/compaction_process.cpp
@@ -190,6 +190,7 @@ void CompactionProcessor::DoDump(DumpIndexTask *dump_task) {
         TxnTableStore *txn_table_store = dump_txn->GetTxnTableStore(table_entry);
         SizeT dump_size = 0;
         table_index_entry->MemIndexDump(dump_txn, txn_table_store, false /*spill*/, &dump_size);
+        LOG_TRACE(fmt::format("Dump size = {}", dump_size));
 
         txn_mgr_->CommitTxn(dump_txn);
 

--- a/src/storage/knn_index/knn_ivf/ivf_index_data_in_mem.cpp
+++ b/src/storage/knn_index/knn_ivf/ivf_index_data_in_mem.cpp
@@ -40,6 +40,11 @@ import ivf_index_data;
 import buffer_handle;
 import knn_scan_data;
 import ivf_index_util_func;
+import base_memindex;
+import memindex_tracer;
+import table_index_entry;
+import infinity_context;
+import third_party;
 
 namespace infinity {
 
@@ -47,9 +52,11 @@ IVFIndexInMem::IVFIndexInMem(const RowID begin_row_id,
                              const IndexIVFOption &ivf_option,
                              const LogicalType column_logical_type,
                              const EmbeddingDataType embedding_data_type,
-                             const u32 embedding_dimension)
+                             const u32 embedding_dimension,
+                             SegmentIndexEntry *segment_index_entry)
     : begin_row_id_{begin_row_id},
-      ivf_index_storage_{new IVF_Index_Storage(ivf_option, column_logical_type, embedding_data_type, embedding_dimension)} {}
+      ivf_index_storage_{new IVF_Index_Storage(ivf_option, column_logical_type, embedding_data_type, embedding_dimension)},
+      segment_index_entry_(segment_index_entry) {}
 
 IVFIndexInMem::~IVFIndexInMem() {
     std::unique_lock lock(rw_mutex_);
@@ -65,13 +72,16 @@ u32 IVFIndexInMem::GetInputRowCount() const {
 }
 
 template <LogicalType column_logical_type, EmbeddingDataType embedding_data_type>
-struct InMemStorage;
+struct InMemStorage {
+    SizeT MemoryUsed() const { UnrecoverableError("only embedding and multi-vector is supported!"); }
+};
 
 template <EmbeddingDataType embedding_data_type>
 struct InMemStorage<LogicalType::kEmbedding, embedding_data_type> {
     using ColumnEmbeddingElementT = EmbeddingDataTypeToCppTypeT<embedding_data_type>;
     Vector<ColumnEmbeddingElementT> raw_source_data_{};
     Vector<SegmentOffset> source_offsets_{};
+    SizeT MemoryUsed() const { return sizeof(ColumnEmbeddingElementT) * raw_source_data_.size() + sizeof(SegmentOffset) * source_offsets_.size(); }
 };
 
 template <EmbeddingDataType embedding_data_type>
@@ -81,6 +91,10 @@ struct InMemStorage<LogicalType::kMultiVector, embedding_data_type> {
     Vector<SegmentOffset> source_offsets_{};
     Vector<u32> multi_vector_data_start_pos_{};
     Vector<u32> multi_vector_embedding_num_{};
+    SizeT MemoryUsed() const {
+        return sizeof(ColumnEmbeddingElementT) * raw_source_data_.size() + sizeof(SegmentOffset) * source_offsets_.size() +
+               sizeof(u32) * (multi_vector_data_start_pos_.size() + multi_vector_embedding_num_.size());
+    }
 };
 
 template <LogicalType column_logical_type, EmbeddingDataType embedding_data_type>
@@ -90,8 +104,28 @@ class IVFIndexInMemT final : public IVFIndexInMem {
     u32 build_index_bar_embedding_num_ = 0;
 
 public:
-    IVFIndexInMemT(const RowID begin_row_id, const IndexIVFOption &ivf_option, const u32 embedding_dimension)
-        : IVFIndexInMem(begin_row_id, ivf_option, column_logical_type, embedding_data_type, embedding_dimension) {
+    SizeT MemoryUsed() const override {
+        if (have_ivf_index_.test(std::memory_order_acquire)) {
+            return ivf_index_storage_->MemoryUsed();
+        } else {
+            return in_mem_storage_.MemoryUsed();
+        }
+    }
+
+    MemIndexTracerInfo GetInfo() const override {
+        auto *table_index_entry = segment_index_entry_->table_index_entry();
+        SharedPtr<String> index_name = table_index_entry->GetIndexName();
+        auto *table_entry = table_index_entry->table_index_meta()->GetTableEntry();
+        SharedPtr<String> table_name = table_entry->GetTableName();
+        SharedPtr<String> db_name = table_entry->GetDBName();
+
+        return MemIndexTracerInfo(index_name, table_name, db_name, MemoryUsed(), input_row_count_);
+    }
+
+    TableIndexEntry *table_index_entry() const override { return segment_index_entry_->table_index_entry(); }
+
+    IVFIndexInMemT(const RowID begin_row_id, const IndexIVFOption &ivf_option, const u32 embedding_dimension, SegmentIndexEntry *segment_index_entry)
+        : IVFIndexInMem(begin_row_id, ivf_option, column_logical_type, embedding_data_type, embedding_dimension, segment_index_entry) {
         const auto mid = this->ivf_option().centroid_option_.centroids_num_ratio_ * this->ivf_option().centroid_option_.min_points_per_centroid_;
         build_index_bar_embedding_num_ = std::ceil(mid * mid + 3);
     }
@@ -103,6 +137,7 @@ public:
                          const u32 row_count) override {
         const auto column_vector = block_column_entry->GetConstColumnVector(buffer_manager, row_offset);
         std::unique_lock lock(rw_mutex_);
+        SizeT mem1 = MemoryUsed();
         if (have_ivf_index_.test(std::memory_order_acquire)) {
             if constexpr (column_logical_type == LogicalType::kEmbedding) {
                 const auto *column_embedding_ptr = reinterpret_cast<const ColumnEmbeddingElementT *>(column_vector.data());
@@ -151,6 +186,10 @@ public:
                 BuildIndex();
             }
         }
+        SizeT mem2 = MemoryUsed();
+        LOG_TRACE(fmt::format("ivf mem usage = {}", mem2));
+        LOG_TRACE(fmt::format("ivf mem added = {}", mem2 - mem1));
+        AddMemUsed(mem2 > mem1 ? mem2 - mem1 : 0);
     }
 
     void BuildIndex() {
@@ -181,12 +220,16 @@ public:
         have_ivf_index_.test_and_set(std::memory_order_release);
     }
 
-    SharedPtr<ChunkIndexEntry> Dump(SegmentIndexEntry *segment_index_entry, BufferManager *buffer_mgr) override {
+    SharedPtr<ChunkIndexEntry> Dump(SegmentIndexEntry *segment_index_entry, BufferManager *buffer_mgr, SizeT *p_dump_size) override {
         std::unique_lock lock(rw_mutex_);
+        SizeT dump_size = MemoryUsed();
         if (!have_ivf_index_.test(std::memory_order_acquire)) {
             BuildIndex();
         }
         auto new_chunk_index_entry = segment_index_entry->CreateIVFIndexChunkIndexEntry(begin_row_id_, input_row_count_, buffer_mgr);
+        if (p_dump_size != nullptr) {
+            *p_dump_size = dump_size;
+        }
         BufferHandle handle = new_chunk_index_entry->GetIndex();
         auto *data_ptr = static_cast<IVFIndexInChunk *>(handle.GetDataMut());
         data_ptr->GetMemData(std::move(*ivf_index_storage_));
@@ -272,10 +315,16 @@ public:
 };
 
 template <LogicalType column_logical_type>
-SharedPtr<IVFIndexInMem> GetNewIVFIndexInMem(const DataType *column_data_type, const RowID begin_row_id, const IndexIVFOption &index_ivf_option) {
+SharedPtr<IVFIndexInMem> GetNewIVFIndexInMem(const DataType *column_data_type,
+                                             const RowID begin_row_id,
+                                             const IndexIVFOption &index_ivf_option,
+                                             SegmentIndexEntry *segment_index_entry) {
     const auto *embedding_info_ptr = static_cast<const EmbeddingInfo *>(column_data_type->type_info().get());
     auto GetResult = [&]<EmbeddingDataType embedding_data_type> {
-        return MakeShared<IVFIndexInMemT<column_logical_type, embedding_data_type>>(begin_row_id, index_ivf_option, embedding_info_ptr->Dimension());
+        return MakeShared<IVFIndexInMemT<column_logical_type, embedding_data_type>>(begin_row_id,
+                                                                                    index_ivf_option,
+                                                                                    embedding_info_ptr->Dimension(),
+                                                                                    segment_index_entry);
     };
     switch (embedding_info_ptr->Type()) {
         case EmbeddingDataType::kElemInt8: {
@@ -307,14 +356,17 @@ SharedPtr<IVFIndexInMem> GetNewIVFIndexInMem(const DataType *column_data_type, c
     }
 }
 
-SharedPtr<IVFIndexInMem> IVFIndexInMem::NewIVFIndexInMem(const ColumnDef *column_def, const IndexBase *index_base, const RowID begin_row_id) {
+SharedPtr<IVFIndexInMem> IVFIndexInMem::NewIVFIndexInMem(const ColumnDef *column_def,
+                                                         const IndexBase *index_base,
+                                                         const RowID begin_row_id,
+                                                         SegmentIndexEntry *segment_index_entry) {
     auto *index_ivf_ptr = static_cast<const IndexIVF *>(index_base);
     const auto &index_ivf_option = index_ivf_ptr->ivf_option_;
     const auto *column_data_type = column_def->type().get();
     if (const auto column_logical_type = column_data_type->type(); column_logical_type == LogicalType::kEmbedding) {
-        return GetNewIVFIndexInMem<LogicalType::kEmbedding>(column_data_type, begin_row_id, index_ivf_option);
+        return GetNewIVFIndexInMem<LogicalType::kEmbedding>(column_data_type, begin_row_id, index_ivf_option, segment_index_entry);
     } else if (column_logical_type == LogicalType::kMultiVector) {
-        return GetNewIVFIndexInMem<LogicalType::kMultiVector>(column_data_type, begin_row_id, index_ivf_option);
+        return GetNewIVFIndexInMem<LogicalType::kMultiVector>(column_data_type, begin_row_id, index_ivf_option, segment_index_entry);
     }
     UnrecoverableError("IVFIndex can only apply to Embedding and multi-vector column");
     return {};

--- a/src/storage/knn_index/knn_ivf/ivf_index_data_in_mem.cppm
+++ b/src/storage/knn_index/knn_ivf/ivf_index_data_in_mem.cppm
@@ -23,6 +23,9 @@ import ivf_index_storage;
 import column_def;
 import logical_type;
 import buffer_handle;
+import base_memindex;
+import memindex_tracer;
+import table_index_entry;
 
 namespace infinity {
 
@@ -33,7 +36,7 @@ struct SegmentIndexEntry;
 class IndexBase;
 class KnnDistanceBase1;
 
-export class IVFIndexInMem {
+export class IVFIndexInMem : public BaseMemIndex {
 protected:
     const RowID begin_row_id_ = {};
     std::atomic_flag have_ivf_index_ = {};
@@ -43,6 +46,7 @@ protected:
     IVF_Index_Storage *ivf_index_storage_ = nullptr;
     bool own_ivf_index_storage_ = true;
     BufferHandle dump_handle_{};
+    SegmentIndexEntry *segment_index_entry_ = nullptr;
 
     const IndexIVFOption &ivf_option() const { return ivf_index_storage_->ivf_option(); }
     u32 embedding_dimension() const { return ivf_index_storage_->embedding_dimension(); }
@@ -52,7 +56,8 @@ public:
                   const IndexIVFOption &ivf_option,
                   LogicalType column_logical_type,
                   EmbeddingDataType embedding_data_type,
-                  u32 embedding_dimension);
+                  u32 embedding_dimension,
+                  SegmentIndexEntry *segment_index_entry);
     virtual ~IVFIndexInMem();
     u32 GetInputRowCount() const;
     virtual void InsertBlockData(SegmentOffset block_offset,
@@ -60,14 +65,17 @@ public:
                                  BufferManager *buffer_manager,
                                  u32 row_offset,
                                  u32 row_count) = 0;
-    virtual SharedPtr<ChunkIndexEntry> Dump(SegmentIndexEntry *segment_index_entry, BufferManager *buffer_mgr) = 0;
+    virtual SharedPtr<ChunkIndexEntry> Dump(SegmentIndexEntry *segment_index_entry, BufferManager *buffer_mgr, SizeT *p_dump_size = nullptr) = 0;
     void SearchIndex(const KnnDistanceBase1 *knn_distance,
                      const void *query_ptr,
                      EmbeddingDataType query_element_type,
                      u32 nprobe,
                      const std::function<bool(SegmentOffset)> &satisfy_filter_func,
                      const std::function<void(f32, SegmentOffset)> &add_result_func) const;
-    static SharedPtr<IVFIndexInMem> NewIVFIndexInMem(const ColumnDef *column_def, const IndexBase *index_base, RowID begin_row_id);
+    static SharedPtr<IVFIndexInMem>
+    NewIVFIndexInMem(const ColumnDef *column_def, const IndexBase *index_base, RowID begin_row_id, SegmentIndexEntry *segment_index_entry);
+
+    virtual SizeT MemoryUsed() const = 0;
 
 private:
     virtual void SearchIndexInMem(const KnnDistanceBase1 *knn_distance,

--- a/src/storage/knn_index/knn_ivf/ivf_index_storage.cpp
+++ b/src/storage/knn_index/knn_ivf/ivf_index_storage.cpp
@@ -94,6 +94,8 @@ Pair<u32, const f32 *> IVF_Centroids_Storage::GetCentroidDataForMetric(const Knn
 
 // IVF_Index_Storage
 
+SizeT IVF_Index_Storage::MemoryUsed() const { return ivf_centroids_storage_.MemoryUsed() + ivf_parts_storage_->MemoryUsed(); }
+
 void IVF_Index_Storage::Save(LocalFileHandle &file_handle) const {
     file_handle.Append(&row_count_, sizeof(row_count_));
     file_handle.Append(&embedding_count_, sizeof(embedding_count_));
@@ -227,10 +229,10 @@ void IVF_Index_Storage::AddEmbeddingBatchT(const SegmentOffset start_segment_off
                                   ivf_centroids_storage_.data(),
                                   part_ids.data());
     for (u32 i = 0; i < embedding_num; ++i) {
-        ivf_parts_storage_->AppendOneEmbedding(part_ids[i],
-                                               embedding_ptr + i * embedding_dimension_,
-                                               start_segment_offset + i,
-                                               &ivf_centroids_storage_);
+        ivf_parts_storage_->AppendOneEmbeddingWithStat(part_ids[i],
+                                                       embedding_ptr + i * embedding_dimension_,
+                                                       start_segment_offset + i,
+                                                       &ivf_centroids_storage_);
     }
     embedding_count_ += embedding_num;
     row_count_ += embedding_num;
@@ -252,7 +254,10 @@ void IVF_Index_Storage::AddEmbeddingBatchT(const SegmentOffset *segment_offset_p
                                   ivf_centroids_storage_.data(),
                                   part_ids.data());
     for (u32 i = 0; i < embedding_num; ++i) {
-        ivf_parts_storage_->AppendOneEmbedding(part_ids[i], embedding_ptr + i * embedding_dimension_, segment_offset_ptr[i], &ivf_centroids_storage_);
+        ivf_parts_storage_->AppendOneEmbeddingWithStat(part_ids[i],
+                                                       embedding_ptr + i * embedding_dimension_,
+                                                       segment_offset_ptr[i],
+                                                       &ivf_centroids_storage_);
     }
     embedding_count_ += embedding_num;
     row_count_ += embedding_num;
@@ -274,7 +279,10 @@ void IVF_Index_Storage::AddMultiVectorT(const SegmentOffset segment_offset,
                                   ivf_centroids_storage_.data(),
                                   part_ids.data());
     for (u32 i = 0; i < embedding_num; ++i) {
-        ivf_parts_storage_->AppendOneEmbedding(part_ids[i], multi_vector_ptr + i * embedding_dimension_, segment_offset, &ivf_centroids_storage_);
+        ivf_parts_storage_->AppendOneEmbeddingWithStat(part_ids[i],
+                                                       multi_vector_ptr + i * embedding_dimension_,
+                                                       segment_offset,
+                                                       &ivf_centroids_storage_);
     }
     embedding_count_ += embedding_num;
     ++row_count_;

--- a/src/storage/tracer/memindex_tracer.cppm
+++ b/src/storage/tracer/memindex_tracer.cppm
@@ -92,8 +92,10 @@ inline void MemIndexTracer::AddMemUsed(SizeT add) {
     SizeT old_index_memory = cur_index_memory_.fetch_add(add);
     if (SizeT new_index_memory = old_index_memory + add; new_index_memory > index_memory_limit_) {
         if (new_index_memory > index_memory_limit_ + acc_proposed_dump_.load()) {
+            LOG_TRACE(fmt::format("acc_proposed_dump_ = {}", acc_proposed_dump_.load()));
             auto dump_task = MakeDumpTask();
             if (dump_task.get() != nullptr) {
+                LOG_TRACE(fmt::format("Dump triggered!"));
                 TriggerDump(std::move(dump_task));
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Add IVFIndexInMem as an instance of BaseMemIndex, so that when a index has its memory usage above certain threshold, it is dumped by the MemIndexTracer.

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
