### PR TITLE
Fix data race in slow test

### DIFF
--- a/src/storage/invertedindex/memory_indexer.cpp
+++ b/src/storage/invertedindex/memory_indexer.cpp
@@ -175,11 +175,16 @@ void MemoryIndexer::InsertGap(u32 row_count) {
 }
 
 void MemoryIndexer::Commit(bool offline) {
-    if (offline) {
-        commiting_thread_pool_.push([this](int id) { this->CommitOffline(); });
-    } else {
-        commiting_thread_pool_.push([this](int id) { this->CommitSync(); });
-    }
+    commiting_thread_pool_.push([offline, weak_ptr = weak_from_this()](int id) {
+        if (const auto shared_ptr = weak_ptr.lock(); shared_ptr) {
+            auto *memory_indexer = static_cast<MemoryIndexer *>(shared_ptr.get());
+            if (offline) {
+                memory_indexer->CommitOffline();
+            } else {
+                memory_indexer->CommitSync();
+            }
+        }
+    });
 }
 
 SizeT MemoryIndexer::CommitOffline(SizeT wait_if_empty_ms) {
@@ -213,6 +218,7 @@ SizeT MemoryIndexer::CommitOffline(SizeT wait_if_empty_ms) {
 }
 
 SizeT MemoryIndexer::CommitSync(SizeT wait_if_empty_ms) {
+    std::shared_lock commit_sync_lock(mutex_commit_sync_share_);
     Vector<SharedPtr<ColumnInverter>> inverters;
     // LOG_INFO("MemoryIndexer::CommitSync begin");
     u64 seq_commit = this->ring_inverted_.GetBatch(inverters);
@@ -270,6 +276,7 @@ void MemoryIndexer::Dump(bool offline, bool spill) {
         while (GetInflightTasks() > 0) {
             CommitOffline(100);
         }
+        std::unique_lock lock(mutex_commit_);
         OfflineDump();
         return;
     }
@@ -281,7 +288,7 @@ void MemoryIndexer::Dump(bool offline, bool spill) {
     while (GetInflightTasks() > 0) {
         CommitSync(100);
     }
-    std::unique_lock lock(mutex_commit_);
+    std::unique_lock commit_sync_lock(mutex_commit_sync_share_);
 
     String posting_file = Path(index_dir_) / (base_name_ + POSTING_SUFFIX + (spill ? SPILL_SUFFIX : ""));
     String dict_file = Path(index_dir_) / (base_name_ + DICT_SUFFIX + (spill ? SPILL_SUFFIX : ""));

--- a/src/storage/invertedindex/memory_indexer.cppm
+++ b/src/storage/invertedindex/memory_indexer.cppm
@@ -165,6 +165,7 @@ private:
     std::condition_variable cv_;
     std::mutex mutex_;
     std::mutex mutex_commit_;
+    std::shared_mutex mutex_commit_sync_share_;
 
     u32 num_runs_{0};                  // For offline index building
     FILE *spill_file_handle_{nullptr}; // Temp file for offline external merge sort

--- a/src/storage/meta/entry/block_column_entry.cpp
+++ b/src/storage/meta/entry/block_column_entry.cpp
@@ -292,7 +292,7 @@ void BlockColumnEntry::FlushColumnCheck(TxnTimeStamp checkpoint_ts) {
     }
     bool flush_column = false;
     bool flush_version = false;
-    block_entry_->CheckFlush(checkpoint_ts, flush_column, flush_version);
+    block_entry_->CheckFlush(checkpoint_ts, flush_column, flush_version, true, true);
     if (!flush_column) {
         return;
     }

--- a/src/storage/meta/entry/block_entry.cppm
+++ b/src/storage/meta/entry/block_entry.cppm
@@ -202,7 +202,7 @@ public:
 
     SizeT GetStorageSize() const;
 
-    void CheckFlush(TxnTimeStamp ts, bool &flush_column, bool &flush_version, bool check_commit = true) const;
+    void CheckFlush(TxnTimeStamp ts, bool &flush_column, bool &flush_version, bool check_commit, bool need_lock) const;
 
     bool TryToMmap();
 

--- a/src/storage/meta/entry/segment_index_entry.cpp
+++ b/src/storage/meta/entry/segment_index_entry.cpp
@@ -862,7 +862,7 @@ void SegmentIndexEntry::PickCleanup(CleanupScanner *scanner) {
 void SegmentIndexEntry::ReplaceChunkIndexEntries(TxnTableStore *txn_table_store,
                                                  SharedPtr<ChunkIndexEntry> merged_chunk_index_entry,
                                                  Vector<ChunkIndexEntry *> old_chunks) {
-    TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry_);
+    TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry_, true);
     chunk_index_entries_.push_back(merged_chunk_index_entry);
     txn_index_store->optimize_data_.emplace_back(this, merged_chunk_index_entry.get(), std::move(old_chunks));
 }
@@ -1249,7 +1249,7 @@ Pair<bool, std::function<void()>> SegmentIndexEntry::TrySetOptimizing(Txn *txn) 
     return {true, [this, txn] {
         TableEntry *table_entry = table_index_entry_->table_index_meta()->GetTableEntry();
         TxnTableStore *txn_table_store = txn->txn_store()->GetTxnTableStore(table_entry);
-        TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry_);
+        TxnIndexStore *txn_index_store = txn_table_store->GetIndexStore(table_index_entry_, true);
         txn_index_store->AddSegmentOptimizing(this);
     }};
 }

