### PR TITLE
Support rank features query:part1

### DIFF
--- a/src/common/analyzer/analyzer.cppm
+++ b/src/common/analyzer/analyzer.cppm
@@ -49,11 +49,23 @@ public:
     }
 
 protected:
-    typedef void (*HookType)(void *data, const char *text, const u32 len, const u32 offset, const u32 end_offset, const bool is_special_char);
+    typedef void (*HookType)(void *data,
+                             const char *text,
+                             const u32 len,
+                             const u32 offset,
+                             const u32 end_offset,
+                             const bool is_special_char,
+                             const u16 payload);
 
     virtual int AnalyzeImpl(const Term &input, void *data, HookType func) { return -1; }
 
-    static void AppendTermList(void *data, const char *text, const u32 len, const u32 offset, const u32 end_offset, const bool is_special_char) {
+    static void AppendTermList(void *data,
+                               const char *text,
+                               const u32 len,
+                               const u32 offset,
+                               const u32 end_offset,
+                               const bool is_special_char,
+                               const u16 payload) {
         void **parameters = (void **)data;
         TermList *output = (TermList *)parameters[0];
         Analyzer *analyzer = (Analyzer *)parameters[1];
@@ -62,9 +74,9 @@ protected:
             return;
         if (is_special_char && analyzer->convert_to_placeholder_) {
             if (output->empty() == true || output->back().text_.compare(PLACE_HOLDER) != 0)
-                output->Add(PLACE_HOLDER.c_str(), PLACE_HOLDER.length(), offset, end_offset);
+                output->Add(PLACE_HOLDER.c_str(), PLACE_HOLDER.length(), offset, end_offset, payload);
         } else {
-            output->Add(text, len, offset, end_offset);
+            output->Add(text, len, offset, end_offset, payload);
         }
     }
 

--- a/src/common/analyzer/analyzer_pool.cpp
+++ b/src/common/analyzer/analyzer_pool.cpp
@@ -34,6 +34,7 @@ import ngram_analyzer;
 import rag_analyzer;
 import whitespace_analyzer;
 import ik_analyzer;
+import rank_features_analyzer;
 import logger;
 
 namespace infinity {
@@ -329,6 +330,9 @@ Tuple<UniquePtr<Analyzer>, Status> AnalyzerPool::GetAnalyzer(const std::string_v
                 return {MakeUnique<WhitespaceAnalyzer>(), Status::OK()};
             }
             return {MakeUnique<WhitespaceAnalyzer>(name.substr(suffix_pos + 1)), Status::OK()};
+        }
+        case Str2Int(RANKFEATURES.data()): {
+            return {MakeUnique<RankFeaturesAnalyzer>(), Status::OK()};
         }
         default: {
             if (std::filesystem::is_regular_file(name)) {

--- a/src/common/analyzer/analyzer_pool.cppm
+++ b/src/common/analyzer/analyzer_pool.cppm
@@ -45,6 +45,7 @@ public:
     static constexpr std::string_view IK = "ik";
     static constexpr std::string_view KEYWORD = "keyword";
     static constexpr std::string_view WHITESPACE = "whitespace";
+    static constexpr std::string_view RANKFEATURES = "rankfeatures";
 
 private:
     CacheType cache_{};

--- a/src/common/analyzer/common_analyzer.cpp
+++ b/src/common/analyzer/common_analyzer.cpp
@@ -52,12 +52,12 @@ int CommonLanguageAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType 
 
         if (is_index_) {
             if (IsSpecialChar()) {
-                func(data, token_, len_, offset_, end_offset_, true);
+                func(data, token_, len_, offset_, end_offset_, true, 0);
                 temp_offset = offset_;
                 continue;
             }
             if (is_raw_) {
-                func(data, token_, len_, offset_, end_offset_, false);
+                func(data, token_, len_, offset_, end_offset_, false, 0);
                 temp_offset = offset_;
                 continue;
             }
@@ -77,37 +77,37 @@ int CommonLanguageAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType 
                 bool lowercase_is_different = memcmp(token_, lowercase_term, len_) != 0;
 
                 if (stemming_term_str_size && stem_only_) {
-                    func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, false);
+                    func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, false, 0);
                     temp_offset = offset_;
                 } else if (stemming_term_str_size || (case_sensitive_ && contain_lower_ && lowercase_is_different)) {
                     /// have more than one output
                     if (case_sensitive_) {
-                        func(data, token_, len_, offset_, end_offset_, false);
+                        func(data, token_, len_, offset_, end_offset_, false, 0);
                         temp_offset = offset_;
                     } else {
-                        func(data, lowercase_term, len_, offset_, end_offset_, false);
+                        func(data, lowercase_term, len_, offset_, end_offset_, false, 0);
                         temp_offset = offset_;
                     }
                     if (stemming_term_str_size) {
-                        func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, false);
+                        func(data, stem_term.c_str(), stemming_term_str_size, offset_, end_offset_, false, 0);
                         temp_offset = offset_;
                     }
                     if (case_sensitive_ && contain_lower_ && lowercase_is_different) {
-                        func(data, lowercase_term, len_, offset_, end_offset_, false);
+                        func(data, lowercase_term, len_, offset_, end_offset_, false, 0);
                         temp_offset = offset_;
                     }
                 } else {
                     /// have only one output
                     if (case_sensitive_) {
-                        func(data, token_, len_, offset_, end_offset_, false);
+                        func(data, token_, len_, offset_, end_offset_, false, 0);
                         temp_offset = offset_;
                     } else {
-                        func(data, lowercase_term, len_, offset_, end_offset_, false);
+                        func(data, lowercase_term, len_, offset_, end_offset_, false, 0);
                         temp_offset = offset_;
                     }
                 }
             } else {
-                func(data, token_, len_, offset_, end_offset_, false);
+                func(data, token_, len_, offset_, end_offset_, false, 0);
                 temp_offset = offset_;
             }
         }

