### PR TITLE
Support customizable BM25 score parameters in fulltext search

### DIFF
--- a/src/executor/operator/physical_match.cpp
+++ b/src/executor/operator/physical_match.cpp
@@ -245,7 +245,7 @@ bool PhysicalMatch::ExecuteInner(QueryContext *query_context, OperatorState *ope
                           static_cast<TimeDurationType>(finish_init_query_builder_time - execute_start_time).count()));
 
     // 2 build query iterator
-    FullTextQueryContext full_text_query_context(ft_similarity_, minimum_should_match_option_, top_n_, match_expr_->index_names_);
+    FullTextQueryContext full_text_query_context(ft_similarity_, bm25_params_, minimum_should_match_option_, top_n_, match_expr_->index_names_);
     full_text_query_context.query_tree_ = MakeUnique<FilterQueryNode>(common_query_filter_.get(), std::move(query_tree_));
     const auto query_iterators = CreateQueryIterators(query_builder, full_text_query_context, early_term_algo_, begin_threshold_, score_threshold_);
     const auto finish_query_builder_time = std::chrono::high_resolution_clock::now();
@@ -331,6 +331,7 @@ PhysicalMatch::PhysicalMatch(const u64 id,
                              MinimumShouldMatchOption &&minimum_should_match_option,
                              const f32 score_threshold,
                              const FulltextSimilarity ft_similarity,
+                             const BM25Params &bm25_params,
                              const u64 match_table_index,
                              SharedPtr<Vector<LoadMeta>> load_metas,
                              const bool cache_result)
@@ -338,7 +339,7 @@ PhysicalMatch::PhysicalMatch(const u64 id,
       base_table_ref_(std::move(base_table_ref)), match_expr_(std::move(match_expr)), index_reader_(std::move(index_reader)),
       query_tree_(std::move(query_tree)), begin_threshold_(begin_threshold), early_term_algo_(early_term_algo), top_n_(top_n),
       common_query_filter_(common_query_filter), minimum_should_match_option_(std::move(minimum_should_match_option)),
-      score_threshold_(score_threshold), ft_similarity_(ft_similarity) {}
+      score_threshold_(score_threshold), ft_similarity_(ft_similarity), bm25_params_(bm25_params) {}
 
 PhysicalMatch::~PhysicalMatch() = default;
 

--- a/src/executor/operator/physical_match.cppm
+++ b/src/executor/operator/physical_match.cppm
@@ -56,6 +56,7 @@ public:
                            MinimumShouldMatchOption &&minimum_should_match_option,
                            f32 score_threshold,
                            FulltextSimilarity ft_similarity,
+                           const BM25Params &bm25_params,
                            u64 match_table_index,
                            SharedPtr<Vector<LoadMeta>> load_metas,
                            bool cache_result);
@@ -115,6 +116,7 @@ private:
     MinimumShouldMatchOption minimum_should_match_option_{};
     f32 score_threshold_{};
     FulltextSimilarity ft_similarity_{FulltextSimilarity::kBM25};
+    BM25Params bm25_params_;
 
     bool ExecuteInner(QueryContext *query_context, OperatorState *operator_state);
 };

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -982,6 +982,7 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildMatch(const SharedPtr<LogicalN
                                      std::move(logical_match->minimum_should_match_option_),
                                      logical_match->score_threshold_,
                                      logical_match->ft_similarity_,
+                                     logical_match->bm25_params_,
                                      logical_match->TableIndex(),
                                      logical_operator->load_metas(),
                                      true /*cache_result*/);

--- a/src/planner/bound_select_statement.cpp
+++ b/src/planner/bound_select_statement.cpp
@@ -292,6 +292,43 @@ SharedPtr<LogicalNode> BoundSelectStatement::BuildPlan(QueryContext *query_conte
                             RecoverableError(Status::SyntaxError(R"(similarity option must be "BM25" or "boolean".)"));
                         }
                     }
