### PR TITLE
Fixed data race

### DIFF
--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -240,7 +240,15 @@ void PersistenceManager::CheckValid() {
         }
     }
     const auto part2_begin = std::chrono::high_resolution_clock::now();
-    objects_->CheckValid(current_object_size_);
+
+    // Protect access to current_object_size_ with mutex
+    SizeT current_size;
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        current_size = current_object_size_;
+    }
+    objects_->CheckValid(current_size);
+
     const auto part2_end = std::chrono::high_resolution_clock::now();
     LOG_INFO(fmt::format("PersistenceManager::CheckValid part 1: {} ms, part2: {} ms",
                          static_cast<TimeDurationType>(part2_begin - part1_begin).count(),


### PR DESCRIPTION
### What problem does this PR solve?

Fixed data race of current_object_size_

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

```
==================
WARNING: ThreadSanitizer: data race (pid=70464)
  Read of size 8 at 0x722800000588 by thread T365:
    #0 infinity::PersistenceManager@persistence_manager::CheckValid() /infinity/src/storage/persistence/persistence_manager.cpp:243:26 (infinity+0x15ba097)
    #1 infinity::PersistenceManager@persistence_manager::CurrentObjFinalize(bool) /infinity/src/storage/persistence/persistence_manager.cpp:215:9 (infinity+0x15b99c9)
    #2 infinity::NewTxn@new_txn::Checkpoint(unsigned long) /infinity/src/storage/new_txn/new_txn.cpp:1484:41 (infinity+0x1490ced)
    #3 infinity::NewCheckpointTask@bg_task::ExecuteWithNewTxn() /infinity/src/storage/bg_task/bg_task.cpp:52:37 (infinity+0xfc150d)
    #4 infinity::BGTaskProcessor@background_process::Process() /infinity/src/storage/background_process.cpp:96:55 (infinity+0xfb6237)
    #5 infinity::BGTaskProcessor@background_process::Start()::$_0::operator()() const /infinity/src/storage/background_process.cpp:45:41 (infinity+0xfb7a95)
    #6 decltype(std::declval<infinity::BGTaskProcessor@background_process::Start()::$_0>()()) std::__1::__invoke[abi:ne180100]<infinity::BGTaskProcessor@background_process::Start()::$_0>(infinity::BGTaskProcessor@background_process::Start()::$_0&&) /usr/local/include/c++/v1/__type_traits/invoke.h:344:25 (infinity+0xfb79f5)
    #7 void std::__1::__thread_execute[abi:ne180100]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, infinity::BGTaskProcessor@background_process::Start()::$_0>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, infinity::BGTaskProcessor@background_process::Start()::$_0>&, std::__1::__tuple_indices<...>) /usr/local/include/c++/v1/__thread/thread.h:193:3 (infinity+0xfb79ad)
    #8 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, infinity::BGTaskProcessor@background_process::Start()::$_0>>(void*) /usr/local/include/c++/v1/__thread/thread.h:202:3 (infinity+0xfb7642)

  Previous write of size 8 at 0x722800000588 by thread T65 (mutexes: write M0, write M1):
    #0 infinity::PersistenceManager@persistence_manager::Persist(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool) /infinity/src/storage/persistence/persistence_manager.cpp:182:26 (infinity+0x15b524a)
    #1 infinity::FileWorker@file_worker::WriteToFile(bool, infinity::FileWorkerSaveCtx@file_worker const&) /infinity/src/storage/buffer/file_worker/file_worker.cpp:93:67 (infinity+0xfef12e)
    #2 infinity::BufferObj@buffer_obj::Save(infinity::FileWorkerSaveCtx@file_worker const&) /infinity/src/storage/buffer/buffer_obj.cpp:195:47 (infinity+0xfeaa1f)
    #3 infinity::NewTxn@new_txn::CommitSegmentVersion(infinity::WalSegmentInfo@wal_entry&, infinity::SegmentMeta@segment_meta&) /infinity/src/storage/new_txn/new_txn_data.cpp:1724:25 (infinity+0x14f4647)
    #4 infinity::NewTxn@new_txn::PrepareCommitImport(infinity::WalCmdImportV2@wal_entry*) /infinity/src/storage/new_txn/new_txn_data.cpp:1346:20 (infinity+0x14e7141)
    #5 infinity::NewTxn@new_txn::PrepareCommit() /infinity/src/storage/new_txn/new_txn.cpp:1936:33 (infinity+0x1494a94)
    #6 infinity::NewTxn@new_txn::Commit() /infinity/src/storage/new_txn/new_txn.cpp:1726:24 (infinity+0x1493a57)
    #7 infinity::NewTxnManager@new_txn_manager::CommitTxn(infinity::NewTxn@new_txn*, unsigned long*) /infinity/src/storage/new_txn/new_txn_manager.cpp:275:26 (infinity+0x156d42c)
    #8 infinity::QueryContext@query_context::CommitTxn() /infinity/src/main/query_context.cpp:471:50 (infinity+0xe40018)
    #9 infinity::QueryContext@query_context::QueryStatementInternal(infinity::BaseStatement const*) /infinity/src/main/query_context.cpp:284:15 (infinity+0xe3f00f)
    #10 infinity::QueryContext@query_context::QueryStatement(infinity::BaseStatement const*) /infinity/src/main/query_context.cpp:136:24 (infinity+0xe3dd87)
    #11 infinity::Infinity@infinity::Import(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, infinity::ImportOptions@query_options) /infinity/src/main/infinity.cpp:939:45 (infinity+0xdf6d74)
    #12 infinity::InfinityThriftService@infinity_thrift_service::Import(infinity_thrift_rpc::CommonResponse&, infinity_thrift_rpc::ImportRequest const&) /infinity/src/network/infinity_thrift_service.cpp:386:42 (infinity+0xc7fde9)
    #13 infinity_thrift_rpc::InfinityServiceProcessor::process_Import(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) /infinity/src/network/infinity_thrift/InfinityService.cpp:10142:13 (infinity+0x2cfa3fd)
    #14 infinity_thrift_rpc::InfinityServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int, void*) /infinity/src/network/infinity_thrift/InfinityService.cpp:9737:3 (infinity+0x2cf5ec3)
    #15 apache::thrift::TDispatchProcessor::process(std::__1::shared_ptr<apache::thrift::protocol::TProtocol>, std::__1::shared_ptr<apache::thrift::protocol::TProtocol>, void*) /infinity/third_party/thrift/lib/cpp/src/thrift/TDispatchProcessor.h:121:12 (infinity+0x2d30fa9)
    #16 apache::thrift::server::TConnectedClient::run() /infinity/third_party/thrift/lib/cpp/src/thrift/server/TConnectedClient.cpp:61:24 (infinity+0x472c38c)
    #17 apache::thrift::concurrency::ThreadManager::Task::run() /infinity/third_party/thrift/lib/cpp/src/thrift/concurrency/ThreadManager.cpp:195:18 (infinity+0x4702c31)
    #18 apache::thrift::concurrency::ThreadManager::Worker::run() /infinity/third_party/thrift/lib/cpp/src/thrift/concurrency/ThreadManager.cpp:310:19 (infinity+0x46fcd70)
    #19 apache::thrift::concurrency::Thread::threadMain(std::__1::shared_ptr<apache::thrift::concurrency::Thread>) /infinity/third_party/thrift/lib/cpp/src/thrift/concurrency/Thread.cpp:28:23 (infinity+0x4722a4e)
    #20 decltype(std::declval<void (*)(std::__1::shared_ptr<apache::thrift::concurrency::Thread>)>()(std::declval<std::__1::shared_ptr<apache::thrift::concurrency::Thread>>())) std::__1::__invoke[abi:ne180100]<void (*)(std::__1::shared_ptr<apache::thrift::concurrency::Thread>), std::__1::shared_ptr<apache::thrift::concurrency::Thread>>(void (*&&)(std::__1::shared_ptr<apache::thrift::concurrency::Thread>), std::__1::shared_ptr<apache::thrift::concurrency::Thread>&&) /usr/local/include/c++/v1/__type_traits/invoke.h:344:25 (infinity+0x472218b)
    #21 void std::__1::__thread_execute[abi:ne180100]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(std::__1::shared_ptr<apache::thrift::concurrency::Thread>), std::__1::shared_ptr<apache::thrift::concurrency::Thread>, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(std::__1::shared_ptr<apache::thrift::concurrency::Thread>), std::__1::shared_ptr<apache::thrift::concurrency::Thread>>&, std::__1::__tuple_indices<2ul>) /usr/local/include/c++/v1/__thread/thread.h:193:3 (infinity+0x47220fe)
    #22 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(std::__1::shared_ptr<apache::thrift::concurrency::Thread>), std::__1::shared_ptr<apache::thrift::concurrency::Thread>>>(void*) /usr/local/include/c++/v1/__thread/thread.h:202:3 (infinity+0x4721d02)

  Location is heap block of size 160 at 0x722800000500 allocated by main thread:
    #0 operator new(unsigned long) /root/llvm-project-18.1.8.src/compiler-rt/lib/tsan/rtl/tsan_new_delete.cpp:64:3 (infinity+0x5575b7)
    #1 std::__1::__unique_if<infinity::PersistenceManager@persistence_manager>::__unique_single std::__1::make_unique[abi:ne180100]<infinity::PersistenceManager@persistence_manager, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, unsigned long>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&, unsigned long&&) /usr/local/include/c++/v1/__memory/unique_ptr.h:597:26 (infinity+0x7860a1)
    #2 std::__1::unique_ptr<infinity::PersistenceManager@persistence_manager, std::__1::default_delete<infinity::PersistenceManager@persistence_manager>> infinity::MakeUnique@stl<infinity::PersistenceManager@persistence_manager, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, unsigned long>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&, unsigned long&&) /infinity/src/common/stl.cppm:559:16 (infinity+0x781a95)
    #3 infinity::Storage@storage::InitToAdmin() /infinity/src/storage/storage.cpp:136:36 (infinity+0x7788d8)
    #4 infinity::Storage@storage::SetStorageMode(infinity::StorageMode@wal_manager) /infinity/src/storage/storage.cpp:713:20 (infinity+0x77ff9d)
    #5 infinity::InfinityContext@infinity_context::ChangeServerRole(infinity::NodeRole, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, unsigned short) /infinity/src/main/infinity_context.cpp:134:23 (infinity+0x6b6c05)
    #6 infinity::InfinityContext@infinity_context::InitPhase1(std::__1::shared_ptr<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>> const&, infinity::DefaultConfig@config*) /infinity/src/main/infinity_context.cpp:84:28 (infinity+0x6b6468)
    #7 main /infinity/src/bin/infinity_main.cpp:263:33 (infinity+0x55909f)

```