### PR TITLE
Fix heap-buffer-overflow error during search using BMP index

### DIFF
--- a/src/storage/knn_index/sparse/bmp_alg.cppm
+++ b/src/storage/knn_index/sparse/bmp_alg.cppm
@@ -58,6 +58,10 @@ public:
             return {{}, {}};
         }
 
+        if (u32(topk) > doc_ids_.size()) {
+            topk = doc_ids_.size();
+        }
+
         SizeT block_size = block_fwd_.block_size();
         SparseVecEle<DataType, IdxType> keeped_query;
         if (options.beta_ < 1.0) {
@@ -477,8 +481,8 @@ public:
             UnrecoverableError(fmt::format("BMPAlg::LoadFromPtr: p - start != size: {} != {}", p - start, size));
         }
         return MakeUnique<BMPAlg<DataType, IdxType, CompressType, BMPOwnMem::kFalse>>(std::move(bm_ivt),
-                                                                          std::move(block_fwd),
-                                                                          VecPtr<BMPDocID, BMPOwnMem::kFalse>(doc_ids, doc_num));
+                                                                                      std::move(block_fwd),
+                                                                                      VecPtr<BMPDocID, BMPOwnMem::kFalse>(doc_ids, doc_num));
     }
 
 private:

--- a/test/sql/dql/knn/sparse/test_knn_sparse_bmp.slt
+++ b/test/sql/dql/knn/sparse/test_knn_sparse_bmp.slt
@@ -28,6 +28,33 @@ SELECT col1 FROM test_knn_sparse_bmp SEARCH MATCH SPARSE (col2, [0:1.0,20:2.0,80
 1
 
 query I
+SELECT col1 FROM test_knn_sparse_bmp SEARCH MATCH SPARSE (col2, [0:1.0,20:2.0,80:3.0], 'ip', 10);
+----
+4
+2
+1
+3
+5
+
+query I
+SELECT col1 FROM test_knn_sparse_bmp SEARCH MATCH SPARSE (col2, [0:1.0,20:2.0,80:3.0], 'ip', 10) USING INDEX(idx1);
+----
+4
+2
+1
+3
+5
+
+query I
+SELECT col1 FROM test_knn_sparse_bmp SEARCH MATCH SPARSE (col2, [0:1.0,20:2.0,80:3.0], 'ip', 10) USING INDEX(idx2);
+----
+4
+2
+1
+3
+5
+
+query I
 SELECT col1 FROM test_knn_sparse_bmp SEARCH MATCH SPARSE (col2, [0:1.0,20:2.0,80:3.0], 'ip', 3);
 ----
 4


### PR DESCRIPTION
### What problem does this PR solve?

Fix heap-buffer-overflow error during search using BMP index.

Issue link: https://github.com/infiniflow/infinity/issues/2766

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases