### PR TITLE
Add more mutex protection in NewTxnManager

### DIFF
--- a/src/storage/buffer/buffer_manager.cpp
+++ b/src/storage/buffer/buffer_manager.cpp
@@ -162,6 +162,7 @@ BufferObj *BufferManager::GetBufferObject(const String &file_path) {
     if (auto iter = buffer_map_.find(file_path); iter != buffer_map_.end()) {
         return iter->second.get();
     }
+    LOG_TRACE(fmt::format("BufferManager::GetBufferObject: file {} not found.", file_path));
     return nullptr;
 }
 

--- a/src/storage/new_txn/new_txn_manager.cpp
+++ b/src/storage/new_txn/new_txn_manager.cpp
@@ -167,6 +167,7 @@ UniquePtr<NewTxn> NewTxnManager::BeginRecoveryTxn() {
         UnrecoverableError(error_message);
     }
 
+    std::lock_guard guard(locker_);
     //    current_ts_ += 2;
     prepare_commit_ts_ = current_ts_ + 2;
     TxnTimeStamp commit_ts = current_ts_ + 2; // Will not be used
@@ -293,6 +294,7 @@ void NewTxnManager::CommitReplayTxn(NewTxn *txn) {
         UnrecoverableError(fmt::format("Fail to commit replay txn: {}", status.message()));
     }
 
+    std::lock_guard guard(locker_);
     current_ts_ = txn->CommitTS();
     prepare_commit_ts_ = txn->CommitTS();
 }

--- a/src/storage/new_txn/new_txn_manager.cppm
+++ b/src/storage/new_txn/new_txn_manager.cppm
@@ -94,11 +94,20 @@ public:
 
     void SetCurrentTransactionID(TransactionID latest_transaction_id);
 
-    TransactionID current_transaction_id() const { return current_transaction_id_; }
+    TransactionID current_transaction_id() const {
+        std::lock_guard guard(locker_);
+        return current_transaction_id_;
+    }
 
-    TxnTimeStamp CurrentTS() const { return current_ts_; }
+    TxnTimeStamp CurrentTS() const {
+        std::lock_guard guard(locker_);
+        return current_ts_;
+    }
 
-    TxnTimeStamp PrepareCommitTS() const { return prepare_commit_ts_; }
+    TxnTimeStamp PrepareCommitTS() const {
+        std::lock_guard guard(locker_);
+        return prepare_commit_ts_;
+    }
 
     TxnTimeStamp GetOldestAliveTS();
 
@@ -124,7 +133,10 @@ private:
 
 public:
     // Only used by follower and learner when received the replicated log from leader
-    void SetStartTS(TxnTimeStamp new_start_ts) { current_ts_ = new_start_ts; }
+    void SetStartTS(TxnTimeStamp new_start_ts) {
+        std::lock_guard guard(locker_);
+        current_ts_ = new_start_ts;
+    }
 
     void PrintAllKeyValue() const;
 

--- a/src/storage/new_txn/txn_allocator.cppm
+++ b/src/storage/new_txn/txn_allocator.cppm
@@ -49,8 +49,6 @@ private:
 
     Atomic<u64> task_count_{};
 
-    mutable std::mutex task_mutex_;
-
     SystemCache* system_cache_{};
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Data race is detected by ThreadSanitizer in slow test. We need to add more mutex protection.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
