### PR TITLE
Disable conditions for kEmbedding type in expression binder.

### DIFF
--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -487,6 +487,9 @@ SharedPtr<BaseExpression> ExpressionBinder::BuildFuncExpr(const FunctionExpr &ex
             ScalarFunction scalar_function = scalar_function_set_ptr->GetMostMatchFunction(arguments);
 
             for (SizeT idx = 0; idx < arguments.size(); ++idx) {
+                if (arguments[idx]->Type().type() == LogicalType::kEmbedding) {
+                    return nullptr;
+                }
                 // check if the argument types are matched to the scalar function parameter types
                 // if not match, add the cast function to the input parameter.
                 if (arguments[idx]->Type() == scalar_function.parameter_types_[idx]) {


### PR DESCRIPTION
### What problem does this PR solve?

Disable conditions for kEmbedding type in expression binder.

issue: #2741

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
