### PR TITLE
Support customizable whitespace analyzer

### DIFF
--- a/src/common/analyzer/analyzer_pool.cpp
+++ b/src/common/analyzer/analyzer_pool.cpp
@@ -46,6 +46,10 @@ constexpr u64 Str2Int(const char *str, u64 last_value = basis) {
     return (*str != '\0' && *str != '-') ? Str2Int(str + 1, (*str ^ last_value) * prime) : last_value;
 }
 
+u64 AnalyzerPool::AnalyzerNameToInt(const char *str) {
+    return Str2Int(str);
+}
+
 bool IcharEquals(char a, char b) { return ToLower(static_cast<int>(a)) == ToLower(static_cast<int>(b)); }
 
 bool IEquals(std::string_view lhs, std::string_view rhs) { return std::ranges::equal(lhs, rhs, IcharEquals); }

--- a/src/common/analyzer/analyzer_pool.cpp
+++ b/src/common/analyzer/analyzer_pool.cpp
@@ -321,11 +321,13 @@ Tuple<UniquePtr<Analyzer>, Status> AnalyzerPool::GetAnalyzer(const std::string_v
             }
             return {MakeUnique<NGramAnalyzer>(ngram), Status::OK()};
         }
-        case Str2Int(KEYWORD.data()): {
-            return {MakeUnique<WhitespaceAnalyzer>(), Status::OK()};
-        }
+        case Str2Int(KEYWORD.data()):
         case Str2Int(WHITESPACE.data()): {
-            return {MakeUnique<WhitespaceAnalyzer>(), Status::OK()};
+            const auto suffix_pos = name.find_first_of('-');
+            if (suffix_pos == std::string_view::npos || suffix_pos + 1 == name.size()) {
+                return {MakeUnique<WhitespaceAnalyzer>(), Status::OK()};
+            }
+            return {MakeUnique<WhitespaceAnalyzer>(name.substr(suffix_pos + 1)), Status::OK()};
         }
         default: {
             if(std::filesystem::is_regular_file(name)) {

--- a/src/common/analyzer/analyzer_pool.cppm
+++ b/src/common/analyzer/analyzer_pool.cppm
@@ -30,6 +30,8 @@ public:
 
     Tuple<UniquePtr<Analyzer>, Status> GetAnalyzer(const std::string_view &name);
 
+    static u64 AnalyzerNameToInt(const char *str);
+
     void Set(const std::string_view &name);
 
 public:

--- a/src/common/analyzer/whitespace_analyzer.cpp
+++ b/src/common/analyzer/whitespace_analyzer.cpp
@@ -23,14 +23,42 @@ import analyzer;
 
 namespace infinity {
 
+WhitespaceAnalyzer::WhitespaceAnalyzer(const std::string_view delimiters) {
+    delimiters_ = delimiters;
+    std::sort(delimiters_.begin(), delimiters_.end());
+    const auto last_unique = std::unique(delimiters_.begin(), delimiters_.end());
+    delimiters_.erase(last_unique, delimiters_.end());
+}
+
 int WhitespaceAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
-    std::istringstream is(input.text_);
-    std::string t;
-    u32 offset = 0;
-    while (is >> t) {
-        func(data, t.data(), t.size(), offset++, 0, Term::AND, 0, false);
+    if (delimiters_.empty()) {
+        // split by std::isspace()
+        std::istringstream is(input.text_);
+        std::string t;
+        u32 offset = 0;
+        while (is >> t) {
+            func(data, t.data(), t.size(), offset++, 0, Term::AND, 0, false);
+        }
+        return 0;
+    } else {
+        // split by delimiters
+        const std::string_view delimiters = delimiters_;
+        const std::string_view input_text = input.text_;
+        u32 search_start = 0;
+        u32 offset = 0;
+        while (search_start < input_text.size()) {
+            const auto found = input_text.find_first_of(delimiters, search_start);
+            if (found == std::string_view::npos) {
+                func(data, input_text.data() + search_start, input_text.size() - search_start, offset++, 0, Term::AND, 0, false);
+                break;
+            }
+            if (found > search_start) {
+                func(data, input_text.data() + search_start, found - search_start, offset++, 0, Term::AND, 0, false);
+            }
+            search_start = found + 1;
+        }
+        return 0;
     }
-    return 0;
 }
 
 } // namespace infinity

--- a/src/common/analyzer/whitespace_analyzer.cppm
+++ b/src/common/analyzer/whitespace_analyzer.cppm
@@ -22,8 +22,11 @@ import analyzer;
 namespace infinity {
 
 export class WhitespaceAnalyzer : public Analyzer {
+    String delimiters_{};
+
 public:
     WhitespaceAnalyzer() = default;
+    explicit WhitespaceAnalyzer(std::string_view delimiters);
     ~WhitespaceAnalyzer() override = default;
 
 protected:

--- a/test/sql/dql/fulltext/fulltext_whitespace_sharp.slt
+++ b/test/sql/dql/fulltext/fulltext_whitespace_sharp.slt
@@ -1,0 +1,45 @@
+
+statement ok
+DROP TABLE IF EXISTS ft_whitespace_sharp;
+
+statement ok
+CREATE TABLE ft_whitespace_sharp(num int, doc varchar DEFAULT 'default text');
+
+statement ok
+INSERT INTO ft_whitespace_sharp VALUES (1, '2020-01-01#2023-01-01'), (2, '2023@01$01'), (3, '01 01#@2023'), (4);
+
+statement ok
+CREATE INDEX ft_index ON ft_whitespace_sharp(doc) USING FULLTEXT WITH (analyzer = 'whitespace-#@$');
+
+query I
+SELECT * FROM ft_whitespace_sharp;
+----
+1 2020-01-01#2023-01-01
+2 2023@01$01
+3 01 01#@2023
+4 default text
+
+query I
+SELECT * FROM ft_whitespace_sharp SEARCH MATCH TEXT ('doc^4.5', '2023-01-01^5.0', 'topn=10');
+----
+1 2020-01-01#2023-01-01
+
+query II
+SELECT * FROM ft_whitespace_sharp SEARCH MATCH TEXT ('doc^4.5', '"01 01"^3.3', 'topn=10');
+----
+3 01 01#@2023
+
+query III
+SELECT * FROM ft_whitespace_sharp SEARCH MATCH TEXT ('doc^4.5', '"01#01"^3.3', 'topn=10');
+----
+2 2023@01$01
+
+query IV rowsort
+SELECT * FROM ft_whitespace_sharp SEARCH MATCH TEXT ('doc^4.5', '2023^3.3', 'topn=10');
+----
+2 2023@01$01
+3 01 01#@2023
+
+# Clean up
+statement ok
+DROP TABLE ft_whitespace_sharp;


### PR DESCRIPTION
### What problem does this PR solve?

Support user provided delimiters for whitespace analyzer
For example, analyzer 'whitespace-#$@' will use any character of "#$@" as the delimiter.
resolve #2405

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring
- [x] Test cases
