### PR TITLE
Fix logical error in filter usage

### DIFF
--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -60,7 +60,7 @@ def process_test(sqllogictest_bin: str, slt_dir: str, data_dir: str, copy_dir: s
 
     test_cnt = 0
     # FIXME: Following slt files contain `SEARCH.*WHERE` queries which fail to run.
-    skipped_files = {'fusion.slt', 'filter_fulltext_function.slt', 'fulltext_delete.slt', 'test_knn_hnsw_ip_filter.slt', 'test_knn_hnsw_l2_filter.slt', 'test_knn_ip_filter.slt', 'test_knn_ivf_ip_filter.slt', 'test_knn_ivf_l2_filter.slt', 'test_knn_l2_filter.slt', 'test_knn_sparse_bmp_filter.slt', 'test_knn_sparse.slt', 'tensor_maxsim.slt', 'cached_sparse_scan.slt', 'explain_fusion.slt'}
+    skipped_files = {'fusion.slt', 'filter_fulltext_function.slt', 'fulltext_delete.slt'}
     skipped_files.update({'big_index_scan.slt', 'index_scan_delete.slt', 'cached_index_scan.slt', 'cache_config.slt'}) # FIXME: secdonary index of integer doesn't work
     for dirpath, dirnames, filenames in os.walk(slt_dir):
         for filename in filenames:


### PR DESCRIPTION
### What problem does this PR solve?

1. ​​Fix incorrect filter evaluation logic in CommonQueryFilter::NewBuildFilter and modify the filter skipping logic​​.
2. Add filter-related test cases in sqllogictest.py​.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases
