### PR TITLE
Fix txn conflict check bug, which lead to drop db cache error

### DIFF
--- a/src/storage/new_txn/new_txn_manager.cppm
+++ b/src/storage/new_txn/new_txn_manager.cppm
@@ -132,7 +132,7 @@ public:
 
     KVStore *kv_store() const { return kv_store_; }
 
-    Vector<SharedPtr<NewTxn>> GetCheckTxns(TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
+    Vector<SharedPtr<NewTxn>> GetCheckCandidateTxns(TransactionID txn_id, TxnTimeStamp begin_ts, TxnTimeStamp commit_ts);
 
     void SubmitForAllocation(SharedPtr<TxnAllocatorTask> txn_allocator_task);
 

--- a/src/unit_test/storage/new_catalog/new_txn_mgr.cpp
+++ b/src/unit_test/storage/new_catalog/new_txn_mgr.cpp
@@ -204,7 +204,7 @@ TEST_F(TestTxnManagerTest, test_check_txns) {
 
     auto get_check_txns = [&](NewTxn *txn) {
         TxnTimeStamp fake_commit_ts = new_txn_mgr->CurrentTS() + 1;
-        Vector<SharedPtr<NewTxn>> check_txn_ptrs = new_txn_mgr->GetCheckTxns(txn->BeginTS(), fake_commit_ts);
+        Vector<SharedPtr<NewTxn>> check_txn_ptrs = new_txn_mgr->GetCheckTxns(txn->TxnID(), txn->BeginTS(), fake_commit_ts);
         Vector<NewTxn *> check_txns;
         for (auto &check_txn : check_txn_ptrs) {
             check_txns.push_back(check_txn.get());


### PR DESCRIPTION
### What problem does this PR solve?

Txn confrlict check bug:
txn1, txn2, they will drop the same table.
they can't do the conflict check between each other. which will lead to double drop of the db catalog cache.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

