### PR TITLE
Rollback dump index

### DIFF
--- a/src/storage/catalog/meta/segment_index_meta.cpp
+++ b/src/storage/catalog/meta/segment_index_meta.cpp
@@ -343,14 +343,18 @@ Status SegmentIndexMeta::UninitSet1(UsageFlag usage_flag) {
         next_chunk_id_.reset();
     }
     if (usage_flag == UsageFlag::kOther) {
-        {
-            // Remove mem index
-            String mem_index_key = GetSegmentIndexTag("mem_index");
-            NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
-            Status status = new_catalog->DropMemIndexByMemIndexKey(mem_index_key);
-            if (!status.ok()) {
-                return status;
-            }
+        // Clear mem index
+        SharedPtr<MemIndex> mem_index = GetMemIndex();
+        if (mem_index != nullptr) {
+            mem_index->ClearMemIndex();
+        }
+
+        // Remove mem index
+        String mem_index_key = GetSegmentIndexTag("mem_index");
+        NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
+        Status status = new_catalog->DropMemIndexByMemIndexKey(mem_index_key);
+        if (!status.ok()) {
+            return status;
         }
     }
     {

--- a/src/storage/new_txn/base_txn_store.cpp
+++ b/src/storage/new_txn/base_txn_store.cpp
@@ -265,7 +265,6 @@ SharedPtr<WalEntry> DumpMemIndexTxnStore::ToWalEntry(TxnTimeStamp commit_ts) con
         SharedPtr<WalCmdDumpIndexV2> wal_command =
             MakeShared<WalCmdDumpIndexV2>(db_name_, db_id_str_, table_name_, table_id_str_, index_name_, index_id_str_, segment_id, table_key_);
         wal_command->dump_cause_ = DumpIndexCause::kDumpMemIndex;
-        wal_command->clear_mem_index_ = true;
         wal_command->chunk_infos_ = chunk_infos_in_segments_.at(segment_id);
         wal_entry->cmds_.push_back(wal_command);
     }

--- a/src/storage/new_txn/new_txn.cpp
+++ b/src/storage/new_txn/new_txn.cpp
@@ -3763,8 +3763,8 @@ Status NewTxn::PostRollback(TxnTimeStamp abort_ts) {
             for (SizeT i = 0; i < index_names_size; ++i) {
                 // Restore memory index here
                 auto index_id_str = compact_txn_store->index_ids_str_[i];
-                const Vector<SegmentID> &deprecated_ids = compact_txn_store->deprecated_segment_ids_;
-                for (SegmentID segment_id : deprecated_ids) {
+                const Vector<SegmentID> &segment_ids = compact_txn_store->segment_ids_;
+                for (const SegmentID &segment_id : segment_ids) {
                     metas.emplace_back(MakeUnique<SegmentMetaKey>(db_id_str, table_id_str, segment_id));
                     metas.emplace_back(MakeUnique<SegmentIndexMetaKey>(db_id_str, table_id_str, index_id_str, segment_id));
                 }

--- a/src/storage/new_txn/new_txn_data.cpp
+++ b/src/storage/new_txn/new_txn_data.cpp
@@ -168,15 +168,15 @@ struct NewTxnCompactState {
         return status;
     }
 
-    TxnTimeStamp commit_ts_;
-    Optional<SegmentMeta> new_segment_meta_;
-    Optional<BlockMeta> block_meta_;
+    TxnTimeStamp commit_ts_{};
+    Optional<SegmentMeta> new_segment_meta_{};
+    Optional<BlockMeta> block_meta_{};
 
-    Vector<SizeT> block_row_cnts_;
-    SizeT segment_row_cnt_ = 0;
-    BlockOffset cur_block_row_cnt_ = 0;
-    Vector<ColumnVector> column_vectors_;
-    SizeT column_cnt_ = 0;
+    Vector<SizeT> block_row_cnts_{};
+    SizeT segment_row_cnt_{};
+    BlockOffset cur_block_row_cnt_{};
+    Vector<ColumnVector> column_vectors_{};
+    SizeT column_cnt_{};
 };
 
 Status NewTxn::Import(const String &db_name, const String &table_name, const Vector<SharedPtr<DataBlock>> &input_blocks) {

--- a/src/storage/new_txn/new_txn_index.cpp
+++ b/src/storage/new_txn/new_txn_index.cpp
@@ -249,15 +249,6 @@ Status NewTxn::CommitBottomDumpMemIndex(WalCmdDumpIndexV2 *dump_index_cmd) {
         return status;
     }
 
-    // Clean Mem Index
-    if (dump_index_cmd->clear_mem_index_) {
-        SegmentIndexMeta segment_index_meta(segment_id, *table_index_meta);
-        SharedPtr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
-        if (mem_index != nullptr) {
-            mem_index->ClearMemIndex();
-        }
-    }
-
     TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     auto [index_base, status2] = table_index_meta->GetIndexBase();
     if (!status2.ok()) {
@@ -2040,13 +2031,6 @@ Status NewTxn::PostCommitDumpIndex(const WalCmdDumpIndexV2 *dump_index_cmd, KVIn
 
     const String &index_id_str_ = dump_index_cmd->index_id_;
     TableIndexMeeta table_index_meta(index_id_str_, table_meta);
-    if (dump_index_cmd->clear_mem_index_) {
-        SegmentIndexMeta segment_index_meta(segment_id, table_index_meta);
-        SharedPtr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
-        if (mem_index != nullptr) {
-            mem_index->ClearMemIndex();
-        }
-    }
 
     auto [index_base, status] = table_index_meta.GetIndexBase();
     if (!status.ok()) {

--- a/src/storage/wal/wal_entry.cppm
+++ b/src/storage/wal/wal_entry.cppm
@@ -866,9 +866,6 @@ export struct WalCmdDumpIndexV2 final : public WalCmd {
 
     // Redudant but useful in commit phase.
     String table_key_{};
-
-    // Only used in commit phase. Don't need to write to WAL.
-    bool clear_mem_index_{};
     DumpIndexCause dump_cause_{DumpIndexCause::kInvalid};
 };
 

--- a/src/unit_test/storage/new_catalog/compact.cpp
+++ b/src/unit_test/storage/new_catalog/compact.cpp
@@ -1547,7 +1547,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         EXPECT_TRUE(status.ok());
     };
 
-    auto CheckWithNoIndex = [&] {
+    auto CheckWithNoIndex = [&](const Vector<SegmentID> &segment_ids) {
         auto *txn = new_txn_mgr->BeginTxn(MakeUnique<String>("check table"), TransactionType::kNormal);
 
         Optional<DBMeeta> db_meta;
@@ -1558,7 +1558,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         Vector<SegmentID> *segment_ids_ptr = nullptr;
         std::tie(segment_ids_ptr, status) = table_meta->GetSegmentIDs1();
         EXPECT_TRUE(status.ok());
-        EXPECT_EQ(*segment_ids_ptr, Vector<SegmentID>({2}));
+        EXPECT_EQ(*segment_ids_ptr, segment_ids);
 
         Vector<String> *index_ids_strs_ptr = nullptr;
         Vector<String> *index_names_ptr = nullptr;
@@ -1601,10 +1601,10 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn2);
         EXPECT_TRUE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({2});
         DropDB();
     }
-    /* FIXME: PostRollback() for dump index is not implemented.
+
     {
         PrepareForCompact();
 
@@ -1627,7 +1627,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn2);
         EXPECT_FALSE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({0,1});
         DropDB();
     }
     {
@@ -1652,7 +1652,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn2);
         EXPECT_FALSE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({0,1});
         DropDB();
     }
     {
@@ -1676,10 +1676,10 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({2});
         DropDB();
     }
-    */
+
     {
         PrepareForCompact();
 
@@ -1703,7 +1703,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({2});
         DropDB();
     }
     {
@@ -1727,7 +1727,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({2});
         DropDB();
     }
     {
@@ -1752,7 +1752,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({2});
         DropDB();
     }
     {
@@ -1775,7 +1775,7 @@ TEST_P(TestTxnCompact, compact_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn);
         EXPECT_TRUE(status.ok());
 
-        CheckWithNoIndex();
+        CheckWithNoIndex({2});
         DropDB();
     }
 }

--- a/src/unit_test/storage/new_catalog/dump_mem_index.cpp
+++ b/src/unit_test/storage/new_catalog/dump_mem_index.cpp
@@ -402,9 +402,8 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
         EXPECT_TRUE(status.ok());
     }
 
-    /* FIXME: PostRollback() for dump index is not implemented.
     // dump index and drop db
-    //  t1            dump index                             commit (success)
+    //  t1            dump index                             commit (fail)
     //  |--------------|------------------------------------------|
     //                         |------------------|----------|
     //                        t2                drop db    commit
@@ -428,7 +427,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get db"), TransactionType::kNormal);
         auto [db_info, db_status] = txn7->GetDatabaseInfo(*db_name);
@@ -438,7 +437,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
     }
 
     // dump index and drop db
-    //  t1            dump index                             commit (success)
+    //  t1            dump index                             commit (fail)
     //  |--------------|------------------------------------------|
     //         |------------------|----------|
     //         t2                drop db    commit
@@ -464,7 +463,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get db"), TransactionType::kNormal);
         auto [db_info, db_status] = txn7->GetDatabaseInfo(*db_name);
@@ -474,7 +473,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
     }
 
     // dump index and drop db
-    //  t1                                  dump index                             commit (success)
+    //  t1                                  dump index                             commit (fail)
     //  |---------------------------------------|------------------------------------------|
     //         |------------------|----------|
     //         t2                drop db    commit
@@ -498,7 +497,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
         status = txn->DumpMemIndex(*db_name, *table_name, *index_name1, segment_id);
         EXPECT_TRUE(status.ok());
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get db"), TransactionType::kNormal);
         auto [db_info, db_status] = txn7->GetDatabaseInfo(*db_name);
@@ -508,7 +507,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
     }
 
     // dump index and drop db
-    //                                 t1                    dump index                             commit (success)
+    //                                 t1                    dump index                             commit (fail)
     //                                 |----------------------|------------------------------------------|
     //         |------------------|----------|
     //         t2                drop db    commit
@@ -533,7 +532,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
         status = txn->DumpMemIndex(*db_name, *table_name, *index_name1, segment_id);
         EXPECT_TRUE(status.ok());
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get db"), TransactionType::kNormal);
         auto [db_info, db_status] = txn7->GetDatabaseInfo(*db_name);
@@ -541,7 +540,6 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_db) {
         status = new_txn_mgr->RollBackTxn(txn7);
         EXPECT_TRUE(status.ok());
     }
-    */
 
     // dump index and drop db
     //                                            t1                    dump index                             commit (success)
@@ -929,9 +927,8 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
         drop_db(*db_name);
     }
 
-    /* FIXME: PostRollback() for dump index is not implemented.
     // dump index and drop db
-    //  t1            dump index                             commit (success)
+    //  t1            dump index                             commit (fail)
     //  |--------------|------------------------------------------|
     //                         |------------------|----------|
     //                        t2                drop table    commit
@@ -961,13 +958,13 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         drop_db(*db_name);
     }
 
     // dump index and drop db
-    //  t1            dump index                             commit (success)
+    //  t1            dump index                             commit (fail)
     //  |--------------|------------------------------------------|
     //         |------------------|-------------|
     //         t2                drop table    commit
@@ -993,7 +990,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get table"), TransactionType::kNormal);
         auto [table_info, table_status] = txn7->GetTableInfo(*db_name, *table_name);
@@ -1005,7 +1002,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
     }
 
     // dump index and drop db
-    //  t1                                  dump index                             commit (success)
+    //  t1                                  dump index                             commit (fail)
     //  |---------------------------------------|------------------------------------------|
     //         |------------------|----------|
     //         t2                drop table    commit
@@ -1030,7 +1027,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get table"), TransactionType::kNormal);
         auto [table_info, table_status] = txn7->GetTableInfo(*db_name, *table_name);
@@ -1042,7 +1039,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
     }
 
     // dump index and drop db
-    //                                 t1                    dump index                             commit (success)
+    //                                 t1                    dump index                             commit (fail)
     //                                 |----------------------|------------------------------------------|
     //         |------------------|----------|
     //         t2                drop table    commit
@@ -1068,7 +1065,7 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("get table"), TransactionType::kNormal);
         auto [table_info, table_status] = txn7->GetTableInfo(*db_name, *table_name);
@@ -1078,7 +1075,6 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_table) {
 
         drop_db(*db_name);
     }
-    */
 
     // dump index and drop db
     //                                            t1                    dump index                             commit (success)
@@ -3546,7 +3542,6 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_index) {
         drop_db(*db_name);
     }
 
-    /* FIXME: PostRollback() for dump index is not implemented.
     //  t1            dump index                                               commit (fail)
     //  |--------------|--------------------------------------------------------------|
     //                         |------------------|--------------------|
@@ -3696,7 +3691,6 @@ TEST_P(TestTxnDumpMemIndex, dump_and_drop_index) {
 
         drop_db(*db_name);
     }
-    */
 
     //                                            t1                    dump index                             commit (success)
     //                                            |----------------------|------------------------------------------|

--- a/src/unit_test/storage/new_catalog/import.cpp
+++ b/src/unit_test/storage/new_catalog/import.cpp
@@ -5430,7 +5430,6 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         EXPECT_TRUE(status.ok());
     }
 
-    /* FIXME: PostRollback() for dump index is not implemented.
     //    t1      import                                   commit (fail)
     //    |----------|-----------------------------------------------|
     //                    |-------------|-----------------------|
@@ -5463,7 +5462,7 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         auto *txn3 = new_txn_mgr->BeginTxn(MakeUnique<String>("import"), TransactionType::kNormal);
         Vector<SharedPtr<DataBlock>> input_blocks1 = {make_input_block(), make_input_block()};
         status = txn3->Import(*db_name, *table_name, input_blocks1);
-        EXPECT_FALSE(status.ok());
+        EXPECT_TRUE(status.ok());
 
         // drop index idx1
         auto *txn7 = new_txn_mgr->BeginTxn(MakeUnique<String>("drop index"), TransactionType::kNormal);
@@ -5473,7 +5472,7 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         EXPECT_TRUE(status.ok());
 
         status = new_txn_mgr->CommitTxn(txn3);
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok());
 
         // Scan and check
         auto *txn5 = new_txn_mgr->BeginTxn(MakeUnique<String>("scan"), TransactionType::kNormal);
@@ -5481,7 +5480,7 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         Optional<TableMeeta> table_meta;
         status = txn5->GetTableMeta(*db_name, *table_name, db_meta, table_meta);
         EXPECT_TRUE(status.ok());
-        check_table(*table_meta, txn5, {0});
+        check_table(*table_meta, txn5, {});
         status = new_txn_mgr->CommitTxn(txn5);
         EXPECT_TRUE(status.ok());
 
@@ -5545,7 +5544,7 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         Optional<TableMeeta> table_meta;
         status = txn5->GetTableMeta(*db_name, *table_name, db_meta, table_meta);
         EXPECT_TRUE(status.ok());
-        check_table(*table_meta, txn5, {0});
+        check_table(*table_meta, txn5, {});
         status = new_txn_mgr->CommitTxn(txn5);
         EXPECT_TRUE(status.ok());
 
@@ -5607,7 +5606,7 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         Optional<TableMeeta> table_meta;
         status = txn5->GetTableMeta(*db_name, *table_name, db_meta, table_meta);
         EXPECT_TRUE(status.ok());
-        check_table(*table_meta, txn5, {0});
+        check_table(*table_meta, txn5, {});
         status = new_txn_mgr->CommitTxn(txn5);
         EXPECT_TRUE(status.ok());
 
@@ -5670,7 +5669,7 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         Optional<TableMeeta> table_meta;
         status = txn5->GetTableMeta(*db_name, *table_name, db_meta, table_meta);
         EXPECT_TRUE(status.ok());
-        check_table(*table_meta, txn5, {0});
+        check_table(*table_meta, txn5, {});
         status = new_txn_mgr->CommitTxn(txn5);
         EXPECT_TRUE(status.ok());
 
@@ -5681,7 +5680,6 @@ TEST_P(TestTxnImport, test_import_and_drop_index) {
         status = new_txn_mgr->CommitTxn(txn6);
         EXPECT_TRUE(status.ok());
     }
-    */
 
     //                                                           t1                  import                             commit (success)
     //                                                          |--------------------|------------------------------------------|


### PR DESCRIPTION
### What problem does this PR solve?

1）Clear mem index in 2 places:
- At the end of DumpSegmentMemIndex() if dump is successful.
- In SegmentIndexMeta::UninitSet1()

2) Fix bug of compact during PostRollback()

3) Update tests.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Refactoring
