### PR TITLE
Fix EMVBIndexInMem::Insert data num check

### DIFF
--- a/src/storage/knn_index/emvb/emvb_index_in_mem.cpp
+++ b/src/storage/knn_index/emvb/emvb_index_in_mem.cpp
@@ -90,7 +90,7 @@ void EMVBIndexInMem::Insert(const ColumnVector &column_vector, u32 row_offset, u
             TableMeeta table_meta(db_id_str_, table_id_str_, &kv_instance, begin_ts, MAX_TIMESTAMP);
             SegmentMeta segment_meta(segment_id_, table_meta);
             emvb_index_->BuildEMVBIndex(begin_row_id_, row_count_, segment_meta, column_def_);
-            if (emvb_index_->GetDocNum() != row_count || emvb_index_->GetTotalEmbeddingNum() != embedding_count_) {
+            if (emvb_index_->GetDocNum() != row_count_ || emvb_index_->GetTotalEmbeddingNum() != embedding_count_) {
                 UnrecoverableError("EMVBIndexInMem Insert doc num or embedding num not consistent!");
             }
             is_built_.test_and_set(std::memory_order_release);


### PR DESCRIPTION
### What problem does this PR solve?

Fix the issue where EMVB throws an "embedding num not consistent" error when inserting vectors (Adjust the judgment conditions).

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
