### PR TITLE
Remove duplicate std::shared_lock

### DIFF
--- a/src/storage/meta/entry/table_index_entry.cpp
+++ b/src/storage/meta/entry/table_index_entry.cpp
@@ -246,7 +246,6 @@ nlohmann::json TableIndexEntry::Serialize(TxnTimeStamp max_commit_ts) {
         json["index_dir"] = *this->index_dir_;
         json["index_base"] = this->index_base_->Serialize();
 
-        std::shared_lock r_lock(rw_locker_);
         for (const auto &[segment_id, index_entry] : this->index_by_segment_) {
             if (!index_entry->CheckDeprecate(max_commit_ts)) {
                 segment_index_entry_candidates.push_back(index_entry);


### PR DESCRIPTION
### What problem does this PR solve?

Fix Bug: Trying to lock rw_locker_ twice will freeze all read / write operations to TableIndexEntry.

Issue link: infiniflow/ragflow#4163

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