+                    // option: bm25_params
+                    if (iter = search_ops.options_.find("bm25_param_k1"); iter != search_ops.options_.end()) {
+                        const auto k1_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (k1_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_k1 must be a non-negative float. default value: 1.2"));
+                        }
+                        match_node->bm25_params_.k1 = k1_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_b"); iter != search_ops.options_.end()) {
+                        const auto b_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (b_v < 0.0f || b_v > 1.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_b must be in the range [0.0f, 1.0f]. default value: 0.75"));
+                        }
+                        match_node->bm25_params_.b = b_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_delta"); iter != search_ops.options_.end()) {
+                        const auto delta_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (delta_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_delta must be a non-negative float. default value: 0.0"));
+                        }
+                        match_node->bm25_params_.delta_term = delta_v;
+                        match_node->bm25_params_.delta_phrase = delta_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_delta_term"); iter != search_ops.options_.end()) {
+                        const auto delta_term_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (delta_term_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_delta_term must be a non-negative float. default value: 0.0"));
+                        }
+                        match_node->bm25_params_.delta_term = delta_term_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_delta_phrase"); iter != search_ops.options_.end()) {
+                        const auto delta_phrase_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (delta_phrase_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_delta_phrase must be a non-negative float. default value: 0.0"));
+                        }
+                        match_node->bm25_params_.delta_phrase = delta_phrase_v;
+                    }
 
                     SearchDriver search_driver(column2analyzer, default_field, query_operator_option);
                     UniquePtr<QueryNode> query_tree =

--- a/src/planner/node/logical_match.cppm
+++ b/src/planner/node/logical_match.cppm
@@ -68,6 +68,7 @@ public:
     MinimumShouldMatchOption minimum_should_match_option_{};
     f32 score_threshold_{};
     FulltextSimilarity ft_similarity_{FulltextSimilarity::kBM25};
+    BM25Params bm25_params_;
 };
 
 } // namespace infinity

--- a/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter.cpp
@@ -461,6 +461,7 @@ private:
                 MinimumShouldMatchOption minimum_should_match_option;
                 f32 score_threshold = {};
                 FulltextSimilarity ft_similarity = FulltextSimilarity::kBM25;
+                BM25Params bm25_params;
                 Vector<String> index_names;
                 {
                     SearchOptions search_ops(filter_fulltext_expr->options_text_);
@@ -528,6 +529,43 @@ private:
                             RecoverableError(Status::SyntaxError(R"(similarity option must be "BM25" or "boolean".)"));
                         }
                     }
