### PR TITLE
Remove use_new_catalog - 3

### DIFF
--- a/src/executor/operator/physical_compact.cpp
+++ b/src/executor/operator/physical_compact.cpp
@@ -24,7 +24,6 @@ import operator_state;
 import base_table_ref;
 import block_index;
 import column_vector;
-import catalog;
 import table_entry;
 import segment_entry;
 import block_entry;
@@ -90,184 +89,21 @@ private:
 };
 
 void PhysicalCompact::Init(QueryContext *query_context) {
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-    if (use_new_catalog) {
-        return;
-    }
-
-    auto [table_entry, status] =
-        query_context->GetTxn()->GetTableByName(*base_table_ref_->table_info_->db_name_, *base_table_ref_->table_info_->table_name_);
-    if (!status.ok()) {
-        RecoverableError(status);
-    }
-
-    if (compact_type_ == CompactStatementType::kManual) {
-        LOG_DEBUG(fmt::format("Manual compact {} start", *table_entry->GetTableName()));
-        if (!table_entry->CompactPrepare()) {
-            LOG_WARN(fmt::format("Table {} is not compactable.", *table_entry->GetTableName()));
-            return;
-        }
-        GreedyCompactableSegmentsGenerator generator(base_table_ref_.get(), DEFAULT_SEGMENT_CAPACITY);
-        while (true) {
-            Vector<SegmentEntry *> compactible_segments = generator.generate();
-            if (compactible_segments.empty()) {
-                break;
-            }
-            compactible_segments_group_.push_back(compactible_segments);
-        }
-    } else {
-        LOG_DEBUG(fmt::format("Auto compact {} start", *table_entry->GetTableName()));
-        Vector<SegmentEntry *> compactible_segments;
-        const auto &block_index = *base_table_ref_->block_index_;
-        for (const auto &[segment_id, segment_snapshot] : block_index.segment_block_index_) {
-            SegmentEntry *segment_entry = segment_snapshot.segment_entry_;
-            if (segment_entry->status() == SegmentStatus::kSealed) {
-                compactible_segments.push_back(segment_entry);
-            }
-        }
-        compactible_segments_group_.push_back(compactible_segments);
-    }
 }
 
 bool PhysicalCompact::Execute(QueryContext *query_context, OperatorState *operator_state) {
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-    if (use_new_catalog) {
-        auto *compact_operator_state = static_cast<CompactOperatorState *>(operator_state);
-
-        const String &db_name = *base_table_ref_->table_info_->db_name_;
-        const String &table_name = *base_table_ref_->table_info_->table_name_;
-        NewTxn *new_txn = query_context->GetNewTxn();
-
-        auto compact_task = MakeShared<NewCompactTask>(new_txn, db_name, table_name);
-        auto *compaction_processor = InfinityContext::instance().storage()->compaction_processor();
-        compaction_processor->Submit(compact_task);
-        compact_task->Wait();
-
-        compact_operator_state->SetComplete();
-        return true;
-    }
-
-    StorageMode storage_mode = InfinityContext::instance().storage()->GetStorageMode();
-    if (storage_mode == StorageMode::kUnInitialized) {
-        UnrecoverableError("Uninitialized storage mode");
-    }
-
-    if (storage_mode != StorageMode::kWritable) {
-        operator_state->status_ = Status::InvalidNodeRole("Attempt to write on non-writable node");
-        operator_state->SetComplete();
-        return true;
-    }
-
     auto *compact_operator_state = static_cast<CompactOperatorState *>(operator_state);
-    SizeT group_idx = compact_operator_state->compact_idx_;
-    CompactStateData *compact_state_data = compact_operator_state->compact_state_data_.get();
-    RowIDRemap &remapper = compact_state_data->remapper_;
-    if (group_idx == compact_operator_state->segment_groups_.size()) {
-        compact_operator_state->SetComplete();
-        return true;
-    }
-    const Vector<SegmentEntry *> &candidate_segments = compact_operator_state->segment_groups_[group_idx];
-    Vector<SegmentEntry *> compactible_segments;
-    {
-        String log_str = fmt::format("PhysicalCompact::Execute: group_idx: {}, candidate_segments: ", group_idx);
-        for (auto *candidate_segment : candidate_segments) {
-            if (candidate_segment->TrySetCompacting(compact_state_data)) {
-                compactible_segments.push_back(candidate_segment);
-            }
-            log_str += fmt::format("{}, ", candidate_segment->segment_id());
-        }
-        LOG_INFO(log_str);
-    }
 
-    auto *txn = query_context->GetTxn();
-    if (compactible_segments.empty()) {
-        RecoverableError(Status::TxnRollback(txn->TxnID(), "No segment to compact."));
-    }
-    auto *txn_mgr = txn->txn_mgr();
-    auto *buffer_mgr = query_context->storage()->buffer_manager();
-    TxnTimeStamp scan_ts = txn_mgr->GetNewTimeStamp();
-    compact_state_data->SetScanTS(scan_ts);
+    const String &db_name = *base_table_ref_->table_info_->db_name_;
+    const String &table_name = *base_table_ref_->table_info_->table_name_;
+    NewTxn *new_txn = query_context->GetNewTxn();
 
-    auto [table_entry, status] = txn->GetTableByName(*base_table_ref_->table_info_->db_name_, *base_table_ref_->table_info_->table_name_);
-    if (!status.ok()) {
-        RecoverableError(status);
-    }
+    auto compact_task = MakeShared<NewCompactTask>(new_txn, db_name, table_name);
+    auto *compaction_processor = InfinityContext::instance().storage()->compaction_processor();
+    compaction_processor->Submit(compact_task);
+    compact_task->Wait();
 
-    BlockIndex *block_index = base_table_ref_->block_index_.get();
-
-    SizeT column_count = table_entry->ColumnCount();
-
-    auto new_segment = SegmentEntry::NewSegmentEntry(table_entry, Catalog::GetNextSegmentID(table_entry), txn);
-    SegmentID new_segment_id = new_segment->segment_id();
-    LOG_INFO(fmt::format("PhysicalCompact::Execute: txn_id: {}, scan_ts: {}, new segment id: {}", txn->TxnID(), scan_ts, new_segment_id));
-
-    UniquePtr<BlockEntry> new_block =
-        BlockEntry::NewBlockEntry(new_segment.get(), new_segment->GetNextBlockID(), 0 /*checkpoint_ts*/, column_count, txn);
-    const SizeT block_capacity = new_block->row_capacity();
-
-    Vector<SegmentID> old_segment_ids;
-    for (SegmentEntry *segment : compactible_segments) {
-        SegmentID segment_id = segment->segment_id();
-        old_segment_ids.push_back(segment_id);
-        const auto &segment_info = block_index->segment_block_index_.at(segment_id);
-        for (const auto *block_entry : segment_info.block_map_) {
-            BlockID block_id = block_entry->block_id();
-            Vector<ColumnVector> input_column_vectors;
-            for (ColumnID column_id = 0; column_id < column_count; ++column_id) {
-                input_column_vectors.emplace_back(block_entry->GetConstColumnVector(buffer_mgr, column_id));
-            }
-            SizeT read_offset = 0;
-            while (true) {
-                auto [row_begin, row_end] = block_entry->GetVisibleRange(scan_ts, read_offset);
-                SizeT read_size = row_end - row_begin;
-                if (read_size == 0) {
-                    break;
-                }
-
-                auto block_entry_append = [&](SizeT row_begin, SizeT read_size1) {
-                    if (read_size1 == 0) {
-                        return;
-                    }
-                    RowID new_row_id(new_segment_id, new_block->block_id() * block_capacity + new_block->row_count());
-                    new_block->AppendBlock(input_column_vectors, row_begin, read_size1, buffer_mgr);
-                    remapper.AddMap(segment_id, block_id, row_begin, new_row_id);
-                    read_offset = row_begin + read_size1;
-                };
-
-                if (read_size + new_block->row_count() > block_capacity) {
-                    SizeT read_size1 = block_capacity - new_block->row_count();
-                    block_entry_append(row_begin, read_size1);
-                    row_begin += read_size1;
-                    read_size -= read_size1;
-                    new_segment->AppendBlockEntry(std::move(new_block));
-
-                    new_block = BlockEntry::NewBlockEntry(new_segment.get(), new_segment->GetNextBlockID(), 0, column_count, txn);
-                }
-                block_entry_append(row_begin, read_size);
-            }
-        }
-    }
-    if (new_block->row_count() > 0) {
-        new_segment->AppendBlockEntry(std::move(new_block));
-    } else {
-        std::move(*new_block).Cleanup();
-    }
-    if (new_segment->actual_row_count() > new_segment->row_capacity()) {
-        UnrecoverableError(fmt::format("Compact segment {} error because of row count overflow.", new_segment_id));
-    }
-    compact_state_data->AddNewSegment(new_segment, std::move(compactible_segments), txn);
-    compact_operator_state->compact_idx_ = ++group_idx;
-    if (group_idx == compact_operator_state->segment_groups_.size()) {
-        compact_operator_state->SetComplete();
-    }
     compact_operator_state->SetComplete();
-
-    String db_name = *table_entry->GetDBName();
-    String table_name = *table_entry->GetTableName();
-    Vector<WalSegmentInfo> new_segment_infos;
-    new_segment_infos.emplace_back(new_segment.get());
-    txn->AddWalCmd(MakeShared<WalCmdCompact>(std::move(db_name), std::move(table_name), std::move(new_segment_infos), std::move(old_segment_ids)));
-
     return true;
 }
 

--- a/src/executor/operator/physical_optimize.cpp
+++ b/src/executor/operator/physical_optimize.cpp
@@ -19,7 +19,6 @@ module;
 module physical_optimize;
 
 import stl;
-import txn;
 import query_context;
 
 import operator_state;
