### PR TITLE
Fix BM25 score for PhraseDocIterator

### DIFF
--- a/test/sql/dql/fulltext/fulltext.slt
+++ b/test/sql/dql/fulltext/fulltext.slt
@@ -36,26 +36,26 @@ Anarchism 30-APR-2012 03:25:17.000 0 22.299635
 query TTIR rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare') USING INDEXES ('ft_index');
 ----
-Anarchism 30-APR-2012 03:25:17.000 6 20.753590
+Anarchism 30-APR-2012 03:25:17.000 6 27.133215
 
 # only phrase
 query TTIR rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare');
 ----
-Anarchism 30-APR-2012 03:25:17.000 6 20.753590
+Anarchism 30-APR-2012 03:25:17.000 6 27.133215
 
 # phrase and term
 query TTIR rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3');
 ----
 Anarchism 30-APR-2012 03:25:17.000 0 22.299635
-Anarchism 30-APR-2012 03:25:17.000 6 20.753590
+Anarchism 30-APR-2012 03:25:17.000 6 27.133215
 
 # phrase and term
 query TTIR rowsort
-SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3;threshold=21.5');
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3;threshold=25');
 ----
-Anarchism 30-APR-2012 03:25:17.000 0 22.299635
+Anarchism 30-APR-2012 03:25:17.000 6 27.133215
 
 # copy data from csv file
 query I


### PR DESCRIPTION
### What problem does this PR solve?

Update IDF formula for PhraseDocIterator
reference: https://lucene.apache.org/core/10_1_0/core/org/apache/lucene/search/similarities/BM25Similarity.html#idfExplain(org.apache.lucene.search.CollectionStatistics,org.apache.lucene.search.TermStatistics[])

Issue link:#1320

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
- [x] Test cases
