### PR TITLE
Fix NewTxn::Import to request more than one segment when needed

### DIFF
--- a/python/infinity_http.py
+++ b/python/infinity_http.py
@@ -702,6 +702,19 @@ class table_http:
         self.net.raise_exception(r)
         return database_result()
 
+    def show_segments(self):
+        url = f"databases/{self.database_name}/tables/{self.table_name}/segments"
+        h = self.net.set_up_header(["accept", "content-type"])
+        r = self.net.request(url, "get", h)
+        self.net.raise_exception(r)
+        return pd.DataFrame(r.json()['segments'])
+
+    def show_blocks(self, segment_id: int):
+        url = f"databases/{self.database_name}/tables/{self.table_name}/segments/{segment_id}/blocks"
+        h = self.net.set_up_header(["accept", "content-type"])
+        r = self.net.request(url, "get", h)
+        self.net.raise_exception(r)
+        return pd.DataFrame(r.json()['blocks'])
 
 class table_http_result:
     def __init__(self, output: list, table_http: table_http):

--- a/python/test_pysdk/test_py_import.py
+++ b/python/test_pysdk/test_py_import.py
@@ -443,19 +443,21 @@ class TestInfinity:
 
         db_obj.drop_table("test_import_exceeding_rows"+suffix, ConflictType.Error)
 