@@ -66,51 +65,23 @@ void PhysicalOptimize::OptimizeIndex(QueryContext *query_context, OperatorState 
     // Get tables from catalog
     LOG_INFO(fmt::format("OptimizeIndex {}.{} begin", db_name_, table_name_));
 
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-    if (use_new_catalog) {
-        NewTxn *new_txn = query_context->GetNewTxn();
-        Status status = new_txn->OptimizeTableIndexes(db_name_, table_name_);
-        if (!status.ok()) {
-            operator_state->status_ = status;
-            RecoverableError(status);
-            return;
-        }
-        return;
-    }
-
-    auto txn = query_context->GetTxn();
-    Status status = txn->OptimizeTableIndexes(db_name_, table_name_);
+    NewTxn *new_txn = query_context->GetNewTxn();
+    Status status = new_txn->OptimizeTableIndexes(db_name_, table_name_);
     if (!status.ok()) {
         operator_state->status_ = status;
         RecoverableError(status);
-        return;
     }
-    LOG_INFO(fmt::format("OptimizeIndex {}.{} end", db_name_, table_name_));
 }
 
 void PhysicalOptimize::OptIndex(QueryContext *query_context, OperatorState *operator_state) {
     LOG_INFO(fmt::format("OptimizeIndex {}.{}::{} begin", db_name_, table_name_, index_name_));
 
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-    if (use_new_catalog) {
-        NewTxn *new_txn = query_context->GetNewTxn();
-        Status status = new_txn->OptimizeIndexByParams(db_name_, table_name_, index_name_, std::move(opt_params_));
-        if (!status.ok()) {
-            operator_state->status_ = status;
-            RecoverableError(status);
-            return;
-        }
-        return;
-    }
-
-    auto txn = query_context->GetTxn();
-    Status status = txn->OptimizeIndexByName(db_name_, table_name_, index_name_, std::move(opt_params_));
+    NewTxn *new_txn = query_context->GetNewTxn();
+    Status status = new_txn->OptimizeIndexByParams(db_name_, table_name_, index_name_, std::move(opt_params_));
     if (!status.ok()) {
         operator_state->status_ = status;
         RecoverableError(status);
-        return;
     }
-    LOG_INFO(fmt::format("OptimizeIndex {}.{}::{} end", db_name_, table_name_, index_name_));
 }
 
 } // namespace infinity

--- a/src/executor/operator/physical_scan/physical_index_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_index_scan.cpp
@@ -26,7 +26,6 @@ import buffer_handle;
 import infinity_exception;
 import logger;
 import third_party;
-import txn;
 import data_block;
 import logical_type;
 import table_index_entry;