--- a/src/storage/tracer/base_memindex.cppm
+++ b/src/storage/tracer/base_memindex.cppm
@@ -23,8 +23,10 @@ namespace infinity {
 
 struct TableIndexEntry;
 
-export class BaseMemIndex {
+export class BaseMemIndex : public EnableSharedFromThis<BaseMemIndex> {
 public:
+    virtual ~BaseMemIndex() = default;
+
     virtual MemIndexTracerInfo GetInfo() const = 0;
 
     virtual TableIndexEntry *table_index_entry() const = 0;

--- a/src/storage/txn/txn_store.cppm
+++ b/src/storage/txn/txn_store.cppm
@@ -113,7 +113,7 @@ public:
 
     void AddChunkIndexStore(TableIndexEntry *table_index_entry, ChunkIndexEntry *chunk_index_entry);
 
-    TxnIndexStore *GetIndexStore(TableIndexEntry *table_index_entry);
+    TxnIndexStore *GetIndexStore(TableIndexEntry *table_index_entry, bool need_lock);
 
     void DropIndexStore(TableIndexEntry *table_index_entry);
 
@@ -151,7 +151,7 @@ public:
     void MaintainCompactionAlg();
 
 public: // Setter, Getter
-    const HashMap<String, UniquePtr<TxnIndexStore>> &txn_indexes_store() const { return txn_indexes_store_; }
+    Pair<std::shared_lock<std::shared_mutex>, const HashMap<String, UniquePtr<TxnIndexStore>> &> txn_indexes_store() const;
 
     const HashMap<SegmentID, TxnSegmentStore> &txn_segments() const { return txn_segments_store_; }
 
@@ -178,7 +178,7 @@ public: // Setter, Getter
     bool AddedTxnNum() const { return added_txn_num_; }
 
 private:
-    std::mutex mtx_{};
+    mutable std::shared_mutex txn_table_store_mtx_{};
 
     HashMap<SegmentID, TxnSegmentStore> txn_segments_store_{};
     Vector<SegmentEntry *> flushed_segments_{};

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -1162,7 +1162,7 @@ void WalManager::WalCmdCreateIndexReplay(const WalCmdCreateIndex &cmd, Transacti
     table_index_entry->CreateIndexPrepare(base_table_ref.get(), fake_txn.get(), false, true);
 
     auto *txn_store = fake_txn->GetTxnTableStore(table_entry);
-    for (const auto &[index_name, txn_index_store] : txn_store->txn_indexes_store()) {
+    for (const auto &[lock, txn_indexes_store] = txn_store->txn_indexes_store(); const auto &[index_name, txn_index_store] : txn_indexes_store) {
         Catalog::CommitCreateIndex(txn_index_store.get(), commit_ts, true /*is_replay*/);
     }
     table_index_entry->Commit(commit_ts);


### PR DESCRIPTION
### What problem does this PR solve?

Fix data race in `infinity::BlockEntry@block_entry::AppendData(unsigned long, unsigned long, infinity::DataBlock@data_block*, unsigned short, unsigned short, infinity::BufferManager@buffer_manager*)`
Fix data race in `infinity::TxnTableStore@txn_store::CheckConflict(infinity::TxnTableStore@txn_store const*) const`

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