+                    // option: bm25_params
+                    if (iter = search_ops.options_.find("bm25_param_k1"); iter != search_ops.options_.end()) {
+                        const auto k1_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (k1_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_k1 must be a non-negative float. default value: 1.2"));
+                        }
+                        bm25_params.k1 = k1_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_b"); iter != search_ops.options_.end()) {
+                        const auto b_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (b_v < 0.0f || b_v > 1.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_b must be in the range [0.0f, 1.0f]. default value: 0.75"));
+                        }
+                        bm25_params.b = b_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_delta"); iter != search_ops.options_.end()) {
+                        const auto delta_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (delta_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_delta must be a non-negative float. default value: 0.0"));
+                        }
+                        bm25_params.delta_term = delta_v;
+                        bm25_params.delta_phrase = delta_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_delta_term"); iter != search_ops.options_.end()) {
+                        const auto delta_term_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (delta_term_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_delta_term must be a non-negative float. default value: 0.0"));
+                        }
+                        bm25_params.delta_term = delta_term_v;
+                    }
+                    if (iter = search_ops.options_.find("bm25_param_delta_phrase"); iter != search_ops.options_.end()) {
+                        const auto delta_phrase_v = DataType::StringToValue<FloatT>(iter->second);
+                        if (delta_phrase_v < 0.0f) {
+                            RecoverableError(Status::SyntaxError("bm25_param_delta_phrase must be a non-negative float. default value: 0.0"));
+                        }
+                        bm25_params.delta_phrase = delta_phrase_v;
+                    }
 
                     // option: indexes
                     if (iter = search_ops.options_.find("indexes"); iter != search_ops.options_.end()) {
@@ -564,6 +602,7 @@ private:
                                                                 std::move(minimum_should_match_option),
                                                                 score_threshold,
                                                                 ft_similarity,
+                                                                bm25_params,
                                                                 std::move(index_names));
             }
             case Enum::kAndExpr: {

--- a/src/planner/optimizer/index_scan/index_filter_evaluators.cpp
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators.cpp
@@ -481,7 +481,7 @@ Bitmask IndexFilterEvaluatorFulltext::Evaluate(const SegmentID segment_id, const
     result.SetAllFalse();
     const RowID begin_rowid(segment_id, 0);
     const RowID end_rowid(segment_id, segment_row_count);
-    const CreateSearchParams params{table_entry_, &index_reader_, early_term_algo_, ft_similarity_, minimum_should_match_, 0u, index_names_};
+    const CreateSearchParams params{table_entry_, &index_reader_, early_term_algo_, ft_similarity_, bm25_params_, minimum_should_match_, 0u, index_names_};
     auto ft_iter = query_tree_->CreateSearch(params);
     if (ft_iter && score_threshold_ > 0.0f) {
         auto new_ft_iter = MakeUnique<ScoreThresholdIterator>(std::move(ft_iter), score_threshold_);
@@ -524,6 +524,7 @@ Bitmask IndexFilterEvaluatorAND::Evaluate(const SegmentID segment_id, const Segm
                                             &(fulltext_evaluator_->index_reader_),
                                             fulltext_evaluator_->early_term_algo_,
                                             fulltext_evaluator_->ft_similarity_,
+                                            fulltext_evaluator_->bm25_params_,
                                             fulltext_evaluator_->minimum_should_match_,
                                             0u,
                                             fulltext_evaluator_->index_names_};

--- a/src/planner/optimizer/index_scan/index_filter_evaluators.cppm
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators.cppm
@@ -94,6 +94,7 @@ export struct IndexFilterEvaluatorFulltext final : IndexFilterEvaluator {
     std::atomic_flag after_optimize_ = {};
     f32 score_threshold_ = {};
     FulltextSimilarity ft_similarity_ = FulltextSimilarity::kBM25;
+    BM25Params bm25_params_;
     Vector<String> index_names_;
 
     IndexFilterEvaluatorFulltext(const FilterFulltextExpression *src_filter_fulltext_expression,
@@ -104,11 +105,12 @@ export struct IndexFilterEvaluatorFulltext final : IndexFilterEvaluator {
                                  MinimumShouldMatchOption &&minimum_should_match_option,
                                  const f32 score_threshold,
                                  const FulltextSimilarity ft_similarity,
+                                 const BM25Params &bm25_params,
                                  Vector<String> &&index_names)
         : IndexFilterEvaluator(Type::kFulltextIndex), src_filter_fulltext_expressions_({src_filter_fulltext_expression}), table_entry_(table_entry),
           early_term_algo_(early_term_algo), index_reader_(std::move(index_reader)), query_tree_(std::move(query_tree)),
           minimum_should_match_option_(std::move(minimum_should_match_option)), score_threshold_(std::max(score_threshold, 0.0f)),
-          ft_similarity_(ft_similarity), index_names_(std::move(index_names)) {}
+          ft_similarity_(ft_similarity), bm25_params_(bm25_params), index_names_(std::move(index_names)) {}
     Bitmask Evaluate(SegmentID segment_id, SegmentOffset segment_row_count, Txn *txn) const override;
     bool HaveMinimumShouldMatchOption() const { return !minimum_should_match_option_.empty(); }
     void OptimizeQueryTree();

--- a/src/storage/invertedindex/search/blockmax_leaf_iterator.cppm
+++ b/src/storage/invertedindex/search/blockmax_leaf_iterator.cppm
@@ -28,10 +28,6 @@ public:
     // ref: https://en.wikipedia.org/wiki/Okapi_BM25
     virtual void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader, float delta, float k1, float b) = 0;
 
-    void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader, const float delta = 0.0F) {
-        return InitBM25Info(std::move(column_length_reader), delta, 1.2F, 0.75F);
-    }
-
     virtual RowID BlockMinPossibleDocID() const = 0;
 
     virtual RowID BlockLastDocID() const = 0;

--- a/src/storage/invertedindex/search/blockmax_leaf_iterator.cppm
+++ b/src/storage/invertedindex/search/blockmax_leaf_iterator.cppm
@@ -19,11 +19,19 @@ export module blockmax_leaf_iterator;
 import stl;
 import internal_types;
 import doc_iterator;
+import column_length_io;
 
 namespace infinity {
 
 export class BlockMaxLeafIterator : public DocIterator {
 public:
+    // ref: https://en.wikipedia.org/wiki/Okapi_BM25
+    virtual void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader, float delta, float k1, float b) = 0;
+
+    void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader, const float delta = 0.0F) {
+        return InitBM25Info(std::move(column_length_reader), delta, 1.2F, 0.75F);
+    }
+
     virtual RowID BlockMinPossibleDocID() const = 0;
 
     virtual RowID BlockLastDocID() const = 0;

--- a/src/storage/invertedindex/search/parse_fulltext_options.cppm
+++ b/src/storage/invertedindex/search/parse_fulltext_options.cppm
@@ -42,4 +42,11 @@ export enum class FulltextSimilarity {
     kBoolean,
 };
 
+export struct BM25Params {
+    float k1 = 1.2F;
+    float b = 0.75F;
+    float delta_term = 0.0F;
+    float delta_phrase = 0.0F;
+};
+
 } // namespace infinity

--- a/src/storage/invertedindex/search/phrase_doc_iterator.cppm
+++ b/src/storage/invertedindex/search/phrase_doc_iterator.cppm
@@ -26,7 +26,7 @@ public:
 
     float GetPhraseFreq() const { return phrase_freq_; }
 
-    void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader);
+    void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader, float delta, float k1, float b) override;
 
     DocIteratorType GetType() const override { return DocIteratorType::kPhraseIterator; }
     String Name() const override { return "PhraseDocIterator"; }
