### PR TITLE
Update version to 0.6.0-dev2 and use lts-polars-cpu as the pandas module

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Supports a wide range of data types including strings, numerics, vectors, and mo
 Infinity supports two working modes, embedded mode and client-server mode. Infinity's embedded mode enables you to quickly embed Infinity into your Python applications, without the need to connect to a separate backend server. The following shows how to operate in embedded mode:
 
    ```bash
-   pip install infinity-embedded-sdk==0.6.0.dev1
+   pip install infinity-embedded-sdk==0.6.0.dev2
    ```
    Use Infinity to conduct a dense vector search:
    ```python

--- a/benchmark/remote_infinity/remote_query_benchmark.cpp
+++ b/benchmark/remote_infinity/remote_query_benchmark.cpp
@@ -51,7 +51,7 @@ struct InfinityClient {
         transport->open();
         CommonResponse response;
         ConnectRequest request;
-        request.__set_client_version(28); // 0.6.0.dev1
+        request.__set_client_version(28); // 0.6.0.dev1 and 0.6.0.dev2
         client->Connect(response, request);
         session_id = response.session_id;
     }

--- a/client/cpp/infinity_client.cpp
+++ b/client/cpp/infinity_client.cpp
@@ -25,7 +25,7 @@ Client Client::Connect(const std::string &ip_address, uint16_t port) {
     transport->open();
     CommonResponse response;
     ConnectRequest request;
-    request.__set_client_version(28); // 0.6.0.dev1
+    request.__set_client_version(28); // 0.6.0.dev1 and 0.6.0.dev2
     client->Connect(response, request);
     return {socket, transport, protocol, std::move(client), response.session_id};
 }

--- a/docs/getstarted/build_from_source.mdx
+++ b/docs/getstarted/build_from_source.mdx
@@ -264,7 +264,7 @@ cmake --build . -t test_main
 
 2. Install Python sdk of infinity:
    ```bash
-   pip install infinity-sdk==0.6.0.dev1
+   pip install infinity-sdk==0.6.0.dev2
    ```
 
 3. Run the functional tests:
@@ -286,7 +286,7 @@ cmake --build . -t test_main
 
 2. Install Python sdk of infinity:
    ```bash
-   pip install infinity-sdk==0.6.0.dev1
+   pip install infinity-sdk==0.6.0.dev2
    ```
 
 3. Run the functional tests: 
@@ -309,7 +309,7 @@ cmake --build . -t test_main
 
 2. Install Python sdk of infinity:
    ```bash
-   pip install infinity-sdk==0.6.0.dev1
+   pip install infinity-sdk==0.6.0.dev2
    ```
 
 3. Run the functional tests: 

--- a/docs/getstarted/deploy_infinity_server.mdx
+++ b/docs/getstarted/deploy_infinity_server.mdx
@@ -34,7 +34,7 @@ This approach allows you to call Infinity as a Python module. To deploy Infinity
 ### Install Infinity as a module
 
 ```
-pip install infinity-embedded-sdk==0.6.0.dev1
+pip install infinity-embedded-sdk==0.6.0.dev2
 ```
 
 ### Create an Infinity object
@@ -101,7 +101,7 @@ If you are on Windows 10+, you must enable WSL or WSL2 to deploy Infinity using 
 ### Install Infinity client
 
 ```
-pip install infinity-sdk==0.6.0.dev1
+pip install infinity-sdk==0.6.0.dev2
 ```
 
 ### Run a vector search
@@ -151,7 +151,7 @@ This section provides instructions on deploying Infinity using binary package on
 
 Fedora/RHEL/CentOS/OpenSUSE
 ```bash
-sudo rpm -i infinity-0.6.0.dev1-x86_64.rpm
+sudo rpm -i infinity-0.6.0.dev2-x86_64.rpm
 ```
 
 ```bash
@@ -162,7 +162,7 @@ sudo systemctl start infinity
   <TabItem value="ubuntu">
 
 ```bash
-sudo dpkg -i infinity-0.6.0.dev1-x86_64.deb
+sudo dpkg -i infinity-0.6.0.dev2-x86_64.deb
 ```
 
 ```bash
@@ -175,7 +175,7 @@ sudo systemctl start infinity
 ### Install Infinity client
 
 ```
-pip install infinity-sdk==0.6.0.dev1
+pip install infinity-sdk==0.6.0.dev2
 ```
 
 ### Run a vector search

--- a/docs/getstarted/quickstart.md
+++ b/docs/getstarted/quickstart.md
@@ -21,7 +21,7 @@ If you wish to embed Infinity into your Python application without the need for 
 
 1. Install the Infinity-embedded SDK:
    ```bash
-   pip install infinity-embedded-sdk==0.6.0.dev1
+   pip install infinity-embedded-sdk==0.6.0.dev2
    ```
 2. Use Infinity to conduct a dense vector search:
    ```python

