### PR TITLE
Add dumping emvb index to dump index process

### DIFF
--- a/src/storage/bg_task/bg_task.cpp
+++ b/src/storage/bg_task/bg_task.cpp
@@ -17,6 +17,7 @@ module;
 module bg_task;
 
 import base_memindex;
+import emvb_index_in_mem;
 import chunk_index_entry;
 import cleanup_scanner;
 import infinity_context;
@@ -63,6 +64,9 @@ NewCompactTask::NewCompactTask(NewTxn *new_txn, String db_name, String table_nam
 
 DumpIndexTask::DumpIndexTask(BaseMemIndex *mem_index, NewTxn *new_txn)
     : BGTask(BGTaskType::kDumpIndex, true), mem_index_(mem_index), new_txn_(new_txn) {}
+
+DumpIndexTask::DumpIndexTask(EMVBIndexInMem *emvb_mem_index, NewTxn *new_txn)
+    : BGTask(BGTaskType::kDumpIndex, true), emvb_mem_index_(emvb_mem_index), new_txn_(new_txn) {}
 
 AppendMemIndexTask::AppendMemIndexTask(const SharedPtr<MemIndex> &mem_index,
                                        const SharedPtr<ColumnVector> &input_column,

--- a/src/storage/bg_task/bg_task.cppm
+++ b/src/storage/bg_task/bg_task.cppm
@@ -27,6 +27,7 @@ namespace infinity {
 struct MemIndex;
 struct ColumnVector;
 class BaseMemIndex;
+class EMVBIndexInMem;
 struct ChunkIndexEntry;
 class NewTxn;
 
@@ -142,6 +143,7 @@ public:
 export class DumpIndexTask final : public BGTask {
 public:
     DumpIndexTask(BaseMemIndex *mem_index, NewTxn *new_txn);
+    DumpIndexTask(EMVBIndexInMem *emvb_mem_index, NewTxn *new_txn);
 
     ~DumpIndexTask() override = default;
 
@@ -149,6 +151,7 @@ public:
 
 public:
     BaseMemIndex *mem_index_{};
+    EMVBIndexInMem *emvb_mem_index_{};
     NewTxn *new_txn_{};
 };
 

--- a/src/storage/catalog/mem_index.cpp
+++ b/src/storage/catalog/mem_index.cpp
@@ -108,4 +108,25 @@ void MemIndex::SetBaseMemIndexInfo(const String &db_name, const String &table_na
     res->segment_id_ = segment_id;
 }
 
+void MemIndex::SetEMVBMemIndexInfo(const String &db_name, const String &table_name, const String &index_name, const SegmentID &segment_id) {
+    EMVBIndexInMem *res = memory_emvb_index_.get();
+    if (res != nullptr) {
+        res->db_name_ = db_name;
+        res->table_name_ = table_name;
+        res->index_name_ = index_name;
+        res->segment_id_ = segment_id;
+    }
+}
+
+EMVBIndexInMem *MemIndex::GetEMVBMemIndex(const MemIndexID &mem_index_id) {
+    EMVBIndexInMem *res = memory_emvb_index_.get();
+    if (res != nullptr) {
+        res->db_name_ = mem_index_id.db_name_;
+        res->table_name_ = mem_index_id.table_name_;
+        res->index_name_ = mem_index_id.index_name_;
+        res->segment_id_ = mem_index_id.segment_id_;
+    }
+    return res;
+}
+
 } // namespace infinity

--- a/src/storage/catalog/mem_index.cppm
+++ b/src/storage/catalog/mem_index.cppm
@@ -44,6 +44,9 @@ export struct MemIndex {
     const BaseMemIndex *GetBaseMemIndex() const;
     void SetBaseMemIndexInfo(const String &db_name, const String &table_name, const String &index_name, const SegmentID &segment_id);
 
+    void SetEMVBMemIndexInfo(const String &db_name, const String &table_name, const String &index_name, const SegmentID &segment_id);
+    EMVBIndexInMem *GetEMVBMemIndex(const MemIndexID &mem_index_id);
+
     SharedPtr<HnswIndexInMem> GetHnswIndex() {
         std::unique_lock<std::mutex> lock(mtx_);
         return memory_hnsw_index_;

--- a/src/storage/dump_index_process.cpp
+++ b/src/storage/dump_index_process.cpp
@@ -26,6 +26,7 @@ import third_party;
 import blocking_queue;
 import infinity_context;
 import base_memindex;
+import emvb_index_in_mem;
 import status;
 import wal_manager;
 import global_resource_usage;
@@ -74,10 +75,23 @@ void DumpIndexProcessor::DoDump(DumpIndexTask *dump_task) {
     auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
 
     NewTxn *new_txn = dump_task->new_txn_;
-    const String &db_name = dump_task->mem_index_->db_name_;
-    const String &table_name = dump_task->mem_index_->table_name_;
-    const String &index_name = dump_task->mem_index_->index_name_;
-    SegmentID segment_id = dump_task->mem_index_->segment_id_;
+    String db_name{};
+    String table_name{};
+    String index_name{};
+    SegmentID segment_id{};
+    if (dump_task->mem_index_ != nullptr) {
+        db_name = dump_task->mem_index_->db_name_;
+        table_name = dump_task->mem_index_->table_name_;
+        index_name = dump_task->mem_index_->index_name_;
+        segment_id = dump_task->mem_index_->segment_id_;
+    } else if (dump_task->emvb_mem_index_ != nullptr) {
+        db_name = dump_task->emvb_mem_index_->db_name_;
+        table_name = dump_task->emvb_mem_index_->table_name_;
+        index_name = dump_task->emvb_mem_index_->index_name_;
+        segment_id = dump_task->emvb_mem_index_->segment_id_;
+    } else {
+        UnrecoverableError("Invalid mem index");
+    }
 
     Status commit_status = Status::OK();
     Status rollback_status = Status::OK();

--- a/src/storage/knn_index/emvb/emvb_index_in_mem.cppm
+++ b/src/storage/knn_index/emvb/emvb_index_in_mem.cppm
@@ -49,7 +49,6 @@ export class EMVBIndexInMem {
 
     String db_id_str_;
     String table_id_str_;
-    SegmentID segment_id_ = -1;
 
     u32 row_count_ = 0;       // row of tensors
     u32 embedding_count_ = 0; // count of total embeddings
@@ -59,6 +58,11 @@ export class EMVBIndexInMem {
     u32 build_index_threshold_ = 0; // bar for building index
 
 public:
+    String db_name_{};
+    String table_name_{};
+    String index_name_{};
+    SegmentID segment_id_ = -1;
+
     static SharedPtr<EMVBIndexInMem>
     NewEMVBIndexInMem(const SharedPtr<IndexBase> &index_base, const SharedPtr<ColumnDef> &column_def, RowID begin_row_id);
 

--- a/src/storage/tracer/memindex_tracer.cpp
+++ b/src/storage/tracer/memindex_tracer.cpp
@@ -20,6 +20,7 @@ module memindex_tracer;
 
 import stl;
 import base_memindex;
+import emvb_index_in_mem;
 import bg_task;
 import infinity_context;
 import infinity_exception;
@@ -140,7 +141,6 @@ UniquePtr<DumpIndexTask> MemIndexTracer::MakeDumpTask() {
 
     auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
     NewTxn *new_txn = new_txn_mgr->BeginTxn(MakeUnique<String>("Dump index"), TransactionType::kNormal);
-    Vector<BaseMemIndex *> mem_indexes = GetUndumpedMemIndexes(new_txn);
 
     bool make_task = false;
     DeferFn defer_op([&] {
@@ -153,20 +153,27 @@ UniquePtr<DumpIndexTask> MemIndexTracer::MakeDumpTask() {
         }
     });
 
-    if (mem_indexes.empty()) {
+    UniquePtr<DumpIndexTask> dump_task{};
+    Vector<BaseMemIndex *> mem_indexes = GetUndumpedMemIndexes(new_txn);
+    Vector<EMVBIndexInMem *> emvb_indexes = GetEMVBMemIndexes(new_txn);
+    if (!mem_indexes.empty()) {
+        SizeT dump_idx = ChooseDump(mem_indexes);
+        BaseMemIndex *mem_index = mem_indexes[dump_idx];
+        MemIndexTracerInfo info = mem_index->GetInfo();
+        dump_task = MakeUnique<DumpIndexTask>(mem_index, new_txn);
+
+        acc_proposed_dump_.fetch_add(info.mem_used_);
+        proposed_dump_[mem_index] = info.mem_used_;
+    } else if (!emvb_indexes.empty()) {
+        // FIXME: We do not calculate the memory used for each EMVB index,
+        // so we choose the first EMVB index to dump.
+        EMVBIndexInMem *emvb_index = emvb_indexes[0];
+        dump_task = MakeUnique<DumpIndexTask>(emvb_index, new_txn);
+    } else {
         LOG_WARN("Cannot find memindex to dump");
         return nullptr;
     }
-    SizeT dump_idx = ChooseDump(mem_indexes);
-    auto *mem_index = mem_indexes[dump_idx];
-    auto info = mem_index->GetInfo();
 
-    UniquePtr<DumpIndexTask> dump_task;
-
-    dump_task = MakeUnique<DumpIndexTask>(mem_index, new_txn);
-
-    acc_proposed_dump_.fetch_add(info.mem_used_);
-    proposed_dump_[mem_index] = info.mem_used_;
     make_task = true;
     return dump_task;
 }
@@ -239,9 +246,11 @@ Vector<BaseMemIndex *> BGMemIndexTracer::GetAllMemIndexes(NewTxn *new_txn) {
     for (SizeT i = 0; i < mem_indexes.size(); ++i) {
         auto &mem_index = mem_indexes[i];
         auto &mem_index_id = mem_index_ids[i];
-        auto *base_mem_index = mem_index->GetBaseMemIndex(mem_index_id);
-        if (base_mem_index) {
+        BaseMemIndex *base_mem_index = mem_index->GetBaseMemIndex(mem_index_id);
+        EMVBIndexInMem *emvb_index = mem_index->GetEMVBMemIndex(mem_index_id);
+        if (base_mem_index != nullptr) {
             base_mem_indexes.emplace_back(base_mem_index);
+        } else if (emvb_index != nullptr) {
         } else {
             LOG_WARN(fmt::format("Not implement base index of index {}.{}.{}.{}",
                                  mem_index_id.db_name_,
@@ -251,6 +260,35 @@ Vector<BaseMemIndex *> BGMemIndexTracer::GetAllMemIndexes(NewTxn *new_txn) {
         }
     }
     return base_mem_indexes;
+}
+
+Vector<EMVBIndexInMem *> BGMemIndexTracer::GetEMVBMemIndexes(NewTxn *new_txn) {
+    Vector<SharedPtr<MemIndex>> mem_indexes;
+    Vector<MemIndexID> mem_index_ids;
+    Status status = NewCatalog::GetAllMemIndexes(new_txn, mem_indexes, mem_index_ids);
+    if (!status.ok()) {
+        UnrecoverableError(status.message());
+    }
+
+    Vector<EMVBIndexInMem *> emvb_indexes;
+    for (SizeT i = 0; i < mem_indexes.size(); ++i) {
+        auto &mem_index = mem_indexes[i];
+        auto &mem_index_id = mem_index_ids[i];
+        BaseMemIndex *base_mem_index = mem_index->GetBaseMemIndex(mem_index_id);
+        EMVBIndexInMem *emvb_index = mem_index->GetEMVBMemIndex(mem_index_id);
+
+        if (emvb_index != nullptr) {
+            emvb_indexes.emplace_back(emvb_index);
+        } else if (base_mem_index != nullptr) {
+        } else {
+            LOG_WARN(fmt::format("Not implement base index of index {}.{}.{}.{}",
+                                 mem_index_id.db_name_,
+                                 mem_index_id.table_name_,
+                                 mem_index_id.index_name_,
+                                 mem_index_id.segment_id_));
+        }
+    }
+    return emvb_indexes;
 }
 
 } // namespace infinity

--- a/src/storage/tracer/memindex_tracer.cppm
+++ b/src/storage/tracer/memindex_tracer.cppm
@@ -31,7 +31,7 @@ struct Catalog;
 class TxnManager;
 class NewTxnManager;
 class DumpIndexTask;
-class NewTxn;
+class EMVBIndexInMem;
 
 export struct MemIndexTracerInfo {
 public:
@@ -82,6 +82,8 @@ protected:
 
     virtual Vector<BaseMemIndex *> GetAllMemIndexes(NewTxn *new_txn) = 0;
 
+    virtual Vector<EMVBIndexInMem *> GetEMVBMemIndexes(NewTxn *new_txn) = 0;
+
     using MemIndexMapIter = HashSet<BaseMemIndex *>::iterator;
 
     UniquePtr<DumpIndexTask> MakeDumpTask();
@@ -126,6 +128,8 @@ protected:
     Vector<BaseMemIndex *> GetAllMemIndexes(Txn *txn) override;
 
     Vector<BaseMemIndex *> GetAllMemIndexes(NewTxn *new_txn) override;
+
+    Vector<EMVBIndexInMem *> GetEMVBMemIndexes(NewTxn *new_txn) override;
 
 private:
     NewTxnManager *txn_mgr_;

--- a/src/unit_test/storage/tracer/test_tracer.cpp
+++ b/src/unit_test/storage/tracer/test_tracer.cpp
@@ -18,6 +18,7 @@ import base_test;
 import stl;
 import memindex_tracer;
 import base_memindex;
+import emvb_index_in_mem;
 import bg_task;
 import blocking_queue;
 import third_party;
@@ -171,6 +172,8 @@ public:
     Vector<BaseMemIndex *> GetAllMemIndexes(Txn *txn) override { return catalog_.GetMemIndexes(); }
 
     Vector<BaseMemIndex *> GetAllMemIndexes(NewTxn *new_txn) override { return {}; }
+
+    Vector<EMVBIndexInMem *> GetEMVBMemIndexes(NewTxn *new_txn) override { return {}; }
 
     void HandleDump(UniquePtr<DumpIndexTask> task);
 


### PR DESCRIPTION
### What problem does this PR solve?
Trigger dump index process to dump EMVB index when needed.
2 cases:
1) Dump sealed segment during Append
2) Memory usage is higher than limits.

-----------------
2 issues in current code:
1) proposed_dump_  and acc_proposed_dump_ in MemIndexTracer are  calculated wrongly.
2) No memory usage calculation for EMVB index.


### Type of change

- [x] Refactoring

