### PR TITLE
Fix txn and commit timestamp error after restart

### DIFF
--- a/src/storage/catalog/kv_utility.cpp
+++ b/src/storage/catalog/kv_utility.cpp
@@ -75,7 +75,7 @@ Vector<SegmentID> GetTableIndexSegments(KVInstance *kv_instance,
             // the key is committed before the txn or the key isn't committed
             segment_ids.push_back(segment_id);
         } else {
-            LOG_DEBUG(fmt::format("Invalid segment id key: {}", iter->Key().ToString()));
+            LOG_DEBUG(fmt::format("Key: {} isn't segment id", iter->Key().ToString()));
         }
         iter->Next();
     }

--- a/src/storage/new_txn/new_txn.cpp
+++ b/src/storage/new_txn/new_txn.cpp
@@ -1238,6 +1238,7 @@ Status NewTxn::Commit() {
         TxnTimeStamp commit_ts = txn_mgr_->GetReadCommitTS(this);
         this->SetTxnCommitting(commit_ts);
         this->SetTxnCommitted();
+        LOG_TRACE(fmt::format("Commit READ txn: {}. begin ts: {}, Command: {}", txn_context_ptr_->txn_id_, BeginTS(), *GetTxnText()));
         return PostReadTxnCommit();
     }
 
@@ -1254,7 +1255,11 @@ Status NewTxn::Commit() {
     } else {
         commit_ts = txn_mgr_->GetWriteCommitTS(shared_from_this());
     }
-    LOG_TRACE(fmt::format("NewTxn: {} is committing, begin_ts:{} committing ts: {}", txn_context_ptr_->txn_id_, BeginTS(), commit_ts));
+    LOG_TRACE(fmt::format("Committing WRITE txn: {}, begin_ts:{} committing ts: {}, Command: {}",
+                          txn_context_ptr_->txn_id_,
+                          BeginTS(),
+                          commit_ts,
+                          *GetTxnText()));
 
     this->SetTxnCommitting(commit_ts);
 

--- a/src/storage/new_txn/new_txn_manager.cpp
+++ b/src/storage/new_txn/new_txn_manager.cpp
@@ -148,9 +148,9 @@ SharedPtr<NewTxn> NewTxnManager::BeginTxnShared(UniquePtr<String> txn_text, Tran
     }
 
     if (txn_text == nullptr) {
-        LOG_DEBUG(fmt::format("NewTxn: {} is Begin. begin ts: {}, No command text", new_txn_id, begin_ts));
+        LOG_DEBUG(fmt::format("Begin new txn: {}, begin ts: {}, No command text", new_txn_id, begin_ts));
     } else {
-        LOG_DEBUG(fmt::format("NewTxn: {} is Begin. begin ts: {}, Command: {}", new_txn_id, begin_ts, *txn_text));
+        LOG_DEBUG(fmt::format("Begin new txn: {}. begin ts: {}, Command: {}", new_txn_id, begin_ts, *txn_text));
     }
 
     // Create txn instance

--- a/src/storage/new_txn/new_txn_manager.cpp
+++ b/src/storage/new_txn/new_txn_manager.cpp
@@ -120,8 +120,6 @@ void NewTxnManager::Stop() {
     LOG_INFO("NewTxn manager is stopped");
 }
 
