### PR TITLE
Fix the database clean-up fails after checkpoint and restart

### DIFF
--- a/src/storage/catalog/meta/block_meta.cpp
+++ b/src/storage/catalog/meta/block_meta.cpp
@@ -113,14 +113,6 @@ Status BlockMeta::LoadSet(TxnTimeStamp checkpoint_ts) {
 }
 
 Status BlockMeta::RestoreSet() {
-    NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
-    {
-        String block_lock_key = GetBlockTag("lock");
-        Status status = new_catalog->AddBlockLock(std::move(block_lock_key), 0);
-        if (!status.ok()) {
-            return status;
-        }
-    }
     auto *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
     SharedPtr<String> block_dir_ptr = this->GetBlockDir();
     auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
@@ -141,13 +133,6 @@ Status BlockMeta::RestoreSet() {
 }
 
 Status BlockMeta::UninitSet(UsageFlag usage_flag) {
-    // {
-    //     String block_row_cnt_key = GetBlockTag("row_cnt");
-    //     Status status = kv_instance_.Delete(block_row_cnt_key);
-    //     if (!status.ok()) {
-    //         return status;
-    //     }
-    // }
     if (usage_flag == UsageFlag::kOther) {
         NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
         {

--- a/src/storage/catalog/meta/block_meta.cpp
+++ b/src/storage/catalog/meta/block_meta.cpp
@@ -129,7 +129,8 @@ Status BlockMeta::RestoreSet() {
                                                              BlockVersion::FileName(),
                                                              this->block_capacity(),
                                                              buffer_mgr->persistence_manager());
-    if (!buffer_mgr->GetBufferObject(version_file_worker->GetFilePath())) {
+    auto *buffer_obj = buffer_mgr->GetBufferObject(version_file_worker->GetFilePath());
+    if (buffer_obj == nullptr) {
         version_buffer_ = buffer_mgr->GetBufferObject(std::move(version_file_worker));
         if (!version_buffer_) {
             return Status::BufferManagerError(fmt::format("Get version buffer failed: {}", version_file_worker->GetFilePath()));

--- a/src/storage/catalog/meta/block_meta.cpp
+++ b/src/storage/catalog/meta/block_meta.cpp
@@ -112,12 +112,11 @@ Status BlockMeta::LoadSet(TxnTimeStamp checkpoint_ts) {
     return Status::OK();
 }
 
-Status BlockMeta::RestoreSet(TxnTimeStamp checkpoint_ts) {
-    checkpoint_ts = begin_ts_;
+Status BlockMeta::RestoreSet() {
     NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
     {
         String block_lock_key = GetBlockTag("lock");
-        Status status = new_catalog->AddBlockLock(std::move(block_lock_key), checkpoint_ts);
+        Status status = new_catalog->AddBlockLock(std::move(block_lock_key), 0);
         if (!status.ok()) {
             return status;
         }

--- a/src/storage/catalog/meta/block_meta.cppm
+++ b/src/storage/catalog/meta/block_meta.cppm
@@ -52,7 +52,7 @@ public:
 
     Status LoadSet(TxnTimeStamp checkpoint_ts);
 
-    Status RestoreSet(TxnTimeStamp checkpoint_ts);
+    Status RestoreSet();
 
     Status UninitSet(UsageFlag usage_flag);
 

--- a/src/storage/catalog/meta/block_meta.cppm
+++ b/src/storage/catalog/meta/block_meta.cppm
@@ -52,6 +52,8 @@ public:
 
     Status LoadSet(TxnTimeStamp checkpoint_ts);
 
+    Status RestoreSet(TxnTimeStamp checkpoint_ts);
+
     Status UninitSet(UsageFlag usage_flag);
 
     // Tuple<SizeT, Status> GetRowCnt();

--- a/src/storage/catalog/meta/chunk_index_meta.cpp
+++ b/src/storage/catalog/meta/chunk_index_meta.cpp
@@ -42,6 +42,7 @@ import persistence_manager;
 import persist_result_handler;
 import virtual_store;
 import logger;
+import file_worker;
 
 namespace infinity {
 
@@ -342,105 +343,87 @@ Status ChunkIndexMeta::RestoreSet() {
         return status;
     }
     SharedPtr<String> index_dir = table_index_meta.GetTableIndexDir();
-
+    UniquePtr<FileWorker> index_file_worker;
     switch (index_base->index_type_) {
         case IndexType::kSecondary: {
             auto secondary_index_file_name = MakeShared<String>(IndexFileName(segment_id, chunk_id_));
-            auto index_file_worker = MakeUnique<SecondaryIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                          MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                          index_dir,
-                                                                          std::move(secondary_index_file_name),
-                                                                          index_base,
-                                                                          column_def,
-                                                                          row_count,
-                                                                          buffer_mgr->persistence_manager());
-            if (!buffer_mgr->GetBufferObject(index_file_worker->GetFilePath())) {
-                index_buffer_ = buffer_mgr->GetBufferObject(std::move(index_file_worker));
-                index_buffer_->AddObjRc();
-            }
+            index_file_worker = MakeUnique<SecondaryIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                                     MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                                     index_dir,
+                                                                     std::move(secondary_index_file_name),
+                                                                     index_base,
+                                                                     column_def,
+                                                                     row_count,
+                                                                     buffer_mgr->persistence_manager());
             break;
         }
         case IndexType::kFullText: {
             auto column_length_file_name = MakeShared<String>(base_name + LENGTH_SUFFIX);
-            auto index_file_worker = MakeUnique<RawFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                               MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                               index_dir,
-                                                               std::move(column_length_file_name),
-                                                               row_count * sizeof(u32),
-                                                               buffer_mgr->persistence_manager());
-            if (!buffer_mgr->GetBufferObject(index_file_worker->GetFilePath())) {
-                index_buffer_ = buffer_mgr->GetBufferObject(std::move(index_file_worker));
-                index_buffer_->AddObjRc();
-            }
+            index_file_worker = MakeUnique<RawFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                          MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                          index_dir,
+                                                          std::move(column_length_file_name),
+                                                          row_count * sizeof(u32),
+                                                          buffer_mgr->persistence_manager());
             break;
         }
         case IndexType::kIVF: {
             auto ivf_index_file_name = MakeShared<String>(IndexFileName(segment_id, chunk_id_));
-            auto index_file_worker = MakeUnique<IVFIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                    MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                    index_dir,
-                                                                    std::move(ivf_index_file_name),
-                                                                    index_base,
-                                                                    column_def,
-                                                                    buffer_mgr->persistence_manager());
-            if (!buffer_mgr->GetBufferObject(index_file_worker->GetFilePath())) {
-                index_buffer_ = buffer_mgr->GetBufferObject(std::move(index_file_worker));
-                index_buffer_->AddObjRc();
-            }
+            index_file_worker = MakeUnique<IVFIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                               MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                               index_dir,
+                                                               std::move(ivf_index_file_name),
+                                                               index_base,
+                                                               column_def,
+                                                               buffer_mgr->persistence_manager());
             break;
         }
         case IndexType::kHnsw: {
             auto hnsw_index_file_name = MakeShared<String>(IndexFileName(segment_id, chunk_id_));
-            auto index_file_worker = MakeUnique<HnswFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                index_dir,
-                                                                std::move(hnsw_index_file_name),
-                                                                index_base,
-                                                                column_def,
-                                                                buffer_mgr->persistence_manager(),
-                                                                index_size);
-            if (!buffer_mgr->GetBufferObject(index_file_worker->GetFilePath())) {
-                index_buffer_ = buffer_mgr->GetBufferObject(std::move(index_file_worker));
-                index_buffer_->AddObjRc();
-            }
+            index_file_worker = MakeUnique<HnswFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                           MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                           index_dir,
+                                                           std::move(hnsw_index_file_name),
+                                                           index_base,
+                                                           column_def,
+                                                           buffer_mgr->persistence_manager(),
+                                                           index_size);
             break;
         }
         case IndexType::kBMP: {
             auto bmp_index_file_name = MakeShared<String>(IndexFileName(segment_id, chunk_id_));
-            auto file_worker = MakeUnique<BMPIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                              index_dir,
-                                                              std::move(bmp_index_file_name),
-                                                              index_base,
-                                                              column_def,
-                                                              buffer_mgr->persistence_manager(),
-                                                              index_size);
-            if (!buffer_mgr->GetBufferObject(file_worker->GetFilePath())) {
-                index_buffer_ = buffer_mgr->GetBufferObject(std::move(file_worker));
-                index_buffer_->AddObjRc();
-            }
+            index_file_worker = MakeUnique<BMPIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                               MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                               index_dir,
+                                                               std::move(bmp_index_file_name),
+                                                               index_base,
+                                                               column_def,
+                                                               buffer_mgr->persistence_manager(),
+                                                               index_size);
             break;
         }
         case IndexType::kEMVB: {
             auto emvb_index_file_name = MakeShared<String>(IndexFileName(segment_id, chunk_id_));
             const auto segment_start_offset = base_row_id.segment_offset_;
-            auto file_worker = MakeUnique<EMVBIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                               MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                               index_dir,
-                                                               std::move(emvb_index_file_name),
-                                                               index_base,
-                                                               column_def,
-                                                               segment_start_offset,
-                                                               buffer_mgr->persistence_manager());
-            if (!buffer_mgr->GetBufferObject(file_worker->GetFilePath())) {
-                index_buffer_ = buffer_mgr->GetBufferObject(std::move(file_worker));
-                index_buffer_->AddObjRc();
-            }
+            index_file_worker = MakeUnique<EMVBIndexFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                                MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                                index_dir,
+                                                                std::move(emvb_index_file_name),
+                                                                index_base,
+                                                                column_def,
+                                                                segment_start_offset,
+                                                                buffer_mgr->persistence_manager());
+
             break;
         }
         default: {
             UnrecoverableError("Not implemented yet");
         }