@@ -117,17 +116,8 @@ bool PhysicalIndexScan::Execute(QueryContext *query_context, OperatorState *oper
 SizeT PhysicalIndexScan::TaskletCount() { return base_table_ref_->block_index_->SegmentCount(); }
 
 void PhysicalIndexScan::ExecuteInternal(QueryContext *query_context, IndexScanOperatorState *index_scan_operator_state) const {
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-
-    Txn *txn = nullptr;
-    TxnTimeStamp begin_ts;
-    if (use_new_catalog) {
-        NewTxn *new_txn = query_context->GetNewTxn();
-        begin_ts = new_txn->BeginTS();
-    } else {
-        txn = query_context->GetTxn();
-        begin_ts = txn->BeginTS();
-    }
+    NewTxn *new_txn = query_context->GetNewTxn();
+    TxnTimeStamp begin_ts = new_txn->BeginTS();
 
     auto &output_data_blocks = index_scan_operator_state->data_block_array_;
     auto &segment_ids = *(index_scan_operator_state->segment_ids_);
@@ -199,76 +189,41 @@ void PhysicalIndexScan::ExecuteInternal(QueryContext *query_context, IndexScanOp
         }
     };
 
-    if (use_new_catalog) {
-        SegmentMeta *segment_meta = nullptr;
-        SegmentOffset segment_row_count = 0;
-        const auto &segment_block_index_ = base_table_ref_->block_index_->new_segment_block_index_;
-        if (auto iter = segment_block_index_.find(segment_id); iter == segment_block_index_.end()) {
-            UnrecoverableError(fmt::format("Cannot find SegmentEntry for segment id: {}", segment_id));
-        } else {
-            segment_meta = iter->second.segment_meta_.get();
-            segment_row_count = iter->second.segment_offset_;
-        }
-
-        // check FastRoughFilter
-        SharedPtr<FastRoughFilter> segment_filter;
-        Status status = segment_meta->GetFastRoughFilter(segment_filter);
-        if (status.ok()) {
-            if (fast_rough_filter_evaluator_ and !fast_rough_filter_evaluator_->Evaluate(begin_ts, *segment_filter)) {
-                // skip this segment
-                LOG_TRACE(
-                    fmt::format("IndexScan: job number: {}, segment_ids.size(): {}, skipped after FastRoughFilter", next_idx, segment_ids.size()));
-                Bitmask result_empty(segment_row_count);
-                result_empty.SetAllFalse();
-                OutputBitmaskResult(result_empty, segment_row_count);
-                return;
-            }
-        }
-
-        LOG_TRACE(fmt::format("IndexScan: job number: {}, segment_ids.size(): {}, not skipped after FastRoughFilter", next_idx, segment_ids.size()));
-
-        Bitmask result_elem = index_filter_evaluator_->Evaluate(segment_id, segment_row_count, txn);
-        if (result_elem.CountTrue() > 0) {
-            // Remove deleted rows from the result
-            // segment_entry->CheckRowsVisible(result_elem, begin_ts);
-            Status status = NewCatalog::CheckSegmentRowsVisible(*segment_meta, begin_ts, result_elem);
-            if (!status.ok()) {
-                UnrecoverableError(status.message());
-            }
-        }
-        // output
-        OutputBitmaskResult(result_elem, segment_row_count);
-        LOG_TRACE(fmt::format("IndexScan: job number: {}, segment_ids.size(): {}, finished", next_idx, segment_ids.size()));
-
-        return;
-    }
-
-    SegmentEntry *segment_entry = nullptr;
-    SegmentOffset segment_row_count = 0; // count of rows in segment, include deleted rows
-    const auto &segment_block_index_ = base_table_ref_->block_index_->segment_block_index_;
+    SegmentMeta *segment_meta = nullptr;
+    SegmentOffset segment_row_count = 0;
+    const auto &segment_block_index_ = base_table_ref_->block_index_->new_segment_block_index_;
     if (auto iter = segment_block_index_.find(segment_id); iter == segment_block_index_.end()) {
         UnrecoverableError(fmt::format("Cannot find SegmentEntry for segment id: {}", segment_id));
     } else {
-        segment_entry = iter->second.segment_entry_;
+        segment_meta = iter->second.segment_meta_.get();
         segment_row_count = iter->second.segment_offset_;
     }
 
     // check FastRoughFilter
-    const auto &fast_rough_filter = *segment_entry->GetFastRoughFilter();
-    if (fast_rough_filter_evaluator_ and !fast_rough_filter_evaluator_->Evaluate(begin_ts, fast_rough_filter)) {
-        // skip this segment
-        LOG_TRACE(fmt::format("IndexScan: job number: {}, segment_ids.size(): {}, skipped after FastRoughFilter", next_idx, segment_ids.size()));
-        Bitmask result_empty(segment_row_count);
-        result_empty.SetAllFalse();
-        OutputBitmaskResult(result_empty, segment_row_count);
-        return;
+    SharedPtr<FastRoughFilter> segment_filter;
+    Status status = segment_meta->GetFastRoughFilter(segment_filter);
+    if (status.ok()) {
+        if (fast_rough_filter_evaluator_ and !fast_rough_filter_evaluator_->Evaluate(begin_ts, *segment_filter)) {
+            // skip this segment
+            LOG_TRACE(
+                fmt::format("IndexScan: job number: {}, segment_ids.size(): {}, skipped after FastRoughFilter", next_idx, segment_ids.size()));
+            Bitmask result_empty(segment_row_count);
+            result_empty.SetAllFalse();
+            OutputBitmaskResult(result_empty, segment_row_count);
+            return;
+        }
     }
+
     LOG_TRACE(fmt::format("IndexScan: job number: {}, segment_ids.size(): {}, not skipped after FastRoughFilter", next_idx, segment_ids.size()));
 
-    Bitmask result_elem = index_filter_evaluator_->Evaluate(segment_id, segment_row_count, txn);
+    Bitmask result_elem = index_filter_evaluator_->Evaluate(segment_id, segment_row_count, nullptr);
     if (result_elem.CountTrue() > 0) {
         // Remove deleted rows from the result
-        segment_entry->CheckRowsVisible(result_elem, begin_ts);
+        // segment_entry->CheckRowsVisible(result_elem, begin_ts);
+        Status status = NewCatalog::CheckSegmentRowsVisible(*segment_meta, begin_ts, result_elem);
+        if (!status.ok()) {
+            UnrecoverableError(status.message());
+        }
     }
     // output
     OutputBitmaskResult(result_elem, segment_row_count);

--- a/src/executor/operator/physical_scan/physical_match_tensor_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_match_tensor_scan.cpp
@@ -22,7 +22,6 @@ module;
 module physical_match_tensor_scan;
 
 import stl;
-import txn;
 import query_context;
 import operator_state;
 import physical_operator;
@@ -184,64 +183,28 @@ void PhysicalMatchTensorScan::CheckColumn() {
 }
 
 void PhysicalMatchTensorScan::PlanWithIndex(QueryContext *query_context) {
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
+    Status status;
+    SizeT search_column_id = SearchColumnID();
 
-    if (use_new_catalog) {
-        Status status;
-        SizeT search_column_id = SearchColumnID();
+    block_metas_ = MakeUnique<Vector<BlockMeta *>>();
+    segment_index_metas_ = MakeUnique<Vector<SegmentIndexMeta>>();
 
-        block_metas_ = MakeUnique<Vector<BlockMeta *>>();
-        segment_index_metas_ = MakeUnique<Vector<SegmentIndexMeta>>();
+    TableMeeta *table_meta = base_table_ref_->block_index_->table_meta_.get();
 
-        TableMeeta *table_meta = base_table_ref_->block_index_->table_meta_.get();
+    Set<SegmentID> index_entry_map;
 
-        Set<SegmentID> index_entry_map;
+    if (!src_match_tensor_expr_->ignore_index_) {
+        Vector<String> *index_id_strs_ptr = nullptr;
+        Vector<String> *index_names_ptr = nullptr;
+        status = table_meta->GetIndexIDs(index_id_strs_ptr, &index_names_ptr);
+        if (!status.ok()) {
+            RecoverableError(status);
+        }
 
-        if (!src_match_tensor_expr_->ignore_index_) {
-            Vector<String> *index_id_strs_ptr = nullptr;
-            Vector<String> *index_names_ptr = nullptr;
-            status = table_meta->GetIndexIDs(index_id_strs_ptr, &index_names_ptr);
-            if (!status.ok()) {
-                RecoverableError(status);
-            }
-
-            if (src_match_tensor_expr_->index_name_.empty()) {
-                LOG_TRACE("Try to find an index to use");
-                for (SizeT i = 0; i < index_id_strs_ptr->size(); ++i) {
-                    const String &index_id_str = (*index_id_strs_ptr)[i];
-                    auto table_index_meta = MakeUnique<TableIndexMeeta>(index_id_str, *table_meta);
-
-                    SharedPtr<IndexBase> index_base;
-                    std::tie(index_base, status) = table_index_meta->GetIndexBase();
-                    if (!status.ok()) {
-                        RecoverableError(status);
-                    }
-
-                    ColumnID column_id = 0;
-                    std::tie(column_id, status) = table_meta->GetColumnIDByColumnName(index_base->column_name());
-                    if (!status.ok()) {
-                        RecoverableError(status);
-                    }
-                    if (column_id != search_column_id) {
-                        // search_column_id isn't in this table index
-                        continue;
-                    }
-                    // check index type
-                    if (auto index_type = index_base->index_type_; index_type != IndexType::kEMVB) {
-                        LOG_TRACE(fmt::format("MatchTensorScan: PlanWithIndex(): Skipping non-knn index."));
-                        continue;
-                    }
-                    table_index_meta_ = std::move(table_index_meta);
-                    break;
-                }
-            } else {
-                LOG_TRACE(fmt::format("Use index: {}", src_match_tensor_expr_->index_name_));
-                auto iter = std::find(index_names_ptr->begin(), index_names_ptr->end(), src_match_tensor_expr_->index_name_);
-                if (iter == index_names_ptr->end()) {
-                    Status status = Status::IndexNotExist(src_match_tensor_expr_->index_name_);
-                    RecoverableError(std::move(status));
-                }
-                const String &index_id_str = (*index_id_strs_ptr)[iter - index_names_ptr->begin()];
+        if (src_match_tensor_expr_->index_name_.empty()) {
+            LOG_TRACE("Try to find an index to use");
+            for (SizeT i = 0; i < index_id_strs_ptr->size(); ++i) {
+                const String &index_id_str = (*index_id_strs_ptr)[i];
                 auto table_index_meta = MakeUnique<TableIndexMeeta>(index_id_str, *table_meta);
 
                 SharedPtr<IndexBase> index_base;
@@ -257,141 +220,76 @@ void PhysicalMatchTensorScan::PlanWithIndex(QueryContext *query_context) {
                 }
                 if (column_id != search_column_id) {
                     // search_column_id isn't in this table index
-                    LOG_ERROR(fmt::format("Column {} not found", index_base->column_name()));
-                    Status error_status = Status::ColumnNotExist(index_base->column_name());
-                    RecoverableError(std::move(error_status));
+                    continue;
                 }
                 // check index type
                 if (auto index_type = index_base->index_type_; index_type != IndexType::kEMVB) {
-                    Status error_status = Status::InvalidIndexType("invalid index");
-                    RecoverableError(std::move(error_status));
+                    LOG_TRACE(fmt::format("MatchTensorScan: PlanWithIndex(): Skipping non-knn index."));
+                    continue;
                 }
                 table_index_meta_ = std::move(table_index_meta);
-            }
-            // Fill the segment with index
-            if (table_index_meta_) {
-                Vector<SegmentID> *segment_ids_ptr = nullptr;
-                std::tie(segment_ids_ptr, status) = table_index_meta_->GetSegmentIndexIDs1();
-                if (!status.ok()) {
-                    RecoverableError(status);
-                }
-                index_entry_map.insert(segment_ids_ptr->begin(), segment_ids_ptr->end());
-            }
-        }
-
-        // Generate task set: index segment and no index block
-        BlockIndex *block_index = base_table_ref_->block_index_.get();
-        for (const auto &[segment_id, segment_info] : block_index->new_segment_block_index_) {
-            if (auto iter = index_entry_map.find(segment_id); iter != index_entry_map.end()) {
-                segment_index_metas_->emplace_back(segment_id, *table_index_meta_);
-            } else {
-                const auto &block_map = segment_info.block_map_;
-                for (const auto &block_meta : block_map) {
-                    block_metas_->emplace_back(block_meta.get());
-                }
-            }
-        }
-        LOG_TRACE(fmt::format("MatchTensorScan: brute force task: {}, index task: {}", block_metas_->size(), segment_index_metas_->size()));
-
-        return;
-    }
-
-    Txn *txn = query_context->GetTxn();
-
-    auto *table_info = base_table_ref_->table_info_.get();
-    auto [table_entry, status] = txn->GetTableByName(*table_info->db_name_, *table_info->table_name_);
-    if (!status.ok()) {
-        RecoverableError(status);
-    }
-
-    const TransactionID txn_id = txn->TxnID();
-    const TxnTimeStamp begin_ts = txn->BeginTS();
-    const auto search_column_id = SearchColumnID();
-
-    Map<u32, SharedPtr<SegmentIndexEntry>> index_entry_map;
-
-    // if not ignoring index
-    if (!src_match_tensor_expr_->ignore_index_) {
-        auto map_guard = table_entry->IndexMetaMap();
-        // if index is specified
-        if (src_match_tensor_expr_->index_name_.empty()) {
-            for (auto map_guard = table_entry->IndexMetaMap(); auto &[index_name, table_index_meta] : *map_guard) {
-                auto [table_index_entry, status] = table_index_meta->GetEntryNolock(txn_id, begin_ts);
-                if (!status.ok()) {
-                    // already dropped
-                    LOG_WARN(status.message());
-                    continue;
-                }
-                if (const String column_name = table_index_entry->index_base()->column_name();
-                    table_entry->GetColumnIdByName(column_name) != search_column_id) {
-                    // search_column_id isn't in this table index
-                    continue;
-                }
-                // check index type
-                if (auto index_type = table_index_entry->index_base()->index_type_; index_type != IndexType::kEMVB) {
-                    // Skip non-EMVB index
-                    LOG_ERROR("Invalid index type");
-                    Status error_status = Status::InvalidIndexType("invalid index");
-                    RecoverableError(std::move(error_status));
-                }
-                // Fill the segment with index
-                index_entry_map = table_index_entry->index_by_segment();
-                // found one index
                 break;
             }
         } else {
-            auto iter = (*map_guard).find(src_match_tensor_expr_->index_name_);
-            if (iter == (*map_guard).end()) {
+            LOG_TRACE(fmt::format("Use index: {}", src_match_tensor_expr_->index_name_));
+            auto iter = std::find(index_names_ptr->begin(), index_names_ptr->end(), src_match_tensor_expr_->index_name_);
+            if (iter == index_names_ptr->end()) {
                 Status status = Status::IndexNotExist(src_match_tensor_expr_->index_name_);
                 RecoverableError(std::move(status));
             }
+            const String &index_id_str = (*index_id_strs_ptr)[iter - index_names_ptr->begin()];
+            auto table_index_meta = MakeUnique<TableIndexMeeta>(index_id_str, *table_meta);
 
-            auto &table_index_meta = iter->second;
-
-            auto [table_index_entry, status] = table_index_meta->GetEntryNolock(txn_id, begin_ts);
+            SharedPtr<IndexBase> index_base;
+            std::tie(index_base, status) = table_index_meta->GetIndexBase();
             if (!status.ok()) {
-                // already dropped
-                RecoverableError(std::move(status));
+                RecoverableError(status);
             }
 
-            const String column_name = table_index_entry->index_base()->column_name();
-            SizeT column_id = table_entry->GetColumnIdByName(column_name);
+            ColumnID column_id = 0;
+            std::tie(column_id, status) = table_meta->GetColumnIDByColumnName(index_base->column_name());
+            if (!status.ok()) {
+                RecoverableError(status);
+            }
             if (column_id != search_column_id) {
-                LOG_ERROR(fmt::format("Column {} not found", column_name));
-                Status error_status = Status::ColumnNotExist(column_name);
+                // search_column_id isn't in this table index
+                LOG_ERROR(fmt::format("Column {} not found", index_base->column_name()));
+                Status error_status = Status::ColumnNotExist(index_base->column_name());
                 RecoverableError(std::move(error_status));
             }
             // check index type
-            if (auto index_type = table_index_entry->index_base()->index_type_; index_type != IndexType::kEMVB) {
-                LOG_ERROR("Invalid index type");
+            if (auto index_type = index_base->index_type_; index_type != IndexType::kEMVB) {
                 Status error_status = Status::InvalidIndexType("invalid index");
                 RecoverableError(std::move(error_status));
             }
-
-            // Fill the segment with index
-            index_entry_map = table_index_entry->index_by_segment();
+            table_index_meta_ = std::move(table_index_meta);
+        }
+        // Fill the segment with index
+        if (table_index_meta_) {
+            Vector<SegmentID> *segment_ids_ptr = nullptr;
+            std::tie(segment_ids_ptr, status) = table_index_meta_->GetSegmentIndexIDs1();
+            if (!status.ok()) {
+                RecoverableError(status);
+            }
+            index_entry_map.insert(segment_ids_ptr->begin(), segment_ids_ptr->end());
         }
     }
 
     // Generate task set: index segment and no index block
-    for (BlockIndex *block_index = base_table_ref_->block_index_.get(); const auto &[segment_id, segment_info] : block_index->segment_block_index_) {
+    BlockIndex *block_index = base_table_ref_->block_index_.get();
+    for (const auto &[segment_id, segment_info] : block_index->new_segment_block_index_) {
         if (auto iter = index_entry_map.find(segment_id); iter != index_entry_map.end()) {
-            index_entries_.emplace_back(iter->second.get());
+            segment_index_metas_->emplace_back(segment_id, *table_index_meta_);
         } else {
-            for (const auto &block_map = segment_info.block_map_; const auto *block_entry : block_map) {
-                BlockColumnEntry *block_column_entry = block_entry->GetColumnBlockEntry(search_column_id);
-                block_column_entries_.emplace_back(block_column_entry);
+            const auto &block_map = segment_info.block_map_;
+            for (const auto &block_meta : block_map) {
+                block_metas_->emplace_back(block_meta.get());
             }
         }
     }
-    if (!block_column_entries_.empty()) {
-        // check unused option text
-        if (const SearchOptions options(src_match_tensor_expr_->options_text_);
-            options.size() != options.options_.count("topn") + options.options_.count("threshold")) {
-            RecoverableError(Status::SyntaxError(fmt::format(R"(Input option text "{}" has unused part.)", src_match_tensor_expr_->options_text_)));
-        }
-    }
-    LOG_TRACE(fmt::format("MatchTensorScan: brute force task: {}, index task: {}", block_column_entries_.size(), index_entries_.size()));
+    LOG_TRACE(fmt::format("MatchTensorScan: brute force task: {}, index task: {}", block_metas_->size(), segment_index_metas_->size()));
+
+    return;
 }
 
 Vector<SharedPtr<Vector<GlobalBlockID>>> PhysicalMatchTensorScan::PlanBlockEntries(i64 parallel_count) const {
@@ -427,207 +325,10 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
         String error_message = "TensorScan output data block array should be empty";
         UnrecoverableError(error_message);
     }
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
 
-    if (use_new_catalog) {
-        Status status;
-        NewTxn *new_txn = query_context->GetNewTxn();
-        const TxnTimeStamp begin_ts = new_txn->BeginTS();
-        if (!common_query_filter_->TryFinishBuild()) {
-            // not ready, abort and wait for next time
-            return;
-        }
-        MatchTensorScanFunctionData &function_data = *(operator_state->match_tensor_scan_function_data_);
-        if (function_data.finished_) [[unlikely]] {
-            String error_message = "MatchTensorScanFunctionData is finished";
-            UnrecoverableError(error_message);
-        }
-        const BlockIndex *block_index = base_table_ref_->block_index_.get();
-        if (const u32 task_job_index = task_executed_++; task_job_index < segment_index_metas_->size()) {
-            // use index
-            SegmentIndexMeta &segment_index_meta = (*segment_index_metas_)[task_job_index];
-            SegmentID segment_id = segment_index_meta.segment_id();
-            // SegmentEntry *segment_entry = nullptr;
-            SegmentOffset segment_row_count = 0;
-            SegmentMeta *segment_meta = nullptr;
-            const auto &segment_index_hashmap = base_table_ref_->block_index_->new_segment_block_index_;
-            if (auto iter = segment_index_hashmap.find(segment_id); iter == segment_index_hashmap.end()) {
-                String error_message = fmt::format("Cannot find SegmentMeta for segment id: {}", segment_id);
-                UnrecoverableError(error_message);
-            } else {
-                // segment_entry = iter->second.segment_entry_;
-                segment_meta = iter->second.segment_meta_.get();
-                std::tie(segment_row_count, status) = segment_meta->GetRowCnt1();
-                if (!status.ok()) {
-                    String error_message = fmt::format("GetRowCnt1 failed: {}", status.message());
-                    UnrecoverableError(error_message);
-                }
-            }
-
-            bool has_some_result = false;
-            Bitmask segment_bitmask;
-            if (common_query_filter_->AlwaysTrue()) {
-                has_some_result = true;
-                segment_bitmask.SetAllTrue();
-            } else {
-                if (auto it = common_query_filter_->filter_result_.find(segment_id); it != common_query_filter_->filter_result_.end()) {
-                    LOG_TRACE(fmt::format("MatchTensorScan: index {}/{} not skipped after common_query_filter",
-                                          task_job_index,
-                                          segment_index_metas_->size()));
-                    segment_bitmask = it->second;
-                    if (segment_row_count != segment_bitmask.count()) {
-                        UnrecoverableError(
-                            fmt::format("Segment row count {} not match with bitmask size {}", segment_row_count, segment_bitmask.count()));
-                    }
-                    has_some_result = true;
-                }
-            }
-
-            if (has_some_result) {
-                LOG_TRACE(
-                    fmt::format("MatchTensorScan: index {}/{} not skipped after common_query_filter", task_job_index, segment_index_metas_->size()));
-                // TODO: now only have EMVB index
-                // const Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<EMVBIndexInMem>> emvb_snapshot = index_entry->GetEMVBIndexSnapshot();
-                auto [chunk_ids_ptr, status] = segment_index_meta.GetChunkIDs1();
-                if (!status.ok()) {
-                    UnrecoverableError(status.message());
-                }
-                SharedPtr<MemIndex> mem_index;
-                status = segment_index_meta.GetMemIndex(mem_index);
-                if (!status.ok()) {
-                    UnrecoverableError(status.message());
-                }
-
-                // 1. in mem index
-                if (const EMVBIndexInMem *emvb_index_in_mem = mem_index->memory_emvb_index_.get(); emvb_index_in_mem) {
-                    // TODO: fix the parameters
-                    const auto result =
-                        emvb_index_in_mem->SearchWithBitmask(reinterpret_cast<const f32 *>(calc_match_tensor_expr_->query_embedding_.ptr),
-                                                             calc_match_tensor_expr_->num_of_embedding_in_query_tensor_,
-                                                             topn_,
-                                                             segment_bitmask,
-                                                             block_index,
-                                                             begin_ts,
-                                                             index_options_->emvb_centroid_nprobe_,
-                                                             index_options_->emvb_threshold_first_,
-                                                             index_options_->emvb_n_doc_to_score_,
-                                                             index_options_->emvb_n_doc_out_second_stage_,
-                                                             index_options_->emvb_threshold_final_);
-                    std::visit(
-                        Overload{[segment_id, &function_data](const Tuple<u32, UniquePtr<f32[]>, UniquePtr<u32[]>> &index_result) {
-                                     const auto &[result_num, score_ptr, row_id_ptr] = index_result;
-                                     for (u32 i = 0; i < result_num; ++i) {
-                                         function_data.result_handler_->AddResult(0, score_ptr[i], RowID(segment_id, row_id_ptr[i]));
-                                     }
-                                 },
-                                 [this, begin_ts, segment_id, &function_data, &segment_meta](const Pair<u32, u32> &in_mem_result) {
-                                     const auto &[start_offset, total_row_count] = in_mem_result;
-                                     BlockID block_id = start_offset / DEFAULT_BLOCK_CAPACITY;
-                                     BlockOffset block_offset = start_offset % DEFAULT_BLOCK_CAPACITY;
-                                     u32 row_leftover = total_row_count;
-                                     do {
-                                         const u32 row_to_read = std::min<u32>(row_leftover, DEFAULT_BLOCK_CAPACITY - block_offset);
-                                         Bitmask block_bitmask;
-                                         if (this->CalculateFilterBitmask(segment_id, block_id, row_to_read, block_bitmask)) {
-                                             BlockMeta block_meta(block_id, *segment_meta);
-                                             Status status = NewCatalog::SetBlockDeleteBitmask(block_meta, begin_ts, block_bitmask);
-                                             if (!status.ok()) {
-                                                 UnrecoverableError(status.message());
-                                             }
-                                             ColumnMeta column_meta(this->search_column_id_, block_meta);
-                                             ColumnVector column_vector;
-                                             status =
-                                                 NewCatalog::GetColumnVector(column_meta, row_to_read, ColumnVectorTipe::kReadOnly, column_vector);
-                                             if (!status.ok()) {
-                                                 UnrecoverableError(status.message());
-                                             }
-
-                                             // output score will always be float type
-                                             CalculateScoreOnColumnVector(column_vector,
-                                                                          segment_id,
-                                                                          block_id,
-                                                                          block_offset,
-                                                                          row_to_read,
-                                                                          block_bitmask,
-                                                                          *(this->calc_match_tensor_expr_),
-                                                                          function_data);
-                                         }
-                                         // prepare next block
-                                         row_leftover -= row_to_read;
-                                         ++block_id;
-                                         block_offset = 0;
-                                     } while (row_leftover);
-                                 }},
-                        result);
-                }
-                // 2. chunk index
-                for (ChunkID chunk_id : *chunk_ids_ptr) {
-                    ChunkIndexMeta chunk_index_meta(chunk_id, segment_index_meta);
-                    BufferObj *index_buffer = nullptr;
-                    Status status = chunk_index_meta.GetIndexBuffer(index_buffer);
-                    if (!status.ok()) {
-                        UnrecoverableError(status.message());
-                    }
-                    BufferHandle index_handle = index_buffer->Load();
-                    const auto *emvb_index = static_cast<const EMVBIndex *>(index_handle.GetData());
-
-                    const auto [result_num, score_ptr, row_id_ptr] =
-                        emvb_index->SearchWithBitmask(reinterpret_cast<const f32 *>(calc_match_tensor_expr_->query_embedding_.ptr),
-                                                      calc_match_tensor_expr_->num_of_embedding_in_query_tensor_,
-                                                      topn_,
-                                                      segment_bitmask,
-                                                      block_index,
-                                                      begin_ts,
-                                                      index_options_->emvb_centroid_nprobe_,
-                                                      index_options_->emvb_threshold_first_,
-                                                      index_options_->emvb_n_doc_to_score_,
-                                                      index_options_->emvb_n_doc_out_second_stage_,
-                                                      index_options_->emvb_threshold_final_);
-                    for (u32 i = 0; i < result_num; ++i) {
-                        function_data.result_handler_->AddResult(0, score_ptr[i], RowID(segment_id, row_id_ptr[i]));
-                    }
-                }
-            }
-        } else if (const u32 task_job_block = task_job_index - segment_index_metas_->size(); task_job_block < block_metas_->size()) {
-            BlockMeta *block_meta = (*block_metas_)[task_job_block];
-            BlockID block_id = block_meta->block_id();
-            SegmentID segment_id = block_meta->segment_meta().segment_id();
-            BlockOffset row_count = block_index->GetBlockOffset(segment_id, block_id);
-
-            Bitmask bitmask;
-            if (this->CalculateFilterBitmask(segment_id, block_id, row_count, bitmask)) {
-                Status status = NewCatalog::SetBlockDeleteBitmask(*block_meta, begin_ts, bitmask);
-                if (!status.ok()) {
-                    UnrecoverableError(status.message());
-                }
-                ColumnMeta column_meta(this->search_column_id_, *block_meta);
-                ColumnVector column_vector;
-                status = NewCatalog::GetColumnVector(column_meta, row_count, ColumnVectorTipe::kReadOnly, column_vector);
-                if (!status.ok()) {
-                    UnrecoverableError(status.message());
-                }
-                // output score will always be float type
-                CalculateScoreOnColumnVector(column_vector, segment_id, block_id, 0, row_count, bitmask, *calc_match_tensor_expr_, function_data);
-            }
-        } else {
-            // all task Complete
-            const u32 result_n = function_data.End();
-            float *result_scores = function_data.score_result_.get();
-            RowID *result_row_ids = function_data.row_id_result_.get();
-            SetOutput(Vector<char *>{reinterpret_cast<char *>(result_scores)},
-                      Vector<RowID *>{result_row_ids},
-                      sizeof(std::remove_pointer_t<decltype(result_scores)>),
-                      result_n,
-                      query_context,
-                      operator_state);
-            operator_state->SetComplete();
-        }
-        return;
-    }
-
-    Txn *txn = query_context->GetTxn();
-    const TxnTimeStamp begin_ts = txn->BeginTS();
-    BufferManager *buffer_mgr = query_context->storage()->buffer_manager();
+    Status status;
+    NewTxn *new_txn = query_context->GetNewTxn();
+    const TxnTimeStamp begin_ts = new_txn->BeginTS();
     if (!common_query_filter_->TryFinishBuild()) {
         // not ready, abort and wait for next time
         return;
@@ -638,19 +339,25 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
         UnrecoverableError(error_message);
     }
     const BlockIndex *block_index = base_table_ref_->block_index_.get();
-    if (const u32 task_job_index = task_executed_++; task_job_index < index_entries_.size()) {
+    if (const u32 task_job_index = task_executed_++; task_job_index < segment_index_metas_->size()) {
         // use index
-        auto *index_entry = index_entries_[task_job_index];
-        const auto segment_id = index_entry->segment_id();
-        SegmentEntry *segment_entry = nullptr;
+        SegmentIndexMeta &segment_index_meta = (*segment_index_metas_)[task_job_index];
+        SegmentID segment_id = segment_index_meta.segment_id();
+        // SegmentEntry *segment_entry = nullptr;
         SegmentOffset segment_row_count = 0;
-        const auto &segment_index_hashmap = base_table_ref_->block_index_->segment_block_index_;
+        SegmentMeta *segment_meta = nullptr;
+        const auto &segment_index_hashmap = base_table_ref_->block_index_->new_segment_block_index_;
         if (auto iter = segment_index_hashmap.find(segment_id); iter == segment_index_hashmap.end()) {
-            String error_message = fmt::format("Cannot find SegmentEntry for segment id: {}", segment_id);
+            String error_message = fmt::format("Cannot find SegmentMeta for segment id: {}", segment_id);
             UnrecoverableError(error_message);
         } else {
-            segment_entry = iter->second.segment_entry_;
-            segment_row_count = iter->second.segment_offset_;
+            // segment_entry = iter->second.segment_entry_;
+            segment_meta = iter->second.segment_meta_.get();
+            std::tie(segment_row_count, status) = segment_meta->GetRowCnt1();
+            if (!status.ok()) {
+                String error_message = fmt::format("GetRowCnt1 failed: {}", status.message());
+                UnrecoverableError(error_message);
+            }
         }
 
         bool has_some_result = false;
@@ -660,7 +367,9 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
             segment_bitmask.SetAllTrue();
         } else {
             if (auto it = common_query_filter_->filter_result_.find(segment_id); it != common_query_filter_->filter_result_.end()) {
-                LOG_TRACE(fmt::format("MatchTensorScan: index {}/{} not skipped after common_query_filter", task_job_index, index_entries_.size()));
+                LOG_TRACE(fmt::format("MatchTensorScan: index {}/{} not skipped after common_query_filter",
+                                      task_job_index,
+                                      segment_index_metas_->size()));
                 segment_bitmask = it->second;
                 if (segment_row_count != segment_bitmask.count()) {
                     UnrecoverableError(
@@ -671,95 +380,128 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
         }
 
         if (has_some_result) {
-            LOG_TRACE(fmt::format("MatchTensorScan: index {}/{} not skipped after common_query_filter", task_job_index, index_entries_.size()));
+            LOG_TRACE(
+                fmt::format("MatchTensorScan: index {}/{} not skipped after common_query_filter", task_job_index, segment_index_metas_->size()));
             // TODO: now only have EMVB index
-            const Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<EMVBIndexInMem>> emvb_snapshot = index_entry->GetEMVBIndexSnapshot();
+            // const Tuple<Vector<SharedPtr<ChunkIndexEntry>>, SharedPtr<EMVBIndexInMem>> emvb_snapshot = index_entry->GetEMVBIndexSnapshot();
+            auto [chunk_ids_ptr, status] = segment_index_meta.GetChunkIDs1();
+            if (!status.ok()) {
+                UnrecoverableError(status.message());
+            }
+            SharedPtr<MemIndex> mem_index;
+            status = segment_index_meta.GetMemIndex(mem_index);
+            if (!status.ok()) {
+                UnrecoverableError(status.message());
+            }
+
             // 1. in mem index
-            if (const EMVBIndexInMem *emvb_index_in_mem = std::get<SharedPtr<EMVBIndexInMem>>(emvb_snapshot).get(); emvb_index_in_mem) {
+            if (const EMVBIndexInMem *emvb_index_in_mem = mem_index->memory_emvb_index_.get(); emvb_index_in_mem) {
                 // TODO: fix the parameters
-                const auto result = emvb_index_in_mem->SearchWithBitmask(reinterpret_cast<const f32 *>(calc_match_tensor_expr_->query_embedding_.ptr),
-                                                                         calc_match_tensor_expr_->num_of_embedding_in_query_tensor_,
-                                                                         topn_,
-                                                                         segment_bitmask,
-                                                                         block_index,
-                                                                         begin_ts,
-                                                                         index_options_->emvb_centroid_nprobe_,
-                                                                         index_options_->emvb_threshold_first_,
-                                                                         index_options_->emvb_n_doc_to_score_,
-                                                                         index_options_->emvb_n_doc_out_second_stage_,
-                                                                         index_options_->emvb_threshold_final_);
-                std::visit(Overload{[segment_id, &function_data](const Tuple<u32, UniquePtr<f32[]>, UniquePtr<u32[]>> &index_result) {
-                                        const auto &[result_num, score_ptr, row_id_ptr] = index_result;
-                                        for (u32 i = 0; i < result_num; ++i) {
-                                            function_data.result_handler_->AddResult(0, score_ptr[i], RowID(segment_id, row_id_ptr[i]));
-                                        }
-                                    },
-                                    [this, buffer_mgr, begin_ts, segment_id, &segment_entry, &function_data](const Pair<u32, u32> &in_mem_result) {
-                                        const auto &[start_offset, total_row_count] = in_mem_result;
-                                        BlockID block_id = start_offset / DEFAULT_BLOCK_CAPACITY;
-                                        BlockOffset block_offset = start_offset % DEFAULT_BLOCK_CAPACITY;
-                                        u32 row_leftover = total_row_count;
-                                        BlocksGuard block_guard = segment_entry->GetBlocksGuard();
-                                        do {
-                                            const u32 row_to_read = std::min<u32>(row_leftover, DEFAULT_BLOCK_CAPACITY - block_offset);
-                                            Bitmask block_bitmask;
-                                            if (this->CalculateFilterBitmask(segment_id, block_id, row_to_read, block_bitmask)) {
-                                                const BlockEntry *block_entry = block_guard.block_entries_[block_id].get();
-                                                block_entry->SetDeleteBitmask(begin_ts, block_bitmask);
-                                                auto column_vector = block_entry->GetConstColumnVector(buffer_mgr, this->search_column_id_);
-                                                // output score will always be float type
-                                                CalculateScoreOnColumnVector(column_vector,
-                                                                             segment_id,
-                                                                             block_id,
-                                                                             block_offset,
-                                                                             row_to_read,
-                                                                             block_bitmask,
-                                                                             *(this->calc_match_tensor_expr_),
-                                                                             function_data);
-                                            }
-                                            // prepare next block
-                                            row_leftover -= row_to_read;
-                                            ++block_id;
-                                            block_offset = 0;
-                                        } while (row_leftover);
-                                    }},
-                           result);
+                const auto result =
+                    emvb_index_in_mem->SearchWithBitmask(reinterpret_cast<const f32 *>(calc_match_tensor_expr_->query_embedding_.ptr),
+                                                         calc_match_tensor_expr_->num_of_embedding_in_query_tensor_,
+                                                         topn_,
+                                                         segment_bitmask,
+                                                         block_index,
+                                                         begin_ts,
+                                                         index_options_->emvb_centroid_nprobe_,
+                                                         index_options_->emvb_threshold_first_,
+                                                         index_options_->emvb_n_doc_to_score_,
+                                                         index_options_->emvb_n_doc_out_second_stage_,
+                                                         index_options_->emvb_threshold_final_);
+                std::visit(
+                    Overload{[segment_id, &function_data](const Tuple<u32, UniquePtr<f32[]>, UniquePtr<u32[]>> &index_result) {
+                                 const auto &[result_num, score_ptr, row_id_ptr] = index_result;
+                                 for (u32 i = 0; i < result_num; ++i) {
+                                     function_data.result_handler_->AddResult(0, score_ptr[i], RowID(segment_id, row_id_ptr[i]));
+                                 }
+                             },
+                             [this, begin_ts, segment_id, &function_data, &segment_meta](const Pair<u32, u32> &in_mem_result) {
+                                 const auto &[start_offset, total_row_count] = in_mem_result;
+                                 BlockID block_id = start_offset / DEFAULT_BLOCK_CAPACITY;
+                                 BlockOffset block_offset = start_offset % DEFAULT_BLOCK_CAPACITY;
+                                 u32 row_leftover = total_row_count;
+                                 do {
+                                     const u32 row_to_read = std::min<u32>(row_leftover, DEFAULT_BLOCK_CAPACITY - block_offset);
+                                     Bitmask block_bitmask;
+                                     if (this->CalculateFilterBitmask(segment_id, block_id, row_to_read, block_bitmask)) {
+                                         BlockMeta block_meta(block_id, *segment_meta);
+                                         Status status = NewCatalog::SetBlockDeleteBitmask(block_meta, begin_ts, block_bitmask);
+                                         if (!status.ok()) {
+                                             UnrecoverableError(status.message());
+                                         }
+                                         ColumnMeta column_meta(this->search_column_id_, block_meta);
+                                         ColumnVector column_vector;
+                                         status =
+                                             NewCatalog::GetColumnVector(column_meta, row_to_read, ColumnVectorTipe::kReadOnly, column_vector);
+                                         if (!status.ok()) {
+                                             UnrecoverableError(status.message());
+                                         }
+
+                                         // output score will always be float type
+                                         CalculateScoreOnColumnVector(column_vector,
+                                                                      segment_id,
+                                                                      block_id,
+                                                                      block_offset,
+                                                                      row_to_read,
+                                                                      block_bitmask,
+                                                                      *(this->calc_match_tensor_expr_),
+                                                                      function_data);
+                                     }
+                                     // prepare next block
+                                     row_leftover -= row_to_read;
+                                     ++block_id;
+                                     block_offset = 0;
+                                 } while (row_leftover);
+                             }},
+                    result);
             }
             // 2. chunk index
-            for (const auto &chunk_index_entry : std::get<Vector<SharedPtr<ChunkIndexEntry>>>(emvb_snapshot)) {
-                if (chunk_index_entry->CheckVisible(txn)) {
-                    const BufferHandle index_handle = chunk_index_entry->GetIndex();
-                    const auto *emvb_index = static_cast<const EMVBIndex *>(index_handle.GetData());
-                    // TODO: fix the parameters
-                    const auto [result_num, score_ptr, row_id_ptr] =
-                        emvb_index->SearchWithBitmask(reinterpret_cast<const f32 *>(calc_match_tensor_expr_->query_embedding_.ptr),
-                                                      calc_match_tensor_expr_->num_of_embedding_in_query_tensor_,
-                                                      topn_,
-                                                      segment_bitmask,
-                                                      block_index,
-                                                      begin_ts,
-                                                      index_options_->emvb_centroid_nprobe_,
-                                                      index_options_->emvb_threshold_first_,
-                                                      index_options_->emvb_n_doc_to_score_,
-                                                      index_options_->emvb_n_doc_out_second_stage_,
-                                                      index_options_->emvb_threshold_final_);
-                    for (u32 i = 0; i < result_num; ++i) {
-                        function_data.result_handler_->AddResult(0, score_ptr[i], RowID(segment_id, row_id_ptr[i]));
-                    }
+            for (ChunkID chunk_id : *chunk_ids_ptr) {
+                ChunkIndexMeta chunk_index_meta(chunk_id, segment_index_meta);
+                BufferObj *index_buffer = nullptr;
+                Status status = chunk_index_meta.GetIndexBuffer(index_buffer);
+                if (!status.ok()) {
+                    UnrecoverableError(status.message());
+                }
+                BufferHandle index_handle = index_buffer->Load();
+                const auto *emvb_index = static_cast<const EMVBIndex *>(index_handle.GetData());
+
+                const auto [result_num, score_ptr, row_id_ptr] =
+                    emvb_index->SearchWithBitmask(reinterpret_cast<const f32 *>(calc_match_tensor_expr_->query_embedding_.ptr),
+                                                  calc_match_tensor_expr_->num_of_embedding_in_query_tensor_,
+                                                  topn_,
+                                                  segment_bitmask,
+                                                  block_index,
+                                                  begin_ts,
+                                                  index_options_->emvb_centroid_nprobe_,
+                                                  index_options_->emvb_threshold_first_,
+                                                  index_options_->emvb_n_doc_to_score_,
+                                                  index_options_->emvb_n_doc_out_second_stage_,
+                                                  index_options_->emvb_threshold_final_);
+                for (u32 i = 0; i < result_num; ++i) {
+                    function_data.result_handler_->AddResult(0, score_ptr[i], RowID(segment_id, row_id_ptr[i]));
                 }
             }
         }
-    } else if (const u32 task_job_block = task_job_index - index_entries_.size(); task_job_block < block_column_entries_.size()) {
-        auto *block_column_entry = block_column_entries_[task_job_block];
-        const BlockEntry *block_entry = block_column_entry->block_entry();
-        const BlockID block_id = block_entry->block_id();
-        const SegmentEntry *segment_entry = block_entry->GetSegmentEntry();
-        const SegmentID segment_id = segment_entry->segment_id();
+    } else if (const u32 task_job_block = task_job_index - segment_index_metas_->size(); task_job_block < block_metas_->size()) {
+        BlockMeta *block_meta = (*block_metas_)[task_job_block];
+        BlockID block_id = block_meta->block_id();
+        SegmentID segment_id = block_meta->segment_meta().segment_id();
         BlockOffset row_count = block_index->GetBlockOffset(segment_id, block_id);
+
         Bitmask bitmask;
         if (this->CalculateFilterBitmask(segment_id, block_id, row_count, bitmask)) {
-            block_entry->SetDeleteBitmask(begin_ts, bitmask);
-            auto column_vector = block_entry->GetConstColumnVector(buffer_mgr, search_column_id_);
+            Status status = NewCatalog::SetBlockDeleteBitmask(*block_meta, begin_ts, bitmask);
+            if (!status.ok()) {
+                UnrecoverableError(status.message());
+            }
+            ColumnMeta column_meta(this->search_column_id_, *block_meta);
+            ColumnVector column_vector;
+            status = NewCatalog::GetColumnVector(column_meta, row_count, ColumnVectorTipe::kReadOnly, column_vector);
+            if (!status.ok()) {
+                UnrecoverableError(status.message());
+            }
             // output score will always be float type
             CalculateScoreOnColumnVector(column_vector, segment_id, block_id, 0, row_count, bitmask, *calc_match_tensor_expr_, function_data);
         }
@@ -776,6 +518,7 @@ void PhysicalMatchTensorScan::ExecuteInner(QueryContext *query_context, MatchTen
                   operator_state);
         operator_state->SetComplete();
     }
+    return;
 }
 
 // TensorElemT: bit, QueryElemT: bit (unaligned).

--- a/src/executor/operator/physical_scan/physical_table_scan.cpp
+++ b/src/executor/operator/physical_scan/physical_table_scan.cpp
@@ -19,7 +19,6 @@ module;
 module physical_table_scan;
 
 import stl;
-import txn;
 import query_context;
 import table_def;
 import data_table;
@@ -117,13 +116,7 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
         return;
     }
 
-    TxnTimeStamp begin_ts;
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-    if (!use_new_catalog) {
-        begin_ts = query_context->GetTxn()->BeginTS();
-    } else {
-        begin_ts = query_context->GetNewTxn()->BeginTS();
-    }
+    TxnTimeStamp begin_ts = query_context->GetNewTxn()->BeginTS();
 
 #ifdef INFINITY_DEBUG
     // This part has performance issue
@@ -142,152 +135,87 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
         u32 segment_id = block_ids->at(block_ids_idx).segment_id_;
         u16 block_id = block_ids->at(block_ids_idx).block_id_;
 
-        if (use_new_catalog) {
-            BlockMeta *current_block_meta = block_index->GetBlockMeta(segment_id, block_id);
+        BlockMeta *current_block_meta = block_index->GetBlockMeta(segment_id, block_id);
 
-            Optional<NewTxnGetVisibleRangeState> &range_state = table_scan_function_data_ptr->get_visible_range_state_;
-            if (!range_state) {
-                // TODO
-                range_state = NewTxnGetVisibleRangeState();
-                Status status = NewCatalog::GetBlockVisibleRange(*current_block_meta, begin_ts, *range_state);
-                if (!status.ok()) {
-                    RecoverableError(status);
-                }
-
-                // new block, check FastRoughFilter
-                SharedPtr<FastRoughFilter> block_filter;
-                status = current_block_meta->GetFastRoughFilter(block_filter);
-                if (status.ok()) {
-                    if (fast_rough_filter_evaluator_ and !fast_rough_filter_evaluator_->Evaluate(begin_ts, *block_filter)) {
-                        // skip this block
-                        LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}, skipped after apply FastRoughFilter",
-                                              block_ids_idx,
-                                              block_ids_count));
-                        ++block_ids_idx;
-                        continue;
-                    } else {
-                        LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}, not skipped after apply FastRoughFilter",
-                                              block_ids_idx,
-                                              block_ids_count));
-                    }
-                }
+        Optional<NewTxnGetVisibleRangeState> &range_state = table_scan_function_data_ptr->get_visible_range_state_;
+        if (!range_state) {
+            // TODO
+            range_state = NewTxnGetVisibleRangeState();
+            Status status = NewCatalog::GetBlockVisibleRange(*current_block_meta, begin_ts, *range_state);
+            if (!status.ok()) {
+                RecoverableError(status);
             }
 
-            Pair<BlockOffset, BlockOffset> visible_range;
-            bool has_next = range_state->Next(visible_range);
-            if (!has_next || visible_range.first == visible_range.second) {
-                // we have read all data from current block, move to next block
-                ++block_ids_idx;
-                range_state.reset();
-                continue;
-            }
-            if (write_capacity == 0) {
-                // output is full
-                break;
-            }
-
-            auto write_size = std::min(write_capacity, SizeT(visible_range.second - visible_range.first));
-            SizeT output_column_id{0};
-            for (auto column_id : column_ids) {
-                switch (column_id) {
-                    case COLUMN_IDENTIFIER_ROW_ID: {
-                        u32 segment_offset = block_id * DEFAULT_BLOCK_CAPACITY + visible_range.first;
-                        output_ptr->column_vectors[output_column_id]->AppendWith(RowID(segment_id, segment_offset), write_size);
-                        break;
-                    }
-                    case COLUMN_IDENTIFIER_CREATE: {
-                        Status status = NewCatalog::GetCreateTSVector(*current_block_meta,
-                                                                      visible_range.first,
-                                                                      write_size,
-                                                                      *output_ptr->column_vectors[output_column_id]);
-                        if (!status.ok()) {
-                            RecoverableError(status);
-                        }
-                        break;
-                    }
-                    case COLUMN_IDENTIFIER_DELETE: {
-                        Status status = NewCatalog::GetDeleteTSVector(*current_block_meta,
-                                                                      visible_range.first,
-                                                                      write_size,
-                                                                      *output_ptr->column_vectors[output_column_id]);
-                        if (!status.ok()) {
-                            RecoverableError(status);
-                        }
-                        break;
-                    }
-                    default: {
-                        ColumnVector column_vector;
-                        ColumnMeta column_meta(column_id, *current_block_meta);
-                        SizeT row_cnt = range_state->block_offset_end();
-                        Status status = NewCatalog::GetColumnVector(column_meta, row_cnt, ColumnVectorTipe::kReadOnly, column_vector);
-                        if (!status.ok()) {
-                            RecoverableError(status);
-                        }
-                        output_ptr->column_vectors[output_column_id]->AppendWith(column_vector, visible_range.first, write_size);
-                    }
-                }
-                ++output_column_id;
-            }
-
-            // write_size = already read size = already write size
-            write_capacity -= write_size;
-            range_state->SetBlockOffsetBegin(visible_range.first + write_size);
-            continue;
-        }
-        SizeT &read_offset = table_scan_function_data_ptr->current_read_offset_;
-        BlockEntry *current_block_entry = block_index->GetBlockEntry(segment_id, block_id);
-        if (read_offset == 0) {
             // new block, check FastRoughFilter
-            const auto &fast_rough_filter = *current_block_entry->GetFastRoughFilter();
-            if (fast_rough_filter_evaluator_ and !fast_rough_filter_evaluator_->Evaluate(begin_ts, fast_rough_filter)) {
-                // skip this block
-                LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}, skipped after apply FastRoughFilter",
-                                      block_ids_idx,
-                                      block_ids_count));
-                ++block_ids_idx;
-                continue;
-            } else {
-                LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}, not skipped after apply FastRoughFilter",
-                                      block_ids_idx,
-                                      block_ids_count));
+            SharedPtr<FastRoughFilter> block_filter;
+            status = current_block_meta->GetFastRoughFilter(block_filter);
+            if (status.ok()) {
+                if (fast_rough_filter_evaluator_ and !fast_rough_filter_evaluator_->Evaluate(begin_ts, *block_filter)) {
+                    // skip this block
+                    LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}, skipped after apply FastRoughFilter",
+                                          block_ids_idx,
+                                          block_ids_count));
+                    ++block_ids_idx;
+                    continue;
+                } else {
+                    LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}, not skipped after apply FastRoughFilter",
+                                          block_ids_idx,
+                                          block_ids_count));
+                }
             }
         }