@@ -97,6 +97,7 @@ private:
     float f1 = 0.0f;
     float f2 = 0.0f;
     float f3 = 0.0f;
+    float f4 = 0.0f;
     float bm25_common_score_ = 0.0f;
     UniquePtr<FullTextColumnLengthReader> column_length_reader_ = nullptr;
     float block_max_bm25_score_cache_ = 0.0f;

--- a/src/storage/invertedindex/search/query_builder.cpp
+++ b/src/storage/invertedindex/search/query_builder.cpp
@@ -55,6 +55,7 @@ UniquePtr<DocIterator> QueryBuilder::CreateSearch(FullTextQueryContext &context)
                                     &index_reader_,
                                     context.early_term_algo_,
                                     context.ft_similarity_,
+                                    context.bm25_params_,
                                     context.minimum_should_match_,
                                     context.topn_,
                                     context.index_names_};

--- a/src/storage/invertedindex/search/query_builder.cppm
+++ b/src/storage/invertedindex/search/query_builder.cppm
@@ -34,16 +34,20 @@ export struct FullTextQueryContext {
     UniquePtr<QueryNode> query_tree_{};
     UniquePtr<QueryNode> optimized_query_tree_{};
     const FulltextSimilarity ft_similarity_{};
+    const BM25Params bm25_params_{};
     const MinimumShouldMatchOption minimum_should_match_option_{};
     u32 minimum_should_match_ = 0;
     u32 topn_ = 0;
     EarlyTermAlgo early_term_algo_ = EarlyTermAlgo::kNaive;
     const Vector<String> &index_names_;
+
     FullTextQueryContext(const FulltextSimilarity ft_similarity,
+                         const BM25Params &bm25_params,
                          const MinimumShouldMatchOption &minimum_should_match_option,
                          const u32 topn,
                          const Vector<String> &index_names)
-        : ft_similarity_(ft_similarity), minimum_should_match_option_(minimum_should_match_option), topn_(topn), index_names_(index_names) {}
+        : ft_similarity_(ft_similarity), bm25_params_(bm25_params), minimum_should_match_option_(minimum_should_match_option), topn_(topn),
+          index_names_(index_names) {}
 };
 
 export class QueryBuilder {
@@ -54,7 +58,7 @@ public:
 
     ~QueryBuilder();
 
-    Map<String, String> GetColumn2Analyzer(const Vector<String> &hints) { return index_reader_.GetColumn2Analyzer(hints); }
+    Map<String, String> GetColumn2Analyzer(const Vector<String> &hints) const { return index_reader_.GetColumn2Analyzer(hints); }
 
     UniquePtr<DocIterator> CreateSearch(FullTextQueryContext &context);
 

--- a/src/storage/invertedindex/search/query_node.cpp
+++ b/src/storage/invertedindex/search/query_node.cpp
@@ -26,6 +26,7 @@ import parse_fulltext_options;
 import keyword_iterator;
 import must_first_iterator;
 import batch_or_iterator;
+import blockmax_leaf_iterator;
 
 namespace infinity {
 
@@ -421,10 +422,10 @@ std::unique_ptr<DocIterator> TermQueryNode::CreateSearch(const CreateSearchParam
         return nullptr;
     }
     auto search = MakeUnique<TermDocIterator>(std::move(posting_iterator), column_id, GetWeight(), params.ft_similarity);
-    auto column_length_reader = MakeUnique<FullTextColumnLengthReader>(column_index_reader);
-    search->InitBM25Info(std::move(column_length_reader));
     search->term_ptr_ = &term_;
     search->column_name_ptr_ = &column_;
+    auto column_length_reader = MakeUnique<FullTextColumnLengthReader>(column_index_reader);
+    search->InitBM25Info(std::move(column_length_reader), params.bm25_params.delta_term, params.bm25_params.k1, params.bm25_params.b);
     return search;
 }
 
@@ -449,10 +450,10 @@ std::unique_ptr<DocIterator> PhraseQueryNode::CreateSearch(const CreateSearchPar
         posting_iterators.emplace_back(std::move(posting_iterator));
     }
     auto search = MakeUnique<PhraseDocIterator>(std::move(posting_iterators), GetWeight(), slop_, params.ft_similarity);
-    auto column_length_reader = MakeUnique<FullTextColumnLengthReader>(column_index_reader);
-    search->InitBM25Info(std::move(column_length_reader));
     search->terms_ptr_ = &terms_;
     search->column_name_ptr_ = &column_;
+    auto column_length_reader = MakeUnique<FullTextColumnLengthReader>(column_index_reader);
+    search->InitBM25Info(std::move(column_length_reader), params.bm25_params.delta_phrase, params.bm25_params.k1, params.bm25_params.b);
     return search;
 }
 