--- a/src/common/analyzer/ik/ik_analyzer.cpp
+++ b/src/common/analyzer/ik/ik_analyzer.cpp
@@ -90,7 +90,7 @@ int IKAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
     while ((lexeme = context_->GetNextLexeme()) != nullptr) {
         std::wstring text = lexeme->GetLexemeText();
         String token = CharacterUtil::UTF16ToUTF8(text);
-        func(data, token.c_str(), token.size(), offset++, 0, false);
+        func(data, token.c_str(), token.size(), offset++, 0, false, 0);
         delete lexeme;
     };
     return 0;

--- a/src/common/analyzer/ngram_analyzer.cpp
+++ b/src/common/analyzer/ngram_analyzer.cpp
@@ -59,7 +59,7 @@ int NGramAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
     while (cur < len && NextInString(input.text_.c_str(), len, &cur, &token_start, &token_length)) {
         if (token_length == 0)
             continue;
-        func(data, input.text_.c_str() + token_start, token_length, offset, offset + token_length, false);
+        func(data, input.text_.c_str() + token_start, token_length, offset, offset + token_length, false, 0);
         offset++;
     }
 

--- a/src/common/analyzer/rag_analyzer.cpp
+++ b/src/common/analyzer/rag_analyzer.cpp
@@ -1438,7 +1438,7 @@ int RAGAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
         Split(output, blank_pattern_, tokens);
     unsigned offset = 0;
     for (auto &t : tokens) {
-        func(data, t.c_str(), t.size(), offset++, 0, false);
+        func(data, t.c_str(), t.size(), offset++, 0, false, 0);
     }
     return 0;
 }

--- a/src/common/analyzer/rank_features_analyzer.cpp
+++ b/src/common/analyzer/rank_features_analyzer.cpp
@@ -1,0 +1,52 @@
+// Copyright(C) 2025 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <string>
+module rank_features_analyzer;
+import stl;
+import term;
+import analyzer;
+import third_party;
+
+namespace infinity {
+
+u16 FloatToU16(float value) {
+    if (value < 0.0f)
+        value = 0.0f;
+    if (value > 65535.0f)
+        value = 65535.0f;
+    return static_cast<u16>(value);
+}
+
+int RankFeaturesAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
+    nlohmann::json line_json = nlohmann::json::parse(input.text_);
+    u32 offset = 0;
+    for (auto iter = line_json.begin(); iter != line_json.end(); ++iter) {
+        String key = iter.key();
+        String value = iter.value();
+        float target = 0;
+        try {
+            target = std::stof(value);
+        } catch (const std::exception &e) {
+        }
+        u16 weight = FloatToU16(target);
+        func(data, key.data(), key.size(), offset++, 0, false, weight);
+    }
+
+    return 0;
+}
+
+} // namespace infinity

--- a/src/common/analyzer/rank_features_analyzer.cppm
+++ b/src/common/analyzer/rank_features_analyzer.cppm
@@ -1,0 +1,35 @@
+// Copyright(C) 2025 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module rank_features_analyzer;
+import stl;
+import term;
+import analyzer;
+
+namespace infinity {
+
+export class RankFeaturesAnalyzer : public Analyzer {
+    String delimiters_{};
+
+public:
+    RankFeaturesAnalyzer() = default;
+    ~RankFeaturesAnalyzer() override = default;
+
+protected:
+    int AnalyzeImpl(const Term &input, void *data, HookType func) override;
+};
+
+} // namespace infinity

