### PR TITLE
Show tasks for background activities

### DIFF
--- a/src/storage/bg_task/bg_task.cpp
+++ b/src/storage/bg_task/bg_task.cpp
@@ -83,11 +83,11 @@ Status NewCleanupTask::Execute(TxnTimeStamp last_cleanup_ts, TxnTimeStamp &cur_c
 NewCompactTask::NewCompactTask(NewTxn *new_txn, String db_name, String table_name)
     : BGTask(BGTaskType::kNewCompact, false), new_txn_(new_txn), db_name_(db_name), table_name_(table_name) {}
 
-DumpIndexTask::DumpIndexTask(BaseMemIndex *mem_index, NewTxn *new_txn)
-    : BGTask(BGTaskType::kDumpIndex, true), mem_index_(mem_index), new_txn_(new_txn) {}
+DumpIndexTask::DumpIndexTask(BaseMemIndex *mem_index, SharedPtr<NewTxn> &new_txn_shared)
+    : BGTask(BGTaskType::kDumpIndex, true), mem_index_(mem_index), new_txn_shared_(new_txn_shared) {}
 
-DumpIndexTask::DumpIndexTask(EMVBIndexInMem *emvb_mem_index, NewTxn *new_txn)
-    : BGTask(BGTaskType::kDumpIndex, true), emvb_mem_index_(emvb_mem_index), new_txn_(new_txn) {}
+DumpIndexTask::DumpIndexTask(EMVBIndexInMem *emvb_mem_index, SharedPtr<NewTxn> &new_txn_shared)
+    : BGTask(BGTaskType::kDumpIndex, true), emvb_mem_index_(emvb_mem_index), new_txn_shared_(new_txn_shared) {}
 
 AppendMemIndexTask::AppendMemIndexTask(const SharedPtr<MemIndex> &mem_index,
                                        const SharedPtr<ColumnVector> &input_column,
@@ -108,6 +108,6 @@ void AppendMemIndexBatch::WaitForCompletion() {
 
 TestCommandTask::TestCommandTask(String command_content) : BGTask(BGTaskType::kTestCommand, true), command_content_(std::move(command_content)) {}
 
-BGTaskInfo::BGTaskInfo(BGTaskType type) : type_(type) {}
+BGTaskInfo::BGTaskInfo(BGTaskType type) : type_(type), task_time_(std::chrono::system_clock::now()) {}
 
 } // namespace infinity

--- a/src/storage/bg_task/bg_task.cppm
+++ b/src/storage/bg_task/bg_task.cppm
@@ -142,8 +142,8 @@ public:
 
 export class DumpIndexTask final : public BGTask {
 public:
-    DumpIndexTask(BaseMemIndex *mem_index, NewTxn *new_txn);
-    DumpIndexTask(EMVBIndexInMem *emvb_mem_index, NewTxn *new_txn);
+    DumpIndexTask(BaseMemIndex *mem_index, SharedPtr<NewTxn> &new_txn_shared);
+    DumpIndexTask(EMVBIndexInMem *emvb_mem_index, SharedPtr<NewTxn> &new_txn_shared);
 
     ~DumpIndexTask() override = default;
 
@@ -152,7 +152,7 @@ public:
 public:
     BaseMemIndex *mem_index_{};
     EMVBIndexInMem *emvb_mem_index_{};
-    NewTxn *new_txn_{};
+    SharedPtr<NewTxn> new_txn_shared_{};
 };
 
 export class AppendMemIndexTask final : public BGTask {
@@ -199,6 +199,7 @@ export struct BGTaskInfo {
     Vector<String> task_info_list_{};
     Vector<String> status_list_{};
     BGTaskType type_{BGTaskType::kInvalid};
+    std::chrono::system_clock::time_point task_time_{};
 };
 
 } // namespace infinity

--- a/src/storage/dump_index_process.cpp
+++ b/src/storage/dump_index_process.cpp
@@ -37,6 +37,7 @@ import column_vector;
 import mem_index;
 import memory_indexer;
 import txn_state;
+import base_txn_store;
 
 namespace infinity {
 
@@ -74,7 +75,7 @@ void DumpIndexProcessor::Submit(SharedPtr<BGTask> bg_task) {
 void DumpIndexProcessor::DoDump(DumpIndexTask *dump_task) {
     auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
 
-    NewTxn *new_txn = dump_task->new_txn_;
+    SharedPtr<NewTxn> new_txn_shared = dump_task->new_txn_shared_;
     String db_name{};
     String table_name{};
     String index_name{};
@@ -97,22 +98,55 @@ void DumpIndexProcessor::DoDump(DumpIndexTask *dump_task) {
     Status rollback_status = Status::OK();
     i64 retry_count = 0;
     do {
+        SharedPtr<BGTaskInfo> bg_task_info = MakeShared<BGTaskInfo>(BGTaskType::kDumpIndex);
+
         if (!commit_status.ok()) {
-            new_txn = new_txn_mgr->BeginTxn(MakeUnique<String>("dump mem index"), TransactionType::kNormal);
+            new_txn_shared = new_txn_mgr->BeginTxnShared(MakeUnique<String>("Dump index"), TransactionType::kNormal);
         }
 
-        Status status = new_txn->DumpMemIndex(db_name, table_name, index_name, segment_id);
+        Status status = new_txn_shared->DumpMemIndex(db_name, table_name, index_name, segment_id);
         if (status.ok()) {
-            commit_status = new_txn_mgr->CommitTxn(new_txn);
+            commit_status = new_txn_mgr->CommitTxn(new_txn_shared.get());
             if (!commit_status.ok()) {
-                LOG_ERROR(fmt::format("Commit dump mem index failed: {}", commit_status.message()));
+                LOG_ERROR(fmt::format("Commit dump mem index {}.{}.{} in segment: failed: {}",
+                                      db_name,
+                                      table_name,
+                                      index_name,
+                                      segment_id,
+                                      status.message()));
+            }
+
+            DumpMemIndexTxnStore *dump_index_txn_store = static_cast<DumpMemIndexTxnStore *>(new_txn_shared->GetTxnStore());
+            if (dump_index_txn_store != nullptr) {
+                String task_text = fmt::format("Txn: {}, commit: {}, dump mem index: {}.{}.{} in segment: {} into chunk:{}",
+                                               new_txn_shared->TxnID(),
+                                               new_txn_shared->CommitTS(),
+                                               db_name,
+                                               table_name,
+                                               dump_index_txn_store->index_name_,
+                                               dump_index_txn_store->segment_ids_[0],
+                                               dump_index_txn_store->chunk_infos_in_segments_[dump_index_txn_store->segment_ids_[0]][0].chunk_id_);
+                bg_task_info->task_info_list_.emplace_back(task_text);
+                if (commit_status.ok()) {
+                    bg_task_info->status_list_.emplace_back("OK");
+                } else {
+                    bg_task_info->status_list_.emplace_back(commit_status.message());
+                }
             }
         } else {
-            LOG_ERROR(fmt::format("Dump mem index failed: {}", status.message()));
-            Status rollback_status = new_txn_mgr->RollBackTxn(new_txn);
+            LOG_ERROR(fmt::format("Dump mem index {}.{}.{} in segment: failed: {}", db_name, table_name, index_name, segment_id, status.message()));
+            Status rollback_status = new_txn_mgr->RollBackTxn(new_txn_shared.get());
             if (!rollback_status.ok()) {
                 UnrecoverableError(rollback_status.message());
             }
+
+            String task_text = fmt::format("Dump mem index: {}.{}.{} in segment: {}", db_name, table_name, index_name, segment_id);
+            bg_task_info->task_info_list_.emplace_back(task_text);
+            bg_task_info->status_list_.emplace_back(status.message());
+        }
+
+        if (!bg_task_info->task_info_list_.empty()) {
+            new_txn_mgr->AddTaskInfo(bg_task_info);
         }
     } while (!commit_status.ok() && rollback_status.ok() && (commit_status.code_ == ErrorCode::kTxnConflict || ++retry_count <= 3));
 }


### PR DESCRIPTION
### What problem does this PR solve?

Show tasks for  periodic compact, periodic optimize, dump mem index, checkpoint and cleanup.

The output of "show tasks":

```
 2025-06-12 14:46:52 | NewCheckpoint | OK     | Txn: 97136, commit: 136096, checkpoint data: 1.3242.0.1 data and version
 2025-06-12 14:46:52 | NewCheckpoint | OK     | Txn: 97136, commit: 136096, checkpoint data: 1.3242.0.2 data and version
 2025-06-12 14:46:52 | NewCheckpoint | OK     | Txn: 97136, commit: 136096, checkpoint data: 1.3242.0.3 data and version
 2025-06-12 14:47:22 | NewCheckpoint | OK     | Txn: 113065, commit: 143154, checkpoint data: 1.3297.0.0 data and version
 2025-06-12 14:48:02 | NotifyCompact | OK     | Txn: 116015, commit: 143892, compact table: default_db.test_vector_index_parallel with segments: 0,1,2,3 into 164
 2025-06-11 04:20:43 | NotifyOptimize | OK    | Txn: 16, commit: 26, optimize index: db1.tb1.index1 segment: 0 with chunks: 0,1,2 into 3
 2025-06-11 05:58:43 | DumpIndex     | OK     | Txn: 148341, commit: 152896, dump mem index: default_db.test_insert_with_index_large_data_remote.my_index in segment: 0 into chunk:0
```

### Type of change

- [x] New Feature (non-breaking change which adds functionality)