+    }
+    auto *buffer_obj = buffer_mgr->GetBufferObject(index_file_worker->GetFilePath());
+    if (buffer_obj == nullptr) {
+        index_buffer_ = buffer_mgr->GetBufferObject(std::move(index_file_worker));
+        index_buffer_->AddObjRc();
     }
     if (index_buffer_ == nullptr) {
         return Status::BufferManagerError("GetBufferObject failed");

--- a/src/storage/catalog/meta/chunk_index_meta.cppm
+++ b/src/storage/catalog/meta/chunk_index_meta.cppm
@@ -64,6 +64,8 @@ public:
 
     Status LoadSet();
 
+    Status RestoreSet();
+
     Status UninitSet(UsageFlag usage_flag);
 
     Status SetChunkInfo(const ChunkIndexMetaInfo &chunk_info);

--- a/src/storage/catalog/meta/column_meta.cpp
+++ b/src/storage/catalog/meta/column_meta.cpp
@@ -184,7 +184,8 @@ Status ColumnMeta::RestoreSet(const ColumnDef *column_def) {
                                                       filename,
                                                       total_data_size,
                                                       buffer_mgr->persistence_manager());
-        if (!buffer_mgr->GetBufferObject(file_worker->GetFilePath())) {
+        auto *buffer_obj = buffer_mgr->GetBufferObject(file_worker->GetFilePath());
+        if (buffer_obj == nullptr) {
             column_buffer_ = buffer_mgr->GetBufferObject(std::move(file_worker));
             if (!column_buffer_) {
                 return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", file_worker->GetFilePath()));
@@ -208,7 +209,8 @@ Status ColumnMeta::RestoreSet(const ColumnDef *column_def) {
                                                              filename,
                                                              chunk_offset,
                                                              buffer_mgr->persistence_manager());
-        if (!buffer_mgr->GetBufferObject(outline_file_worker->GetFilePath())) {
+        auto *buffer_obj = buffer_mgr->GetBufferObject(outline_file_worker->GetFilePath());
+        if (buffer_obj == nullptr) {
             outline_buffer_ = buffer_mgr->GetBufferObject(std::move(outline_file_worker));
             if (!outline_buffer_) {
                 return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", outline_file_worker->GetFilePath()));

--- a/src/storage/catalog/meta/column_meta.cpp
+++ b/src/storage/catalog/meta/column_meta.cpp
@@ -167,14 +167,6 @@ Status ColumnMeta::LoadSet() {
 
 Status ColumnMeta::RestoreSet(const ColumnDef *column_def) {
     Status status;
-    if (!column_def) {
-        SharedPtr<Vector<SharedPtr<ColumnDef>>> column_defs_ptr;
-        std::tie(column_defs_ptr, status) = block_meta_.segment_meta().table_meta().GetColumnDefs();
-        if (!status.ok()) {
-            return status;
-        }
-        column_def = (*column_defs_ptr)[column_idx_].get();
-    }
 
     auto *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
     SharedPtr<String> block_dir_ptr = block_meta_.GetBlockDir();

--- a/src/storage/catalog/meta/column_meta.cppm
+++ b/src/storage/catalog/meta/column_meta.cppm
@@ -55,6 +55,8 @@ public:
 
     Status LoadSet();
 
+    Status RestoreSet(const ColumnDef *column_def);
+
     Status UninitSet(const ColumnDef *column_def, UsageFlag usage_flag);
 
     Status GetColumnBuffer(BufferObj *&column_buffer, BufferObj *&outline_buffer);

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -1432,18 +1432,20 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
             SharedPtr<String> block_dir_ptr =
                 MakeShared<String>(fmt::format("db_{}/tbl_{}/seg_{}/blk_{}", meta_infos[0], meta_infos[1], meta_infos[2], meta_infos[3]));
             BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-            {
-                auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                         MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                         block_dir_ptr,
-                                                                         BlockVersion::FileName(),
-                                                                         DEFAULT_BLOCK_CAPACITY,
-                                                                         buffer_mgr->persistence_manager());
-                auto version_buffer = buffer_mgr->AllocateBufferObject(std::move(version_file_worker));
-                // if (!version_buffer) {
-                //     return Status::BufferManagerError(fmt::format("Get version buffer failed: {}", version_file_worker->GetFilePath()));
-                // }
-                version_buffer->AddObjRc();
+            if (buffer_mgr->GetBufferObject(*block_dir_ptr)) {
+                {
+                    auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                                             MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                                             block_dir_ptr,
+                                                                             BlockVersion::FileName(),
+                                                                             DEFAULT_BLOCK_CAPACITY,
+                                                                             buffer_mgr->persistence_manager());
+                    auto version_buffer = buffer_mgr->AllocateBufferObject(std::move(version_file_worker));
+                    // if (!version_buffer) {
+                    //     return Status::BufferManagerError(fmt::format("Get version buffer failed: {}", version_file_worker->GetFilePath()));
+                    // }
+                    version_buffer->AddObjRc();
+                }
             }
 
             metas.emplace_back(
@@ -1464,40 +1466,42 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
             SharedPtr<String> block_dir_ptr =
                 MakeShared<String>(fmt::format("db_{}/tbl_{}/seg_{}/blk_{}", meta_infos[0], meta_infos[1], meta_infos[2], meta_infos[3]));
             BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-            {
-                auto filename = MakeShared<String>(fmt::format("{}.col", column_id));
-                SizeT total_data_size = 0;
-                if (col_def->type()->type() == LogicalType::kBoolean) {
-                    total_data_size = (DEFAULT_BLOCK_CAPACITY + 7) / 8;
-                } else {
-                    total_data_size = DEFAULT_BLOCK_CAPACITY * col_def->type()->Size();
+            if (buffer_mgr->GetBufferObject(*block_dir_ptr)) {
+                {
+                    auto filename = MakeShared<String>(fmt::format("{}.col", column_id));
+                    SizeT total_data_size = 0;
+                    if (col_def->type()->type() == LogicalType::kBoolean) {
+                        total_data_size = (DEFAULT_BLOCK_CAPACITY + 7) / 8;
+                    } else {
+                        total_data_size = DEFAULT_BLOCK_CAPACITY * col_def->type()->Size();
+                    }
+                    auto file_worker = MakeUnique<DataFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                                  MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                                  block_dir_ptr,
+                                                                  filename,
+                                                                  total_data_size,
+                                                                  buffer_mgr->persistence_manager());
+                    auto column_buffer = buffer_mgr->AllocateBufferObject(std::move(file_worker));
+                    // if (!column_buffer) {
+                    //     return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", file_worker->GetFilePath()));
+                    // }
+                    column_buffer->AddObjRc();
                 }
-                auto file_worker = MakeUnique<DataFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                              block_dir_ptr,
-                                                              filename,
-                                                              total_data_size,
-                                                              buffer_mgr->persistence_manager());
-                auto column_buffer = buffer_mgr->AllocateBufferObject(std::move(file_worker));
-                // if (!column_buffer) {
-                //     return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", file_worker->GetFilePath()));
-                // }
-                column_buffer->AddObjRc();
-            }
-            VectorBufferType buffer_type = ColumnVector::GetVectorBufferType(*col_def->type());
-            if (buffer_type == VectorBufferType::kVarBuffer) {
-                auto filename = MakeShared<String>(fmt::format("col_{}_out_0", column_id));
-                auto outline_file_worker = MakeUnique<VarFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                     MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                     block_dir_ptr,
-                                                                     filename,
-                                                                     0, /*buffer_size*/
-                                                                     buffer_mgr->persistence_manager());
-                auto outline_buffer = buffer_mgr->AllocateBufferObject(std::move(outline_file_worker));
-                // if (!outline_buffer) {
-                //     return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", outline_file_worker->GetFilePath()));
-                // }
-                outline_buffer->AddObjRc();
+                VectorBufferType buffer_type = ColumnVector::GetVectorBufferType(*col_def->type());
+                if (buffer_type == VectorBufferType::kVarBuffer) {
+                    auto filename = MakeShared<String>(fmt::format("col_{}_out_0", column_id));
+                    auto outline_file_worker = MakeUnique<VarFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+                                                                         MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+                                                                         block_dir_ptr,
+                                                                         filename,
+                                                                         0, /*buffer_size*/
+                                                                         buffer_mgr->persistence_manager());
+                    auto outline_buffer = buffer_mgr->AllocateBufferObject(std::move(outline_file_worker));
+                    // if (!outline_buffer) {
+                    //     return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", outline_file_worker->GetFilePath()));
+                    // }
+                    outline_buffer->AddObjRc();
+                }
             }
 
             metas.emplace_back(MakeUnique<ColumnMetaKey>(std::move(meta_infos[0]),

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -74,20 +74,6 @@ import segment_index_entry;
 import chunk_index_entry;
 import table_index_meta;
 import meta_type;
-import version_file_worker;
-import block_version;
-import data_file_worker;
-import var_file_worker;
-import vector_buffer;
-import logical_type;
-import chunk_index_entry;
-import secondary_index_file_worker;
-import raw_file_worker;
-import ivf_index_file_worker;
-import hnsw_file_worker;
-import bmp_index_file_worker;
-import emvb_index_file_worker;
-import index_defines;
 
 namespace infinity {
 
@@ -1160,8 +1146,8 @@ Status NewCatalog::DropMemIndexByMemIndexKey(const String &mem_index_key) {
         delete_success = mem_index_map_.erase(mem_index_key) > 0;
     }
     if (!delete_success) {
+        LOG_INFO(fmt::format("MemIndex key: {} not found", mem_index_key));
         return Status::OK();
-        // return Status::CatalogError(fmt::format("MemIndex key: {} not found", mem_index_key));
     }
     return Status::OK();
 }

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -1432,7 +1432,7 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
             SharedPtr<String> block_dir_ptr =
                 MakeShared<String>(fmt::format("db_{}/tbl_{}/seg_{}/blk_{}", meta_infos[0], meta_infos[1], meta_infos[2], meta_infos[3]));
             BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-            if (buffer_mgr->GetBufferObject(*block_dir_ptr)) {
+            if (!buffer_mgr->GetBufferObject(fmt::format("/var/infinity/data/{}", *block_dir_ptr))) {
                 {
                     auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
                                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
@@ -1466,7 +1466,10 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
             SharedPtr<String> block_dir_ptr =
                 MakeShared<String>(fmt::format("db_{}/tbl_{}/seg_{}/blk_{}", meta_infos[0], meta_infos[1], meta_infos[2], meta_infos[3]));
             BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-            if (buffer_mgr->GetBufferObject(*block_dir_ptr)) {
+
+            SharedPtr<String> full_path_ptr =
+    MakeShared<String>(fmt::format("{}/{}.col", *block_dir_ptr, column_id));
+            if (!buffer_mgr->GetBufferObject(fmt::format("/var/infinity/data/{}", *full_path_ptr))) {
                 {
                     auto filename = MakeShared<String>(fmt::format("{}.col", column_id));
                     SizeT total_data_size = 0;

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -80,6 +80,14 @@ import data_file_worker;
 import var_file_worker;
 import vector_buffer;
 import logical_type;
+import chunk_index_entry;
+import secondary_index_file_worker;
+import raw_file_worker;
+import ivf_index_file_worker;
+import hnsw_file_worker;
+import bmp_index_file_worker;
+import emvb_index_file_worker;
+import index_defines;
 
 namespace infinity {
 
@@ -1429,83 +1437,29 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
         } else if (type_str == "seg") {
             metas.emplace_back(MakeUnique<SegmentMetaKey>(std::move(meta_infos[0]), std::move(meta_infos[1]), std::stoull(meta_infos[2])));
         } else if (type_str == "blk") {
-            SharedPtr<String> block_dir_ptr =
-                MakeShared<String>(fmt::format("db_{}/tbl_{}/seg_{}/blk_{}", meta_infos[0], meta_infos[1], meta_infos[2], meta_infos[3]));
-            BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-            if (!buffer_mgr->GetBufferObject(fmt::format("/var/infinity/data/{}", *block_dir_ptr))) {
-                {
-                    auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                             MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                             block_dir_ptr,
-                                                                             BlockVersion::FileName(),
-                                                                             DEFAULT_BLOCK_CAPACITY,
-                                                                             buffer_mgr->persistence_manager());
-                    auto version_buffer = buffer_mgr->AllocateBufferObject(std::move(version_file_worker));
-                    // if (!version_buffer) {
-                    //     return Status::BufferManagerError(fmt::format("Get version buffer failed: {}", version_file_worker->GetFilePath()));
-                    // }
-                    version_buffer->AddObjRc();
-                }
-            }
+            SegmentID segment_id = std::stoull(meta_infos[2]);
+            BlockID block_id = std::stoull(meta_infos[3]);
+
+            TableMeeta table_meta{meta_infos[0], meta_infos[1], *kv_instance, 0};
+            SegmentMeta segment_meta{segment_id, table_meta};
+            BlockMeta block_meta{block_id, segment_meta};
+            block_meta.LoadSet();
 
             metas.emplace_back(
                 MakeUnique<BlockMetaKey>(std::move(meta_infos[0]), std::move(meta_infos[1]), std::stoull(meta_infos[2]), std::stoull(meta_infos[3])));
         } else if (type_str == "blk_col") {
+            SegmentID segment_id = std::stoull(meta_infos[2]);
+            BlockID block_id = std::stoull(meta_infos[3]);
+
             SharedPtr<ColumnDef> col_def = ColumnDef::FromJson(nlohmann::json::parse(std::move(meta_infos[4])));
-            // Status status;
-            // {
-            //     SharedPtr<Vector<SharedPtr<ColumnDef>>> column_defs_ptr;
-            //     std::tie(column_defs_ptr, status) = block_meta_.segment_meta().table_meta().GetColumnDefs();
-            //     if (!status.ok()) {
-            //         return status;
-            //     }
-            //     col_def = (*column_defs_ptr)[column_idx_];
-            // }
             ColumnID column_id = col_def->id();
 
-            SharedPtr<String> block_dir_ptr =
-                MakeShared<String>(fmt::format("db_{}/tbl_{}/seg_{}/blk_{}", meta_infos[0], meta_infos[1], meta_infos[2], meta_infos[3]));
-            BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
+            TableMeeta table_meta{meta_infos[0], meta_infos[1], *kv_instance, 0};
+            SegmentMeta segment_meta{segment_id, table_meta};
+            BlockMeta block_meta{block_id, segment_meta};
+            ColumnMeta column_meta{column_id, block_meta};
 
-            SharedPtr<String> full_path_ptr =
-    MakeShared<String>(fmt::format("{}/{}.col", *block_dir_ptr, column_id));
-            if (!buffer_mgr->GetBufferObject(fmt::format("/var/infinity/data/{}", *full_path_ptr))) {
-                {
-                    auto filename = MakeShared<String>(fmt::format("{}.col", column_id));
-                    SizeT total_data_size = 0;
-                    if (col_def->type()->type() == LogicalType::kBoolean) {
-                        total_data_size = (DEFAULT_BLOCK_CAPACITY + 7) / 8;
-                    } else {
-                        total_data_size = DEFAULT_BLOCK_CAPACITY * col_def->type()->Size();
-                    }
-                    auto file_worker = MakeUnique<DataFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                  MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                  block_dir_ptr,
-                                                                  filename,
-                                                                  total_data_size,
-                                                                  buffer_mgr->persistence_manager());
-                    auto column_buffer = buffer_mgr->AllocateBufferObject(std::move(file_worker));
-                    // if (!column_buffer) {
-                    //     return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", file_worker->GetFilePath()));
-                    // }
-                    column_buffer->AddObjRc();
-                }
-                VectorBufferType buffer_type = ColumnVector::GetVectorBufferType(*col_def->type());
-                if (buffer_type == VectorBufferType::kVarBuffer) {
-                    auto filename = MakeShared<String>(fmt::format("col_{}_out_0", column_id));
-                    auto outline_file_worker = MakeUnique<VarFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-                                                                         MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-                                                                         block_dir_ptr,
-                                                                         filename,
-                                                                         0, /*buffer_size*/
-                                                                         buffer_mgr->persistence_manager());
-                    auto outline_buffer = buffer_mgr->AllocateBufferObject(std::move(outline_file_worker));
-                    // if (!outline_buffer) {
-                    //     return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", outline_file_worker->GetFilePath()));
-                    // }
-                    outline_buffer->AddObjRc();
-                }
-            }
+            column_meta.LoadSet();
 
             metas.emplace_back(MakeUnique<ColumnMetaKey>(std::move(meta_infos[0]),
                                                          std::move(meta_infos[1]),
@@ -1523,6 +1477,16 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
                                                                std::move(meta_infos[2]),
                                                                std::stoull(meta_infos[3])));
         } else if (type_str == "idx_chunk") {
+            SegmentID segment_id = std::stoull(meta_infos[3]);
+            ChunkID chunk_id = std::stoull(meta_infos[4]);
+
+            TableMeeta table_meta{meta_infos[0], meta_infos[1], *kv_instance, 0};
+            TableIndexMeeta table_index_meta{meta_infos[2], table_meta};
+            SegmentIndexMeta segment_index_meta{segment_id, table_index_meta};
+            ChunkIndexMeta chunk_index_meta{chunk_id, segment_index_meta};
+
+            chunk_index_meta.LoadSet();
+
             metas.emplace_back(MakeUnique<ChunkIndexMetaKey>(std::move(meta_infos[0]),
                                                              std::move(meta_infos[1]),
                                                              std::move(meta_infos[2]),

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -1160,7 +1160,8 @@ Status NewCatalog::DropMemIndexByMemIndexKey(const String &mem_index_key) {
         delete_success = mem_index_map_.erase(mem_index_key) > 0;
     }
     if (!delete_success) {
-        return Status::CatalogError(fmt::format("MemIndex key: {} not found", mem_index_key));
+        return Status::OK();
+        // return Status::CatalogError(fmt::format("MemIndex key: {} not found", mem_index_key));
     }
     return Status::OK();
 }
@@ -1492,15 +1493,6 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
         if (!status.ok()) {
             UnrecoverableError(fmt::format("Remove clean meta failed. {}", *status.msg_));
         }
-
-        // // Restore buffer_manager
-        // const String &type_str = keys[1];
-        // if (type_str == "blk") {
-        //
-        // } else if (type_str == "blk_col") {
-        //
-        // } else if (type_str == "idx_chunk") {
-        // }
     }
 }
 

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -1437,30 +1437,9 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
         } else if (type_str == "seg") {
             metas.emplace_back(MakeUnique<SegmentMetaKey>(std::move(meta_infos[0]), std::move(meta_infos[1]), std::stoull(meta_infos[2])));
         } else if (type_str == "blk") {
-            SegmentID segment_id = std::stoull(meta_infos[2]);
-            BlockID block_id = std::stoull(meta_infos[3]);
-
-            TableMeeta table_meta{meta_infos[0], meta_infos[1], *kv_instance, 0};
-            SegmentMeta segment_meta{segment_id, table_meta};
-            BlockMeta block_meta{block_id, segment_meta};
-            block_meta.LoadSet();
-
             metas.emplace_back(
                 MakeUnique<BlockMetaKey>(std::move(meta_infos[0]), std::move(meta_infos[1]), std::stoull(meta_infos[2]), std::stoull(meta_infos[3])));
         } else if (type_str == "blk_col") {
-            SegmentID segment_id = std::stoull(meta_infos[2]);
-            BlockID block_id = std::stoull(meta_infos[3]);
-
-            SharedPtr<ColumnDef> col_def = ColumnDef::FromJson(nlohmann::json::parse(std::move(meta_infos[4])));
-            ColumnID column_id = col_def->id();
-
-            TableMeeta table_meta{meta_infos[0], meta_infos[1], *kv_instance, 0};
-            SegmentMeta segment_meta{segment_id, table_meta};
-            BlockMeta block_meta{block_id, segment_meta};
-            ColumnMeta column_meta{column_id, block_meta};
-
-            column_meta.LoadSet();
-
             metas.emplace_back(MakeUnique<ColumnMetaKey>(std::move(meta_infos[0]),
                                                          std::move(meta_infos[1]),
                                                          std::stoull(meta_infos[2]),
@@ -1477,16 +1456,6 @@ void NewCatalog::GetCleanedMeta(TxnTimeStamp ts, Vector<UniquePtr<MetaKey>> &met
                                                                std::move(meta_infos[2]),
                                                                std::stoull(meta_infos[3])));
         } else if (type_str == "idx_chunk") {
-            SegmentID segment_id = std::stoull(meta_infos[3]);
-            ChunkID chunk_id = std::stoull(meta_infos[4]);
-
-            TableMeeta table_meta{meta_infos[0], meta_infos[1], *kv_instance, 0};
-            TableIndexMeeta table_index_meta{meta_infos[2], table_meta};
-            SegmentIndexMeta segment_index_meta{segment_id, table_index_meta};
-            ChunkIndexMeta chunk_index_meta{chunk_id, segment_index_meta};
-
-            chunk_index_meta.LoadSet();
-
             metas.emplace_back(MakeUnique<ChunkIndexMetaKey>(std::move(meta_infos[0]),
                                                              std::move(meta_infos[1]),
                                                              std::move(meta_infos[2]),

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -1107,7 +1107,7 @@ Status NewCatalog::DropBlockLockByBlockKey(const String &block_key) {
         delete_success = block_lock_map_.erase(block_key) > 0;
     }
     if (!delete_success) {
-        return Status::CatalogError(fmt::format("Block key: {} not found", block_key));
+        LOG_WARN(fmt::format("Block key: {} not found", block_key));
     }
     return Status::OK();
 }
@@ -1146,8 +1146,7 @@ Status NewCatalog::DropMemIndexByMemIndexKey(const String &mem_index_key) {
         delete_success = mem_index_map_.erase(mem_index_key) > 0;
     }
     if (!delete_success) {
-        LOG_INFO(fmt::format("MemIndex key: {} not found", mem_index_key));
-        return Status::OK();
+        LOG_WARN(fmt::format("MemIndex key: {} not found", mem_index_key));
     }
     return Status::OK();
 }

--- a/src/storage/catalog/new_catalog_static.cpp
+++ b/src/storage/catalog/new_catalog_static.cpp
@@ -527,7 +527,6 @@ Status NewCatalog::AddNewTable(DBMeeta &db_meta,
 }
 
 Status NewCatalog::CleanTable(TableMeeta &table_meta, const String &table_name, TxnTimeStamp begin_ts, UsageFlag usage_flag) {
-    // table_meta.RestoreSet();
     KVInstance &kv_instance = table_meta.kv_instance();
     String table_prefix = KeyEncode::CatalogTablePrefix(table_meta.db_id_str(), table_name);
     auto iter = kv_instance.GetIterator();
@@ -1022,8 +1021,6 @@ Status NewCatalog::AddNewSegmentIndex1(TableIndexMeeta &table_index_meta,
 }
 
 Status NewCatalog::CleanSegmentIndex(SegmentIndexMeta &segment_index_meta, UsageFlag usage_flag) {
-    // segment_index_meta.RestoreSet();
-
     auto [chunk_ids_ptr, status] = segment_index_meta.GetChunkIDs1();
     if (!status.ok()) {
         return status;

--- a/src/storage/catalog/new_catalog_static.cpp
+++ b/src/storage/catalog/new_catalog_static.cpp
@@ -527,6 +527,7 @@ Status NewCatalog::AddNewTable(DBMeeta &db_meta,
 }
 
 Status NewCatalog::CleanTable(TableMeeta &table_meta, const String &table_name, TxnTimeStamp begin_ts, UsageFlag usage_flag) {
+    // table_meta.RestoreSet();
     KVInstance &kv_instance = table_meta.kv_instance();
     String table_prefix = KeyEncode::CatalogTablePrefix(table_meta.db_id_str(), table_name);
     auto iter = kv_instance.GetIterator();
@@ -919,6 +920,7 @@ Status NewCatalog::LoadFlushedBlock1(SegmentMeta &segment_meta, const WalBlockIn
 }
 
 Status NewCatalog::CleanBlock(BlockMeta &block_meta, UsageFlag usage_flag) {
+    block_meta.RestoreSet(0);
     Status status;
     SharedPtr<Vector<SharedPtr<ColumnDef>>> column_defs_ptr;
 
@@ -974,6 +976,7 @@ Status NewCatalog::AddNewBlockColumnForTransform(BlockMeta &block_meta, SizeT co
 }
 
 Status NewCatalog::CleanBlockColumn(ColumnMeta &column_meta, const ColumnDef *column_def, UsageFlag usage_flag) {
+    column_meta.RestoreSet(column_def);
     Status status;
 
     status = column_meta.UninitSet(column_def, usage_flag);
@@ -1019,6 +1022,7 @@ Status NewCatalog::AddNewSegmentIndex1(TableIndexMeeta &table_index_meta,
 }
 
 Status NewCatalog::CleanSegmentIndex(SegmentIndexMeta &segment_index_meta, UsageFlag usage_flag) {
+    // segment_index_meta.RestoreSet();
 
     auto [chunk_ids_ptr, status] = segment_index_meta.GetChunkIDs1();
     if (!status.ok()) {
@@ -1192,6 +1196,7 @@ Status NewCatalog::LoadFlushedChunkIndex1(SegmentIndexMeta &segment_index_meta, 
 }
 
 Status NewCatalog::CleanChunkIndex(ChunkIndexMeta &chunk_index_meta, UsageFlag usage_flag) {
+    chunk_index_meta.RestoreSet();
     Status status;
 
     status = chunk_index_meta.UninitSet(usage_flag);

--- a/src/storage/catalog/new_catalog_static.cpp
+++ b/src/storage/catalog/new_catalog_static.cpp
@@ -920,7 +920,7 @@ Status NewCatalog::LoadFlushedBlock1(SegmentMeta &segment_meta, const WalBlockIn
 }
 
 Status NewCatalog::CleanBlock(BlockMeta &block_meta, UsageFlag usage_flag) {
-    block_meta.RestoreSet(0);
+    block_meta.RestoreSet();
     Status status;
     SharedPtr<Vector<SharedPtr<ColumnDef>>> column_defs_ptr;
 

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -72,6 +72,23 @@ using namespace infinity;
 
 class TestTxnCleanup : public BaseTestParamStr {
 public:
+    void SetUp() override {
+        BaseTestParamStr::SetUp();
+
+        new_txn_mgr_ = infinity::InfinityContext::instance().storage()->new_txn_manager();
+        wal_manager_ = infinity::InfinityContext::instance().storage()->wal_manager();
+    }
+
+    void TearDown() override {
+        new_txn_mgr_->PrintAllKeyValue();
+
+        SizeT kv_num = new_txn_mgr_->KeyValueNum();
+        EXPECT_EQ(kv_num, 5);
+
+        new_txn_mgr_ = nullptr;
+        BaseTestParamStr::TearDown();
+    }
+
     void Init() {
         auto config_path = std::make_shared<std::string>(std::filesystem::absolute(GetParam()));
         infinity::InfinityContext::instance().InitPhase1(config_path);
@@ -83,10 +100,6 @@ public:
 
     void UnInit() {
         new_txn_mgr_->PrintAllKeyValue();
-
-        // SizeT kv_num = new_txn_mgr_->KeyValueNum();
-        // EXPECT_EQ(kv_num, 5);
-
         new_txn_mgr_ = nullptr;
 
         infinity::InfinityContext::instance().UnInit();
@@ -116,7 +129,6 @@ protected:
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams, TestTxnCleanup, ::testing::Values(BaseTestParamStr::NEW_VFS_OFF_CONFIG_PATH));
 
 TEST_P(TestTxnCleanup, test_cleanup_db) {
-    Init();
     SharedPtr<String> db_name = std::make_shared<String>("db1");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -184,11 +196,9 @@ TEST_P(TestTxnCleanup, test_cleanup_db) {
     }
 
     this->CheckFilePaths();
-    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_table) {
-    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -258,11 +268,9 @@ TEST_P(TestTxnCleanup, test_cleanup_table) {
     }
 
     this->CheckFilePaths();
-    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_index) {
-    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -366,11 +374,9 @@ TEST_P(TestTxnCleanup, test_cleanup_index) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
-    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_compact) {
-    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -466,11 +472,9 @@ TEST_P(TestTxnCleanup, test_cleanup_compact) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
-    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_optimize) {
-    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -581,11 +585,9 @@ TEST_P(TestTxnCleanup, test_cleanup_optimize) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
-    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
-    Init();
     using namespace infinity;
 
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
@@ -666,10 +668,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
         EXPECT_TRUE(status.ok());
     }
 
-    UnInit();
-
-    Init();
-
     new_txn_mgr_->PrintAllKeyValue();
 
     {
@@ -677,11 +675,9 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
-    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
-    Init();
     using namespace infinity;
 
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
@@ -816,5 +812,4 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
-    UnInit();
 }

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -706,244 +706,137 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
     UnInit();
 }
 
-// BlockMeta for Version
-// SharedPtr<String> block_dir_ptr = this->GetBlockDir();
-// BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-// {
-//     auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-//                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-//                                                              block_dir_ptr,
-//                                                              BlockVersion::FileName(),
-//                                                              this->block_capacity(),
-//                                                              buffer_mgr->persistence_manager());
-//     version_buffer_ = buffer_mgr->AllocateBufferObject(std::move(version_file_worker));
-//     if (!version_buffer_) {
-//         return Status::BufferManagerError(fmt::format("Get version buffer failed: {}", version_file_worker->GetFilePath()));
-//     }
-//     version_buffer_->AddObjRc();
-// }
-
 // ChunkIndexMeta for Index
 
-// ColumnMeta for Data and Var(outline)
-// SharedPtr<ColumnDef> col_def;
-//     {
-//         SharedPtr<Vector<SharedPtr<ColumnDef>>> column_defs_ptr;
-//         std::tie(column_defs_ptr, status) = block_meta_.segment_meta().table_meta().GetColumnDefs();
-//         if (!status.ok()) {
-//             return status;
-//         }
-//         col_def = (*column_defs_ptr)[column_idx_];
-//     }
-//     ColumnID column_id = col_def->id();
-//
-//     SharedPtr<String> block_dir_ptr = block_meta_.GetBlockDir();
-//     BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
-//     {
-//         auto filename = MakeShared<String>(fmt::format("{}.col", column_id));
-//         SizeT total_data_size = 0;
-//         if (col_def->type()->type() == LogicalType::kBoolean) {
-//             total_data_size = (block_meta_.block_capacity() + 7) / 8;
-//         } else {
-//             total_data_size = block_meta_.block_capacity() * col_def->type()->Size();
-//         }
-//         auto file_worker = MakeUnique<DataFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-//                                                       MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-//                                                       block_dir_ptr,
-//                                                       filename,
-//                                                       total_data_size,
-//                                                       buffer_mgr->persistence_manager());
-//         column_buffer_ = buffer_mgr->AllocateBufferObject(std::move(file_worker));
-//         if (!column_buffer_) {
-//             return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", file_worker->GetFilePath()));
-//         }
-//         column_buffer_->AddObjRc();
-//     }
-//     VectorBufferType buffer_type = ColumnVector::GetVectorBufferType(*col_def->type());
-//     if (buffer_type == VectorBufferType::kVarBuffer) {
-//         auto filename = MakeShared<String>(fmt::format("col_{}_out_0", column_id));
-//         auto outline_file_worker = MakeUnique<VarFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
-//                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
-//                                                              block_dir_ptr,
-//                                                              filename,
-//                                                              0, /*buffer_size*/
-//                                                              buffer_mgr->persistence_manager());
-//         outline_buffer_ = buffer_mgr->AllocateBufferObject(std::move(outline_file_worker));
-//         if (!outline_buffer_) {
-//             return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", outline_file_worker->GetFilePath()));
-//         }
-//         outline_buffer_->AddObjRc();
-//     }
+TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
+    Init();
+    using namespace infinity;
 
-// TEST_P(CleanupTaskTest, test_with_index_compact_and_restart_and_cleanup) {
-//     constexpr int kImportN = 5;
-//
-//     Init();
-//     // close auto cleanup task
-//     Storage *storage = InfinityContext::instance().storage();
-//     EXPECT_NE(storage, nullptr);
-//
-//     NewTxnManager *txn_mgr = storage->new_txn_manager();
-//
-//     auto db_name = MakeShared<String>("default_db");
-//     auto table_name = MakeShared<String>("tbl1");
-//     auto index_name = MakeShared<String>("idx1");
-//     auto column_name = MakeShared<String>("col1");
-//
-//     Vector<SharedPtr<ColumnDef>> column_defs;
-//     {
-//         std::set<ConstraintType> constraints;
-//         ColumnID column_id = 0;
-//         column_defs.push_back(MakeShared<ColumnDef>(column_id++, MakeShared<DataType>(DataType(LogicalType::kInteger)), *column_name,
-//         constraints));
-//     }
-//     {
-//         auto table_def = MakeUnique<TableDef>(db_name, table_name, MakeShared<String>(), column_defs);
-//         auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("create tbl1"), TransactionType::kNormal);
-//         auto status = txn->CreateTable(*db_name, std::move(table_def), ConflictType::kIgnore);
-//         EXPECT_TRUE(status.ok());
-//         txn_mgr->CommitTxn(txn);
-//     }
-//     {
-//         u32 block_row_cnt = 8192;
-//         auto make_input_block = [&](SizeT val) {
-//             auto input_block = MakeShared<DataBlock>();
-//             auto append_to_col = [&](ColumnVector &col, Value v1) {
-//                 for (u32 i = 0; i < block_row_cnt; ++i) {
-//                     col.AppendValue(v1);
-//                 }
-//             };
-//             // Initialize input block
-//             {
-//                 auto col1 = ColumnVector::Make(MakeShared<DataType>(DataType(LogicalType::kInteger)));
-//                 col1->Initialize();
-//                 append_to_col(*col1, Value::MakeInt(val));
-//                 input_block->InsertVector(col1, 0);
-//             }
-//             input_block->Finalize();
-//             return input_block;
-//         };
-//
-//         // Import two segments, each segments contains two blocks
-//         for (SizeT i = 0; i < kImportN; ++i) {
-//             auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("import"), TransactionType::kNormal);
-//             Vector<SharedPtr<DataBlock>> input_blocks = {make_input_block(1), make_input_block(5)};
-//             Status status = txn->Import(*db_name, *table_name, input_blocks);
-//             EXPECT_TRUE(status.ok());
-//             status = txn_mgr->CommitTxn(txn);
-//             EXPECT_TRUE(status.ok());
-//         }
-//     }
-//     {
-//         SharedPtr<IndexBase> index_base =
-//             IndexSecondary::Make(index_name, MakeShared<String>("test comment"), fmt::format("{}_{}", *table_name, *index_name), {*column_name});
-//
-//         auto *txn3 = txn_mgr->BeginTxn(MakeUnique<String>("create index"), TransactionType::kNormal);
-//         Status status = txn3->CreateIndex(*db_name, *table_name, index_base, ConflictType::kIgnore);
-//         EXPECT_TRUE(status.ok());
-//         status = txn_mgr->CommitTxn(txn3);
-//         EXPECT_TRUE(status.ok());
-//     }
-//
-//     {
-//         auto *txn4 = txn_mgr->BeginTxn(MakeUnique<String>("drop column"), TransactionType::kNormal);
-//         //     Status NewTxn::DropColumns(const String &db_name, const String &table_name, const Vector<String> &column_names) {
-//         //
-//         //     if (column_names.empty()) {
-//         //         return Status::NotSupport("DropColumns: column_names is empty");
-//         //     }
-//         //
-//         //     {
-//         //         Set<String> name_set;
-//         //         for (const auto &name : column_names) {
-//         //             if (!name_set.insert(name).second) {
-//         //                 return Status::DuplicateColumnName(name);
-//         //             }
-//         //         }
-//         //     }
-//         //
-//         //     Optional<DBMeeta> db_meta;
-//         //     Optional<TableMeeta> table_meta;
-//         //     String table_key;
-//         //     Status status = GetTableMeta(db_name, table_name, db_meta, table_meta, &table_key);
-//         //     if (!status.ok()) {
-//         //         return status;
-//         //     }
-//         //
-//         //     SharedPtr<Vector<SharedPtr<ColumnDef>>> old_column_defs;
-//         //     std::tie(old_column_defs, status) = table_meta->GetColumnDefs();
-//         //     if (!status.ok()) {
-//         //         return status;
-//         //     }
-//         //     Map<String, ColumnID> column_name_set;
-//         //     for (const auto &column_def : *old_column_defs) {
-//         //         column_name_set.emplace(column_def->name(), column_def->id());
-//         //     }
-//         //     Vector<ColumnID> column_ids;
-//         //     for (const auto &column_name : column_names) {
-//         //         if (auto iter = column_name_set.find(column_name); iter != column_name_set.end()) {
-//         //             column_ids.push_back(iter->second);
-//         //         } else {
-//         //             return Status::ColumnNotExist(column_name);
-//         //         }
-//         //     }
-//         //
-//         //     if (column_names.size() == old_column_defs->size()) {
-//         //         return Status::NotSupport("Cannot delete all the columns of a table");
-//         //     }
-//         //
-//         //     Vector<String> *index_id_strs_ptr = nullptr;
-//         //     status = table_meta->GetIndexIDs(index_id_strs_ptr);
-//         //     if (!status.ok()) {
-//         //         return status;
-//         //     }
-//         //
-//         //     for (const String &index_id : *index_id_strs_ptr) {
-//         //         TableIndexMeeta table_index_meta(index_id, *table_meta);
-//         //         auto [index_base, index_status] = table_index_meta.GetIndexBase();
-//         //         if (!index_status.ok()) {
-//         //             return index_status;
-//         //         }
-//         //         for (const String &column_name : column_names) {
-//         //             if (IsEqual(index_base->column_name(), column_name)) {
-//         //                 return Status::IndexOnColumn(column_name);
-//         //             }
-//         //         }
-//         //     }
-//         //
-//         //     // Put the data into local txn store
-//         //     if (base_txn_store_ != nullptr) {
-//         //         return Status::UnexpectedError("txn store is not null");
-//         //     }
-//         //
-//         //     base_txn_store_ = MakeShared<DropColumnsTxnStore>();
-//         //     DropColumnsTxnStore *txn_store = static_cast<DropColumnsTxnStore *>(base_txn_store_.get());
-//         //     txn_store->db_name_ = db_name;
-//         //     txn_store->db_id_str_ = db_meta->db_id_str();
-//         //     txn_store->db_id_ = std::stoull(db_meta->db_id_str());
-//         //     txn_store->table_name_ = table_name;
-//         //     txn_store->column_names_ = column_names;
-//         //
-//         //     auto wal_command =
-//         //         MakeShared<WalCmdDropColumnsV2>(db_name, db_meta->db_id_str(), table_name, table_meta->table_id_str(), column_names,
-//         column_ids);
-//         //     wal_command->table_key_ = table_key;
-//         //     wal_entry_->cmds_.push_back(wal_command);
-//         //     txn_context_ptr_->AddOperation(MakeShared<String>(wal_command->ToString()));
-//         //
-//         //     return Status::OK();
-//         // }
-//         Status status = txn4->DropColumns();
-//         EXPECT_TRUE(status.ok());
-//         status = txn_mgr->CommitTxn(txn4);
-//         EXPECT_TRUE(status.ok());
-//     }
-//
-//     UnInit();
-//
-//     Init();
-//
-//     {
-//         auto *txn5 = txn_mgr->BeginTxn(MakeUnique<String>("get column"), TransactionType::kNormal);
-//     }
-// }
+    SharedPtr<String> db_name = std::make_shared<String>("default_db");
+    auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
+    auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
+    auto table_name = std::make_shared<std::string>("tb1");
+    auto table_def = TableDef::Make(db_name, table_name, MakeShared<String>(), {column_def1, column_def2});
+    {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("create table"), TransactionType::kNormal);
+        Status status = txn->CreateTable(*db_name, std::move(table_def), ConflictType::kIgnore);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    u32 block_row_cnt = 8192;
+    auto make_input_block = [&] {
+        auto input_block = MakeShared<DataBlock>();
+        auto append_to_col = [&](ColumnVector &col, Value v) {
+            for (u32 i = 0; i < block_row_cnt; ++i) {
+                col.AppendValue(v);
+            }
+        };
+        // Initialize input block
+        {
+            auto col1 = ColumnVector::Make(column_def1->type());
+            col1->Initialize();
+            append_to_col(*col1, Value::MakeInt(1));
+            input_block->InsertVector(col1, 0);
+        }
+        {
+            auto col2 = ColumnVector::Make(column_def2->type());
+            col2->Initialize();
+            append_to_col(*col2, Value::MakeVarchar("abcdefghijklmnopqrstuvwxyz"));
+            input_block->InsertVector(col2, 1);
+        }
+        input_block->Finalize();
+        return input_block;
+    };
+
+    for (SizeT i = 0; i < 2; ++i) {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("append"), TransactionType::kNormal);
+        Status status = txn->Append(*db_name, *table_name, make_input_block());
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    // auto index_name1 = std::make_shared<std::string>("index1");
+    // auto index_def1 = IndexSecondary::Make(index_name1, MakeShared<String>(), "my_file_name", {column_def1->name()});
+    // auto index_name2 = std::make_shared<String>("index2");
+    // auto index_def2 = IndexFullText::Make(index_name2, MakeShared<String>(), "my_file_name", {column_def2->name()}, {});
+    //
+    // auto create_index = [&](const SharedPtr<IndexBase> &index_base) {
+    //     auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>(fmt::format("create index {}", *index_base->index_name_)), TransactionType::kNormal);
+    //     Status status = txn->CreateIndex(*db_name, *table_name, index_base, ConflictType::kIgnore);
+    //     EXPECT_TRUE(status.ok());
+    //     status = new_txn_mgr_->CommitTxn(txn);
+    //     EXPECT_TRUE(status.ok());
+    // };
+    // create_index(index_def1);
+    // create_index(index_def2);
+
+    {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("drop column"), TransactionType::kNormal);
+
+        Status status = txn->GetColumnFilePaths(*db_name, *table_name, column_def2->name_, file_paths_);
+        EXPECT_TRUE(status.ok());
+
+        Vector<String> column_names = {column_def2->name_};
+        status = txn->DropColumns(*db_name, *table_name, column_names);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("checkpoint"), TransactionType::kNewCheckpoint);
+        Status status = txn->Checkpoint(wal_manager_->LastCheckpointTS());
+        EXPECT_TRUE(status.ok());
+
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    UnInit();
+
+    Init();
+
+    {
+        Status status = new_txn_mgr_->Cleanup();
+        EXPECT_TRUE(status.ok());
+    }
+    this->CheckFilePaths();
+
+    {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("drop table"), TransactionType::kNormal);
+
+        Status status = txn->GetTableFilePaths(*db_name, *table_name, file_paths_);
+        EXPECT_TRUE(status.ok());
+
+        status = txn->DropTable(*db_name, *table_name, ConflictType::kError);
+        EXPECT_TRUE(status.ok());
+
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("checkpoint"), TransactionType::kNewCheckpoint);
+
+        Status status = txn->Checkpoint(wal_manager_->LastCheckpointTS());
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    UnInit();
+
+    Init();
+
+    new_txn_mgr_->PrintAllKeyValue();
+
+    {
+        Status status = new_txn_mgr_->Cleanup();
+        EXPECT_TRUE(status.ok());
+    }
+    this->CheckFilePaths();
+    UnInit();
+}

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -772,7 +772,7 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
     }
 
     create_index(index_def1);
-    // create_index(index_def2);
+    create_index(index_def2);
 
     {
         auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("drop index"), TransactionType::kNormal);

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -727,8 +727,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
 
     auto index_name1 = std::make_shared<std::string>("index1");
     auto index_def1 = IndexSecondary::Make(index_name1, MakeShared<String>(), "my_file_name", {column_def1->name()});
-    auto index_name2 = std::make_shared<String>("index2");
-    auto index_def2 = IndexFullText::Make(index_name2, MakeShared<String>(), "my_file_name", {column_def2->name()}, {});
 
     auto create_index = [&](const SharedPtr<IndexBase> &index_base) {
         auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>(fmt::format("create index {}", *index_base->index_name_)), TransactionType::kNormal);

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -772,7 +772,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
     }
 
     create_index(index_def1);
-    create_index(index_def2);
 
     {
         auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("drop index"), TransactionType::kNormal);

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -71,22 +71,29 @@ import constant_expr;
 using namespace infinity;
 
 class TestTxnCleanup : public BaseTestParamStr {
-protected:
-    void SetUp() override {
-        BaseTestParamStr::SetUp();
+public:
+    // void SetUp() override { BaseTestParamStr::SetUp(); }
+
+    // void TearDown() override {}
+
+    void Init() {
+        auto config_path = std::make_shared<std::string>(std::filesystem::absolute(GetParam()));
+        infinity::InfinityContext::instance().InitPhase1(config_path);
+        infinity::InfinityContext::instance().InitPhase2();
 
         new_txn_mgr_ = infinity::InfinityContext::instance().storage()->new_txn_manager();
         wal_manager_ = infinity::InfinityContext::instance().storage()->wal_manager();
     }
 
-    void TearDown() override {
+    void UnInit() {
         new_txn_mgr_->PrintAllKeyValue();
 
-        SizeT kv_num = new_txn_mgr_->KeyValueNum();
-        EXPECT_EQ(kv_num, 5);
+        // SizeT kv_num = new_txn_mgr_->KeyValueNum();
+        // EXPECT_EQ(kv_num, 5);
 
         new_txn_mgr_ = nullptr;
-        BaseTestParamStr::TearDown();
+
+        infinity::InfinityContext::instance().UnInit();
     }
 
     void CheckFilePaths() {
@@ -113,6 +120,7 @@ protected:
 INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams, TestTxnCleanup, ::testing::Values(BaseTestParamStr::NEW_VFS_OFF_CONFIG_PATH));
 
 TEST_P(TestTxnCleanup, test_cleanup_db) {
+    Init();
     SharedPtr<String> db_name = std::make_shared<String>("db1");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -180,9 +188,11 @@ TEST_P(TestTxnCleanup, test_cleanup_db) {
     }
 
     this->CheckFilePaths();
+    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_table) {
+    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -252,9 +262,11 @@ TEST_P(TestTxnCleanup, test_cleanup_table) {
     }
 
     this->CheckFilePaths();
+    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_index) {
+    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -358,9 +370,11 @@ TEST_P(TestTxnCleanup, test_cleanup_index) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
+    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_compact) {
+    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -456,9 +470,11 @@ TEST_P(TestTxnCleanup, test_cleanup_compact) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
+    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_optimize) {
+    Init();
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
     auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "col1", std::set<ConstraintType>());
     auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kVarchar), "col2", std::set<ConstraintType>());
@@ -569,9 +585,11 @@ TEST_P(TestTxnCleanup, test_cleanup_optimize) {
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
+    UnInit();
 }
 
 TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
+    Init();
     using namespace infinity;
 
     SharedPtr<String> db_name = std::make_shared<String>("default_db");
@@ -643,6 +661,19 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
     }
 
     {
+        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("checkpoint"), TransactionType::kNewCheckpoint);
+
+        Status status = txn->Checkpoint(wal_manager_->LastCheckpointTS());
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr_->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    UnInit();
+
+    Init();
+
+    {
         Status status = new_txn_mgr_->Cleanup();
         EXPECT_TRUE(status.ok());
     }
@@ -660,9 +691,262 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
         status = new_txn_mgr_->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
     }
+
+
+
+    UnInit();
+
+    Init();
+
+    new_txn_mgr_->PrintAllKeyValue();
+
     {
         Status status = new_txn_mgr_->Cleanup();
         EXPECT_TRUE(status.ok());
     }
     this->CheckFilePaths();
+    UnInit();
 }
+
+// BlockMeta for Version
+// SharedPtr<String> block_dir_ptr = this->GetBlockDir();
+// BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
+// {
+//     auto version_file_worker = MakeUnique<VersionFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+//                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+//                                                              block_dir_ptr,
+//                                                              BlockVersion::FileName(),
+//                                                              this->block_capacity(),
+//                                                              buffer_mgr->persistence_manager());
+//     version_buffer_ = buffer_mgr->AllocateBufferObject(std::move(version_file_worker));
+//     if (!version_buffer_) {
+//         return Status::BufferManagerError(fmt::format("Get version buffer failed: {}", version_file_worker->GetFilePath()));
+//     }
+//     version_buffer_->AddObjRc();
+// }
+
+// ChunkIndexMeta for Index
+
+
+// ColumnMeta for Data and Var(outline)
+// SharedPtr<ColumnDef> col_def;
+//     {
+//         SharedPtr<Vector<SharedPtr<ColumnDef>>> column_defs_ptr;
+//         std::tie(column_defs_ptr, status) = block_meta_.segment_meta().table_meta().GetColumnDefs();
+//         if (!status.ok()) {
+//             return status;
+//         }
+//         col_def = (*column_defs_ptr)[column_idx_];
+//     }
+//     ColumnID column_id = col_def->id();
+//
+//     SharedPtr<String> block_dir_ptr = block_meta_.GetBlockDir();
+//     BufferManager *buffer_mgr = InfinityContext::instance().storage()->buffer_manager();
+//     {
+//         auto filename = MakeShared<String>(fmt::format("{}.col", column_id));
+//         SizeT total_data_size = 0;
+//         if (col_def->type()->type() == LogicalType::kBoolean) {
+//             total_data_size = (block_meta_.block_capacity() + 7) / 8;
+//         } else {
+//             total_data_size = block_meta_.block_capacity() * col_def->type()->Size();
+//         }
+//         auto file_worker = MakeUnique<DataFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+//                                                       MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+//                                                       block_dir_ptr,
+//                                                       filename,
+//                                                       total_data_size,
+//                                                       buffer_mgr->persistence_manager());
+//         column_buffer_ = buffer_mgr->AllocateBufferObject(std::move(file_worker));
+//         if (!column_buffer_) {
+//             return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", file_worker->GetFilePath()));
+//         }
+//         column_buffer_->AddObjRc();
+//     }
+//     VectorBufferType buffer_type = ColumnVector::GetVectorBufferType(*col_def->type());
+//     if (buffer_type == VectorBufferType::kVarBuffer) {
+//         auto filename = MakeShared<String>(fmt::format("col_{}_out_0", column_id));
+//         auto outline_file_worker = MakeUnique<VarFileWorker>(MakeShared<String>(InfinityContext::instance().config()->DataDir()),
+//                                                              MakeShared<String>(InfinityContext::instance().config()->TempDir()),
+//                                                              block_dir_ptr,
+//                                                              filename,
+//                                                              0, /*buffer_size*/
+//                                                              buffer_mgr->persistence_manager());
+//         outline_buffer_ = buffer_mgr->AllocateBufferObject(std::move(outline_file_worker));
+//         if (!outline_buffer_) {
+//             return Status::BufferManagerError(fmt::format("Get buffer object failed: {}", outline_file_worker->GetFilePath()));
+//         }
+//         outline_buffer_->AddObjRc();
+//     }
+
+// TEST_P(CleanupTaskTest, test_with_index_compact_and_restart_and_cleanup) {
+//     constexpr int kImportN = 5;
+//
+//     Init();
+//     // close auto cleanup task
+//     Storage *storage = InfinityContext::instance().storage();
+//     EXPECT_NE(storage, nullptr);
+//
+//     NewTxnManager *txn_mgr = storage->new_txn_manager();
+//
+//     auto db_name = MakeShared<String>("default_db");
+//     auto table_name = MakeShared<String>("tbl1");
+//     auto index_name = MakeShared<String>("idx1");
+//     auto column_name = MakeShared<String>("col1");
+//
+//     Vector<SharedPtr<ColumnDef>> column_defs;
+//     {
+//         std::set<ConstraintType> constraints;
+//         ColumnID column_id = 0;
+//         column_defs.push_back(MakeShared<ColumnDef>(column_id++, MakeShared<DataType>(DataType(LogicalType::kInteger)), *column_name,
+//         constraints));
+//     }
+//     {
+//         auto table_def = MakeUnique<TableDef>(db_name, table_name, MakeShared<String>(), column_defs);
+//         auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("create tbl1"), TransactionType::kNormal);
+//         auto status = txn->CreateTable(*db_name, std::move(table_def), ConflictType::kIgnore);
+//         EXPECT_TRUE(status.ok());
+//         txn_mgr->CommitTxn(txn);
+//     }
+//     {
+//         u32 block_row_cnt = 8192;
+//         auto make_input_block = [&](SizeT val) {
+//             auto input_block = MakeShared<DataBlock>();
+//             auto append_to_col = [&](ColumnVector &col, Value v1) {
+//                 for (u32 i = 0; i < block_row_cnt; ++i) {
+//                     col.AppendValue(v1);
+//                 }
+//             };
+//             // Initialize input block
+//             {
+//                 auto col1 = ColumnVector::Make(MakeShared<DataType>(DataType(LogicalType::kInteger)));
+//                 col1->Initialize();
+//                 append_to_col(*col1, Value::MakeInt(val));
+//                 input_block->InsertVector(col1, 0);
+//             }
+//             input_block->Finalize();
+//             return input_block;
+//         };
+//
+//         // Import two segments, each segments contains two blocks
+//         for (SizeT i = 0; i < kImportN; ++i) {
+//             auto *txn = txn_mgr->BeginTxn(MakeUnique<String>("import"), TransactionType::kNormal);
+//             Vector<SharedPtr<DataBlock>> input_blocks = {make_input_block(1), make_input_block(5)};
+//             Status status = txn->Import(*db_name, *table_name, input_blocks);
+//             EXPECT_TRUE(status.ok());
+//             status = txn_mgr->CommitTxn(txn);
+//             EXPECT_TRUE(status.ok());
+//         }
+//     }
+//     {
+//         SharedPtr<IndexBase> index_base =
+//             IndexSecondary::Make(index_name, MakeShared<String>("test comment"), fmt::format("{}_{}", *table_name, *index_name), {*column_name});
+//
+//         auto *txn3 = txn_mgr->BeginTxn(MakeUnique<String>("create index"), TransactionType::kNormal);
+//         Status status = txn3->CreateIndex(*db_name, *table_name, index_base, ConflictType::kIgnore);
+//         EXPECT_TRUE(status.ok());
+//         status = txn_mgr->CommitTxn(txn3);
+//         EXPECT_TRUE(status.ok());
+//     }
+//
+//     {
+//         auto *txn4 = txn_mgr->BeginTxn(MakeUnique<String>("drop column"), TransactionType::kNormal);
+//         //     Status NewTxn::DropColumns(const String &db_name, const String &table_name, const Vector<String> &column_names) {
+//         //
+//         //     if (column_names.empty()) {
+//         //         return Status::NotSupport("DropColumns: column_names is empty");
+//         //     }
+//         //
+//         //     {
+//         //         Set<String> name_set;
+//         //         for (const auto &name : column_names) {
+//         //             if (!name_set.insert(name).second) {
+//         //                 return Status::DuplicateColumnName(name);
+//         //             }
+//         //         }
+//         //     }
+//         //
+//         //     Optional<DBMeeta> db_meta;
+//         //     Optional<TableMeeta> table_meta;
+//         //     String table_key;
+//         //     Status status = GetTableMeta(db_name, table_name, db_meta, table_meta, &table_key);
+//         //     if (!status.ok()) {
+//         //         return status;
+//         //     }
+//         //
+//         //     SharedPtr<Vector<SharedPtr<ColumnDef>>> old_column_defs;
+//         //     std::tie(old_column_defs, status) = table_meta->GetColumnDefs();
+//         //     if (!status.ok()) {
+//         //         return status;
+//         //     }
+//         //     Map<String, ColumnID> column_name_set;
+//         //     for (const auto &column_def : *old_column_defs) {
+//         //         column_name_set.emplace(column_def->name(), column_def->id());
+//         //     }
+//         //     Vector<ColumnID> column_ids;
+//         //     for (const auto &column_name : column_names) {
+//         //         if (auto iter = column_name_set.find(column_name); iter != column_name_set.end()) {
+//         //             column_ids.push_back(iter->second);
+//         //         } else {
+//         //             return Status::ColumnNotExist(column_name);
+//         //         }
+//         //     }
+//         //
+//         //     if (column_names.size() == old_column_defs->size()) {
+//         //         return Status::NotSupport("Cannot delete all the columns of a table");
+//         //     }
+//         //
+//         //     Vector<String> *index_id_strs_ptr = nullptr;
+//         //     status = table_meta->GetIndexIDs(index_id_strs_ptr);
+//         //     if (!status.ok()) {
+//         //         return status;
+//         //     }
+//         //
+//         //     for (const String &index_id : *index_id_strs_ptr) {
+//         //         TableIndexMeeta table_index_meta(index_id, *table_meta);
+//         //         auto [index_base, index_status] = table_index_meta.GetIndexBase();
+//         //         if (!index_status.ok()) {
+//         //             return index_status;
+//         //         }
+//         //         for (const String &column_name : column_names) {
+//         //             if (IsEqual(index_base->column_name(), column_name)) {
+//         //                 return Status::IndexOnColumn(column_name);
+//         //             }
+//         //         }
+//         //     }
+//         //
+//         //     // Put the data into local txn store
+//         //     if (base_txn_store_ != nullptr) {
+//         //         return Status::UnexpectedError("txn store is not null");
+//         //     }
+//         //
+//         //     base_txn_store_ = MakeShared<DropColumnsTxnStore>();
+//         //     DropColumnsTxnStore *txn_store = static_cast<DropColumnsTxnStore *>(base_txn_store_.get());
+//         //     txn_store->db_name_ = db_name;
+//         //     txn_store->db_id_str_ = db_meta->db_id_str();
+//         //     txn_store->db_id_ = std::stoull(db_meta->db_id_str());
+//         //     txn_store->table_name_ = table_name;
+//         //     txn_store->column_names_ = column_names;
+//         //
+//         //     auto wal_command =
+//         //         MakeShared<WalCmdDropColumnsV2>(db_name, db_meta->db_id_str(), table_name, table_meta->table_id_str(), column_names,
+//         column_ids);
+//         //     wal_command->table_key_ = table_key;
+//         //     wal_entry_->cmds_.push_back(wal_command);
+//         //     txn_context_ptr_->AddOperation(MakeShared<String>(wal_command->ToString()));
+//         //
+//         //     return Status::OK();
+//         // }
+//         Status status = txn4->DropColumns();
+//         EXPECT_TRUE(status.ok());
+//         status = txn_mgr->CommitTxn(txn4);
+//         EXPECT_TRUE(status.ok());
+//     }
+//
+//     UnInit();
+//
+//     Init();
+//
+//     {
+//         auto *txn5 = txn_mgr->BeginTxn(MakeUnique<String>("get column"), TransactionType::kNormal);
+//     }
+// }

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -692,8 +692,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
         EXPECT_TRUE(status.ok());
     }
 
-
-
     UnInit();
 
     Init();
@@ -726,7 +724,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
 // }
 
 // ChunkIndexMeta for Index
-
 
 // ColumnMeta for Data and Var(outline)
 // SharedPtr<ColumnDef> col_def;

--- a/src/unit_test/storage/new_catalog/cleanup.cpp
+++ b/src/unit_test/storage/new_catalog/cleanup.cpp
@@ -72,10 +72,6 @@ using namespace infinity;
 
 class TestTxnCleanup : public BaseTestParamStr {
 public:
-    // void SetUp() override { BaseTestParamStr::SetUp(); }
-
-    // void TearDown() override {}
-
     void Init() {
         auto config_path = std::make_shared<std::string>(std::filesystem::absolute(GetParam()));
         infinity::InfinityContext::instance().InitPhase1(config_path);
@@ -639,15 +635,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
     }
 
     {
-        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("checkpoint"), TransactionType::kNewCheckpoint);
-        Status status = txn->Checkpoint(wal_manager_->LastCheckpointTS());
-        EXPECT_TRUE(status.ok());
-
-        status = new_txn_mgr_->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
-    }
-
-    {
         auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("drop column"), TransactionType::kNormal);
 
         Status status = txn->GetColumnFilePaths(*db_name, *table_name, column_def2->name_, file_paths_);
@@ -659,19 +646,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
         status = new_txn_mgr_->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
     }
-
-    {
-        auto *txn = new_txn_mgr_->BeginTxn(MakeUnique<String>("checkpoint"), TransactionType::kNewCheckpoint);
-
-        Status status = txn->Checkpoint(wal_manager_->LastCheckpointTS());
-        EXPECT_TRUE(status.ok());
-        status = new_txn_mgr_->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
-    }
-
-    UnInit();
-
-    Init();
 
     {
         Status status = new_txn_mgr_->Cleanup();
@@ -705,8 +679,6 @@ TEST_P(TestTxnCleanup, test_cleanup_drop_column) {
     this->CheckFilePaths();
     UnInit();
 }
-
-// ChunkIndexMeta for Index
 
 TEST_P(TestTxnCleanup, test_cleanup_drop_index_and_checkpoint_and_restart) {
     Init();

--- a/src/unit_test/storage/new_catalog/new_catalog.cpp
+++ b/src/unit_test/storage/new_catalog/new_catalog.cpp
@@ -99,7 +99,7 @@ TEST_P(TestTxnNewCatalog, test_block_lock) {
     status = new_catalog->DropBlockLockByBlockKey(block_key1);
     EXPECT_TRUE(status.ok());
     status = new_catalog->DropBlockLockByBlockKey(block_key1);
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
     {
         std::shared_ptr<BlockLock> block_lock;
         status = new_catalog->GetBlockLock(block_key1, block_lock);


### PR DESCRIPTION
### What problem does this PR solve?

After a checkpoint, all operations in the current WAL are cleared. If the db is restarted at this point, the buffer manager wont be replayed. Consequently, if a clean is triggered afterward, an error will occur.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [x] Test cases
