### PR TITLE
Introduce mem index process

### DIFF
--- a/src/storage/mem_index_process.cpp
+++ b/src/storage/mem_index_process.cpp
@@ -1,0 +1,131 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <thread>
+
+module mem_index_process;
+
+import stl;
+import bg_task;
+import logger;
+import infinity_exception;
+import third_party;
+import blocking_queue;
+import infinity_context;
+import base_memindex;
+import status;
+import wal_manager;
+import global_resource_usage;
+
+import new_txn_manager;
+import new_txn;
+
+namespace infinity {
+
+MemIndexProcessor::MemIndexProcessor() {
+#ifdef INFINITY_DEBUG
+    GlobalResourceUsage::IncrObjectCount("MemIndexProcessor");
+#endif
+}
+
+MemIndexProcessor::~MemIndexProcessor() {
+#ifdef INFINITY_DEBUG
+    GlobalResourceUsage::DecrObjectCount("MemIndexProcessor");
+#endif
+}
+
+void MemIndexProcessor::Start() {
+    LOG_INFO("Compaction processor is started.");
+    processor_thread_ = Thread([this] { Process(); });
+}
+
+void MemIndexProcessor::Stop() {
+    LOG_INFO("Compaction processor is stopping.");
+    SharedPtr<StopProcessorTask> stop_task = MakeShared<StopProcessorTask>();
+    this->Submit(stop_task);
+    stop_task->Wait();
+    processor_thread_.join();
+    LOG_INFO("Compaction processor is stopped.");
+}
+
+void MemIndexProcessor::Submit(SharedPtr<BGTask> bg_task) {
+    task_queue_.Enqueue(std::move(bg_task));
+    ++task_count_;
+}
+
+void MemIndexProcessor::DoDump(DumpIndexTask *dump_task) {
+    auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
+
+    NewTxn *new_txn = dump_task->new_txn_;
+    const String &db_name = dump_task->mem_index_->db_name_;
+    const String &table_name = dump_task->mem_index_->table_name_;
+    const String &index_name = dump_task->mem_index_->index_name_;
+    SegmentID segment_id = dump_task->mem_index_->segment_id_;
+
+    Status status = new_txn->DumpMemIndex(db_name, table_name, index_name, segment_id);
+    if (status.ok()) {
+        status = new_txn_mgr->CommitTxn(new_txn);
+    }
+    if (!status.ok()) {
+        Status rollback_status = new_txn_mgr->RollBackTxn(new_txn);
+        if (!rollback_status.ok()) {
+            UnrecoverableError(rollback_status.message());
+        }
+    }
+
+    return;
+}
+
+void MemIndexProcessor::Process() {
+    bool running = true;
+    while (running) {
+        Deque<SharedPtr<BGTask>> tasks;
+        task_queue_.DequeueBulk(tasks);
+
+        for (const auto &bg_task : tasks) {
+            switch (bg_task->type_) {
+                case BGTaskType::kStopProcessor: {
+                    running = false;
+                    break;
+                }
+                case BGTaskType::kDumpIndex: {
+                    StorageMode storage_mode = InfinityContext::instance().storage()->GetStorageMode();
+                    if (storage_mode == StorageMode::kUnInitialized) {
+                        UnrecoverableError("Uninitialized storage mode");
+                    }
+                    if (storage_mode == StorageMode::kWritable) {
+                        auto dump_task = static_cast<DumpIndexTask *>(bg_task.get());
+                        LOG_DEBUG(dump_task->ToString());
+                        // Trigger transaction to save the mem index
+                        DoDump(dump_task);
+                        LOG_DEBUG("Dump index done.");
+                    }
+                    break;
+                }
+                default: {
+                    String error_message = fmt::format("Invalid background task: {}", (u8)bg_task->type_);
+                    UnrecoverableError(error_message);
+                    break;
+                }
+            }
+            bg_task->Complete();
+        }
+        task_count_ -= tasks.size();
+        tasks.clear();
+    }
+}
+
+} // namespace infinity

