### PR TITLE
Avoid rollback txn again on commit failure

### DIFF
--- a/src/storage/dump_index_process.cpp
+++ b/src/storage/dump_index_process.cpp
@@ -82,9 +82,10 @@ void DumpIndexProcessor::DoDump(DumpIndexTask *dump_task) {
     if (status.ok()) {
         Status commit_status = new_txn_mgr->CommitTxn(new_txn);
         if (!commit_status.ok()) {
-            UnrecoverableError(commit_status.message());
+            LOG_ERROR(fmt::format("Commit dump mem index failed: {}", commit_status.message()));
         }
     } else {
+        LOG_ERROR(fmt::format("Dump mem index failed: {}", status.message()));
         Status rollback_status = new_txn_mgr->RollBackTxn(new_txn);
         if (!rollback_status.ok()) {
             UnrecoverableError(rollback_status.message());

--- a/src/storage/meta/catalog.cpp
+++ b/src/storage/meta/catalog.cpp
@@ -1278,12 +1278,15 @@ void Catalog::MemIndexCommit() {
 
     Status status = NewCatalog::MemIndexCommit(new_txn);
     if (status.ok()) {
-        status = new_txn_mgr->CommitTxn(new_txn);
-    }
-    if (!status.ok()) {
-        Status status1 = new_txn_mgr->RollBackTxn(new_txn);
-        if (!status1.ok()) {
-            UnrecoverableError(fmt::format("Rollback mem index commit failed: {}", status1.message()));
+        Status commit_status = new_txn_mgr->CommitTxn(new_txn);
+        if (!commit_status.ok()) {
+            LOG_ERROR(fmt::format("Commit MemIndex commit failed: {}", commit_status.message()));
+        }
+    } else {
+        LOG_ERROR(fmt::format("MemIndex commit failed: {}", status.message()));
+        Status rollback_status = new_txn_mgr->RollBackTxn(new_txn);
+        if (!rollback_status.ok()) {
+            UnrecoverableError(rollback_status.message());
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

NewTxn::Commit() calls PostRollback() if commit fails, we don't need to call NewTxnManager::RollBackTxn() again on commit failure.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)