-bool NewTxnManager::Stopped() { return !is_running_.load(); }
-
 SharedPtr<NewTxn> NewTxnManager::BeginTxnShared(UniquePtr<String> txn_text, TransactionType txn_type) {
     // Check if the is_running_ is true
     if (is_running_.load() == false) {
@@ -129,12 +127,10 @@ SharedPtr<NewTxn> NewTxnManager::BeginTxnShared(UniquePtr<String> txn_text, Tran
         UnrecoverableError(error_message);
     }
 
-    Catalog *catalog_ptr = InfinityContext::instance().storage()->catalog();
-
     std::lock_guard guard(locker_);
 
     // Assign a new txn id
-    u64 new_txn_id = ++catalog_ptr->next_txn_id_;
+    u64 new_txn_id = ++current_transaction_id_;
 
     // Record the start ts of the txn
     TxnTimeStamp begin_ts = current_ts_ + 1;
@@ -389,8 +385,14 @@ Vector<SharedPtr<TxnContext>> NewTxnManager::GetTxnContextHistories() const {
 }
 
 void NewTxnManager::SetNewSystemTS(TxnTimeStamp new_system_ts) {
+    std::lock_guard guard(locker_);
     current_ts_ = new_system_ts;
     prepare_commit_ts_ = new_system_ts;
+}
+
+void NewTxnManager::SetCurrentTransactionID(TransactionID current_transaction_id) {
+    std::lock_guard guard(locker_);
+    current_transaction_id_ = current_transaction_id;
 }
 
 TxnTimeStamp NewTxnManager::GetCleanupScanTS1() {

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -284,13 +284,10 @@ Status Storage::AdminToWriter() {
     // Replay wal
     if (config_ptr_->ReplayWal() && !replay_entries.empty()) {
         auto [wal_max_txn_id, wal_system_start_ts] = wal_mgr_->ReplayWalEntries(replay_entries);
-        if (wal_max_txn_id < max_txn_id) {
-            UnrecoverableError("Wal max txn id is less than max txn id");
-        }
         if (wal_system_start_ts < system_start_ts) {
             UnrecoverableError("Wal system start ts is less than system start ts");
         }
-        max_txn_id = wal_max_txn_id;
+        max_txn_id = std::max(max_txn_id, wal_max_txn_id);
         system_start_ts = wal_system_start_ts;
     }
 

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -282,7 +282,7 @@ Status Storage::AdminToWriter() {
     wal_mgr_->Start();
 
     // Replay wal
-    if (config_ptr_->ReplayWal()) {
+    if (config_ptr_->ReplayWal() && !replay_entries.empty()) {
         auto [wal_max_txn_id, wal_system_start_ts] = wal_mgr_->ReplayWalEntries(replay_entries);
         if (wal_max_txn_id < max_txn_id) {
             UnrecoverableError("Wal max txn id is less than max txn id");

--- a/src/storage/wal/wal_manager.cpp
+++ b/src/storage/wal/wal_manager.cpp
@@ -1144,7 +1144,7 @@ Tuple<TransactionID, TxnTimeStamp, TxnTimeStamp> WalManager::GetReplayEntries(St
                 String error_message = "Found unexpected bad wal entry";
                 UnrecoverableError(error_message);
             }
-            // LOG_TRACE(wal_entry->ToString());
+            LOG_TRACE(wal_entry->ToString());
 
             WalCmdCheckpointV2 *checkpoint_cmd = nullptr;
             if (wal_entry->IsCheckPoint(checkpoint_cmd)) {
@@ -1172,6 +1172,8 @@ Tuple<TransactionID, TxnTimeStamp, TxnTimeStamp> WalManager::GetReplayEntries(St
             // LOG_TRACE(wal_entry->ToString());
 
             if (wal_entry->commit_ts_ > max_checkpoint_ts) {
+                LOG_TRACE(fmt::format("Found WAL entry, commit ts: {} > max checkpoint ts: {}", wal_entry->commit_ts_, max_checkpoint_ts));
+                LOG_TRACE(wal_entry->ToString());
                 replay_entries.push_back(wal_entry);
             } else {
                 break;
@@ -1195,7 +1197,7 @@ Tuple<TransactionID, TxnTimeStamp, TxnTimeStamp> WalManager::GetReplayEntries(St
             }
         }
     }
-    LOG_INFO(fmt::format("Checkpoint found, replay the catalog"));
+    LOG_INFO(fmt::format("Checkpoint found, replay the catalog, wal entry size: {}", replay_entries.size()));
     std::reverse(replay_entries.begin(), replay_entries.end());
 
     return {max_transaction_id, last_commit_ts, max_checkpoint_ts};

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -128,9 +128,9 @@ public:
 
     i64 ReplayWalFile(StorageMode targe_storage_mode);
 
-    Pair<TxnTimeStamp, TxnTimeStamp> GetReplayEntries(StorageMode targe_storage_mode, Vector<SharedPtr<WalEntry>> &replay_entries);
+    Tuple<TransactionID, TxnTimeStamp, TxnTimeStamp> GetReplayEntries(StorageMode targe_storage_mode, Vector<SharedPtr<WalEntry>> &replay_entries);
 
-    void ReplayWalEntries(const Vector<SharedPtr<WalEntry>> &replay_entries);
+    Tuple<TransactionID, TxnTimeStamp> ReplayWalEntries(const Vector<SharedPtr<WalEntry>> &replay_entries);
 
     Optional<Pair<FullCatalogFileInfo, Vector<DeltaCatalogFileInfo>>> GetCatalogFiles() const;
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Get latest txn id and commit timestamp from WAL entry.
2. Set the latest txn id and commit timestamp to transaction manager, when it starts.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