--- a/src/storage/mem_index_process.cppm
+++ b/src/storage/mem_index_process.cppm
@@ -1,0 +1,59 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+export module mem_index_process;
+
+import stl;
+import bg_task_type;
+import blocking_queue;
+import status;
+
+namespace infinity {
+
+class TxnManager;
+class NewTxn;
+class BGTask;
+class DumpIndexTask;
+
+export class MemIndexProcessor {
+public:
+    MemIndexProcessor();
+    ~MemIndexProcessor();
+
+    void Start();
+
+    void Stop();
+
+    void Submit(SharedPtr<BGTask> bg_task);
+
+    u64 RunningTaskCount() const { return task_count_; }
+
+private:
+    void NewScanAndOptimize();
+
+    void DoDump(DumpIndexTask *dump_task);
+
+    void Process();
+
+private:
+    BlockingQueue<SharedPtr<BGTask>> task_queue_{"MemIndexProcessor"};
+
+    Thread processor_thread_{};
+
+    Atomic<u64> task_count_{};
+};
+
+} // namespace infinity

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -337,7 +337,6 @@ Status Storage::AdminToWriter() {
 
     // recover index after start compact process
     catalog_->StartMemoryIndexCommit();
-    catalog_->MemIndexRecover(buffer_mgr_.get(), system_start_ts);
 
     this->RecoverMemIndex();
 

--- a/src/storage/storage.cppm
+++ b/src/storage/storage.cppm
@@ -38,6 +38,7 @@ class KVStore;
 class KVInstance;
 class PeriodicTriggerThread;
 class CompactionProcessor;
+class MemIndexProcessor;
 class BGTaskProcessor;
 class BGMemIndexTracer;
 
@@ -76,6 +77,8 @@ public:
     [[nodiscard]] inline PeriodicTriggerThread *periodic_trigger_thread() const noexcept { return periodic_trigger_thread_.get(); }
 
     [[nodiscard]] inline CompactionProcessor *compaction_processor() const noexcept { return compact_processor_.get(); }
+
+    [[nodiscard]] inline MemIndexProcessor *mem_index_processor() const noexcept { return mem_index_processor_.get(); }
 
     [[nodiscard]] inline CleanupInfoTracer *cleanup_info_tracer() const noexcept { return cleanup_info_tracer_.get(); }
 
@@ -133,6 +136,7 @@ private:
     UniquePtr<NewTxnManager> new_txn_mgr_{};
     UniquePtr<BGTaskProcessor> bg_processor_{};
     UniquePtr<CompactionProcessor> compact_processor_{};
+    UniquePtr<MemIndexProcessor> mem_index_processor_{};
     UniquePtr<PeriodicTriggerThread> periodic_trigger_thread_{};
     UniquePtr<KVStore> kv_store_{};
 

--- a/src/unit_test/storage/new_request/index_request.cpp
+++ b/src/unit_test/storage/new_request/index_request.cpp
@@ -115,17 +115,13 @@ TEST_P(TestIndexRequest, fulltext_index_scan) {
 
         EXPECT_EQ(result_table->data_blocks_.size(), 1);
         SharedPtr<DataBlock> data_block = result_table->data_blocks_[0];
-        if (data_block->row_count() > 0) {
-            {
-                SharedPtr<ColumnVector> col0 = data_block->column_vectors[0];
-                EXPECT_EQ(col0->GetValue(0), Value::MakeInt(2));
-            }
-            {
-                SharedPtr<ColumnVector> col1 = data_block->column_vectors[1];
-                EXPECT_EQ(col1->GetValue(0), Value::MakeVarchar("def"));
-            }
-        } else {
-            LOG_ERROR("No result found for the fulltext search.");
+        {
+            SharedPtr<ColumnVector> col0 = data_block->column_vectors[0];
+            EXPECT_EQ(col0->GetValue(0), Value::MakeInt(2));
+        }
+        {
+            SharedPtr<ColumnVector> col1 = data_block->column_vectors[1];
+            EXPECT_EQ(col1->GetValue(0), Value::MakeVarchar("def"));
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

mem index processor is used for: 
1. Dump mem index, due to reach the row count limit, memory size, and segment is sealed.
2. Append and commit full-text index

### Type of change

- [x] Refactoring