--- a/src/storage/invertedindex/search/query_node.h
+++ b/src/storage/invertedindex/search/query_node.h
@@ -53,16 +53,23 @@ class DocIterator;
 class EarlyTerminateIterator;
 enum class EarlyTermAlgo;
 enum class FulltextSimilarity;
+struct BM25Params;
 
 struct CreateSearchParams {
     const TableEntry *table_entry;
     const IndexReader *index_reader;
     EarlyTermAlgo early_term_algo;
     FulltextSimilarity ft_similarity;
+    const BM25Params &bm25_params;
     uint32_t minimum_should_match;
     uint32_t topn;
     const std::vector<std::string> &index_names_;
-    [[nodiscard]] CreateSearchParams RemoveMSM() const { return {table_entry, index_reader, early_term_algo, ft_similarity, 0, topn, index_names_}; }
+
+    [[nodiscard]] CreateSearchParams RemoveMSM() const {
+        CreateSearchParams copy_value = *this;
+        copy_value.minimum_should_match = 0;
+        return copy_value;
+    }
 };
 
 // step 1. get the query tree from parser

--- a/src/storage/invertedindex/search/term_doc_iterator.cppm
+++ b/src/storage/invertedindex/search/term_doc_iterator.cppm
@@ -47,8 +47,7 @@ public:
 
     u64 GetTermFreq() const { return term_freq_; }
 
-    void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader);
-
+    void InitBM25Info(UniquePtr<FullTextColumnLengthReader> &&column_length_reader, float delta, float k1, float b) override;
     RowID BlockMinPossibleDocID() const override { return iter_->BlockLowestPossibleDocID(); }
     RowID BlockLastDocID() const override { return iter_->BlockLastDocID(); }
     float BlockMaxBM25Score() override;
@@ -113,6 +112,7 @@ private:
     float f1 = 0.0f;
     float f2 = 0.0f;
     float f3 = 0.0f;
+    float f4 = 0.0f;
     float avg_column_len_ = 0;
     UniquePtr<FullTextColumnLengthReader> column_length_reader_ = nullptr;
     float bm25_common_score_ = 0; // include: weight * smooth_idf * (k1 + 1.0F)

--- a/src/unit_test/storage/invertedindex/search/query_builder.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_builder.cpp
@@ -201,7 +201,7 @@ TEST_F(QueryBuilderTest, test_and) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(and_root);
     FakeQueryBuilder fake_query_builder;
@@ -273,7 +273,7 @@ TEST_F(QueryBuilderTest, test_or) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(or_root);
     FakeQueryBuilder fake_query_builder;
@@ -351,7 +351,7 @@ TEST_F(QueryBuilderTest, test_and_not) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(and_not_root);
     FakeQueryBuilder fake_query_builder;
@@ -435,7 +435,7 @@ TEST_F(QueryBuilderTest, test_and_not2) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(and_not_root);
     FakeQueryBuilder fake_query_builder;

