### PR TITLE
Introduced SegmentIndexMeta::PopMemIndex()

### DIFF
--- a/src/storage/catalog/meta/segment_index_meta.cpp
+++ b/src/storage/catalog/meta/segment_index_meta.cpp
@@ -221,15 +221,6 @@ Status SegmentIndexMeta::InitSet() {
             return status;
         }
     }
-    {
-        String mem_index_key = GetSegmentIndexTag("mem_index");
-        NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
-        SharedPtr<MemIndex> mem_index = MakeShared<MemIndex>();
-        bool setted = new_catalog->GetOrSetMemIndex(mem_index_key, mem_index);
-        if (!setted) {
-            return Status(ErrorCode::kDuplicateEntry, "Mem index already exists");
-        }
-    }
     return Status::OK();
 }
 
@@ -238,13 +229,6 @@ Status SegmentIndexMeta::InitSet1() {
         Status status = SetNextChunkID(0);
         if (!status.ok()) {
             return status;
-        }
-    }
-    {
-        SharedPtr<MemIndex> mem_index = MakeShared<MemIndex>();
-        bool setted = GetOrSetMemIndex(mem_index);
-        if (!setted) {
-            return Status(ErrorCode::kDuplicateEntry, "Mem index already exists");
         }
     }
     return Status::OK();
@@ -383,12 +367,10 @@ SharedPtr<MemIndex> SegmentIndexMeta::GetMemIndex() {
     return new_catalog->GetMemIndex(mem_index_key);
 }
 
-bool SegmentIndexMeta::GetOrSetMemIndex(SharedPtr<MemIndex> &mem_index) {
-    // This function is used by populate index and append index (used by append or recover mem index)
-    NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
+SharedPtr<MemIndex> SegmentIndexMeta::PopMemIndex() {
     String mem_index_key = GetSegmentIndexTag("mem_index");
-    bool setted = new_catalog->GetOrSetMemIndex(mem_index_key, mem_index);
-    return setted;
+    NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
+    return new_catalog->PopMemIndex(mem_index_key);
 }
 
 Status SegmentIndexMeta::LoadChunkIDs() {

--- a/src/storage/catalog/meta/segment_index_meta.cppm
+++ b/src/storage/catalog/meta/segment_index_meta.cppm
@@ -76,11 +76,8 @@ public:
 
     Status UninitSet1(UsageFlag usage_flag);
 
-    // read mem index should use this function
     SharedPtr<MemIndex> GetMemIndex();
-
-    // write mem index should use this function
-    bool GetOrSetMemIndex(SharedPtr<MemIndex> &mem_index);
+    SharedPtr<MemIndex> PopMemIndex();
 
     SharedPtr<String> GetSegmentIndexDir() const;
 

--- a/src/storage/catalog/new_catalog.cppm
+++ b/src/storage/catalog/new_catalog.cppm
@@ -178,7 +178,7 @@ private:
 
 public:
     SharedPtr<MemIndex> GetMemIndex(const String &mem_index_key);
-    bool GetOrSetMemIndex(const String &mem_index_key, SharedPtr<MemIndex> &mem_index);
+    SharedPtr<MemIndex> PopMemIndex(const String &mem_index_key);
     Status DropMemIndexByMemIndexKey(const String &mem_index_key);
     Vector<Pair<String, String>> GetAllMemIndexInfo();
 

--- a/src/storage/new_txn/new_txn_index.cpp
+++ b/src/storage/new_txn/new_txn_index.cpp
@@ -746,13 +746,11 @@ NewTxn::AppendMemIndex(SegmentIndexMeta &segment_index_meta, BlockID block_id, c
     if (!index_status.ok()) {
         return index_status;
     }
-    SharedPtr<MemIndex> mem_index = MakeShared<MemIndex>();
-    segment_index_meta.GetOrSetMemIndex(mem_index);
+    SharedPtr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
     switch (index_base->index_type_) {
         case IndexType::kSecondary: {
             SharedPtr<SecondaryIndexInMem> memory_secondary_index;
             {
-                std::unique_lock<std::mutex> lock(mem_index->mtx_);
                 if (mem_index->memory_secondary_index_.get() == nullptr) {
                     auto [column_def, status] = segment_index_meta.table_index_meta().GetColumnDef();
                     if (!status.ok()) {
@@ -1121,8 +1119,7 @@ Status NewTxn::PopulateFtIndexInner(SharedPtr<IndexBase> index_base,
     }
     const IndexFullText *index_fulltext = static_cast<const IndexFullText *>(index_base.get());
     Status status;
-    SharedPtr<MemIndex> mem_index = MakeShared<MemIndex>();
-    segment_index_meta.GetOrSetMemIndex(mem_index);
+    SharedPtr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
 
     RowID base_row_id(segment_index_meta.segment_id(), 0);
     String base_name = fmt::format("ft_{:016x}", base_row_id.ToUint64());
@@ -1586,7 +1583,7 @@ Status NewTxn::ReplayOptimizeIndeByParams(WalCmdOptimizeV2 *optimize_cmd) {
 }
 
 Status NewTxn::DumpSegmentMemIndex(SegmentIndexMeta &segment_index_meta, const ChunkID &new_chunk_id) {
-    SharedPtr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
+    SharedPtr<MemIndex> mem_index = segment_index_meta.PopMemIndex();
     if (mem_index == nullptr || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr)) {
         UnrecoverableError("Invalid mem index");
     }


### PR DESCRIPTION
### What problem does this PR solve?

Introduced SegmentIndexMeta::PopMemIndex() so that NewTxn::DumpSegmentMemIndex and NewTxn::AppendMemIndex  are allowed to use the same or different MemIndex object.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