-    @pytest.mark.parametrize("check_data", [{"file_name": "test_import_more_than_one_segment.csv",
+    @pytest.mark.parametrize("check_data", [{"file_name": "test_sdk_import_more_than_one_segment.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     def test_import_more_than_one_segment(self, check_data, suffix):
+        file_name = "test_sdk_import_more_than_one_segment"
+        table_name = f"{file_name}{suffix}"
         if not check_data:
-            generate_big_rows_csv(1024 * 8192 + 1, "test_import_more_than_one_segment.csv")
-            copy_data("test_import_more_than_one_segment.csv")
+            generate_big_rows_csv(1024 * 8192 + 1, f"{file_name}.csv")
+            copy_data(f"{file_name}.csv")
 
         db_obj = self.infinity_obj.get_database("default_db")
-        db_obj.drop_table("test_import_more_than_one_segment"+suffix, ConflictType.Ignore)
-        table_obj = db_obj.create_table("test_import_more_than_one_segment"+suffix,
+        db_obj.drop_table(table_name, ConflictType.Ignore)
+        table_obj = db_obj.create_table(table_name,
                                         {"c1": {"type": "int"}, "c2": {"type": "varchar"}})
 
-        test_csv_dir = common_values.TEST_TMP_DIR + "test_import_more_than_one_segment.csv"
+        test_csv_dir = common_values.TEST_TMP_DIR + f"{file_name}.csv"
         res = table_obj.import_data(test_csv_dir)
         assert res.error_code == ErrorCode.OK
 
@@ -465,7 +467,7 @@ class TestInfinity:
         assert len(table_obj.show_blocks(0)) == 1024
         assert len(table_obj.show_blocks(1)) == 1
 
-        db_obj.drop_table("test_import_more_than_one_segment"+suffix, ConflictType.Error)
+        db_obj.drop_table(table_name, ConflictType.Error)
 
     @pytest.mark.parametrize("check_data", [{"file_name": "pysdk_test_big_columns.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)

--- a/python/test_pysdk/test_py_import.py
+++ b/python/test_pysdk/test_py_import.py
@@ -438,7 +438,7 @@ class TestInfinity:
 
         res, extra_result = table_obj.output(["count(*)"]).to_pl()
         assert res.height == 1 and res.width == 1 and res.item(0, 0) == 1024 * 8192
-        assert table_obj.show_segments()['id'].to_list() == [0]
+        assert len(table_obj.show_segments()) == 1
         assert len(table_obj.show_blocks(0)) == 1024
 
         db_obj.drop_table("test_import_exceeding_rows"+suffix, ConflictType.Error)
@@ -463,7 +463,7 @@ class TestInfinity:
 
         res, extra_result = table_obj.output(["count(*)"]).to_pl()
         assert res.height == 1 and res.width == 1 and res.item(0, 0) == 1024 * 8192 + 1
-        assert table_obj.show_segments()['id'].to_list() == [0, 1]
+        assert len(table_obj.show_segments()) == 2
         assert len(table_obj.show_blocks(0)) == 1024
         assert len(table_obj.show_blocks(1)) == 1
 

--- a/src/common/default_values.cppm
+++ b/src/common/default_values.cppm
@@ -67,6 +67,7 @@ export {
 
     // segment related constants
     constexpr SizeT DEFAULT_SEGMENT_CAPACITY = 1024 * 8192; // 1024 * 8192 = 8M rows
+    constexpr SizeT DEFAULT_BLOCK_PER_SEGMENT = DEFAULT_SEGMENT_CAPACITY / DEFAULT_BLOCK_CAPACITY;
     constexpr SizeT SEGMENT_OFFSET_IN_DOCID = 23;           // it should be adjusted together with DEFAULT_SEGMENT_CAPACITY
     constexpr u64 SEGMENT_MASK_IN_DOCID = 0x7FFFFF;         // it should be adjusted together with DEFAULT_SEGMENT_CAPACITY
     constexpr u32 INVALID_SEGMENT_ID = std::numeric_limits<u32>::max();

--- a/src/storage/new_txn/new_txn_data.cpp
+++ b/src/storage/new_txn/new_txn_data.cpp
@@ -209,6 +209,15 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
     SizeT segment_count = input_block_count % DEFAULT_BLOCK_PER_SEGMENT == 0
                         ? input_block_count / DEFAULT_BLOCK_PER_SEGMENT
                         : input_block_count / DEFAULT_BLOCK_PER_SEGMENT + 1;
+
+    // If the number of input blocks is 0, infinity would output
+    // "IMPORT 0 Rows" instead of throwing an exception.
+    // It's debatable which is better. For now, we will keep the
+    // behavior unchanged in order to avoid a breaking change to users.
+    if (segment_count == 0) {
+        segment_count = 1;
+    }
+
     try {
         segment_ids = system_cache->ApplySegmentIDs(db_id, table_id, segment_count);
     } catch (const std::exception &e) {

--- a/src/storage/new_txn/new_txn_data.cpp
+++ b/src/storage/new_txn/new_txn_data.cpp
@@ -199,27 +199,35 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
 
     TxnTimeStamp fake_commit_ts = txn_context_ptr_->begin_ts_;
 
-    Optional<SegmentMeta> segment_meta;
     // status = NewCatalog::AddNewSegment1(table_meta, fake_commit_ts, segment_meta);
     u64 db_id = std::stoull(table_meta.db_id_str());
     u64 table_id = std::stoull(table_meta.table_id_str());
     SystemCache *system_cache = new_catalog_->GetSystemCachePtr();
     Vector<SegmentID> segment_ids;
+
+    SizeT input_block_count = input_blocks.size();
+    SizeT segment_count = input_block_count % DEFAULT_BLOCK_PER_SEGMENT == 0
+                        ? input_block_count / DEFAULT_BLOCK_PER_SEGMENT
+                        : input_block_count / DEFAULT_BLOCK_PER_SEGMENT + 1;
     try {
-        segment_ids = system_cache->ApplySegmentIDs(db_id, table_id, 1);
+        segment_ids = system_cache->ApplySegmentIDs(db_id, table_id, segment_count);
     } catch (const std::exception &e) {
         return Status::UnexpectedError(fmt::format("Database: {} or db is dropped: {}, cause: ", db_name, table_name, e.what()));
     }
-    LOG_TRACE(fmt::format("Import: apply segment id: {}", segment_ids[0]));
-    status = NewCatalog::AddNewSegmentWithID(table_meta, fake_commit_ts, segment_meta, segment_ids[0]);
-    if (!status.ok()) {
-        return status;
+    LOG_TRACE(fmt::format("Import: apply segment id starting at: {}, count {}", segment_ids[0], segment_count));
+
+    for (SizeT segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
+        Optional<SegmentMeta> segment_meta;
+        status = NewCatalog::AddNewSegmentWithID(table_meta, fake_commit_ts, segment_meta, segment_ids[segment_idx]);
+        if (!status.ok()) {
+            return status;
+        }
     }
 
-    SizeT segment_row_cnt = 0;
-    Vector<SizeT> block_row_cnts;
-    for (SizeT j = 0; j < input_blocks.size(); ++j) {
-        const SharedPtr<DataBlock> &input_block = input_blocks[j];
+    Vector<SizeT> segment_row_cnts(segment_count, 0);
+    Vector<Vector<SizeT>> block_row_cnts(segment_count);
+    for (SizeT input_block_idx = 0; input_block_idx < input_blocks.size(); ++input_block_idx) {
+        const SharedPtr<DataBlock> &input_block = input_blocks[input_block_idx];
         if (!input_block->Finalized()) {
             UnrecoverableError("Attempt to import unfinalized data block");
         }
@@ -227,7 +235,9 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
 
         Optional<BlockMeta> block_meta;
         // status = NewCatalog::AddNewBlock(*segment_meta, block_id, block_meta);
-        status = NewCatalog::AddNewBlock1(*segment_meta, fake_commit_ts, block_meta);
+        SizeT segment_idx = input_block_idx / DEFAULT_BLOCK_PER_SEGMENT;
+        SegmentMeta segment_meta(segment_ids[segment_idx], table_meta);
+        status = NewCatalog::AddNewBlock1(segment_meta, fake_commit_ts, block_meta);
         if (!status.ok()) {
             return status;
         }
@@ -238,7 +248,7 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
             return status;
         }
 
-        if (j < input_blocks.size() - 1 && row_cnt != block_meta->block_capacity()) {
+        if (input_block_idx < input_blocks.size() - 1 && row_cnt != block_meta->block_capacity()) {
             UnrecoverableError("Attempt to import data block with different capacity");
         }
 
@@ -288,22 +298,26 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
         // if (!status.ok()) {
         //     return status;
         // }
-        block_row_cnts.push_back(row_cnt);
-        segment_row_cnt += row_cnt;
+        block_row_cnts[segment_idx].push_back(row_cnt);
+        segment_row_cnts[segment_idx] += row_cnt;
     }
     // status = segment_meta->SetRowCnt(segment_row_cnt);
     // if (!status.ok()) {
     //     return status;
     // }
-
-    WalSegmentInfo segment_info(*segment_meta, begin_ts);
-    for (SizeT i = 0; i < block_row_cnts.size(); ++i) {
-        segment_info.block_infos_[i].row_count_ = block_row_cnts[i];
-    }
-    segment_info.row_count_ = segment_row_cnt;
-    status = this->AddSegmentVersion(segment_info, *segment_meta);
-    if (!status.ok()) {
-        return status;
+    Vector<WalSegmentInfo> segment_infos;
+    for (SizeT segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
+        SegmentMeta segment_meta(segment_ids[segment_idx], table_meta);
+        WalSegmentInfo segment_info(segment_meta, begin_ts);
+        for (SizeT i = 0; i < block_row_cnts[segment_idx].size(); ++i) {
+            segment_info.block_infos_[i].row_count_ = block_row_cnts[segment_idx][i];
+        }
+        segment_info.row_count_ = segment_row_cnts[segment_idx];
+        status = this->AddSegmentVersion(segment_info, segment_meta);
+        if (!status.ok()) {
+            return status;
+        }
+        segment_infos.emplace_back(segment_info);
     }
 
     // index
@@ -332,32 +346,37 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
             import_txn_store->index_ids_str_.emplace_back(index_id_str);
             import_txn_store->index_ids_.emplace_back(std::stoull(index_id_str));
         }
-
-        import_txn_store->input_blocks_in_imports_.emplace(segment_ids[0], input_blocks);
-        import_txn_store->segment_infos_.emplace_back(segment_info);
-        import_txn_store->segment_ids_.emplace_back(segment_ids[0]);
-    } else {
-        ImportTxnStore *import_txn_store = static_cast<ImportTxnStore *>(base_txn_store_.get());
-        import_txn_store->input_blocks_in_imports_.emplace(segment_ids[0], input_blocks);
-        import_txn_store->segment_infos_.emplace_back(segment_info);
-        import_txn_store->segment_ids_.emplace_back(segment_ids[0]);
     }
+    ImportTxnStore *import_txn_store = static_cast<ImportTxnStore *>(base_txn_store_.get());
+    for (SizeT segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
+        SizeT input_block_start_idx = segment_idx * DEFAULT_BLOCK_PER_SEGMENT;
+        SizeT input_block_end_idx = std::min(input_block_start_idx + DEFAULT_BLOCK_PER_SEGMENT, input_blocks.size());
+        import_txn_store->input_blocks_in_imports_.emplace(
+            segment_ids[segment_idx], Vector<SharedPtr<DataBlock>>(input_blocks.begin() + input_block_start_idx,
+                                                                   input_blocks.begin() + input_block_end_idx));
+    }
+    import_txn_store->segment_infos_.insert(import_txn_store->segment_infos_.end(), segment_infos.begin(), segment_infos.end());
+    import_txn_store->segment_ids_.insert(import_txn_store->segment_ids_.end(), segment_ids.begin(), segment_ids.end());
 
     for (SizeT i = 0; i < index_id_strs_ptr->size(); ++i) {
         const String &index_id_str = (*index_id_strs_ptr)[i];
         const String &index_name = (*index_names_ptr)[i];
         TableIndexMeeta table_index_meta(index_id_str, table_meta);
 
-        status = this->PopulateIndex(db_name,
-                                     table_name,
-                                     index_name,
-                                     table_key,
-                                     table_index_meta,
-                                     *segment_meta,
-                                     segment_row_cnt,
-                                     DumpIndexCause::kImport);
-        if (!status.ok()) {
-            return status;
+        for (SizeT segment_idx = 0; segment_idx < segment_count; ++segment_idx) {
+            SegmentMeta segment_meta(segment_ids[segment_idx], table_meta);
+            SizeT segment_row_cnt = segment_row_cnts[segment_idx];
+            status = this->PopulateIndex(db_name,
+                                         table_name,
+                                         index_name,
+                                         table_key,
+                                         table_index_meta,
+                                         segment_meta,
+                                         segment_row_cnt,
+                                         DumpIndexCause::kImport);
+            if (!status.ok()) {
+                return status;
+            }
         }
     }
 

--- a/tools/generate_large_import.py
+++ b/tools/generate_large_import.py
@@ -1,4 +1,5 @@
-# generate 'test/sql/dml/compact/test_compact_big.slt' and 'test/data/csv/test_compact_big.csv'
+# generate 'test/sql/dml/import/test_import_more_than_one_segment.slt'
+# generate 'test/data/csv/test_import_more_than_one_segment.csv'
 
 import os
 import argparse

--- a/tools/generate_large_import.py
+++ b/tools/generate_large_import.py
@@ -1,0 +1,92 @@
+# generate 'test/sql/dml/compact/test_compact_big.slt' and 'test/data/csv/test_compact_big.csv'
+
+import os
+import argparse
+import random
+
+
+def generate(generate_if_exists: bool, copy_dir: str):
+    row_n = 8192 * 1024 + 1
+    table_name = "test_import_more_than_one_segment"
+
+    csv_dir = "./test/data/csv"
+    slt_dir = "./test/sql/dml/import"
+    csv_name = "/{}.csv".format(table_name)
+    slt_name = "/{}.slt".format(table_name)
+
+    csv_path = csv_dir + csv_name
+    slt_path = slt_dir + slt_name
+
+    os.makedirs(csv_dir, exist_ok=True)
+    os.makedirs(slt_dir, exist_ok=True)
+    if os.path.exists(csv_path) and os.path.exists(slt_path) and not generate_if_exists:
+        print(
+            "File {} and {} already existed exists. Skip Generating.".format(
+                slt_path, csv_path
+            )
+        )
+        return
+
+    with open(csv_path, "w") as csv_file:
+        for row in range(row_n):
+            csv_file.write(f"{row}\n")
+
+    with open(slt_path, "w") as slt_file:
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE IF EXISTS {};\n".format(table_name))
+        slt_file.write("\n")
+
+        slt_file.write("statement ok\n")
+        slt_file.write(
+            "CREATE TABLE {} (c1 INTEGER);\n".format(table_name))
+        slt_file.write("\n")
+
+        slt_file.write("query I\n")
+        slt_file.write(
+            "COPY {} FROM '{}/{}' WITH ( DELIMITER ',', FORMAT CSV );\n".format(
+                table_name, copy_dir, csv_name
+            )
+        )
+        slt_file.write("----\n")
+        slt_file.write("\n")
+
+        slt_file.write("query I\n")
+        slt_file.write("SELECT COUNT(*) FROM {};\n".format(table_name))
+        slt_file.write("----\n")
+        slt_file.write("{}\n".format(row_n))
+        slt_file.write("\n")
+
+        slt_file.write("statement ok\n")
+        slt_file.write("SHOW TABLE {} SEGMENT 0;\n".format(table_name))
+        slt_file.write("\n")
+
+        slt_file.write("statement ok\n")
+        slt_file.write("SHOW TABLE {} SEGMENT 1;\n".format(table_name))
+        slt_file.write("\n")
+
+        slt_file.write("statement ok\n")
+        slt_file.write("DROP TABLE {};\n".format(table_name))
+        slt_file.write("\n")
+
+    pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate more than 8192 * 1024 rows for testing import")
+
+    parser.add_argument(
+        "-g",
+        "--generate",
+        type=bool,
+        default=False,
+        dest="generate_if_exists",
+    )
+    parser.add_argument(
+        "-c",
+        "--copy",
+        type=str,
+        default="/var/infinity/test_data",
+        dest="copy_dir",
+    )
+    args = parser.parse_args()
+    generate(args.generate_if_exists, args.copy_dir)

--- a/tools/generate_large_import.py
+++ b/tools/generate_large_import.py
@@ -1,5 +1,5 @@
-# generate 'test/sql/dml/import/test_import_more_than_one_segment.slt'
-# generate 'test/data/csv/test_import_more_than_one_segment.csv'
+# generate 'test/sql/dml/import/test_slt_import_more_than_one_segment.slt'
+# generate 'test/data/csv/test_slt_import_more_than_one_segment.csv'
 
 import os
 import argparse
@@ -8,7 +8,7 @@ import random
 
 def generate(generate_if_exists: bool, copy_dir: str):
     row_n = 8192 * 1024 + 1
-    table_name = "test_import_more_than_one_segment"
+    table_name = "test_slt_import_more_than_one_segment"
 
     csv_dir = "./test/data/csv"
     slt_dir = "./test/sql/dml/import"

--- a/tools/sqllogictest.py
+++ b/tools/sqllogictest.py
@@ -36,6 +36,7 @@ from generate_multivector_parquet import generate as generate27
 from generate_multivector_knn_scan import generate as generate28
 from generate_groupby1 import generate as generate29
 from generate_unnest import generate as generate30
+from generate_large_import import generate as generate31
 
 
 class SpinnerThread(threading.Thread):
@@ -187,6 +188,7 @@ if __name__ == "__main__":
     generate28(args.generate_if_exists, args.copy)
     generate29(args.generate_if_exists, args.copy)
     generate30(args.generate_if_exists, args.copy)
+    generate31(args.generate_if_exists, args.copy)
 
     print("Generate file finshed.")
 


### PR DESCRIPTION
### What problem does this PR solve?

Currently the import command in infinity assumes that the data ingested will fit into one segment

```
Status NewTxn::Import(const String &db_name, const String &table_name, const Vector<SharedPtr<DataBlock>> &input_blocks) {
    ...
    Vector<SegmentID> segment_ids;
    try {
        segment_ids = system_cache->ApplySegmentIDs(db_id, table_id, 1);
    ...
}
```

When ingesting larger amount of data (more than 1024 * 8192 rows), the only segment requested during NewTxn:Import will end up having more than 1024 blocks. This violates the assumption that one segment should have no more than 1024 blocks by default.

Issue link:#2744

### Type of change

- [X] Bug Fix (non-breaking change which fixes an issue)


### Testing

#### Added new SLT test

```
[root@c2da7484ce3f infinity]# bash tools/run_cmd_repeatly.sh 'sqllogictest test/sql/dml/import/test_import_more_than_one_segment.slt'

=== Running at: Fri Jun 27 04:16:47 UTC 2025 ===
test/sql/dml/import/test_import_more_than_one_segment.slt    .. [OK] in 90240 ms

=== Running at: Fri Jun 27 04:18:19 UTC 2025 ===
test/sql/dml/import/test_import_more_than_one_segment.slt    .. [OK] in 71684 ms
```

#### Manual
```
>>> import infinity
>>> inf = infinity.connect(infinity.NetworkAddress("0.0.0.0", 23817)) 
>>> db = inf.get_database("test")
>>> tb = db.get_table("tt")                              
>>> tb.import_data("/test.csv")
CommonResponse(error_code=0, error_msg='', session_id=0)
>>> tb.show_segments()
shape: (2, 3)
┌─────┬──────────┬──────┐
│ id  ┆ status   ┆ size │
│ --- ┆ ---      ┆ ---  │
│ i64 ┆ str      ┆ str  │
╞═════╪══════════╪══════╡
│ 0   ┆ No value ┆ TODO │
│ 1   ┆ No value ┆ TODO │
└─────┴──────────┴──────┘
>>> tb.show_blocks(0) 
shape: (1_024, 3)
┌──────┬─────────┬───────────┐
│ id   ┆ size    ┆ row_count │
│ ---  ┆ ---     ┆ ---       │
│ i64  ┆ str     ┆ i64       │
╞══════╪═════════╪═══════════╡
│ 0    ┆ 64.02KB ┆ 8192      │
│ 1    ┆ 64.02KB ┆ 8192      │
│ 2    ┆ 64.02KB ┆ 8192      │
│ 3    ┆ 64.02KB ┆ 8192      │
│ 4    ┆ 64.02KB ┆ 8192      │
│ …    ┆ …       ┆ …         │
│ 1019 ┆ 64.02KB ┆ 8192      │
│ 1020 ┆ 64.02KB ┆ 8192      │
│ 1021 ┆ 64.02KB ┆ 8192      │
│ 1022 ┆ 64.02KB ┆ 8192      │
│ 1023 ┆ 64.02KB ┆ 8192      │
└──────┴─────────┴───────────┘
>>> tb.show_blocks(1)
shape: (75, 3)
┌─────┬─────────┬───────────┐
│ id  ┆ size    ┆ row_count │
│ --- ┆ ---     ┆ ---       │
│ i64 ┆ str     ┆ i64       │
╞═════╪═════════╪═══════════╡
│ 0   ┆ 64.02KB ┆ 8192      │
│ 1   ┆ 64.02KB ┆ 8192      │
│ 2   ┆ 64.02KB ┆ 8192      │
│ 3   ┆ 64.02KB ┆ 8192      │
│ 4   ┆ 64.02KB ┆ 8192      │
│ …   ┆ …       ┆ …         │
│ 70  ┆ 64.02KB ┆ 8192      │
│ 71  ┆ 64.02KB ┆ 8192      │
│ 72  ┆ 64.02KB ┆ 8192      │
│ 73  ┆ 64.02KB ┆ 8192      │
│ 74  ┆ 64.02KB ┆ 5184      │
└─────┴─────────┴───────────┘

```
