### PR TITLE
Fix build for Linux/aarch64 on MacOS Apple Silicon

### DIFF
--- a/src/storage/knn_index/sparse/bmp_fwd.cppm
+++ b/src/storage/knn_index/sparse/bmp_fwd.cppm
@@ -255,10 +255,10 @@ public:
     }
 
     void Prefetch() const {
-        _mm_prefetch(block_size_prefix_sum_, _MM_HINT_T0);
-        _mm_prefetch(term_ids_, _MM_HINT_T0);
-        _mm_prefetch(block_offsets_, _MM_HINT_T0);
-        _mm_prefetch(values_, _MM_HINT_T0);
+        _mm_prefetch(reinterpret_cast<const char *>(block_size_prefix_sum_), _MM_HINT_T0);
+        _mm_prefetch(reinterpret_cast<const char *>(term_ids_), _MM_HINT_T0);
+        _mm_prefetch(reinterpret_cast<const char *>(block_offsets_), _MM_HINT_T0);
+        _mm_prefetch(reinterpret_cast<const char *>(values_), _MM_HINT_T0);
     }
 
 private:

--- a/third_party/fastpfor/CMakeLists.txt
+++ b/third_party/fastpfor/CMakeLists.txt
@@ -28,10 +28,17 @@ include(DetectCPUFeatures)
 #
 # Taken&Modified from Boost.cmake
 #
-set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wcast-align -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -msse4.1 -march=native")
-set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wcast-align -ggdb  -std=c++11 -DHAVE_CXX0X -msse4.1 -march=native")
-set (CMAKE_C_FLAGS_RELEASE "-Wall -Wcast-align -O3 -DNDEBUG -std=c99 -msse4.1 -march=native")
-set (CMAKE_C_FLAGS_DEBUG   "-Wall -Wcast-align -ggdb  -std=c99 -msse4.1 -march=native")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wcast-align -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -msse4.1 -march=native")
+    set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wcast-align -ggdb  -std=c++11 -DHAVE_CXX0X -msse4.1 -march=native")
+    set (CMAKE_C_FLAGS_RELEASE "-Wall -Wcast-align -O3 -DNDEBUG -std=c99 -msse4.1 -march=native")
+    set (CMAKE_C_FLAGS_DEBUG   "-Wall -Wcast-align -ggdb  -std=c99 -msse4.1 -march=native")
+else()
+    set (CMAKE_CXX_FLAGS_RELEASE "-Wall -Wcast-align -O3 -DNDEBUG -std=c++11 -DHAVE_CXX0X -march=native")
+    set (CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wcast-align -ggdb  -std=c++11 -DHAVE_CXX0X -march=native")
+    set (CMAKE_C_FLAGS_RELEASE "-Wall -Wcast-align -O3 -DNDEBUG -std=c99 -march=native")
+    set (CMAKE_C_FLAGS_DEBUG   "-Wall -Wcast-align -ggdb  -std=c99 -march=native")
+endif()
 
 
 MESSAGE( STATUS "CMAKE_CXX_FLAGS_DEBUG: " ${CMAKE_CXX_FLAGS_DEBUG} )


### PR DESCRIPTION
### What problem does this PR solve?

This is a quick patch so Infinity can be built and run via Linux aarch64 on MacOS/AppleSilicon. Currently neither docker image nor "build from source" is an option for development on MacOS.

With this patch, Infinity would run again on my local setup: Ubuntu 22.04.5 LTS VM on Apple M4 Pro. 

Issue link:#2552

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
