### PR TITLE
Fix dump index issue

### DIFF
--- a/src/storage/catalog/kv_utility.cppm
+++ b/src/storage/catalog/kv_utility.cppm
@@ -31,7 +31,8 @@ export Vector<SegmentID> GetTableIndexSegments(KVInstance *kv_instance,
                                                const String &db_id_str,
                                                const String &table_id_str,
                                                const String &index_id_str,
-                                               TxnTimeStamp begin_ts);
+                                               TxnTimeStamp begin_ts,
+                                               TxnTimeStamp commit_ts);
 
 export Vector<BlockID> GetTableSegmentBlocks(KVInstance *kv_instance,
                                              const String &db_id_str,

--- a/src/storage/catalog/meta/segment_index_meta.cpp
+++ b/src/storage/catalog/meta/segment_index_meta.cpp
@@ -117,6 +117,13 @@ Status SegmentIndexMeta::RemoveChunkIDs(const Vector<ChunkID> &chunk_ids) {
         if (!status.ok()) {
             return status;
         }
+
+        for (auto it = chunk_ids_->begin(); it != chunk_ids_->end(); ++it) {
+            if (*it == chunk_id) {
+                chunk_ids_->erase(it);
+                break;
+            }
+        }
     }
     return Status::OK();
 }
@@ -373,6 +380,12 @@ SharedPtr<MemIndex> SegmentIndexMeta::PopMemIndex() {
     return new_catalog->PopMemIndex(mem_index_key);
 }
 
