### PR TITLE
Fix restart test_insert.py in slow test

### DIFF
--- a/python/restart_test/infinity_runner.py
+++ b/python/restart_test/infinity_runner.py
@@ -112,7 +112,7 @@ class InfinityRunner:
         return self.process is not None
 
     def connect(self, uri: str):
-        try_n = 10
+        try_n = 15
         infinity_obj = None
         for i in range(try_n):
             try:

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -405,11 +405,6 @@ Vector<SharedPtr<MetaKey>> NewCatalog::MakeMetaKeys() const {
             simdjson::padded_string json(pm_path_key->value_);
             simdjson::parser parser;
             simdjson::document doc = parser.iterate(json);
-            String object_key = doc["obj_key"].get<String>();
-            if (object_key == "KEY_EMPTY") {
-                kv_instance_ptr->Delete(KeyEncode::PMObjectKey(pm_path_key->path_key_));
-                return true;
-            }
         }
         return false;
     });


### PR DESCRIPTION
### What problem does this PR solve?

Issues:
1) Row count is not as expected after restart
Row count expectation is not correct. Insert while shutdown might fail or succeed, we should accept both results.

2)  Error: BufferManager::FreeUnloadBuffer: memory_size < buffer_size: 2395928 < 8167820@src/storage/buffer/buffer_manager.cpp:300
There is problem with memory request in BufferObj::Load(), we should read from file first and then request memory space.

3) Error: Failed to find object for local path /var/infinity/data/db_1/tbl_0/seg_0/blk_7/col_0_out@src/storage/buffer/file_worker/file_worker.cpp:205
We should avoid deleting the KV in MakeMetaKeys().

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