--- a/example/README.md
+++ b/example/README.md
@@ -5,13 +5,13 @@
 The Python scripts in the current directory provides the examples of the infinity SDK API. Before running these scripts, please ensure that the correct version of infinity SDK is installed. If you are using the server version of Infinity, you can use the following command to install it
 
 ```shell
-pip install infinity-sdk==0.6.0.dev1
+pip install infinity-sdk==0.6.0.dev2
 ```
 
 To use Infinity locally as a Python module, install the Infinity Embedded SDK:
 
 ```shell
-pip install infinity-embedded-sdk==0.6.0.dev1
+pip install infinity-embedded-sdk==0.6.0.dev2
 ```
 
 Once the installation completes, run some simple examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "infinity_embedded_sdk"
-version = "0.6.0.dev1"
+version = "0.6.0.dev2"
 requires-python = ">=3.10"
 dependencies = [
     "sqlglot~=11.7.0",
@@ -22,7 +22,7 @@ dependencies = [
     "pandas~=2.2.0",
     "numpy~=1.26.0",
     "pyarrow~=17.0.0",
-    "polars~=1.9.0",
+    "polars-lts-cpu~=1.9.0",
     "openpyxl~=3.1.0",
     "requests~=2.32.0"
 ]

--- a/python/infinity_sdk/README.md
+++ b/python/infinity_sdk/README.md
@@ -63,7 +63,7 @@ Infinity supports two working modes, embedded mode and client-server mode. The f
 
 2. Install the `infinity-sdk` package:
    ```bash
-   pip install infinity-sdk==0.6.0.dev1
+   pip install infinity-sdk==0.6.0.dev2
    ```
 
 3. Use Infinity to conduct a dense vector search:

--- a/python/infinity_sdk/infinity/remote_thrift/client.py
+++ b/python/infinity_sdk/infinity/remote_thrift/client.py
@@ -98,8 +98,8 @@ class ThriftInfinityClient:
         # version: 0.5.0.dev3, client_version: 25
         # version: 0.5.0.dev4 and 0.5.0.dev5, client_version: 26
         # version: 0.5.0.dev6 and 0.5.0.dev7 and 0.5.0 and 0.5.1 and 0.5.2, client_version: 27
-        # version: 0.6.0.dev1, client_version: 28
-        res = self.client.Connect(ConnectRequest(client_version=28)) # 0.6.0.dev1
+        # version: 0.6.0.dev1 and 0.6.0.dev2, client_version: 28
+        res = self.client.Connect(ConnectRequest(client_version=28)) # 0.6.0.dev1 and 0.6.0.dev2
         if res.error_code != 0:
             raise InfinityException(res.error_code, res.error_msg)
         self.session_id = res.session_id

--- a/python/infinity_sdk/pyproject.toml
+++ b/python/infinity_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infinity-sdk"
-version = "0.6.0.dev1"
+version = "0.6.0.dev2"
 requires-python = ">=3.10"
 dependencies = [
     "sqlglot~=11.7.0",
@@ -11,7 +11,7 @@ dependencies = [
     "pandas~=2.2.0",
     "numpy~=1.26.0",
     "pyarrow~=17.0.0",
-    "polars~=1.9.0",
+    "polars-lts-cpu~=1.9.0",
     "openpyxl~=3.1.0",
     "requests~=2.32.0",
     "readerwriterlock~=1.0.9"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,6 +6,6 @@ pytest~=8.3.0
 pandas~=2.2.0
 numpy~=1.26.0
 pyarrow~=17.0.0
-polars~=1.9.0
+polars-lts-cpu~=1.9.0
 openpyxl~=3.1.0
 requests~=2.32.0

--- a/src/network/infinity_thrift_service.cpp
+++ b/src/network/infinity_thrift_service.cpp
@@ -94,7 +94,7 @@ ClientVersions::ClientVersions() {
     client_version_map_[25] = String("0.5.0.dev3");
     client_version_map_[26] = String("0.5.0.dev5");
     client_version_map_[27] = String("0.5.2");
-    client_version_map_[28] = String("0.6.0.dev1");
+    client_version_map_[28] = String("0.6.0.dev2");
 }
 
 Pair<const char *, Status> ClientVersions::GetVersionByIndex(i64 version_index) {

--- a/src/network/infinity_thrift_service.cppm
+++ b/src/network/infinity_thrift_service.cppm
@@ -60,7 +60,7 @@ struct ClientVersions {
 export class InfinityThriftService final : public infinity_thrift_rpc::InfinityServiceIf {
 private:
     static constexpr std::string_view ErrorMsgHeader = "[THRIFT ERROR]";
-    static constexpr i64 current_version_index_{28}; // 0.6.0.dev1
+    static constexpr i64 current_version_index_{28}; // 0.6.0.dev1 and 0.6.0.dev2
 
     static std::mutex infinity_session_map_mutex_;
     static HashMap<u64, SharedPtr<Infinity>> infinity_session_map_;


### PR DESCRIPTION
### What problem does this PR solve?

- Update version info
- To be compatible with old CPU use lts-polar-cpu

### Type of change

- [x] Refactoring
- [x] Python SDK impacted, Need to update PyPI