--- a/src/unit_test/storage/invertedindex/search/query_match.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_match.cpp
@@ -338,7 +338,7 @@ void QueryMatchTest::QueryMatch(const String &db_name,
         Status status = Status::ParseMatchExprFailed(match_expr->fields_, match_expr->matching_text_);
         RecoverableError(status);
     }
-    FullTextQueryContext full_text_query_context(FulltextSimilarity::kBM25, MinimumShouldMatchOption{}, 10, index_hints);
+    FullTextQueryContext full_text_query_context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, index_hints);
     full_text_query_context.early_term_algo_ = EarlyTermAlgo::kNaive;
     full_text_query_context.query_tree_ = std::move(query_tree);
     UniquePtr<DocIterator> doc_iterator = query_builder.CreateSearch(full_text_query_context);

--- a/test/sql/dql/fulltext/fulltext.slt
+++ b/test/sql/dql/fulltext/fulltext.slt
@@ -44,12 +44,57 @@ SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MAT
 ----
 Anarchism 30-APR-2012 03:25:17.000 6 27.133215
 
+# only phrase
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare;bm25_param_delta_term=1.0');
+----
+Anarchism 30-APR-2012 03:25:17.000 6 27.133215
+
+# only phrase
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare;bm25_param_delta_phrase=0.5');
+----
+Anarchism 30-APR-2012 03:25:17.000 6 40.859940
+
+# only phrase
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare;bm25_param_delta_phrase=1.0');
+----
+Anarchism 30-APR-2012 03:25:17.000 6 54.586658
+
+# only phrase
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs"', 'topn=3;block_max=compare;bm25_param_delta_phrase=4.0');
+----
+Anarchism 30-APR-2012 03:25:17.000 6 136.946991
+
 # phrase and term
 query TTIR rowsort
 SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3');
 ----
 Anarchism 30-APR-2012 03:25:17.000 0 22.299635
 Anarchism 30-APR-2012 03:25:17.000 6 27.133215
+
+# phrase and term
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3;block_max=compare;bm25_param_delta_term=1.0');
+----
+Anarchism 30-APR-2012 03:25:17.000 0 43.298161
+Anarchism 30-APR-2012 03:25:17.000 6 27.133215
+
+# phrase and term
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3;block_max=compare;bm25_param_delta_phrase=1.0');
+----
+Anarchism 30-APR-2012 03:25:17.000 0 22.299635
+Anarchism 30-APR-2012 03:25:17.000 6 54.586658
+
+# phrase and term
+query TTIR rowsort
+SELECT doctitle, docdate, ROW_ID(), SCORE() FROM sqllogic_test_enwiki SEARCH MATCH TEXT ('body^5', '"social customs" harmful', 'topn=3;block_max=compare;bm25_param_delta=1.0');
+----
+Anarchism 30-APR-2012 03:25:17.000 0 43.298161
+Anarchism 30-APR-2012 03:25:17.000 6 54.586658
 
 # phrase and term
 query TTIR rowsort

--- a/test/sql/dql/fulltext/fulltext_minimum_should_match.slt
+++ b/test/sql/dql/fulltext/fulltext_minimum_should_match.slt
@@ -36,7 +36,7 @@ query I
 SELECT *, SCORE() FROM ft_minimum_should_match SEARCH MATCH TEXT ('doc', 'second text', 'topn=10;threshold=-9999');
 ----
 2 second text multiple 1.186260
-4 another second text xxx 1.079068
+4 another second text xxx 1.079067
 1 first text 0.366141
 3 third text many words 0.244768
 
@@ -44,7 +44,7 @@ query I
 SELECT *, SCORE() FROM ft_minimum_should_match SEARCH MATCH TEXT ('doc', 'second text', 'topn=10;threshold=0.3');
 ----
 2 second text multiple 1.186260
-4 another second text xxx 1.079068
+4 another second text xxx 1.079067
 1 first text 0.366141
 
 query I


### PR DESCRIPTION
### What problem does this PR solve?

Support customizable BM25 score parameters, including:
* `k1`, `b` for BM25 score (default value: `k1` = 1.2, `b` = 0.75)
* `delta` for BM25+ score (default value: `delta` = 0.0)
* user can provide different `delta` value for term and phrase

reference: https://en.wikipedia.org/wiki/Okapi_BM25

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Refactoring
- [x] Test cases
