### PR TITLE
Use the relevent commit_ts to perform the deletion

### DIFF
--- a/src/storage/new_txn/new_txn.cpp
+++ b/src/storage/new_txn/new_txn.cpp
@@ -4462,6 +4462,8 @@ Status NewTxn::Cleanup() {
     TxnTimeStamp begin_ts = BeginTS();
     TxnTimeStamp visible_ts = std::min(begin_ts, last_checkpoint_ts);
 
+    LOG_INFO(fmt::format("Cleaning ts < {} dropped entities...", visible_ts));
+
     Vector<String> dropped_keys;
     Vector<UniquePtr<MetaKey>> metas;
     Status status = new_catalog_->GetCleanedMeta(visible_ts, kv_instance, metas, dropped_keys);


### PR DESCRIPTION
### What problem does this PR solve?

When collecting the drop key information for cleaning, we are currently using the value of drop KV pair instead of relevant entity's commit_ts.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
