### PR TITLE
Enable doc payload for inverted index

### DIFF
--- a/src/common/analyzer/analyzer.cppm
+++ b/src/common/analyzer/analyzer.cppm
@@ -49,25 +49,11 @@ public:
     }
 
 protected:
-    typedef void (*HookType)(void *data,
-                             const char *text,
-                             const u32 len,
-                             const u32 offset,
-                             const u32 end_offset,
-                             const u8 and_or_bit,
-                             const u8 level,
-                             const bool is_special_char);
+    typedef void (*HookType)(void *data, const char *text, const u32 len, const u32 offset, const u32 end_offset, const bool is_special_char);
 
     virtual int AnalyzeImpl(const Term &input, void *data, HookType func) { return -1; }
 
-    static void AppendTermList(void *data,
-                               const char *text,
-                               const u32 len,
-                               const u32 offset,
-                               const u32 end_offset,
-                               const u8 and_or_bit,
-                               const u8 level,
-                               const bool is_special_char) {
+    static void AppendTermList(void *data, const char *text, const u32 len, const u32 offset, const u32 end_offset, const bool is_special_char) {
         void **parameters = (void **)data;
         TermList *output = (TermList *)parameters[0];
         Analyzer *analyzer = (Analyzer *)parameters[1];
@@ -76,9 +62,9 @@ protected:
             return;
         if (is_special_char && analyzer->convert_to_placeholder_) {
             if (output->empty() == true || output->back().text_.compare(PLACE_HOLDER) != 0)
-                output->Add(PLACE_HOLDER.c_str(), PLACE_HOLDER.length(), offset, end_offset, and_or_bit, level);
+                output->Add(PLACE_HOLDER.c_str(), PLACE_HOLDER.length(), offset, end_offset);
         } else {
-            output->Add(text, len, offset, end_offset, and_or_bit, level);
+            output->Add(text, len, offset, end_offset);
         }
     }
 

--- a/src/common/analyzer/common_analyzer.cpp
+++ b/src/common/analyzer/common_analyzer.cpp
@@ -38,9 +38,7 @@ void CommonLanguageAnalyzer::InitStemmer(Language language) { stemmer_->Init(lan
 int CommonLanguageAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
     Parse(input.text_);
 
-    unsigned char top_and_or_bit = Term::AND;
     int temp_offset = 0;
-    int last_word_offset = -1;
 
     while (NextToken()) {
         if (len_ == 0)
@@ -52,23 +50,14 @@ int CommonLanguageAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType 
         if (remove_stopwords_ && IsStopword())
             continue;
 
-        if (cjk_) {
-            int cur_word_offset = offset_;
-            if (cur_word_offset == last_word_offset)
-                top_and_or_bit = Term::OR;
-            else
-                top_and_or_bit = Term::AND;
-            last_word_offset = cur_word_offset;
-        }
-
         if (is_index_) {
             if (IsSpecialChar()) {
-                func(data, token_, len_, offset_, end_offset_, Term::AND, level_, true);
+                func(data, token_, len_, offset_, end_offset_, true);
                 temp_offset = offset_;
                 continue;
             }
             if (is_raw_) {
-                func(data, token_, len_, offset_, end_offset_, Term::OR, level_, false);
+                func(data, token_, len_, offset_, end_offset_, false);
                 temp_offset = offset_;
                 continue;
             }
@@ -88,37 +77,37 @@ int CommonLanguageAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType 
                 bool lowercase_is_different = memcmp(token_, lowercase_term, len_) != 0;
 
                 if (stemming_term_str_size && stem_only_) {
-                    func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, Term::OR, level_ + 1, false);
+                    func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, false);
                     temp_offset = offset_;
                 } else if (stemming_term_str_size || (case_sensitive_ && contain_lower_ && lowercase_is_different)) {
                     /// have more than one output
                     if (case_sensitive_) {
-                        func(data, token_, len_, offset_, end_offset_, Term::OR, level_ + 1, false);
+                        func(data, token_, len_, offset_, end_offset_, false);
                         temp_offset = offset_;
                     } else {
-                        func(data, lowercase_term, len_, offset_, end_offset_, Term::OR, level_ + 1, false);
+                        func(data, lowercase_term, len_, offset_, end_offset_, false);
                         temp_offset = offset_;
                     }
                     if (stemming_term_str_size) {
-                        func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, Term::OR, level_ + 1, false);
+                        func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, false);
                         temp_offset = offset_;
                     }
                     if (case_sensitive_ && contain_lower_ && lowercase_is_different) {
-                        func(data, lowercase_term, len_, offset_, end_offset_, Term::OR, level_ + 1, false);
+                        func(data, lowercase_term, len_, offset_, end_offset_, false);
                         temp_offset = offset_;
                     }
                 } else {
                     /// have only one output
                     if (case_sensitive_) {
-                        func(data, token_, len_, offset_, end_offset_, Term::AND, level_, false);
+                        func(data, token_, len_, offset_, end_offset_, false);
                         temp_offset = offset_;
                     } else {
-                        func(data, lowercase_term, len_, offset_, end_offset_, Term::AND, level_, false);
+                        func(data, lowercase_term, len_, offset_, end_offset_, false);
                         temp_offset = offset_;
                     }
                 }
             } else {
-                func(data, token_, len_, offset_, end_offset_, top_and_or_bit, level_, false);
+                func(data, token_, len_, offset_, end_offset_, false);
                 temp_offset = offset_;
             }
         }

