### PR TITLE
Add order by wrong column check.

### DIFF
--- a/src/planner/binder/order_binder.cpp
+++ b/src/planner/binder/order_binder.cpp
@@ -93,6 +93,10 @@ SharedPtr<BaseExpression> OrderBinder::BuildExpression(const ParsedExpr &expr, B
         result->source_position_ = SourcePosition(bind_context_ptr->binding_context_id_, ExprSourceType::kAggregate);
         return result;
     }
+    if (!bind_context_ptr->aggregate_index_by_name_.empty() || !bind_context_ptr->group_index_by_name_.empty()) {
+        String error_message = fmt::format("Column: {} must appear in the GROUP BY clause or be used in an aggregate function", expr_name);
+        RecoverableError(Status::SyntaxError(error_message));
+    }
 
     if (expr.type_ == ParsedExprType::kFunction or expr.type_ == ParsedExprType::kColumn) {
         return ExpressionBinder::BuildExpression(expr, bind_context_ptr, depth, root);

--- a/test/sql/dql/sort_top/sort_by_fail.slt
+++ b/test/sql/dql/sort_top/sort_by_fail.slt
@@ -1,0 +1,37 @@
+statement ok
+DROP TABLE IF EXISTS t1;
+
+statement ok
+CREATE TABLE t1 (c1 INTEGER, c2 VARCHAR);
+
+statement ok
+INSERT INTO t1 VALUES(0, 'abc'), (1, 'abcd'), (2, 'abcd'), (2, 'abcde');
+
+query I nosort
+SELECT COUNT(c2) from t1 WHERE c2 IN ('abc', 'abcd');
+----
+3
+
+statement error
+SELECT COUNT(c2) from t1 WHERE c2 IN ('abc', 'abcd') order by c1;
+
+query T nosort
+SELECT c2 from t1 WHERE c2 IN ('abc', 'abcd') group by c2 order by c2;
+----
+abc
+abcd
+
+statement error
+SELECT c2 from t1 WHERE c2 IN ('abc', 'abcd') group by c2 order by c1;
+
+query TI rowsort
+SELECT c2, COUNT(c1) from t1 WHERE c2 IN ('abc', 'abcd') group by c2;
+----
+abc 1
+abcd 2
+
+statement error
+SELECT c2, COUNT(c1) from t1 WHERE c2 IN ('abc', 'abcd') group by c2 order by c1;
+
+statement ok
+DROP TABLE t1;


### PR DESCRIPTION
### What problem does this PR solve?

Add check if order by column is valid when aggregate/group by is used.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases
