### PR TITLE
Fix the conflict issues within the transaction

### DIFF
--- a/src/main/query_context.cpp
+++ b/src/main/query_context.cpp
@@ -292,7 +292,8 @@ QueryResult QueryContext::QueryStatementInternal(const BaseStatement *base_state
         if (new_txn != nullptr) {
             StopProfile();
             StartProfile(QueryPhase::kRollback);
-            if (new_txn->GetTxnState() == TxnState::kRollbacking) {
+            TxnState txn_state = new_txn->GetTxnState();
+            if (txn_state == TxnState::kRollbacking or txn_state == TxnState::kStarted) {
                 this->RollbackTxn();
             }
             StopProfile(QueryPhase::kRollback);

--- a/src/storage/new_txn/new_txn.cpp
+++ b/src/storage/new_txn/new_txn.cpp
@@ -179,8 +179,15 @@ Status NewTxn::CreateDatabase(const String &db_name, ConflictType conflict_type,
 
     this->CheckTxnStatus();
 
+    String db_id_str;
+    Status status = IncrLatestID(db_id_str, NEXT_DATABASE_ID);
+    LOG_TRACE(fmt::format("txn: {}, create db, apply db_id: {}", txn_context_ptr_->txn_id_, db_id_str));
+    if (!status.ok()) {
+        return Status(status.code(), MakeUnique<String>(fmt::format("Fail to fetch next database id, {}", status.message())));
+    }
+
     Optional<DBMeeta> db_meta;
-    Status status = GetDBMeta(db_name, db_meta);
+    status = GetDBMeta(db_name, db_meta);
     if (status.ok()) {
         if (conflict_type == ConflictType::kIgnore) {
             return Status::OK();
@@ -189,12 +196,6 @@ Status NewTxn::CreateDatabase(const String &db_name, ConflictType conflict_type,
     }
     if (status.code() != ErrorCode::kDBNotExist) {
         return status;
-    }
-
-    String db_id_str;
-    status = IncrLatestID(db_id_str, NEXT_DATABASE_ID);
-    if (!status.ok()) {
-        return Status(status.code(), MakeUnique<String>(fmt::format("Fail to fetch next database id, {}", status.message())));
     }
 
     // Put the data into local txn store
@@ -1997,16 +1998,16 @@ Status NewTxn::CommitCheckpointTable(TableMeeta &table_meta, const WalCmdCheckpo
 }
 
 Status NewTxn::IncrLatestID(String &id_str, std::string_view id_name) const {
-    //    String string_id;
-    //    Status status = kv_instance_->Get(id_name.data(), string_id);
-    //    if (!status.ok()) {
-    //        return status;
-    //    }
-    //    SizeT id_num = std::stoull(string_id);
-    //    ++id_num;
-    //    id_str = fmt::format("{}", id_num);
-    //    return kv_instance_->Put(id_name.data(), id_str);
-    return new_catalog_->IncrLatestID(id_str, id_name);
+    String string_id;
+    Status status = kv_instance_->Get(id_name.data(), string_id);
+    if (!status.ok()) {
+        return status;
+    }
+    SizeT id_num = std::stoull(string_id);
+    ++id_num;
+    id_str = fmt::format("{}", id_num);
+    return kv_instance_->Put(id_name.data(), id_str);
+    // return new_catalog_->IncrLatestID(id_str, id_name);
 }
 
 bool NewTxn::CheckConflictTxnStore(NewTxn *previous_txn, String &cause, bool &retry_query) {
@@ -2057,6 +2058,9 @@ bool NewTxn::CheckConflictCmd(const WalCmd &cmd, NewTxn *previous_txn, String &c
     switch (cmd.GetType()) {
         case WalCommandType::CREATE_DATABASE_V2: {
             return CheckConflictCmd(static_cast<const WalCmdCreateDatabaseV2 &>(cmd), previous_txn, cause, retry_query);
+        }
+        case WalCommandType::DROP_DATABASE_V2: {
+            return CheckConflictCmd(static_cast<const WalCmdDropDatabaseV2 &>(cmd), previous_txn, cause, retry_query);
         }
         case WalCommandType::CREATE_TABLE_V2: {
             return CheckConflictCmd(static_cast<const WalCmdCreateTableV2 &>(cmd), previous_txn, cause, retry_query);
@@ -2109,6 +2113,33 @@ bool NewTxn::CheckConflictCmd(const WalCmdCreateDatabaseV2 &cmd, NewTxn *previou
                 }
                 break;
             }
+            case WalCommandType::DROP_DATABASE_V2: {
+                auto *drop_db_cmd = static_cast<WalCmdDropDatabaseV2 *>(wal_cmd.get());
+                if (drop_db_cmd->db_name_ == db_name) {
+                    retry_query = false;
+                    conflict = true;
+                }
+                break;
+            }
+            default: {
+                //
+            }
+        }
+        if (conflict) {
+            cause = fmt::format("{} vs. {}", wal_cmd->CompactInfo(), cmd.CompactInfo());
+            return true;
+        }
+    }
+    return false;
+}
+
+bool NewTxn::CheckConflictCmd(const WalCmdDropDatabaseV2 &cmd, NewTxn *previous_txn, String &cause, bool &retry_query) {
+    const String &db_name = cmd.db_name_;
+    const Vector<SharedPtr<WalCmd>> &wal_cmds = previous_txn->wal_entry_->cmds_;
+    for (const SharedPtr<WalCmd> &wal_cmd : wal_cmds) {
+        bool conflict = false;
+        WalCommandType command_type = wal_cmd->GetType();
+        switch (command_type) {
             case WalCommandType::DROP_DATABASE_V2: {
                 auto *drop_db_cmd = static_cast<WalCmdDropDatabaseV2 *>(wal_cmd.get());
                 if (drop_db_cmd->db_name_ == db_name) {

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -600,6 +600,7 @@ private:
     // Check transaction conflicts
     bool CheckConflictCmd(const WalCmd &cmd, NewTxn *previous_txn, String &cause, bool &retry_query);
     bool CheckConflictCmd(const WalCmdCreateDatabaseV2 &cmd, NewTxn *previous_txn, String &cause, bool &retry_query);
+    bool CheckConflictCmd(const WalCmdDropDatabaseV2 &cmd, NewTxn *previous_txn, String &cause, bool &retry_query);
     bool CheckConflictCmd(const WalCmdCreateTableV2 &cmd, NewTxn *previous_txn, String &cause, bool &retry_query);
     bool CheckConflictCmd(const WalCmdAppendV2 &cmd, NewTxn *previous_txn, String &cause, bool &retry_query);
     bool CheckConflictCmd(const WalCmdImportV2 &cmd, NewTxn *previous_txn, String &cause, bool &retry_query);

--- a/src/storage/new_txn/new_txn_manager.cppm
+++ b/src/storage/new_txn/new_txn_manager.cppm
@@ -117,6 +117,8 @@ public:
     void CommitBottom(NewTxn *txn);
 
 private:
+    void UpdateCatalogCache(NewTxn *txn);
+
     void CleanupTxn(NewTxn *txn, bool commit);
 
 public:
@@ -144,6 +146,7 @@ public:
     void SetSystemCache();
 
 private:
+    mutable std::mutex locker1_;
     mutable std::mutex locker_{};
     Storage *storage_{};
     BufferManager *buffer_mgr_{};
@@ -175,6 +178,7 @@ private:
     Atomic<u64> total_rollbacked_txn_count_{0};
 
     SharedPtr<SystemCache> system_cache_{};
+
 private:
     // Also protected by locker_, to contain append / import / create index / dump mem index txn.
     Map<TxnTimeStamp, SharedPtr<TxnAllocatorTask>> allocator_map_{};

--- a/src/unit_test/storage/new_catalog/index.cpp
+++ b/src/unit_test/storage/new_catalog/index.cpp
@@ -943,10 +943,10 @@ TEST_P(TestTxnIndex, create_index_create_index) {
 
     {
         // create index and create index
-        //  t1            create index   commit (success)
+        //  t3            create index   commit (success)
         //  |--------------|---------------|
-        //                         |------------------|------------------|
-        //                        t2                create index      commit (fail)
+        //                         |------------------|
+        //                        t4                create index (fail)
         auto *txn1 = new_txn_mgr->BeginTxn(MakeUnique<String>("create db"), TransactionType::kNormal);
         Status status = txn1->CreateDatabase(*db_name, ConflictType::kError, MakeShared<String>());
         EXPECT_TRUE(status.ok());
@@ -974,8 +974,6 @@ TEST_P(TestTxnIndex, create_index_create_index) {
 
         // create index idx1
         status = txn4->CreateIndex(*db_name, *table_name, index_def1, ConflictType::kError);
-        EXPECT_TRUE(status.ok());
-        status = new_txn_mgr->CommitTxn(txn4);
         EXPECT_FALSE(status.ok());
 
         // drop index
@@ -1004,8 +1002,8 @@ TEST_P(TestTxnIndex, create_index_create_index) {
         // create index and create index
         //  t1            create index   commit (success)
         //  |--------------|---------------|
-        //         |------------------|------------------|
-        //        t2                create index      commit (fail)
+        //         |------------------|
+        //        t2                create index (fail)
         auto *txn1 = new_txn_mgr->BeginTxn(MakeUnique<String>("create db"), TransactionType::kNormal);
         Status status = txn1->CreateDatabase(*db_name, ConflictType::kError, MakeShared<String>());
         EXPECT_TRUE(status.ok());
@@ -1030,15 +1028,10 @@ TEST_P(TestTxnIndex, create_index_create_index) {
         EXPECT_TRUE(status.ok());
 
         status = txn4->CreateIndex(*db_name, *table_name, index_def1, ConflictType::kError);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn3);
         EXPECT_TRUE(status.ok());
-
-        // create index idx1
-
-        status = new_txn_mgr->CommitTxn(txn4);
-        EXPECT_FALSE(status.ok());
 
         // drop index
         auto *txn6 = new_txn_mgr->BeginTxn(MakeUnique<String>("drop index"), TransactionType::kNormal);
@@ -1064,10 +1057,10 @@ TEST_P(TestTxnIndex, create_index_create_index) {
 
     {
         // create index and create index
-        //  t1            create index               commit (fail)
-        //  |--------------|--------------------------------|
-        //         |------------------|------------------|
-        //        t2                create index      commit (success)
+        //  t1         create index           commit (success)
+        //  |--------------|-------------------------|
+        //         |------------------|
+        //        t2            create index (fail)
         auto *txn1 = new_txn_mgr->BeginTxn(MakeUnique<String>("create db"), TransactionType::kNormal);
         Status status = txn1->CreateDatabase(*db_name, ConflictType::kError, MakeShared<String>());
         EXPECT_TRUE(status.ok());
@@ -1092,13 +1085,10 @@ TEST_P(TestTxnIndex, create_index_create_index) {
         EXPECT_TRUE(status.ok());
 
         status = txn4->CreateIndex(*db_name, *table_name, index_def1, ConflictType::kError);
-        EXPECT_TRUE(status.ok());
-
-        status = new_txn_mgr->CommitTxn(txn4);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn3);
-        EXPECT_FALSE(status.ok());
+        EXPECT_TRUE(status.ok());
 
         // drop index
         auto *txn6 = new_txn_mgr->BeginTxn(MakeUnique<String>("drop index"), TransactionType::kNormal);

--- a/src/unit_test/storage/new_catalog/new_txn_mgr.cpp
+++ b/src/unit_test/storage/new_catalog/new_txn_mgr.cpp
@@ -154,31 +154,31 @@ TEST_F(TestTxnManagerTest, test_parallel_ts) {
                 {
                     auto *txn = new_txn_mgr->BeginTxn(MakeUnique<String>("create db"), TransactionType::kNormal);
                     TransactionID txn_id = txn->TxnID();
-                    LOG_INFO(fmt::format("{} {} CreateDatabase", thread_i, txn_id));
+                    LOG_INFO(fmt::format("Thread: {}, txn_id: {} CreateDatabase", thread_i, txn_id));
                     status = txn->CreateDatabase(*db_name, ConflictType::kError, MakeShared<String>());
                     if (status.ok()) {
                         status = new_txn_mgr->CommitTxn(txn);
                         if (!status.ok()) {
-                            LOG_WARN(fmt::format("Thread: {}, loop: {}, CreateDatabase CommitTxn failed: {}", thread_i, txn_id, status.message()));
+                            LOG_WARN(fmt::format("Thread: {}, txn_id: {}, CreateDatabase CommitTxn failed: {}", thread_i, txn_id, status.message()));
                         } else {
-                            LOG_INFO(fmt::format("Thread: {}, loop: {}, CreateDatabase CommitTxn success", thread_i, txn_id));
+                            LOG_INFO(fmt::format("Thread: {}, txn_id: {}, CreateDatabase CommitTxn success", thread_i, txn_id));
                         }
                     } else {
-                        LOG_WARN(fmt::format("Thread: {}, loop: {}, CreateDatabase failed: {}", thread_i, txn_id, status.message()));
+                        LOG_WARN(fmt::format("Thread: {}, txn_id: {}, CreateDatabase failed: {}", thread_i, txn_id, status.message()));
                         status = new_txn_mgr->RollBackTxn(txn);
                     }
                 }
                 {
                     auto *txn = new_txn_mgr->BeginTxn(MakeUnique<String>("drop"), TransactionType::kNormal);
                     TransactionID txn_id = txn->TxnID();
-                    LOG_INFO(fmt::format("{} {} DropDatabase", thread_i, txn->TxnID()));
+                    LOG_INFO(fmt::format("Thread: {}, txn_id: {} DropDatabase", thread_i, txn->TxnID()));
                     status = txn->DropDatabase(*db_name, ConflictType::kError);
                     if (status.ok()) {
                         status = new_txn_mgr->CommitTxn(txn);
                         if (!status.ok()) {
-                            LOG_WARN(fmt::format("Thread: {}, loop: {}, DropDatabase CommitTxn failed: {}", thread_i, txn_id, status.message()));
+                            LOG_WARN(fmt::format("Thread: {}, txn_id: {}, DropDatabase CommitTxn failed: {}", thread_i, txn_id, status.message()));
                         } else {
-                            LOG_INFO(fmt::format("Thread: {}, loop: {}, DropDatabase CommitTxn success", thread_i, txn_id));
+                            LOG_INFO(fmt::format("Thread: {}, txn_id: {}, DropDatabase CommitTxn success", thread_i, txn_id));
                         }
                     } else {
                         LOG_ERROR(fmt::format("Thread: {}, DropDatabase failed: {}", thread_i, status.message()));

--- a/src/unit_test/storage/txn/database_txn.cpp
+++ b/src/unit_test/storage/txn/database_txn.cpp
@@ -180,6 +180,7 @@ TEST_P(DBTxnTest, test2) {
 //           |            |               |                   |                      |           |
 //       TXN1 Begin       |      TXN1 Create db1              |                  TXN1 Commit     |
 //                    TXN2 Begin                    TXN2 Create db1(WW-Conflict)            TXN2 Commit
+// The diagram above may be outdated.
 TEST_P(DBTxnTest, test3) {
     using namespace infinity;
     NewTxnManager *txn_mgr = infinity::InfinityContext::instance().storage()->new_txn_manager();
@@ -205,6 +206,7 @@ TEST_P(DBTxnTest, test3) {
 //           |            |               |                   |                      |           |
 //       TXN2 Begin       |      TXN2 Create db1              |                      |      TXN2 Commit
 //                    TXN1 Begin                    TXN1 Create db1(WW-Conflict)  TXN1 Commit
+// The diagram above may be outdated.
 TEST_P(DBTxnTest, test4) {
     using namespace infinity;
     NewTxnManager *txn_mgr = infinity::InfinityContext::instance().storage()->new_txn_manager();
@@ -223,11 +225,7 @@ TEST_P(DBTxnTest, test4) {
 
     // Txn2: Create db1, NOT OK
     status = new_txn2->CreateDatabase("db1", ConflictType::kError, MakeShared<String>());
-    EXPECT_TRUE(status.ok());
-
-    // Txn2: Commit, OK
-    status = txn_mgr->CommitTxn(new_txn2);
-    EXPECT_TRUE(!status.ok());
+    EXPECT_FALSE(status.ok());
 }
 
 TEST_P(DBTxnTest, test5) {
@@ -299,6 +297,7 @@ TEST_P(DBTxnTest, test6) {
 //           |            |               |                   |                      |           |       |         |
 //       TXN1 Begin       |      TXN1 Create db1              |                  TXN1 Drop db1   |   TXN1 Commit   |
 //                    TXN2 Begin                    TXN2 Create db1(WW-Conflict)         TXN2 Create db1 OK  TXN2 Commit
+// The diagram above may be outdated.
 TEST_P(DBTxnTest, test7) {
     using namespace infinity;
     NewTxnManager *txn_mgr = infinity::InfinityContext::instance().storage()->new_txn_manager();
@@ -315,13 +314,10 @@ TEST_P(DBTxnTest, test7) {
 
     // Txn2: Create db1, OK
     status = new_txn2->CreateDatabase("db1", ConflictType::kError, MakeShared<String>());
-    EXPECT_TRUE(status.ok());
+    EXPECT_FALSE(status.ok());
 
     // Txn1: Commit, OK
-    txn_mgr->RollBackTxn(new_txn1);
-
-    // Txn2: Commit, OK
-    txn_mgr->CommitTxn(new_txn2);
+    txn_mgr->CommitTxn(new_txn1);
 
     // Txn3: Create, OK
     NewTxn *new_txn3 = txn_mgr->BeginTxn(MakeUnique<String>("get db1"), TransactionType::kRead);


### PR DESCRIPTION
### What problem does this PR solve?
1. For each relevant txn, we calculate LatestID in incrLatestID using the kv_instance obtained during the txn's begin phase. This approach solved some known bugs. Howerver, it introduces some performance issue, such as the inability to create db, table, and index concurrently. A possible solution is to maintain an additional field for each Name to represent the entity name currently being created. When the names differ, concurrent creation will be allowed.
2. Other fixed have been made to accommodate the changes mentioned above.
3. Conflict detection ha been added for dropDB and dropDB.
4. The write-to-cache operation has been moved into commitBottom to avoid conflict.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