--- a/src/common/analyzer/term.cppm
+++ b/src/common/analyzer/term.cppm
@@ -41,11 +41,12 @@ public:
 
 export class TermList : public Deque<Term> {
 public:
-    void Add(const char *text, const u32 len, const u32 offset, const u32 end_offset) {
+    void Add(const char *text, const u32 len, const u32 offset, const u32 end_offset, const u16 payload = 0) {
         push_back(global_temporary_);
         back().text_.assign(text, len);
         back().word_offset_ = offset;
         back().end_offset_ = end_offset;
+        back().payload_ = payload;
     }
 
     void Add(cppjieba::Word &cut_word) {
@@ -54,18 +55,20 @@ public:
         back().word_offset_ = cut_word.offset;
     }
 
-    void Add(const String &token, const u32 offset, const u32 end_offset) {
+    void Add(const String &token, const u32 offset, const u32 end_offset, const u16 payload = 0) {
         push_back(global_temporary_);
         back().text_ = token;
         back().word_offset_ = offset;
         back().end_offset_ = end_offset;
+        back().payload_ = payload;
     }
 
-    void Add(String &token, const u32 offset, const u32 end_offset) {
+    void Add(String &token, const u32 offset, const u32 end_offset, const u16 payload = 0) {
         push_back(global_temporary_);
         std::swap(back().text_, token);
         back().word_offset_ = offset;
         back().end_offset_ = end_offset;
+        back().payload_ = payload;
     }
 
 private:

--- a/src/common/analyzer/whitespace_analyzer.cpp
+++ b/src/common/analyzer/whitespace_analyzer.cpp
@@ -37,7 +37,7 @@ int WhitespaceAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func
         std::string t;
         u32 offset = 0;
         while (is >> t) {
-            func(data, t.data(), t.size(), offset++, 0, false);
+            func(data, t.data(), t.size(), offset++, 0, false, 0);
         }
         return 0;
     } else {
@@ -49,11 +49,11 @@ int WhitespaceAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func
         while (search_start < input_text.size()) {
             const auto found = input_text.find_first_of(delimiters, search_start);
             if (found == std::string_view::npos) {
-                func(data, input_text.data() + search_start, input_text.size() - search_start, offset++, 0, false);
+                func(data, input_text.data() + search_start, input_text.size() - search_start, offset++, 0, false, 0);
                 break;
             }
             if (found > search_start) {
-                func(data, input_text.data() + search_start, found - search_start, offset++, 0, false);
+                func(data, input_text.data() + search_start, found - search_start, offset++, 0, false, 0);
             }
             search_start = found + 1;
         }

--- a/src/executor/operator/physical_match.cpp
+++ b/src/executor/operator/physical_match.cpp
@@ -245,7 +245,12 @@ bool PhysicalMatch::ExecuteInner(QueryContext *query_context, OperatorState *ope
                           static_cast<TimeDurationType>(finish_init_query_builder_time - execute_start_time).count()));
 
     // 2 build query iterator
-    FullTextQueryContext full_text_query_context(ft_similarity_, bm25_params_, minimum_should_match_option_, top_n_, match_expr_->index_names_);
+    FullTextQueryContext full_text_query_context(ft_similarity_,
+                                                 bm25_params_,
+                                                 minimum_should_match_option_,
+                                                 rank_features_option_,
+                                                 top_n_,
+                                                 match_expr_->index_names_);
     full_text_query_context.query_tree_ = MakeUnique<FilterQueryNode>(common_query_filter_.get(), std::move(query_tree_));
     const auto query_iterators = CreateQueryIterators(query_builder, full_text_query_context, early_term_algo_, begin_threshold_, score_threshold_);
     const auto finish_query_builder_time = std::chrono::high_resolution_clock::now();
@@ -329,6 +334,7 @@ PhysicalMatch::PhysicalMatch(const u64 id,
                              const u32 top_n,
                              const SharedPtr<CommonQueryFilter> &common_query_filter,
                              MinimumShouldMatchOption &&minimum_should_match_option,
+                             RankFeaturesOption &&rank_features_option,
                              const f32 score_threshold,
                              const FulltextSimilarity ft_similarity,
                              const BM25Params &bm25_params,
@@ -339,7 +345,8 @@ PhysicalMatch::PhysicalMatch(const u64 id,
       base_table_ref_(std::move(base_table_ref)), match_expr_(std::move(match_expr)), index_reader_(std::move(index_reader)),
       query_tree_(std::move(query_tree)), begin_threshold_(begin_threshold), early_term_algo_(early_term_algo), top_n_(top_n),
       common_query_filter_(common_query_filter), minimum_should_match_option_(std::move(minimum_should_match_option)),
-      score_threshold_(score_threshold), ft_similarity_(ft_similarity), bm25_params_(bm25_params) {}
+      rank_features_option_(std::move(rank_features_option)), score_threshold_(score_threshold), ft_similarity_(ft_similarity),
+      bm25_params_(bm25_params) {}
 
 PhysicalMatch::~PhysicalMatch() = default;
 

--- a/src/executor/operator/physical_match.cppm
+++ b/src/executor/operator/physical_match.cppm
@@ -54,6 +54,7 @@ public:
                            u32 top_n,
                            const SharedPtr<CommonQueryFilter> &common_query_filter,
                            MinimumShouldMatchOption &&minimum_should_match_option,
+                           RankFeaturesOption &&rank_features_option,
                            f32 score_threshold,
                            FulltextSimilarity ft_similarity,
                            const BM25Params &bm25_params,
@@ -112,6 +113,8 @@ private:
     SharedPtr<CommonQueryFilter> common_query_filter_;
     // for minimum_should_match
     MinimumShouldMatchOption minimum_should_match_option_{};
+    // for rank features
+    RankFeaturesOption rank_features_option_{};
     f32 score_threshold_{};
     FulltextSimilarity ft_similarity_{FulltextSimilarity::kBM25};
     BM25Params bm25_params_;

--- a/src/executor/physical_planner.cpp
+++ b/src/executor/physical_planner.cpp
@@ -980,6 +980,7 @@ UniquePtr<PhysicalOperator> PhysicalPlanner::BuildMatch(const SharedPtr<LogicalN
                                      logical_match->top_n_,
                                      logical_match->common_query_filter_,
                                      std::move(logical_match->minimum_should_match_option_),
+                                     std::move(logical_match->rank_features_option_),
                                      logical_match->score_threshold_,
                                      logical_match->ft_similarity_,
                                      logical_match->bm25_params_,

--- a/src/planner/bound_select_statement.cpp
+++ b/src/planner/bound_select_statement.cpp
@@ -275,6 +275,11 @@ SharedPtr<LogicalNode> BoundSelectStatement::BuildPlan(QueryContext *query_conte
                         match_node->minimum_should_match_option_ = ParseMinimumShouldMatchOption(iter->second);
                     }
 
+                    // option: rank_features
+                    if (iter = search_ops.options_.find("rank_features"); iter != search_ops.options_.end()) {
+                        match_node->rank_features_option_ = ParseRankFeaturesOption(iter->second);
+                    }
+
                     // option: threshold
                     if (iter = search_ops.options_.find("threshold"); iter != search_ops.options_.end()) {
                         match_node->score_threshold_ = DataType::StringToValue<FloatT>(iter->second);

--- a/src/planner/node/logical_match.cppm
+++ b/src/planner/node/logical_match.cppm
@@ -66,6 +66,7 @@ public:
 
     SharedPtr<CommonQueryFilter> common_query_filter_{};
     MinimumShouldMatchOption minimum_should_match_option_{};
+    RankFeaturesOption rank_features_option_{};
     f32 score_threshold_{};
     FulltextSimilarity ft_similarity_{FulltextSimilarity::kBM25};
     BM25Params bm25_params_;

--- a/src/planner/optimizer/index_scan/index_filter_evaluators.cppm
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators.cppm
@@ -91,6 +91,7 @@ export struct IndexFilterEvaluatorFulltext final : IndexFilterEvaluator {
     UniquePtr<QueryNode> query_tree_;
     MinimumShouldMatchOption minimum_should_match_option_;
     u32 minimum_should_match_ = 0;
+    RankFeaturesOption rank_features_option_;
     std::atomic_flag after_optimize_ = {};
     f32 score_threshold_ = {};
     FulltextSimilarity ft_similarity_ = FulltextSimilarity::kBM25;

--- a/src/storage/invertedindex/search/doc_iterator.cppm
+++ b/src/storage/invertedindex/search/doc_iterator.cppm
@@ -44,6 +44,8 @@ export enum class DocIteratorType : u8 {
     kScoreThresholdIterator,
     kKeywordIterator,
     kMustFirstIterator,
+    kRankFeatureDocIterator,
+    kRankFeaturesDocIterator,
 };
 
 export struct DocIteratorEstimateIterateCost {

--- a/src/storage/invertedindex/search/parse_fulltext_options.cppm
+++ b/src/storage/invertedindex/search/parse_fulltext_options.cppm
@@ -49,4 +49,14 @@ export struct BM25Params {
     float delta_phrase = 0.0F;
 };
 
+export struct RankFeatureOption {
+    String field_;
+    String feature_;
+    float boost_;
+};
+
+export using RankFeaturesOption = Vector<RankFeatureOption>;
+
+export RankFeaturesOption ParseRankFeaturesOption(std::string_view input_str);
+
 } // namespace infinity

--- a/src/storage/invertedindex/search/query_builder.cpp
+++ b/src/storage/invertedindex/search/query_builder.cpp
@@ -50,6 +50,8 @@ UniquePtr<DocIterator> QueryBuilder::CreateSearch(FullTextQueryContext &context)
             context.minimum_should_match_ = GetMinimumShouldMatchParameter(context.minimum_should_match_option_, leaf_count);
         }
     }
+    if (!context.rank_features_option_.empty()) {
+    }
     // Create the iterator from the query tree.
     const CreateSearchParams params{table_entry_,
                                     &index_reader_,

--- a/src/storage/invertedindex/search/query_builder.cpp
+++ b/src/storage/invertedindex/search/query_builder.cpp
@@ -16,6 +16,9 @@ module;
 
 #include <iostream>
 #include <vector>
+
+#include "query_node.h"
+
 module query_builder;
 
 import stl;
@@ -50,8 +53,6 @@ UniquePtr<DocIterator> QueryBuilder::CreateSearch(FullTextQueryContext &context)
             context.minimum_should_match_ = GetMinimumShouldMatchParameter(context.minimum_should_match_option_, leaf_count);
         }
     }
-    if (!context.rank_features_option_.empty()) {
-    }
     // Create the iterator from the query tree.
     const CreateSearchParams params{table_entry_,
                                     &index_reader_,
@@ -74,6 +75,17 @@ UniquePtr<DocIterator> QueryBuilder::CreateSearch(FullTextQueryContext &context)
         LOG_DEBUG(std::move(oss).str());
     }
 #endif
+    if (!context.rank_features_option_.empty()) {
+        auto rank_features_node = std::make_unique<RankFeaturesQueryNode>();
+        for (auto rank_feature : context.rank_features_option_) {
+            auto rank_feature_node = std::make_unique<RankFeatureQueryNode>();
+            rank_feature_node->term_ = rank_feature.feature_;
+            rank_feature_node->column_ = rank_feature.field_;
+            rank_feature_node->boost_ = rank_feature.boost_;
+            rank_features_node->Add(std::move(rank_feature_node));
+        }
+        // auto rank_features_iter = rank_features_node->CreateSearch(params);
+    }
     return result;
 }
 

--- a/src/storage/invertedindex/search/query_builder.cppm
+++ b/src/storage/invertedindex/search/query_builder.cppm
@@ -36,7 +36,6 @@ export struct FullTextQueryContext {
     const FulltextSimilarity ft_similarity_{};
     const BM25Params bm25_params_{};
     const MinimumShouldMatchOption minimum_should_match_option_{};
-    const RankFeaturesOption rank_features_option_{};
     u32 minimum_should_match_ = 0;
     u32 topn_ = 0;
     EarlyTermAlgo early_term_algo_ = EarlyTermAlgo::kNaive;
@@ -45,11 +44,10 @@ export struct FullTextQueryContext {
     FullTextQueryContext(const FulltextSimilarity ft_similarity,
                          const BM25Params &bm25_params,
                          const MinimumShouldMatchOption &minimum_should_match_option,
-                         const RankFeaturesOption &rank_features_option,
                          const u32 topn,
                          const Vector<String> &index_names)
-        : ft_similarity_(ft_similarity), bm25_params_(bm25_params), minimum_should_match_option_(minimum_should_match_option),
-          rank_features_option_(rank_features_option), topn_(topn), index_names_(index_names) {}
+        : ft_similarity_(ft_similarity), bm25_params_(bm25_params), minimum_should_match_option_(minimum_should_match_option), topn_(topn),
+          index_names_(index_names) {}
 };
 
 export class QueryBuilder {

--- a/src/storage/invertedindex/search/query_builder.cppm
+++ b/src/storage/invertedindex/search/query_builder.cppm
@@ -36,6 +36,7 @@ export struct FullTextQueryContext {
     const FulltextSimilarity ft_similarity_{};
     const BM25Params bm25_params_{};
     const MinimumShouldMatchOption minimum_should_match_option_{};
+    const RankFeaturesOption rank_features_option_{};
     u32 minimum_should_match_ = 0;
     u32 topn_ = 0;
     EarlyTermAlgo early_term_algo_ = EarlyTermAlgo::kNaive;
@@ -44,10 +45,11 @@ export struct FullTextQueryContext {
     FullTextQueryContext(const FulltextSimilarity ft_similarity,
                          const BM25Params &bm25_params,
                          const MinimumShouldMatchOption &minimum_should_match_option,
+                         const RankFeaturesOption &rank_features_option,
                          const u32 topn,
                          const Vector<String> &index_names)
-        : ft_similarity_(ft_similarity), bm25_params_(bm25_params), minimum_should_match_option_(minimum_should_match_option), topn_(topn),
-          index_names_(index_names) {}
+        : ft_similarity_(ft_similarity), bm25_params_(bm25_params), minimum_should_match_option_(minimum_should_match_option),
+          rank_features_option_(rank_features_option), topn_(topn), index_names_(index_names) {}
 };
 
 export class QueryBuilder {

--- a/src/storage/invertedindex/search/query_node.cpp
+++ b/src/storage/invertedindex/search/query_node.cpp
@@ -774,6 +774,21 @@ void TermQueryNode::GetQueryColumnsTerms(std::vector<std::string> &columns, std:
     terms.push_back(term_);
 }
 
+void RankFeatureQueryNode::PrintTree(std::ostream &os, const std::string &prefix, const bool is_final) const {
+    os << prefix;
+    os << (is_final ? "└──" : "├──");
+    os << QueryNodeTypeToString(type_);
+    os << " (weight: " << weight_ << ")";
+    os << " (column: " << column_ << ")";
+    os << " (term: " << term_ << ")";
+    os << '\n';
+}
+
+void RankFeatureQueryNode::GetQueryColumnsTerms(std::vector<std::string> &columns, std::vector<std::string> &terms) const {
+    columns.push_back(column_);
+    terms.push_back(term_);
+}
+
 void PhraseQueryNode::PrintTree(std::ostream &os, const std::string &prefix, const bool is_final) const {
     os << prefix;
     os << (is_final ? "└──" : "├──");

--- a/src/storage/invertedindex/search/query_node.h
+++ b/src/storage/invertedindex/search/query_node.h
@@ -128,6 +128,7 @@ struct TermQueryNode : public QueryNode {
 struct RankFeatureQueryNode : public QueryNode {
     std::string term_;
     std::string column_;
+    float boost_;
 
     RankFeatureQueryNode() : QueryNode(QueryNodeType::TERM) {}
 
@@ -200,6 +201,12 @@ struct AndNotQueryNode final : public MultiQueryNode {
 
 struct OrQueryNode final : public MultiQueryNode {
     OrQueryNode() : MultiQueryNode(QueryNodeType::OR) {}
+    std::unique_ptr<QueryNode> InnerGetNewOptimizedQueryTree() override;
+    std::unique_ptr<DocIterator> CreateSearch(CreateSearchParams params, bool is_top_level) const override;
+};
+
+struct RankFeaturesQueryNode final : public MultiQueryNode {
+    RankFeaturesQueryNode() : MultiQueryNode(QueryNodeType::OR) {}
     std::unique_ptr<QueryNode> InnerGetNewOptimizedQueryTree() override;
     std::unique_ptr<DocIterator> CreateSearch(CreateSearchParams params, bool is_top_level) const override;
 };

--- a/src/storage/invertedindex/search/query_node.h
+++ b/src/storage/invertedindex/search/query_node.h
@@ -125,6 +125,19 @@ struct TermQueryNode : public QueryNode {
     void GetQueryColumnsTerms(std::vector<std::string> &columns, std::vector<std::string> &terms) const override;
 };
 
+struct RankFeatureQueryNode : public QueryNode {
+    std::string term_;
+    std::string column_;
+
+    RankFeatureQueryNode() : QueryNode(QueryNodeType::TERM) {}
+
+    uint32_t LeafCount() const override { return 1; }
+    void PushDownWeight(float factor) override { MultiplyWeight(factor); }
+    std::unique_ptr<DocIterator> CreateSearch(CreateSearchParams params, bool is_top_level) const override;
+    void PrintTree(std::ostream &os, const std::string &prefix, bool is_final) const override;
+    void GetQueryColumnsTerms(std::vector<std::string> &columns, std::vector<std::string> &terms) const override;
+};
+
 struct PhraseQueryNode final : public QueryNode {
     std::vector<std::string> terms_;
     std::string column_;

--- a/src/storage/invertedindex/search/rank_feature_doc_iterator.cpp
+++ b/src/storage/invertedindex/search/rank_feature_doc_iterator.cpp
@@ -1,0 +1,56 @@
+// Copyright(C) 2025 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <cassert>
+#include <iostream>
+module rank_feature_doc_iterator;
+
+import stl;
+import logger;
+
+namespace infinity {
+
+RankFeatureDocIterator::RankFeatureDocIterator(UniquePtr<PostingIterator> &&iter, const u64 column_id, float boost)
+    : column_id_(column_id), boost_(boost), iter_(std::move(iter)) {}
+
+RankFeatureDocIterator::~RankFeatureDocIterator() {}
+
+bool RankFeatureDocIterator::Next(RowID doc_id) {
+    assert(doc_id != INVALID_ROWID);
+    if (doc_id_ != INVALID_ROWID && doc_id_ >= doc_id)
+        return true;
+    doc_id_ = iter_->SeekDoc(doc_id);
+    if (doc_id_ == INVALID_ROWID)
+        return false;
+    return true;
+}
+
+float RankFeatureDocIterator::Score() {
+    u16 payload = iter_->GetCurrentDocPayload();
+    float weight = static_cast<float>(payload);
+    return weight * boost_;
+}
+
+void RankFeatureDocIterator::PrintTree(std::ostream &os, const String &prefix, bool is_final) const {
+    os << prefix;
+    os << (is_final ? "└──" : "├──");
+    os << "RankFeatureDocIterator";
+    os << " (column: " << *column_name_ptr_ << ")";
+    os << " (term: " << *term_ptr_ << ")";
+    os << '\n';
+}
+
+} // namespace infinity

--- a/src/storage/invertedindex/search/rank_feature_doc_iterator.cpp
+++ b/src/storage/invertedindex/search/rank_feature_doc_iterator.cpp
@@ -53,4 +53,16 @@ void RankFeatureDocIterator::PrintTree(std::ostream &os, const String &prefix, b
     os << '\n';
 }
 
+void RankFeatureDocIterator::BatchDecodeTo(const RowID buffer_start_doc_id, const RowID buffer_end_doc_id, u16 *payload_ptr) {
+    auto iter_doc_id = iter_->DocID();
+    assert((buffer_start_doc_id <= iter_doc_id && iter_doc_id < buffer_end_doc_id));
+    while (iter_doc_id < buffer_end_doc_id) {
+        const auto pos = iter_doc_id - buffer_start_doc_id;
+        const auto payload = iter_->GetCurrentDocPayload();
+        payload_ptr[pos] = payload;
+        iter_doc_id = iter_->SeekDoc(iter_doc_id + 1);
+    }
+    doc_id_ = iter_doc_id;
+}
+
 } // namespace infinity

--- a/src/storage/invertedindex/search/rank_feature_doc_iterator.cppm
+++ b/src/storage/invertedindex/search/rank_feature_doc_iterator.cppm
@@ -33,7 +33,7 @@ public:
 
     ~RankFeatureDocIterator() override;
 
-    DocIteratorType GetType() const override { return DocIteratorType::kTermDocIterator; }
+    DocIteratorType GetType() const override { return DocIteratorType::kRankFeatureDocIterator; }
 
     String Name() const override { return "RankFeatureDocIterator"; }
 
@@ -46,6 +46,8 @@ public:
     float Score() override;
 
     void PrintTree(std::ostream &os, const String &prefix, bool is_final) const override;
+
+    void BatchDecodeTo(RowID buffer_start_doc_id, RowID buffer_end_doc_id, u16 *payload_ptr);
 
     const String *term_ptr_ = nullptr;
     const String *column_name_ptr_ = nullptr;

--- a/src/storage/invertedindex/search/rank_feature_doc_iterator.cppm
+++ b/src/storage/invertedindex/search/rank_feature_doc_iterator.cppm
@@ -1,0 +1,59 @@
+// Copyright(C) 2025 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module rank_feature_doc_iterator;
+
+import stl;
+
+import posting_iterator;
+import index_defines;
+import doc_iterator;
+import internal_types;
+import doc_iterator;
+import third_party;
+
+namespace infinity {
+
+export class RankFeatureDocIterator final : public DocIterator {
+public:
+    RankFeatureDocIterator(UniquePtr<PostingIterator> &&iter, u64 column_id, float boost);
+
+    ~RankFeatureDocIterator() override;
+
+    DocIteratorType GetType() const override { return DocIteratorType::kTermDocIterator; }
+
+    String Name() const override { return "RankFeatureDocIterator"; }
+
+    void UpdateScoreThreshold(float threshold) override {}
+
+    u32 MatchCount() const override { return 0; }
+
+    bool Next(RowID doc_id) override;
+
+    float Score() override;
+
+    void PrintTree(std::ostream &os, const String &prefix, bool is_final) const override;
+
+    const String *term_ptr_ = nullptr;
+    const String *column_name_ptr_ = nullptr;
+
+private:
+    u64 column_id_;
+    float boost_ = 1.0f;
+    UniquePtr<PostingIterator> iter_;
+};
+
+} // namespace infinity

--- a/src/storage/invertedindex/search/rank_features_doc_iterator.cpp
+++ b/src/storage/invertedindex/search/rank_features_doc_iterator.cpp
@@ -111,6 +111,17 @@ void RankFeaturesDocIterator::DecodeFrom(const RowID buffer_start_doc_id) {
             it->BatchDecodeTo(buffer_start_doc_id, buffer_end_doc_id, payload_ptr_ + i * BATCH_OR_LEN);
         }
     }
+    for (u32 i = 0; i < BATCH_OR_LEN; ++i) {
+        u32 match_cnt = 0;
+        for (u32 j = 0; j < children_.size(); ++j) {
+            const auto payload = payload_ptr_[j * BATCH_OR_LEN + i];
+            if (payload == 0) {
+                continue;
+            }
+            ++match_cnt;
+        }
+        match_cnt_ptr_[i] = match_cnt;
+    }
 }
 
 } // namespace infinity

--- a/src/storage/invertedindex/search/rank_features_doc_iterator.cpp
+++ b/src/storage/invertedindex/search/rank_features_doc_iterator.cpp
@@ -1,0 +1,116 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <cassert>
+#include <cstdlib>
+#include <tuple>
+#include <vector>
+
+module rank_features_doc_iterator;
+
+import stl;
+import third_party;
+import index_defines;
+import rank_feature_doc_iterator;
+import multi_doc_iterator;
+import internal_types;
+import logger;
+import infinity_exception;
+import simd_functions;
+
+namespace infinity {
+
+constexpr u32 BATCH_OR_LEN = 128;
+
+RankFeaturesDocIterator::RankFeaturesDocIterator(Vector<UniquePtr<DocIterator>> &&iterators) : MultiDocIterator(std::move(iterators)) {
+    estimate_iterate_cost_ = {};
+    const SizeT num_iterators = children_.size();
+    for (SizeT i = 0; i < num_iterators; i++) {
+        auto it = dynamic_cast<const RankFeatureDocIterator *>(children_[i].get());
+        if (it == nullptr) {
+            UnrecoverableError("RankFeaturesDocIterator only supports RankFeatureDocIterator");
+        }
+    }
+    static_assert(sizeof(f32) == sizeof(u32));
+    memset_bytes_ = sizeof(u32) * BATCH_OR_LEN * 2u * num_iterators;
+    const auto alloc_bytes = sizeof(u32) * BATCH_OR_LEN * (2u + 2u * num_iterators);
+    aligned_buffer_ = std::aligned_alloc(64, alloc_bytes);
+    if (!aligned_buffer_) {
+        UnrecoverableError(fmt::format("{}: Out of memory!", __func__));
+    }
+    match_cnt_ptr_ = static_cast<u32 *>(aligned_buffer_);
+    payload_ptr_ = reinterpret_cast<u16 *>(match_cnt_ptr_ + BATCH_OR_LEN * num_iterators);
+}
+
+RankFeaturesDocIterator::~RankFeaturesDocIterator() { std::free(aligned_buffer_); }
+
+bool RankFeaturesDocIterator::Next(RowID doc_id) {
+    if (doc_id_ != INVALID_ROWID) [[likely]] {
+        if (doc_id_ >= doc_id) {
+            return true;
+        }
+        // now buffer_start_doc_id_ <= doc_id_ < doc_id
+        if (u32 pos = doc_id - buffer_start_doc_id_; pos < BATCH_OR_LEN) {
+            for (; pos < BATCH_OR_LEN; ++pos) {
+                if (match_cnt_ptr_[pos]) {
+                    doc_id_ = buffer_start_doc_id_ + pos;
+                    return true;
+                }
+            }
+            // now need to search from buffer_start_doc_id_ + BATCH_OR_LEN
+            doc_id = buffer_start_doc_id_ + BATCH_OR_LEN;
+        }
+    } else {
+        for (const auto &child : children_) {
+            child->Next(doc_id);
+        }
+    }
+    RowID next_buffer_start_doc_id = INVALID_ROWID;
+    for (const auto &child : children_) {
+        if (child->DocID() != INVALID_ROWID) {
+            child->Next(doc_id);
+            const RowID child_doc_id = child->DocID();
+            next_buffer_start_doc_id = std::min(next_buffer_start_doc_id, child_doc_id);
+        }
+    }
+    if (next_buffer_start_doc_id != INVALID_ROWID) [[likely]] {
+        DecodeFrom(next_buffer_start_doc_id);
+    }
+    doc_id_ = next_buffer_start_doc_id;
+    return doc_id_ != INVALID_ROWID;
+}
+
+u32 RankFeaturesDocIterator::MatchCount() const { return match_cnt_ptr_[doc_id_ - buffer_start_doc_id_]; }
+
+void RankFeaturesDocIterator::DecodeFrom(const RowID buffer_start_doc_id) {
+    buffer_start_doc_id_ = buffer_start_doc_id;
+    std::memset(aligned_buffer_, 0, memset_bytes_);
+    const auto buffer_end_doc_id = buffer_start_doc_id + BATCH_OR_LEN;
+    for (u32 i = 0; i < children_.size(); ++i) {
+        const auto child = children_[i].get();
+        if (const auto child_doc_id = child->DocID(); child_doc_id != INVALID_ROWID) {
+            assert(child_doc_id >= buffer_start_doc_id);
+            if (child_doc_id >= buffer_end_doc_id) {
+                // no need to decode
+                continue;
+            }
+            const auto it = dynamic_cast<RankFeatureDocIterator *>(child);
+            it->BatchDecodeTo(buffer_start_doc_id, buffer_end_doc_id, payload_ptr_ + i * BATCH_OR_LEN);
+        }
+    }
+}
+
+} // namespace infinity

--- a/src/storage/invertedindex/search/rank_features_doc_iterator.cppm
+++ b/src/storage/invertedindex/search/rank_features_doc_iterator.cppm
@@ -1,0 +1,55 @@
+// Copyright(C) 2025 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module rank_features_doc_iterator;
+
+import stl;
+import index_defines;
+import doc_iterator;
+import multi_doc_iterator;
+import internal_types;
+
+namespace infinity {
+
+export class RankFeaturesDocIterator : public MultiDocIterator {
+public:
+    explicit RankFeaturesDocIterator(Vector<UniquePtr<DocIterator>> &&iterators);
+
+    ~RankFeaturesDocIterator() override;
+
+    DocIteratorType GetType() const override { return DocIteratorType::kRankFeaturesDocIterator; }
+
+    String Name() const override { return "RankFeaturesDocIterator"; }
+
+    void UpdateScoreThreshold(float threshold) override {}
+
+    bool Next(RowID doc_id) override;
+
+    float Score() override { return 1.0f; }
+
+    u32 MatchCount() const override;
+
+    void DecodeFrom(RowID buffer_start_doc_id);
+
+private:
+    RowID buffer_start_doc_id_ = INVALID_ROWID;
+    u32 memset_bytes_ = 0;
+    void *aligned_buffer_ = nullptr;
+    u32 *match_cnt_ptr_ = nullptr;
+    u16 *payload_ptr_ = nullptr;
+};
+
+} // namespace infinity

--- a/src/unit_test/storage/invertedindex/search/query_builder.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_builder.cpp
@@ -201,7 +201,7 @@ TEST_F(QueryBuilderTest, test_and) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, RankFeaturesOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(and_root);
     FakeQueryBuilder fake_query_builder;
@@ -273,7 +273,7 @@ TEST_F(QueryBuilderTest, test_or) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, RankFeaturesOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(or_root);
     FakeQueryBuilder fake_query_builder;
@@ -351,7 +351,7 @@ TEST_F(QueryBuilderTest, test_and_not) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, RankFeaturesOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(and_not_root);
     FakeQueryBuilder fake_query_builder;
@@ -435,7 +435,7 @@ TEST_F(QueryBuilderTest, test_and_not2) {
     LOG_INFO(oss.str());
     // apply query builder
     Vector<String> hints;
-    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, hints);
+    FullTextQueryContext context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, RankFeaturesOption{}, 10, hints);
     context.early_term_algo_ = EarlyTermAlgo::kNaive;
     context.query_tree_ = std::move(and_not_root);
     FakeQueryBuilder fake_query_builder;

--- a/src/unit_test/storage/invertedindex/search/query_match.cpp
+++ b/src/unit_test/storage/invertedindex/search/query_match.cpp
@@ -339,7 +339,12 @@ void QueryMatchTest::QueryMatch(const String &db_name,
         Status status = Status::ParseMatchExprFailed(match_expr->fields_, match_expr->matching_text_);
         RecoverableError(status);
     }
-    FullTextQueryContext full_text_query_context(FulltextSimilarity::kBM25, BM25Params{}, MinimumShouldMatchOption{}, 10, index_hints);
+    FullTextQueryContext full_text_query_context(FulltextSimilarity::kBM25,
+                                                 BM25Params{},
+                                                 MinimumShouldMatchOption{},
+                                                 RankFeaturesOption{},
+                                                 10,
+                                                 index_hints);
     full_text_query_context.early_term_algo_ = EarlyTermAlgo::kNaive;
     full_text_query_context.query_tree_ = std::move(query_tree);
     UniquePtr<DocIterator> doc_iterator = query_builder.CreateSearch(full_text_query_context);


### PR DESCRIPTION
### What problem does this PR solve?

Insert:
```
`json` string is required for rank features column: 
[{"Tag1":0.1},{"Tag2":0.2}]
```

Query: 
```
SELECT * FROM table SEARCH MATCH TEXT ('doc', 'second text multiple', 'rank_features= field^tag1^1.0,field^tag2^1.0;topn=10');
```

Issue link:#2309

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