-        auto [row_begin, row_end] = current_block_entry->GetVisibleRange(begin_ts, read_offset);
-        if (row_begin == row_end) {
+
+        Pair<BlockOffset, BlockOffset> visible_range;
+        bool has_next = range_state->Next(visible_range);
+        if (!has_next || visible_range.first == visible_range.second) {
             // we have read all data from current block, move to next block
             ++block_ids_idx;
-            read_offset = 0;
+            range_state.reset();
             continue;
         }
         if (write_capacity == 0) {
             // output is full
             break;
         }
-        auto write_size = std::min(write_capacity, SizeT(row_end - row_begin));
 
-        read_offset = row_begin;
+        auto write_size = std::min(write_capacity, SizeT(visible_range.second - visible_range.first));
         SizeT output_column_id{0};
-        auto *buffer_mgr = query_context->storage()->buffer_manager();
         for (auto column_id : column_ids) {
             switch (column_id) {
                 case COLUMN_IDENTIFIER_ROW_ID: {
-                    u32 segment_offset = block_id * DEFAULT_BLOCK_CAPACITY + read_offset;
+                    u32 segment_offset = block_id * DEFAULT_BLOCK_CAPACITY + visible_range.first;
                     output_ptr->column_vectors[output_column_id]->AppendWith(RowID(segment_id, segment_offset), write_size);
                     break;
                 }
                 case COLUMN_IDENTIFIER_CREATE: {
-                    ColumnVector create_ts_vec = current_block_entry->GetCreateTSVector(buffer_mgr, read_offset, write_size);
-                    output_ptr->column_vectors[output_column_id]->AppendWith(create_ts_vec);
+                    Status status = NewCatalog::GetCreateTSVector(*current_block_meta,
+                                                                  visible_range.first,
+                                                                  write_size,
+                                                                  *output_ptr->column_vectors[output_column_id]);
+                    if (!status.ok()) {
+                        RecoverableError(status);
+                    }
                     break;
                 }
                 case COLUMN_IDENTIFIER_DELETE: {
-                    ColumnVector delete_ts_vec = current_block_entry->GetDeleteTSVector(buffer_mgr, read_offset, write_size);
-                    output_ptr->column_vectors[output_column_id]->AppendWith(delete_ts_vec);
+                    Status status = NewCatalog::GetDeleteTSVector(*current_block_meta,
+                                                                  visible_range.first,
+                                                                  write_size,
+                                                                  *output_ptr->column_vectors[output_column_id]);
+                    if (!status.ok()) {
+                        RecoverableError(status);
+                    }
                     break;
                 }
                 default: {
-                    ColumnVector column_vector = current_block_entry->GetConstColumnVector(buffer_mgr, column_id);
-                    output_ptr->column_vectors[output_column_id]->AppendWith(column_vector, read_offset, write_size);
+                    ColumnVector column_vector;
+                    ColumnMeta column_meta(column_id, *current_block_meta);
+                    SizeT row_cnt = range_state->block_offset_end();
+                    Status status = NewCatalog::GetColumnVector(column_meta, row_cnt, ColumnVectorTipe::kReadOnly, column_vector);
+                    if (!status.ok()) {
+                        RecoverableError(status);
+                    }
+                    output_ptr->column_vectors[output_column_id]->AppendWith(column_vector, visible_range.first, write_size);
                 }
             }
             ++output_column_id;
@@ -295,7 +223,7 @@ void PhysicalTableScan::ExecuteInternal(QueryContext *query_context, TableScanOp
 
         // write_size = already read size = already write size
         write_capacity -= write_size;
-        read_offset += write_size;
+        range_state->SetBlockOffsetBegin(visible_range.first + write_size);
     }
 
     LOG_TRACE(fmt::format("TableScan: block_ids_idx: {}, block_ids.size(): {}", block_ids_idx, block_ids_count));

--- a/src/planner/bound_compact_statement.cpp
+++ b/src/planner/bound_compact_statement.cpp
@@ -36,52 +36,8 @@ Vector<SharedPtr<LogicalNode>> BoundCompactStatement::BuildPlans(QueryContext *q
     Vector<SharedPtr<LogicalNode>> res;
     const SharedPtr<BindContext> &bind_context = this->bind_context_;
 
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-    if (use_new_catalog) {
-        auto compact_node = MakeShared<LogicalCompact>(bind_context->GetNewLogicalNodeId(), base_table_ref_, compact_type_);
-        res.emplace_back(compact_node);
-        return res;
-    }
-
     auto compact_node = MakeShared<LogicalCompact>(bind_context->GetNewLogicalNodeId(), base_table_ref_, compact_type_);
-    auto &index_index = base_table_ref_->index_index_;
-    if (!index_index->IsEmpty()) {
-        if (index_index->index_snapshots_.size() == 1) {
-            auto compact_index_node = MakeShared<LogicalCompactIndex>(bind_context->GetNewLogicalNodeId(), base_table_ref_);
-            compact_index_node->set_left_node(compact_node);
-            auto compact_finish_node = MakeShared<LogicalCompactFinish>(bind_context->GetNewLogicalNodeId(), base_table_ref_, compact_type_);
-            compact_finish_node->set_left_node(compact_index_node);
-            res.emplace_back(compact_finish_node);
-        } else {
-            res.emplace_back(compact_node);
-            if (index_index->index_snapshots_.size() > 2) {
-                LOG_WARN(fmt::format("Table {} has more than 2 index, but logical plan is binary tree now", *base_table_ref_->table_name()));
-            }
-            auto index_index1 = MakeShared<IndexIndex>();
-            auto index_index2 = MakeShared<IndexIndex>();
-            SizeT idx = 0;
-            for (const auto &[index_name, index_snapshot] : index_index->index_snapshots_) {
-                if (idx == 0) {
-                    index_index1->Insert(index_name, index_snapshot);
-                } else {
-                    index_index2->Insert(index_name, index_snapshot);
-                }
-                ++idx;
-            }
-            auto base_table_ref1 = MakeShared<BaseTableRef>(base_table_ref_->table_info_, base_table_ref_->block_index_, index_index1);
-            auto base_table_ref2 = MakeShared<BaseTableRef>(base_table_ref_->table_info_, base_table_ref_->block_index_, index_index2);
-            auto compact_index_node1 = MakeShared<LogicalCompactIndex>(bind_context->GetNewLogicalNodeId(), base_table_ref1);
-            auto compact_index_node2 = MakeShared<LogicalCompactIndex>(bind_context->GetNewLogicalNodeId(), base_table_ref2);
-            auto compact_finish = MakeShared<LogicalCompactFinish>(bind_context->GetNewLogicalNodeId(), base_table_ref_, compact_type_);
-            compact_finish->set_left_node(compact_index_node1);
-            compact_finish->set_right_node(compact_index_node2);
-            res.emplace_back(compact_finish);
-        }
-    } else {
-        auto compact_finish = MakeShared<LogicalCompactFinish>(bind_context->GetNewLogicalNodeId(), base_table_ref_, compact_type_);
-        compact_finish->set_left_node(compact_node);
-        res.emplace_back(compact_finish);
-    }
+    res.emplace_back(compact_node);
     return res;
 }
 

--- a/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter.cpp
@@ -44,7 +44,6 @@ import catalog;
 import value;
 import table_index_meta;
 import meta_info;
-import txn;
 import roaring_bitmap;
 import query_node;
 import column_index_reader;
@@ -305,16 +304,9 @@ public:
         const auto and_function_set_ptr = Catalog::GetFunctionSetByName(query_context_->storage()->catalog(), "AND");
         and_scalar_function_set_ptr_ = static_cast<ScalarFunctionSet *>(and_function_set_ptr.get());
         // prepare secondary index info
-        if (query_context_->global_config()->UseNewCatalog()) {
-            if (base_table_ref_ptr_) {
-                table_info_ = base_table_ref_ptr_->table_info_.get();
-                tree_info_.NewInitColumnIndexEntries(table_info_, query_context_->GetNewTxn(), const_cast<BaseTableRef *>(base_table_ref_ptr_));
-            }
-        } else {
-            if (base_table_ref_ptr_) {
-                table_info_ = base_table_ref_ptr_->table_info_.get();
-                tree_info_.InitColumnIndexEntries(table_info_, query_context_->GetTxn());
-            }
+        if (base_table_ref_ptr_) {
+            table_info_ = base_table_ref_ptr_->table_info_.get();
+            tree_info_.NewInitColumnIndexEntries(table_info_, query_context_->GetNewTxn(), const_cast<BaseTableRef *>(base_table_ref_ptr_));
         }
     }
 
@@ -493,24 +485,13 @@ private:
                         case FilterCompareType::kEqual:
                         case FilterCompareType::kLessEqual:
                         case FilterCompareType::kGreaterEqual: {
-                            bool use_new_catalog = query_context_->global_config()->UseNewCatalog();
-                            if (use_new_catalog) {
-                                SharedPtr<TableIndexMeeta> secondary_index = tree_info_.new_candidate_column_index_map_.at(column_id);
-                                return IndexFilterEvaluatorSecondary::Make(function_expression,
-                                                                           column_id,
-                                                                           nullptr,
-                                                                           secondary_index,
-                                                                           compare_type,
-                                                                           value);
-                            } else {
-                                const auto *secondary_index = tree_info_.candidate_column_index_map_.at(column_id);
-                                return IndexFilterEvaluatorSecondary::Make(function_expression,
-                                                                           column_id,
-                                                                           secondary_index,
-                                                                           nullptr,
-                                                                           compare_type,
-                                                                           value);
-                            }
+                            SharedPtr<TableIndexMeeta> secondary_index = tree_info_.new_candidate_column_index_map_.at(column_id);
+                            return IndexFilterEvaluatorSecondary::Make(function_expression,
+                                                                       column_id,
+                                                                       nullptr,
+                                                                       secondary_index,
+                                                                       compare_type,
+                                                                       value);
                         }
                         case FilterCompareType::kAlwaysTrue: {
                             return MakeUnique<IndexFilterEvaluatorAllTrue>();
@@ -544,16 +525,11 @@ private:
             }
             case Enum::kFilterFulltextExpr: {
                 auto *filter_fulltext_expr = static_cast<const FilterFulltextExpression *>(index_filter_tree_node.src_ptr->get());
-                bool use_new_catalog = query_context_->global_config()->UseNewCatalog();
                 SharedPtr<IndexReader> index_reader;
-                if (use_new_catalog) {
-                    NewTxn *new_txn = query_context_->GetNewTxn();
-                    Status status = new_txn->GetFullTextIndexReader(*table_info_->db_name_, *table_info_->table_name_, index_reader);
-                    if (!status.ok()) {
-                        UnrecoverableError(fmt::format("Get full text index reader error: {}", status.message()));
-                    }
-                } else {
-                    index_reader = query_context_->GetTxn()->GetFullTextIndexReader(*table_info_->db_name_, *table_info_->table_name_);
+                NewTxn *new_txn = query_context_->GetNewTxn();
+                Status status = new_txn->GetFullTextIndexReader(*table_info_->db_name_, *table_info_->table_name_, index_reader);
+                if (!status.ok()) {
+                    UnrecoverableError(fmt::format("Get full text index reader error: {}", status.message()));
                 }
 
                 EarlyTermAlgo early_term_algo = EarlyTermAlgo::kAuto;

--- a/src/planner/optimizer/result_cache_getter.cpp
+++ b/src/planner/optimizer/result_cache_getter.cpp
@@ -43,13 +43,7 @@ void ResultCacheGetter::ApplyToPlan(QueryContext *query_context_ptr, SharedPtr<L
     if (cache_mgr == nullptr) {
         return;
     }
-    TxnTimeStamp begin_ts;
-    bool use_new_catalog = query_context_ptr->global_config()->UseNewCatalog();
-    if  (use_new_catalog) {
-        begin_ts = query_context_ptr->GetNewTxn()->BeginTS();
-    } else {
-        begin_ts = query_context_ptr->GetTxn()->BeginTS();
-    }
+    TxnTimeStamp begin_ts = query_context_ptr->GetNewTxn()->BeginTS();
     std::function<void(SharedPtr<LogicalNode> &)> visit_node = [&](SharedPtr<LogicalNode> &op) {
         if (!op) {
             return;

--- a/src/scheduler/fragment_context.cpp
+++ b/src/scheduler/fragment_context.cpp
@@ -721,56 +721,14 @@ SizeT InitKnnScanFragmentContext(PhysicalKnnScan *knn_scan_operator, FragmentCon
     SizeT task_n = knn_scan_operator->TaskletCount();
     KnnExpression *knn_expr = knn_scan_operator->knn_expression_.get();
 
-    bool use_new_catalog = query_context->global_config()->UseNewCatalog();
-
-    if (use_new_catalog) {
-        switch (fragment_context->ContextType()) {
-            case FragmentType::kSerialMaterialize: {
-                SerialMaterializedFragmentCtx *serial_materialize_fragment_ctx = static_cast<SerialMaterializedFragmentCtx *>(fragment_context);
-                serial_materialize_fragment_ctx->knn_scan_shared_data_ =
-                    MakeUnique<KnnScanSharedData>(knn_scan_operator->base_table_ref_,
-                                                  std::move(knn_scan_operator->block_metas_),
-                                                  std::move(knn_scan_operator->table_index_meta_),
-                                                  std::move(knn_scan_operator->segment_index_metas_),
-                                                  std::move(knn_expr->opt_params_),
-                                                  knn_expr->topn_,
-                                                  knn_expr->dimension_,
-                                                  1,
-                                                  knn_scan_operator->real_knn_query_embedding_ptr_,
-                                                  knn_scan_operator->real_knn_query_elem_type_,
-                                                  knn_expr->distance_type_);
-                break;
-            }
-            case FragmentType::kParallelMaterialize: {
-                ParallelMaterializedFragmentCtx *parallel_materialize_fragment_ctx = static_cast<ParallelMaterializedFragmentCtx *>(fragment_context);
-                parallel_materialize_fragment_ctx->knn_scan_shared_data_ =
-                    MakeUnique<KnnScanSharedData>(knn_scan_operator->base_table_ref_,
-                                                  std::move(knn_scan_operator->block_metas_),
-                                                  std::move(knn_scan_operator->table_index_meta_),
-                                                  std::move(knn_scan_operator->segment_index_metas_),
-                                                  std::move(knn_expr->opt_params_),
-                                                  knn_expr->topn_,
-                                                  knn_expr->dimension_,
-                                                  1,
-                                                  knn_scan_operator->real_knn_query_embedding_ptr_,
-                                                  knn_scan_operator->real_knn_query_elem_type_,
-                                                  knn_expr->distance_type_);
-                break;
-            }
-            default: {
-                String error_message = "Invalid fragment type.";
-                UnrecoverableError(error_message);
-            }
-        }
-        return task_n;
-    }
     switch (fragment_context->ContextType()) {
         case FragmentType::kSerialMaterialize: {
             SerialMaterializedFragmentCtx *serial_materialize_fragment_ctx = static_cast<SerialMaterializedFragmentCtx *>(fragment_context);
             serial_materialize_fragment_ctx->knn_scan_shared_data_ =
                 MakeUnique<KnnScanSharedData>(knn_scan_operator->base_table_ref_,
-                                              std::move(knn_scan_operator->block_column_entries_),
-                                              std::move(knn_scan_operator->index_entries_),
+                                              std::move(knn_scan_operator->block_metas_),
+                                              std::move(knn_scan_operator->table_index_meta_),
+                                              std::move(knn_scan_operator->segment_index_metas_),
                                               std::move(knn_expr->opt_params_),
                                               knn_expr->topn_,
                                               knn_expr->dimension_,
@@ -784,8 +742,9 @@ SizeT InitKnnScanFragmentContext(PhysicalKnnScan *knn_scan_operator, FragmentCon
             ParallelMaterializedFragmentCtx *parallel_materialize_fragment_ctx = static_cast<ParallelMaterializedFragmentCtx *>(fragment_context);
             parallel_materialize_fragment_ctx->knn_scan_shared_data_ =
                 MakeUnique<KnnScanSharedData>(knn_scan_operator->base_table_ref_,
-                                              std::move(knn_scan_operator->block_column_entries_),
-                                              std::move(knn_scan_operator->index_entries_),
+                                              std::move(knn_scan_operator->block_metas_),
+                                              std::move(knn_scan_operator->table_index_meta_),
+                                              std::move(knn_scan_operator->segment_index_metas_),
                                               std::move(knn_expr->opt_params_),
                                               knn_expr->topn_,
                                               knn_expr->dimension_,


### PR DESCRIPTION
### What problem does this PR solve?

We will not use old catalog any more.

Remove use_new_catalog in:
src/executor/operator/physical_command.cpp
src/executor/operator/physical_compact.cpp
src/executor/operator/physical_export.cpp
src/executor/operator/physical_optimize.cpp
src/executor/operator/physical_scan/physical_index_scan.cpp
src/executor/operator/physical_scan/physical_match_tensor_scan.cpp
src/executor/operator/physical_scan/physical_table_scan.cpp
src/planner/bound_compact_statement.cpp
src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter.cpp
src/planner/optimizer/result_cache_getter.cpp
src/scheduler/fragment_context.cpp
src/storage/wal/wal_manager.cpp


### Type of change

- [ ] Refactoring