--- a/src/common/analyzer/common_analyzer.cppm
+++ b/src/common/analyzer/common_analyzer.cppm
@@ -66,7 +66,6 @@ protected:
         len_ = 0;
         offset_ = 0;
         end_offset_ = 0;
-        level_ = 0;
         is_index_ = false;
         is_raw_ = false;
     }
@@ -81,7 +80,6 @@ protected:
     u32 offset_{0};
     u32 end_offset_{0};
     u32 local_offset_{0};
-    int level_{0};
     bool is_index_{false};
     bool is_raw_{false};
     bool case_sensitive_{false};

--- a/src/common/analyzer/ik/ik_analyzer.cpp
+++ b/src/common/analyzer/ik/ik_analyzer.cpp
@@ -70,7 +70,6 @@ void IKAnalyzer::Reset() {
 int IKAnalyzer::GetLastUselessCharNum() { return context_->GetLastUselessCharNum(); }
 
 int IKAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
-    unsigned level = 0;
     unsigned offset = 0;
     std::wstring line = CharacterUtil::UTF8ToUTF16(input.text_);
     context_->Reset();
@@ -91,7 +90,7 @@ int IKAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
     while ((lexeme = context_->GetNextLexeme()) != nullptr) {
         std::wstring text = lexeme->GetLexemeText();
         String token = CharacterUtil::UTF16ToUTF8(text);
-        func(data, token.c_str(), token.size(), offset++, 0, Term::AND, level, false);
+        func(data, token.c_str(), token.size(), offset++, 0, false);
         delete lexeme;
     };
     return 0;

--- a/src/common/analyzer/ngram_analyzer.cpp
+++ b/src/common/analyzer/ngram_analyzer.cpp
@@ -48,8 +48,6 @@ bool NGramAnalyzer::NextInString(const char *data,
 }
 
 int NGramAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
-    unsigned char level = 0;
-
     SizeT len = input.text_.length();
     if (len == 0)
         return 0;
@@ -61,7 +59,7 @@ int NGramAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
     while (cur < len && NextInString(input.text_.c_str(), len, &cur, &token_start, &token_length)) {
         if (token_length == 0)
             continue;
-        func(data, input.text_.c_str() + token_start, token_length, offset, offset + token_length, Term::AND, level, false);
+        func(data, input.text_.c_str() + token_start, token_length, offset, offset + token_length, false);
         offset++;
     }
 

--- a/src/common/analyzer/rag_analyzer.cpp
+++ b/src/common/analyzer/rag_analyzer.cpp
@@ -1430,7 +1430,6 @@ void RAGAnalyzer::FineGrainedTokenize(const String &tokens, Vector<String> &resu
 }
 
 int RAGAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
-    unsigned level = 0;
     Vector<String> tokens;
     String output = Tokenize(input.text_);
     if (fine_grained_) {
@@ -1439,7 +1438,7 @@ int RAGAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
         Split(output, blank_pattern_, tokens);
     unsigned offset = 0;
     for (auto &t : tokens) {
-        func(data, t.c_str(), t.size(), offset++, 0, Term::AND, level, false);
+        func(data, t.c_str(), t.size(), offset++, 0, false);
     }
     return 0;
 }

--- a/src/common/analyzer/term.cpp
+++ b/src/common/analyzer/term.cpp
@@ -19,14 +19,12 @@ import stl;
 module term;
 
 namespace infinity {
-const u8 Term::AND = 0;
-const u8 Term::OR = 1;
+
 String PLACE_HOLDER("<PH>");
 
 void Term::Reset() {
     text_.clear();
     word_offset_ = 0;
-    stats_ = 0;
 }
 
 Term TermList::global_temporary_;

--- a/src/common/analyzer/term.cppm
+++ b/src/common/analyzer/term.cppm
@@ -22,25 +22,11 @@ export module term;
 namespace infinity {
 export class Term {
 public:
-    static const u8 OR;
-    static const u8 AND;
-
-    Term() : word_offset_(0), stats_(0) {}
-    Term(const String &str) : text_(str), word_offset_(0), stats_(0) {}
+    Term() : word_offset_(0), payload_(0) {}
+    Term(const String &str) : text_(str), word_offset_(0), payload_(0) {}
     ~Term() {}
 
     void Reset();
-
-    inline void SetStats(u8 and_or_bit, u8 level) { stats_ = ((and_or_bit & 0x01) << 7) | ((u8)(level) & 0x7F); }
-
-    inline void GetStats(u8 &and_or_bit, u8 &level) const {
-        and_or_bit = (stats_ & 0x80) >> 7;
-        level = (u8)(stats_ & 0x7F);
-    }
-
-    inline u8 GetAndOrBit() const { return (stats_ & 0x80) >> 7; }
-
-    inline u8 GetLevel() const { return (u8)(stats_ & 0x7F); }
 
     u32 Length() { return text_.length(); }
 
@@ -50,18 +36,16 @@ public:
     String text_;
     u32 word_offset_;
     u32 end_offset_;
-    u8 stats_;
+    u16 payload_;
 };
 
 export class TermList : public Deque<Term> {
 public:
-    void Add(const char *text, const u32 len, const u32 offset, const u32 end_offset, const u8 and_or_bit = Term::AND, const u8 level = 0) {
+    void Add(const char *text, const u32 len, const u32 offset, const u32 end_offset) {
         push_back(global_temporary_);
         back().text_.assign(text, len);
         back().word_offset_ = offset;
         back().end_offset_ = end_offset;
-        back().end_offset_ = end_offset;
-        back().SetStats(and_or_bit, level);
     }
 
     void Add(cppjieba::Word &cut_word) {

--- a/src/common/analyzer/whitespace_analyzer.cpp
+++ b/src/common/analyzer/whitespace_analyzer.cpp
@@ -37,7 +37,7 @@ int WhitespaceAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func
         std::string t;
         u32 offset = 0;
         while (is >> t) {
-            func(data, t.data(), t.size(), offset++, 0, Term::AND, 0, false);
+            func(data, t.data(), t.size(), offset++, 0, false);
         }
         return 0;
     } else {
@@ -49,11 +49,11 @@ int WhitespaceAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func
         while (search_start < input_text.size()) {
             const auto found = input_text.find_first_of(delimiters, search_start);
             if (found == std::string_view::npos) {
-                func(data, input_text.data() + search_start, input_text.size() - search_start, offset++, 0, Term::AND, 0, false);
+                func(data, input_text.data() + search_start, input_text.size() - search_start, offset++, 0, false);
                 break;
             }
             if (found > search_start) {
-                func(data, input_text.data() + search_start, found - search_start, offset++, 0, Term::AND, 0, false);
+                func(data, input_text.data() + search_start, found - search_start, offset++, 0, false);
             }
             search_start = found + 1;
         }

--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -314,7 +314,7 @@ void ColumnInverter::SpillSortResults(FILE *spill_file, u64 &tuple_count, Unique
             last_term_num = i.term_num_;
             term = GetTermFromNum(last_term_num);
         }
-        record_length = term.size() + sizeof(docid_t) + sizeof(u32) + 1;
+        record_length = term.size() + sizeof(docid_t) + sizeof(u32) + sizeof(u16) + 1;
 
         buf_writer->Write((const char *)&record_length, sizeof(u32));
         buf_writer->Write(term.data(), term.size());

--- a/src/storage/invertedindex/column_inverter.cpp
+++ b/src/storage/invertedindex/column_inverter.cpp
@@ -112,7 +112,7 @@ void ColumnInverter::MergePrepare() {
         for (auto it = terms_once->begin(); it != terms_once->end(); ++it) {
             StringRef term(it->text_);
             u32 term_ref = AddTerm(term);
-            positions_.emplace_back(term_ref, doc_id, it->word_offset_);
+            positions_.emplace_back(term_ref, doc_id, it->word_offset_, it->payload_);
         }
     }
     terms_per_doc_.clear();
@@ -127,7 +127,7 @@ void ColumnInverter::Merge(ColumnInverter &rhs) {
         for (auto it = terms_once->begin(); it != terms_once->end(); ++it) {
             StringRef term(it->text_);
             u32 term_ref = AddTerm(term);
-            positions_.emplace_back(term_ref, doc_id, it->word_offset_);
+            positions_.emplace_back(term_ref, doc_id, it->word_offset_, it->payload_);
         }
     }
     doc_count_ += rhs.doc_count_;
@@ -214,6 +214,7 @@ void ColumnInverter::Sort() {
 MemUsageChange ColumnInverter::GeneratePosting() {
     u32 last_term_num = std::numeric_limits<u32>::max();
     u32 last_doc_id = INVALID_DOCID;
+    u16 last_doc_payload = 0;
     StringRef last_term, term;
     SharedPtr<PostingWriter> posting = nullptr;
     MemUsageChange ret{true, 0};
@@ -223,7 +224,7 @@ MemUsageChange ColumnInverter::GeneratePosting() {
         if (last_term_num != i.term_num_) {
             if (last_doc_id != INVALID_DOCID) {
                 assert(posting.get() != nullptr);
-                posting->EndDocument(last_doc_id, 0);
+                posting->EndDocument(last_doc_id, last_doc_payload);
                 // printf(" EndDocument1-%u\n", last_doc_id);
             }
             term = GetTermFromNum(i.term_num_);
@@ -243,15 +244,16 @@ MemUsageChange ColumnInverter::GeneratePosting() {
             assert(last_doc_id != INVALID_DOCID);
             assert(last_doc_id < i.doc_id_);
             assert(posting.get() != nullptr);
-            posting->EndDocument(last_doc_id, 0);
+            posting->EndDocument(last_doc_id, last_doc_payload);
             // printf(" EndDocument2-%u\n", last_doc_id);
         }
         last_doc_id = i.doc_id_;
+        last_doc_payload = i.doc_payload_;
         posting->AddPosition(i.term_pos_);
         // printf(" pos-%u", i.term_pos_);
     }
     if (last_doc_id != INVALID_DOCID) {
-        posting->EndDocument(last_doc_id, 0);
+        posting->EndDocument(last_doc_id, last_doc_payload);
         // printf(" EndDocument3-%u\n", last_doc_id);
     }
     // printf("GeneratePosting() end begin_doc_id_ %u, doc_count_ %u, merged_ %u", begin_doc_id_, doc_count_, merged_);
@@ -319,6 +321,7 @@ void ColumnInverter::SpillSortResults(FILE *spill_file, u64 &tuple_count, Unique
         buf_writer->Write((const char *)&str_null, sizeof(char));
         buf_writer->Write((const char *)&(i.doc_id_), sizeof(docid_t));
         buf_writer->Write((const char *)&(i.term_pos_), sizeof(u32));
+        buf_writer->Write((const char *)&(i.doc_payload_), sizeof(u16));
     }
     buf_writer->Flush();
     // update data size

--- a/src/storage/invertedindex/column_inverter.cppm
+++ b/src/storage/invertedindex/column_inverter.cppm
@@ -63,6 +63,7 @@ public:
         u32 term_num_{0};
         u32 doc_id_{0};
         u32 term_pos_{0};
+        u16 doc_payload_{0};
 
         bool operator<(const PosInfo &rhs) const {
             if (term_num_ != rhs.term_num_) {

--- a/src/storage/invertedindex/common/external_sort_merger.cpp
+++ b/src/storage/invertedindex/common/external_sort_merger.cpp
@@ -469,7 +469,7 @@ void SortMergerTermTuple<KeyType, LenType>::MergeImpl() {
         auto out_key = top.KEY();
         if (tuple_list == nullptr) {
             tuple_list = MakeShared<TermTupleList>(out_key.term_);
-            tuple_list->Add(out_key.doc_id_, out_key.term_pos_);
+            tuple_list->Add(out_key.doc_id_, out_key.term_pos_, out_key.doc_payload_);
         } else if (idx != last_idx) {
             if (tuple_list->IsFull() || out_key.term_ != tuple_list->term_) {
                 // output
@@ -478,7 +478,7 @@ void SortMergerTermTuple<KeyType, LenType>::MergeImpl() {
                 }
                 tuple_list = MakeShared<TermTupleList>(out_key.term_);
             }
-            tuple_list->Add(out_key.doc_id_, out_key.term_pos_);
+            tuple_list->Add(out_key.doc_id_, out_key.term_pos_, out_key.doc_payload_);
         }
 
         assert(idx < this->MAX_GROUP_SIZE_);

--- a/src/storage/invertedindex/common/external_sort_merger.cppm
+++ b/src/storage/invertedindex/common/external_sort_merger.cppm
@@ -59,6 +59,7 @@ export struct TermTuple {
     std::string_view term_;
     u32 doc_id_;
     u32 term_pos_;
+    u16 doc_payload_;
     int Compare(const TermTuple &rhs) const {
         int ret = term_.compare(rhs.term_);
 
@@ -88,9 +89,10 @@ export struct TermTuple {
 
     bool operator<(const TermTuple &other) const { return Compare(other) < 0; }
 
-    TermTuple(char *p, u32 len) : term_(p, len - sizeof(doc_id_) - sizeof(term_pos_) - 1) {
+    TermTuple(char *p, u32 len) : term_(p, len - sizeof(doc_id_) - sizeof(term_pos_) - sizeof(doc_payload_) - 1) {
         doc_id_ = *((u32 *)(p + term_.size() + 1));
         term_pos_ = *((u32 *)(p + term_.size() + 1 + sizeof(doc_id_)));
+        doc_payload_ = *((u16 *)(p + term_.size() + 1 + sizeof(doc_id_) + sizeof(term_pos_)));
     }
 };
 
@@ -102,13 +104,13 @@ export struct TermTupleList {
 
     bool IsFull() { return doc_pos_list_.size() >= max_tuple_num_; }
 
-    void Add(u32 doc_id, u32 term_pos) { doc_pos_list_.emplace_back(doc_id, term_pos); }
+    void Add(u32 doc_id, u32 term_pos, u16 doc_payload) { doc_pos_list_.emplace_back(doc_id, term_pos, doc_payload); }
 
     SizeT Size() const { return doc_pos_list_.size(); }
 
     String term_;
-    // <doc_id, term_pos>
-    Vector<Pair<u32, u32>> doc_pos_list_;
+    // <doc_id, term_pos, doc_payload>
+    Vector<Tuple<u32, u32, u16>> doc_pos_list_;
     u32 max_tuple_num_{0};
 };
 

--- a/src/storage/invertedindex/common/external_sort_merger.cppm
+++ b/src/storage/invertedindex/common/external_sort_merger.cppm
@@ -99,7 +99,7 @@ export struct TermTuple {
 export struct TermTupleList {
     TermTupleList(std::string_view term, u32 list_size = 2 * 1024 * 1024) : term_(term) {
         doc_pos_list_.reserve(list_size);
-        max_tuple_num_ = list_size / (sizeof(u32) * 2);
+        max_tuple_num_ = list_size / (sizeof(u32) * 2 + sizeof(u16));
     }
 
     bool IsFull() { return doc_pos_list_.size() >= max_tuple_num_; }

--- a/src/storage/invertedindex/search/search_driver.cpp
+++ b/src/storage/invertedindex/search/search_driver.cpp
@@ -129,11 +129,9 @@ inline TermList GetTermListFromAnalyzer(const std::string &analyzer_name, Analyz
             }
             last_term.text_ = term.text_;
             last_term.word_offset_ = term.word_offset_;
-            last_term.stats_ = term.stats_;
         } else {
             if (term.text_.size() < last_term.text_.size()) {
                 last_term.text_ = term.text_;
-                last_term.stats_ = term.stats_;
             }
         }
     }

--- a/src/unit_test/storage/invertedindex/common/external_sort.cpp
+++ b/src/unit_test/storage/invertedindex/common/external_sort.cpp
@@ -130,11 +130,13 @@ protected:
                 String str = std::to_string(i * SIZE / run_num + j);
                 u32 doc_id = 34567; // i * SIZE / run_num + j;
                 u32 term_pos = i;
+                u16 doc_payload = i;
                 memcpy(buffer, str.data(), str.size());
                 buffer[str.size()] = '\0';
                 memcpy(buffer + str.size() + 1, &doc_id, sizeof(u32));
                 memcpy(buffer + str.size() + 1 + sizeof(u32), &term_pos, sizeof(u32));
-                u32 len = str.size() + 1 + sizeof(u32) + sizeof(u32);
+                memcpy(buffer + str.size() + 1 + sizeof(u32) + sizeof(u16), &doc_payload, sizeof(u16));
+                u32 len = str.size() + 1 + sizeof(u32) + sizeof(u32) + sizeof(u16);
                 fwrite(&len, sizeof(u32), 1, f);
                 fwrite(buffer, len, 1, f);
                 s += len + sizeof(u32);

--- a/src/unit_test/storage/invertedindex/common/external_sort.cpp
+++ b/src/unit_test/storage/invertedindex/common/external_sort.cpp
@@ -130,12 +130,12 @@ protected:
                 String str = std::to_string(i * SIZE / run_num + j);
                 u32 doc_id = 34567; // i * SIZE / run_num + j;
                 u32 term_pos = i;
-                u16 doc_payload = i;
+                u16 doc_payload = 10086;
                 memcpy(buffer, str.data(), str.size());
                 buffer[str.size()] = '\0';
                 memcpy(buffer + str.size() + 1, &doc_id, sizeof(u32));
                 memcpy(buffer + str.size() + 1 + sizeof(u32), &term_pos, sizeof(u32));
-                memcpy(buffer + str.size() + 1 + sizeof(u32) + sizeof(u16), &doc_payload, sizeof(u16));
+                memcpy(buffer + str.size() + 1 + sizeof(u32) + sizeof(u32), &doc_payload, sizeof(u16));
                 u32 len = str.size() + 1 + sizeof(u32) + sizeof(u32) + sizeof(u16);
                 fwrite(&len, sizeof(u32), 1, f);
                 fwrite(buffer, len, 1, f);
@@ -157,6 +157,7 @@ protected:
         f = fopen("./tt", "r");
         u64 count = 0;
         u32 doc_id = 34567;
+        u32 doc_payload = 10086;
         fread(&count, sizeof(u64), 1, f);
         EXPECT_EQ(count, SIZE);
         for (u32 i = 0; i < count; ++i) {
@@ -166,6 +167,7 @@ protected:
             fread(buf, len, 1, f);
             TermTuple tuple(buf, len);
             EXPECT_EQ(tuple.doc_id_, doc_id);
+            EXPECT_EQ(tuple.doc_payload_, doc_payload);
             delete[] buf;
         }
         std::filesystem::remove("./tt");


### PR DESCRIPTION
### What problem does this PR solve?

Columns for rank features(#2309) with Map types will have weight for each term, which is better to be represented with doc payload within inverted index.

Issue link:#2309

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