+bool SegmentIndexMeta::HasMemIndex() {
+    String mem_index_key = GetSegmentIndexTag("mem_index");
+    NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
+    return new_catalog->HasMemIndex(mem_index_key);
+}
+
 Status SegmentIndexMeta::LoadChunkIDs() {
     String chunk_ids_key = GetSegmentIndexTag("chunk_ids");
     String chunk_ids_str;
@@ -388,6 +401,7 @@ Status SegmentIndexMeta::LoadChunkIDs1() {
     chunk_ids_ = Vector<ChunkID>();
     Vector<ChunkID> &chunk_ids = *chunk_ids_;
     TxnTimeStamp begin_ts = table_index_meta_.table_meta().begin_ts();
+    TxnTimeStamp commit_ts = table_index_meta_.table_meta().commit_ts();
 
     TableMeeta &table_meta = table_index_meta_.table_meta();
     String chunk_id_prefix =
@@ -398,8 +412,8 @@ Status SegmentIndexMeta::LoadChunkIDs1() {
         String key = iter->Key().ToString();
         auto [chunk_id, is_chunk_id] = ExtractU64FromStringSuffix(key, chunk_id_prefix.size());
         if (is_chunk_id) {
-            TxnTimeStamp commit_ts = std::stoull(iter->Value().ToString());
-            if (commit_ts > begin_ts and commit_ts != std::numeric_limits<TxnTimeStamp>::max()) {
+            TxnTimeStamp chunk_commit_ts = std::stoull(iter->Value().ToString());
+            if (chunk_commit_ts > begin_ts && chunk_commit_ts != commit_ts && chunk_commit_ts != std::numeric_limits<TxnTimeStamp>::max()) {
                 iter->Next();
                 continue;
             }

--- a/src/storage/catalog/meta/segment_index_meta.cppm
+++ b/src/storage/catalog/meta/segment_index_meta.cppm
@@ -78,6 +78,7 @@ public:
 
     SharedPtr<MemIndex> GetMemIndex();
     SharedPtr<MemIndex> PopMemIndex();
+    bool HasMemIndex();
 
     SharedPtr<String> GetSegmentIndexDir() const;
 

--- a/src/storage/catalog/meta/table_index_meeta.cpp
+++ b/src/storage/catalog/meta/table_index_meeta.cpp
@@ -77,7 +77,8 @@ Tuple<Vector<SegmentID> *, Status> TableIndexMeeta::GetSegmentIndexIDs1() {
                                                        table_meta_.db_id_str(),
                                                        table_meta_.table_id_str(),
                                                        index_id_str_,
-                                                       table_meta_.begin_ts());
+                                                       table_meta_.begin_ts(),
+                                                       table_meta_.commit_ts());
     }
     return {&*segment_ids_, Status::OK()};
 }
@@ -268,7 +269,8 @@ Status TableIndexMeeta::GetTableIndexInfo(TableIndexInfo &table_index_info) {
                                                        table_meta_.db_id_str(),
                                                        table_meta_.table_id_str(),
                                                        index_id_str_,
-                                                       table_meta_.begin_ts());
+                                                       table_meta_.begin_ts(),
+                                                       table_meta_.commit_ts());
     }
     if (!index_def_) {
         index_def_ =

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -154,6 +154,14 @@ SharedPtr<MemIndex> NewCatalog::PopMemIndex(const String &mem_index_key) {
     return nullptr;
 }
 
+bool NewCatalog::HasMemIndex(const String &mem_index_key) {
+    std::unique_lock<std::shared_mutex> lck(mem_index_mtx_);
+    if (auto iter = mem_index_map_.find(mem_index_key); iter != mem_index_map_.end()) {
+        return true;
+    }
+    return false;
+}
+
 Status NewCatalog::DropMemIndexByMemIndexKey(const String &mem_index_key) {
     bool delete_success = false;
     {

--- a/src/storage/catalog/new_catalog.cppm
+++ b/src/storage/catalog/new_catalog.cppm
@@ -175,6 +175,7 @@ private:
 public:
     SharedPtr<MemIndex> GetMemIndex(const String &mem_index_key);
     SharedPtr<MemIndex> PopMemIndex(const String &mem_index_key);
+    bool HasMemIndex(const String &mem_index_key);
     Status DropMemIndexByMemIndexKey(const String &mem_index_key);
     Vector<Pair<String, String>> GetAllMemIndexInfo();
 

--- a/src/storage/catalog/new_catalog_static.cpp
+++ b/src/storage/catalog/new_catalog_static.cpp
@@ -1114,39 +1114,20 @@ Status NewCatalog::LoadFlushedChunkIndex(SegmentIndexMeta &segment_index_meta, c
 
 Status NewCatalog::LoadFlushedChunkIndex1(SegmentIndexMeta &segment_index_meta, const WalChunkIndexInfo &chunk_info, NewTxn *new_txn) {
     Status status;
-    ChunkID next_chunk_id = 0;
-    status = segment_index_meta.GetNextChunkID(next_chunk_id);
-    if (!status.ok()) {
-        return status;
-    }
-    if (next_chunk_id <= chunk_info.chunk_id_) {
-        status = segment_index_meta.SetNextChunkID(chunk_info.chunk_id_ + 1);
-        if (!status.ok()) {
-            return status;
-        }
-    }
     Vector<ChunkID> *chunk_ids_ptr = nullptr;
     std::tie(chunk_ids_ptr, status) = segment_index_meta.GetChunkIDs();
     if (!status.ok()) {
         return status;
     }
-    auto iter = std::find(chunk_ids_ptr->begin(), chunk_ids_ptr->end(), chunk_info.chunk_id_);
-    if (iter != chunk_ids_ptr->end()) {
-        TableMeeta &table_meta = segment_index_meta.table_index_meta().table_meta();
-        LOG_WARN(fmt::format("Chunk index {}/{}/{}/{} already exists in KV",
-                             table_meta.db_id_str(),
-                             table_meta.table_id_str(),
-                             segment_index_meta.segment_id(),
-                             chunk_info.chunk_id_));
-        return Status::OK();
+
+    if (std::find(chunk_ids_ptr->begin(), chunk_ids_ptr->end(), chunk_info.chunk_id_) == chunk_ids_ptr->end()) {
+        status = segment_index_meta.AddChunkIndexID1(chunk_info.chunk_id_, new_txn);
+        if (!status.ok()) {
+            return status;
+        }
     }
 
-    status = segment_index_meta.AddChunkIndexID1(chunk_info.chunk_id_, new_txn);
-    if (!status.ok()) {
-        return status;
-    }
     ChunkIndexMeta chunk_index_meta(chunk_info.chunk_id_, segment_index_meta);
-
     ChunkIndexMetaInfo chunk_meta_info;
     {
         chunk_meta_info.base_name_ = chunk_info.base_name_;

--- a/src/storage/knn_index/knn_hnsw/hnsw_handler.cpp
+++ b/src/storage/knn_index/knn_hnsw/hnsw_handler.cpp
@@ -422,7 +422,9 @@ UniquePtr<HnswIndexInMem> HnswIndexInMem::Make(RowID begin_row_id, const IndexBa
     auto memidx = MakeUnique<HnswIndexInMem>(begin_row_id, index_base, column_def, trace);
     if (trace) {
         auto *memindex_tracer = InfinityContext::instance().storage()->memindex_tracer();
-        memindex_tracer->IncreaseMemoryUsage(memidx->hnsw_handler_->MemUsage());
+        if (memindex_tracer != nullptr) {
+            memindex_tracer->IncreaseMemoryUsage(memidx->hnsw_handler_->MemUsage());
+        }
     }
     return memidx;
 }
@@ -432,7 +434,9 @@ UniquePtr<HnswIndexInMem> HnswIndexInMem::Make(const IndexBase *index_base, cons
     auto memidx = MakeUnique<HnswIndexInMem>(begin_row_id, index_base, column_def, trace);
     if (trace) {
         auto *memindex_tracer = InfinityContext::instance().storage()->memindex_tracer();
-        memindex_tracer->IncreaseMemoryUsage(memidx->hnsw_handler_->MemUsage());
+        if (memindex_tracer != nullptr) {
+            memindex_tracer->IncreaseMemoryUsage(memidx->hnsw_handler_->MemUsage());
+        }
     }
     return memidx;
 }

--- a/src/storage/new_txn/new_txn.cpp
+++ b/src/storage/new_txn/new_txn.cpp
@@ -2264,7 +2264,7 @@ Status NewTxn::CommitCheckpointDB(DBMeeta &db_meta, const WalCmdCheckpointV2 *ch
     }
     for (const String &table_id_str : *table_id_strs_ptr) {
         TableMeeta table_meta(db_meta.db_id_str(), table_id_str, this);
-         status = this->CommitCheckpointTable(table_meta, checkpoint_cmd);
+        status = this->CommitCheckpointTable(table_meta, checkpoint_cmd);
         if (!status.ok()) {
             return status;
         }
@@ -4125,7 +4125,7 @@ void NewTxn::CommitBottom() {
             }
             case WalCommandType::DUMP_INDEX_V2: {
                 auto *dump_index_cmd = static_cast<WalCmdDumpIndexV2 *>(command.get());
-                if (dump_index_cmd->dump_cause_ == DumpIndexCause::kDumpMemIndex) {
+                if (dump_index_cmd->dump_cause_ == DumpIndexCause::kDumpMemIndex && !IsReplay()) {
                     Status status = CommitBottomDumpMemIndex(dump_index_cmd);
                     if (!status.ok()) {
                         UnrecoverableError(fmt::format("CommitBottomDumpMemIndex failed: {}", status.message()));

--- a/src/storage/new_txn/new_txn_index.cpp
+++ b/src/storage/new_txn/new_txn_index.cpp
@@ -243,8 +243,7 @@ Status NewTxn::CommitBottomDumpMemIndex(WalCmdDumpIndexV2 *dump_index_cmd) {
     const String &index_name = dump_index_cmd->index_name_;
     const SegmentID &segment_id = dump_index_cmd->segment_id_;
 
-    DumpMemIndexTxnStore *dump_index_txn_store = static_cast<DumpMemIndexTxnStore *>(base_txn_store_.get());
-    ChunkID chunk_id = dump_index_txn_store->chunk_infos_in_segments_.at(segment_id)[0].chunk_id_;
+    ChunkID chunk_id = dump_index_cmd->chunk_infos_[0].chunk_id_;
 
     Optional<DBMeeta> db_meta;
     Optional<TableMeeta> table_meta;
@@ -1057,7 +1056,6 @@ Status NewTxn::PopulateIndex(const String &db_name,
 
 Status NewTxn::ReplayDumpIndex(WalCmdDumpIndexV2 *dump_index_cmd) {
     Status status;
-
     Optional<DBMeeta> db_meta;
     Optional<TableMeeta> table_meta;
     Optional<TableIndexMeeta> table_index_meta;
@@ -1095,9 +1093,9 @@ Status NewTxn::ReplayDumpIndex(WalCmdDumpIndexV2 *dump_index_cmd) {
     SegmentIndexMeta &segment_index_meta = *segment_index_meta_opt;
 
     Vector<ChunkID> chunk_ids_to_delete;
+    Vector<ChunkID> *chunk_ids_ptr = nullptr;
     {
         HashSet<ChunkID> deprecate_chunk_ids(dump_index_cmd->deprecate_ids_.begin(), dump_index_cmd->deprecate_ids_.end());
-        Vector<ChunkID> *chunk_ids_ptr = nullptr;
         std::tie(chunk_ids_ptr, status) = segment_index_meta.GetChunkIDs1();
         if (!status.ok()) {
             return status;
@@ -1108,17 +1106,110 @@ Status NewTxn::ReplayDumpIndex(WalCmdDumpIndexV2 *dump_index_cmd) {
             }
         }
     }
-    for (const WalChunkIndexInfo &chunk_info : dump_index_cmd->chunk_infos_) {
-        status = NewCatalog::LoadFlushedChunkIndex1(segment_index_meta, chunk_info, this);
-        if (!status.ok()) {
-            return status;
-        }
-    }
 
-    // and remove old ones;
+    // Remove old ones;
     status = segment_index_meta.RemoveChunkIDs(chunk_ids_to_delete);
     if (!status.ok()) {
         return status;
+    }
+
+    bool dump_success = true;
+    for (const WalChunkIndexInfo &chunk_info : dump_index_cmd->chunk_infos_) {
+        ChunkID chunk_id = chunk_info.chunk_id_;
+        if (std::find(chunk_ids_ptr->begin(), chunk_ids_ptr->end(), chunk_id) == chunk_ids_ptr->end()) {
+
+            String drop_ts{};
+            kv_instance_->Get(
+                KeyEncode::DropChunkIndexKey(dump_index_cmd->db_id_, dump_index_cmd->table_id_, dump_index_cmd->index_id_, segment_id, chunk_id),
+                drop_ts);
+
+            if (drop_ts.empty()) {
+                dump_success = false;
+                break;
+            }
+        }
+    }
+
+    if (dump_success) {
+        for (const WalChunkIndexInfo &chunk_info : dump_index_cmd->chunk_infos_) {
+            status = NewCatalog::LoadFlushedChunkIndex1(segment_index_meta, chunk_info, this);
+            if (!status.ok()) {
+                return status;
+            }
+        }
+
+        SharedPtr<MemIndex> mem_index = segment_index_meta.PopMemIndex();
+        if (mem_index != nullptr) {
+            mem_index->ClearMemIndex();
+        }
+    } else {
+        u32 dump_row_count = 0;
+        for (const WalChunkIndexInfo &chunk_info : dump_index_cmd->chunk_infos_) {
+            dump_row_count += chunk_info.row_count_;
+        }
+
+        SizeT mem_index_row_count = 0;
+        bool valid_mem_index = false;
+        if (segment_index_meta.HasMemIndex()) {
+            SharedPtr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
+            mem_index_row_count = mem_index->GetRowCount();
+
+            if (mem_index_row_count == dump_row_count) {
+                valid_mem_index = true;
+            } else {
+                LOG_DEBUG(fmt::format("Dump row count {} is not equal to row count in mem index {}, clear the mem index",
+                                      mem_index_row_count,
+                                      dump_row_count));
+                mem_index->ClearMemIndex();
+            }
+        }
+
+        if (!valid_mem_index) {
+            Vector<Pair<RowID, u64>> append_ranges;
+            SegmentMeta segment_meta(segment_id, *table_meta);
+            status = CountMemIndexGapInSegment(segment_index_meta, segment_meta, append_ranges);
+            if (!status.ok()) {
+                return status;
+            }
+
+            u32 append_ranges_row_count = 0;
+            for (const auto &range : append_ranges) {
+                append_ranges_row_count += range.second;
+            }
+
+            if (dump_row_count != append_ranges_row_count) {
+                UnrecoverableError(
+                    fmt::format("Dump row count {} is not equal to row count of append ranges {}", dump_row_count, append_ranges_row_count));
+            }
+
+            for (const auto &range : append_ranges) {
+                status = this->AppendIndex(*table_index_meta, range);
+                if (!status.ok()) {
+                    return status;
+                }
+            }
+        }
+        CommitBottomDumpMemIndex(dump_index_cmd);
+    }
+
+    ChunkID next_chunk_id = 0;
+    status = segment_index_meta.GetNextChunkID(next_chunk_id);
+    if (!status.ok()) {
+        return status;
+    }
+
+    ChunkID max_chunk_id = 0;
+    for (const WalChunkIndexInfo &chunk_info : dump_index_cmd->chunk_infos_) {
+        if (chunk_info.chunk_id_ > max_chunk_id) {
+            max_chunk_id = chunk_info.chunk_id_;
+        }
+
+        if (next_chunk_id <= max_chunk_id) {
+            status = segment_index_meta.SetNextChunkID(max_chunk_id + 1);
+            if (!status.ok()) {
+                return status;
+            }
+        }
     }
 
     return Status::OK();

--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -282,6 +282,12 @@ Status Storage::AdminToWriter() {
     // start WalManager after TxnManager since it depends on TxnManager.
     wal_mgr_->Start();
 
+    if (mem_index_appender_ != nullptr) {
+        UnrecoverableError("mem index appender was initialized before.");
+    }
+    mem_index_appender_ = MakeUnique<MemIndexAppender>();
+    mem_index_appender_->Start();
+
     // Replay wal
     if (config_ptr_->ReplayWal() && !replay_entries.empty()) {
         auto [wal_max_txn_id, wal_system_start_ts] = wal_mgr_->ReplayWalEntries(replay_entries);
@@ -333,12 +339,6 @@ Status Storage::AdminToWriter() {
     }
     dump_index_processor_ = MakeUnique<DumpIndexProcessor>();
     dump_index_processor_->Start();
-
-    if (mem_index_appender_ != nullptr) {
-        UnrecoverableError("mem index appender was initialized before.");
-    }
-    mem_index_appender_ = MakeUnique<MemIndexAppender>();
-    mem_index_appender_->Start();
 
     this->RecoverMemIndex();
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix replay dump index issue.  If previous dump before restart is successful, load the chunk index, otherwise, recover the mem index and dump it.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
