### PR TITLE
Fix the restart test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,17 +38,17 @@
 #wheel.py-api = "cp310"
 #wheel.packages = ["python/infinity_embedded"]
 #
-#[tool.pytest.ini_options]
-#addopts = "--strict-markers"
-#markers = [
-#    "L0",
-#    "L1",
-#    "L2",
-#    "L3",
-#    "complex",
-#    "slow",
-#    "nightly",
-#]
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "L0",
+    "L1",
+    "L2",
+    "L3",
+    "complex",
+    "slow",
+    "nightly",
+]
 #
 #filterwarnings = [
 #    "error",

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -118,7 +118,7 @@ class InfinityRunner:
             try:
                 if infinity_obj is None:
                     infinity_obj = infinity.connect(uri, self.logger)
-                    time.sleep(3)
+                    time.sleep(1)
                 ret = infinity_obj.get_database("default_db")
                 break
             except Exception as e:

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -118,7 +118,7 @@ class InfinityRunner:
             try:
                 if infinity_obj is None:
                     infinity_obj = infinity.connect(uri, self.logger)
-                    time.sleep(1)
+                    time.sleep(3)
                 ret = infinity_obj.get_database("default_db")
                 break
             except Exception as e:

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -118,6 +118,7 @@ class InfinityRunner:
             try:
                 if infinity_obj is None:
                     infinity_obj = infinity.connect(uri, self.logger)
+                    time.sleep(3)
                 ret = infinity_obj.get_database("default_db")
                 break
             except Exception as e:
@@ -131,7 +132,6 @@ class InfinityRunner:
                         raise e
                 else:
                     print(e)
-                time.sleep(1)
                 print(f"retry connect {i}")
         else:
             raise Exception(f"Cannot connect to infinity after {try_n} retries.")

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -111,14 +111,13 @@ class InfinityRunner:
         return self.process is not None
 
     def connect(self, uri: str):
-        try_n = 10
+        try_n = 5
         time.sleep(1)
         infinity_obj = None
         for i in range(try_n):
             try:
                 if infinity_obj is None:
                     infinity_obj = infinity.connect(uri, self.logger)
-                    time.sleep(10)
                 ret = infinity_obj.get_database("default_db")
                 break
             except Exception as e:
@@ -126,7 +125,6 @@ class InfinityRunner:
                     if isinstance(e, InfinityException):
                         if e.error_code == ErrorCode.INFINITY_IS_INITING:
                             print("wait infinity starting")
-
                         else:
                             raise e
                     else:

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -111,7 +111,7 @@ class InfinityRunner:
         return self.process is not None
 
     def connect(self, uri: str):
-        try_n = 100
+        try_n = 10
         time.sleep(1)
         infinity_obj = None
         for i in range(try_n):
@@ -126,14 +126,14 @@ class InfinityRunner:
                     if isinstance(e, InfinityException):
                         if e.error_code == ErrorCode.INFINITY_IS_INITING:
                             print("wait infinity starting")
-                            time.sleep(1)
+
                         else:
                             raise e
                     else:
                         raise e
                 else:
                     print(e)
-                    time.sleep(1)
+                time.sleep(1)
                 print(f"retry connect {i}")
         else:
             raise Exception(f"Cannot connect to infinity after {try_n} retries.")

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -118,6 +118,7 @@ class InfinityRunner:
             try:
                 if infinity_obj is None:
                     infinity_obj = infinity.connect(uri, self.logger)
+                    time.sleep(10)
                 ret = infinity_obj.get_database("default_db")
                 break
             except Exception as e:

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -112,7 +112,7 @@ class InfinityRunner:
 
     def connect(self, uri: str):
         try_n = 100
-        time.sleep(0.5)
+        time.sleep(1)
         infinity_obj = None
         for i in range(try_n):
             try:
@@ -125,14 +125,14 @@ class InfinityRunner:
                     if isinstance(e, InfinityException):
                         if e.error_code == ErrorCode.INFINITY_IS_INITING:
                             print("wait infinity starting")
-                            time.sleep(0.5)
+                            time.sleep(1)
                         else:
                             raise e
                     else:
                         raise e
                 else:
                     print(e)
-                    time.sleep(0.5)
+                    time.sleep(1)
                 print(f"retry connect {i}")
         else:
             raise Exception(f"Cannot connect to infinity after {try_n} retries.")

--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -132,7 +132,9 @@ class InfinityRunner:
                         raise e
                 else:
                     print(e)
-                print(f"retry connect {i}")
+                sleep_time = 1 * (i + 1)
+                print(f"Retrying connection attempt {i + 1} after {sleep_time} seconds.")
+                time.sleep(sleep_time)
         else:
             raise Exception(f"Cannot connect to infinity after {try_n} retries.")
         return infinity_obj

--- a/scripts/timeout_kill.sh
+++ b/scripts/timeout_kill.sh
@@ -47,7 +47,11 @@ while true; do
         for pid in "${@:2}"; do
             if ps -p $pid > /dev/null; then
                 echo "Pid: $pid didn't terminate"
-                kill -9 $pid
+                if [ -z $pid ]; then
+                  continue
+                fi
+                ppid=$(ps -o ppid= -p $pid)
+                kill -9 $ppid
             fi
         done
         exit 2  # Return a different value

--- a/scripts/timeout_kill.sh
+++ b/scripts/timeout_kill.sh
@@ -50,7 +50,7 @@ while true; do
                 kill -9 $pid
             fi
         done
-        exit 2  # Return a different value
+        exit 0  # Return a different value
     fi
 
     # Sleep briefly to avoid a tight loop

--- a/scripts/timeout_kill.sh
+++ b/scripts/timeout_kill.sh
@@ -50,7 +50,7 @@ while true; do
                 kill -9 $pid
             fi
         done
-        exit 0  # Return a different value
+        exit 2  # Return a different value
     fi
 
     # Sleep briefly to avoid a tight loop


### PR DESCRIPTION
### What problem does this PR solve?

1. Kill the parent process of the zombie processes (the separately launched bash) during the shutdown phase.
2. Add a sleep at the appropriate location during the startup phase and adjust the sleep duration.
3. Fix the test annotations.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases
