### PR TITLE
Add mutex protection for BlockVersion

### DIFF
--- a/src/storage/catalog/meta/block_version.cppm
+++ b/src/storage/catalog/meta/block_version.cppm
@@ -76,9 +76,13 @@ export struct BlockVersion {
 
     Status Print(TxnTimeStamp commit_ts, i32 offset, bool ignore_invisible);
 
-    TxnTimeStamp latest_change_ts() const { return latest_change_ts_; }
+    TxnTimeStamp latest_change_ts() const {
+        std::shared_lock<std::shared_mutex> lock(rw_mutex_);
+        return latest_change_ts_;
+    }
 
 private:
+    mutable std::shared_mutex rw_mutex_{};
     Vector<CreateField> created_{}; // second field width is same as timestamp, otherwise Valgrind will issue BlockVersion::SaveToFile has
                                     // risk to write uninitialized buffer. (ts, rows)
     Vector<TxnTimeStamp> deleted_{};


### PR DESCRIPTION
### What problem does this PR solve?

There is issue "heap-use-after-free" when 1 thread is writing created_  of BlockVersion and another thread is reading it. We need to add mutex in BlockVersion.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)