### PR TITLE
Fix data race, avoid query retry on conflicts

### DIFF
--- a/src/storage/catalog/meta/block_meta.cpp
+++ b/src/storage/catalog/meta/block_meta.cpp
@@ -223,6 +223,7 @@ String BlockMeta::GetBlockTag(const String &tag) const {
 }
 
 Tuple<SizeT, Status> BlockMeta::GetRowCnt1() {
+    std::lock_guard<std::mutex> lock(mtx_);
     if (row_cnt_) {
         return {*row_cnt_, Status::OK()};
     }

--- a/src/storage/new_txn/new_txn.cpp
+++ b/src/storage/new_txn/new_txn.cpp
@@ -1727,11 +1727,14 @@ Status NewTxn::Commit() {
     bool retry_query = true;
     bool conflict = txn_mgr_->CheckConflict1(this, conflict_reason, retry_query);
     if (conflict) {
-        if (retry_query) {
-            status = Status::TxnConflict(txn_context_ptr_->txn_id_, fmt::format("NewTxn conflict reason: {}.", conflict_reason));
-        } else {
-            status = Status::TxnConflictNoRetry(txn_context_ptr_->txn_id_, fmt::format("NewTxn conflict reason: {}.", conflict_reason));
-        }
+        // TODO: We are not retrying the query if its transaction is conflicted with other transaction right now. We will add retry logic later.
+        status = Status::TxnConflictNoRetry(txn_context_ptr_->txn_id_, fmt::format("NewTxn conflict reason: {}.", conflict_reason));
+
+        // if (retry_query) {
+        //     status = Status::TxnConflict(txn_context_ptr_->txn_id_, fmt::format("NewTxn conflict reason: {}.", conflict_reason));
+        // } else {
+        //     status = Status::TxnConflictNoRetry(txn_context_ptr_->txn_id_, fmt::format("NewTxn conflict reason: {}.", conflict_reason));
+        // }
 
         this->SetTxnRollbacking(commit_ts);
     }
@@ -4120,7 +4123,7 @@ bool NewTxn::CheckConflict1(SharedPtr<NewTxn> check_txn, String &conflict_reason
     for (SharedPtr<WalCmd> &wal_cmd : wal_entry_->cmds_) {
         bool conflict = this->CheckConflictCmd(*wal_cmd, check_txn.get(), conflict_reason, retry_query);
         if (conflict) {
-            conflicted_txn_ = check_txn;
+            // conflicted_txn_ = check_txn;
             return true;
         }
     }
@@ -4131,7 +4134,7 @@ bool NewTxn::CheckConflictTxnStores(SharedPtr<NewTxn> check_txn, String &conflic
     LOG_TRACE(fmt::format("CheckConflictTxnStores::Txn {} check conflict with txn: {}.", *txn_text_, *check_txn->txn_text_));
     bool conflict = this->CheckConflictTxnStore(check_txn.get(), conflict_reason, retry_query);
     if (conflict) {
-        conflicted_txn_ = check_txn;
+        // conflicted_txn_ = check_txn;
         return true;
     }
     return false;

--- a/src/storage/persistence/obj_stat_accessor.cpp
+++ b/src/storage/persistence/obj_stat_accessor.cpp
@@ -207,14 +207,13 @@ Optional<ObjStat> ObjectStatAccessor_LocalStorage::Get(const String &key) {
     return map_iter->second;
 }
 
-ObjStat *ObjectStatAccessor_LocalStorage::GetNoCount(const String &key) {
+Optional<ObjStat> ObjectStatAccessor_LocalStorage::GetNoCount(const String &key) {
     std::unique_lock<std::mutex> lock(mutex_);
     auto map_iter = obj_map_.find(key);
     if (map_iter == obj_map_.end()) {
-        return nullptr;
+        return None;
     }
-    ObjStat *obj_stat = &map_iter->second;
-    return obj_stat;
+    return map_iter->second;
 }
 
 Optional<ObjStat> ObjectStatAccessor_LocalStorage::Release(const String &key, Vector<String> &drop_keys) {
@@ -351,9 +350,13 @@ Optional<ObjStat> ObjectStatAccessor_ObjectStorage::Get(const String &key) {
     return *obj_stat;
 }
 
-ObjStat *ObjectStatAccessor_ObjectStorage::GetNoCount(const String &key) {
+Optional<ObjStat> ObjectStatAccessor_ObjectStorage::GetNoCount(const String &key) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
-    return obj_map_.GetNoCount(key);
+    ObjStat *obj_stat = obj_map_.GetNoCount(key);
+    if (obj_stat == nullptr) {
+        return None;
+    }
+    return *obj_stat;
 }
 
 Optional<ObjStat> ObjectStatAccessor_ObjectStorage::Release(const String &key, Vector<String> &drop_keys) {

--- a/src/storage/persistence/obj_stat_accessor.cppm
+++ b/src/storage/persistence/obj_stat_accessor.cppm
@@ -83,7 +83,7 @@ public:
 
     virtual Optional<ObjStat> Get(const String &key) = 0;
 
-    virtual ObjStat *GetNoCount(const String &key) = 0;
+    virtual Optional<ObjStat> GetNoCount(const String &key) = 0;
 
     virtual Optional<ObjStat> Release(const String &key, Vector<String> &drop_keys) = 0;
 
@@ -115,7 +115,7 @@ public:
 
     Optional<ObjStat> Get(const String &key) override;
 
-    ObjStat *GetNoCount(const String &key) override;
+    Optional<ObjStat> GetNoCount(const String &key) override;
 
     Optional<ObjStat> Release(const String &key, Vector<String> &drop_keys) override;
 
@@ -149,7 +149,7 @@ public:
 
     Optional<ObjStat> Get(const String &key) override;
 
-    ObjStat *GetNoCount(const String &key) override;
+    Optional<ObjStat> GetNoCount(const String &key) override;
 
     Optional<ObjStat> Release(const String &key, Vector<String> &drop_keys) override;
 

--- a/src/storage/persistence/persistence_manager.cpp
+++ b/src/storage/persistence/persistence_manager.cpp
@@ -233,8 +233,8 @@ void PersistenceManager::CheckValid() {
         if (obj_addr.obj_key_ == ObjAddr::KeyEmpty) {
             continue;
         }
-        ObjStat *obj_stat = objects_->GetNoCount(obj_addr.obj_key_);
-        if (obj_stat == nullptr) {
+        Optional<ObjStat> obj_stat = objects_->GetNoCount(obj_addr.obj_key_);
+        if (!obj_stat.has_value()) {
             String error_message = fmt::format("CheckValid Failed to find object for local path {}", local_path);
             LOG_ERROR(error_message);
         }
@@ -473,15 +473,15 @@ void PersistenceManager::CleanupNoLock(const ObjAddr &object_addr,
                                        Vector<String> &drop_keys,
                                        Vector<String> &drop_from_remote_keys,
                                        bool check_ref_count) {
-    ObjStat *obj_stat = objects_->GetNoCount(object_addr.obj_key_);
-    if (obj_stat == nullptr) {
+    Optional<ObjStat> obj_stat = objects_->GetNoCount(object_addr.obj_key_);
+    if (!obj_stat.has_value()) {
         if (object_addr.obj_key_ == ObjAddr::KeyEmpty) {
             assert(object_addr.part_size_ == 0);
             return;
         } else if (object_addr.obj_key_ == current_object_key_) {
             CurrentObjFinalizeNoLock(persist_keys, drop_keys);
             obj_stat = objects_->GetNoCount(object_addr.obj_key_);
-            assert(obj_stat != nullptr);
+            assert(obj_stat.has_value());
         } else {
             String error_message = fmt::format("CleanupNoLock Failed to find object {}", object_addr.obj_key_);
             UnrecoverableError(error_message);
@@ -568,8 +568,8 @@ void PersistenceManager::CleanupNoLock(const ObjAddr &object_addr,
 
 ObjStat PersistenceManager::GetObjStatByObjAddr(const ObjAddr &obj_addr) {
     std::lock_guard<std::mutex> lock(mtx_);
-    ObjStat *obj_stat = objects_->GetNoCount(obj_addr.obj_key_);
-    if (obj_stat == nullptr) {
+    Optional<ObjStat> obj_stat = objects_->GetNoCount(obj_addr.obj_key_);
+    if (!obj_stat.has_value()) {
         return ObjStat();
     }
     return *obj_stat;

--- a/src/unit_test/storage/persistence/obj_stat_accessor.cpp
+++ b/src/unit_test/storage/persistence/obj_stat_accessor.cpp
@@ -36,11 +36,11 @@ TEST_F(ObjectStatMapTest, test1) {
     drop_keys.clear();
     EXPECT_EQ(obj_map.disk_used(), 8);
 
-    ObjStat *stat2 = obj_map.GetNoCount("key2");
-    EXPECT_NE(stat2, nullptr);
+    Optional<ObjStat> stat2 = obj_map.GetNoCount("key2");
+    EXPECT_NE(stat2, None);
     EXPECT_EQ(stat2->cached_, ObjCached::kNotCached);
     Optional<ObjStat> stat2_opt = obj_map.Invalidate("key2");
     EXPECT_TRUE(stat2_opt.has_value());
     stat2 = obj_map.GetNoCount("key2");
-    EXPECT_EQ(stat2, nullptr);
+    EXPECT_EQ(stat2, None);
 }

--- a/src/unit_test/storage/txn/conflict_check.cpp
+++ b/src/unit_test/storage/txn/conflict_check.cpp
@@ -71,7 +71,7 @@ protected:
 
     void ExpectConflict(NewTxn *txn) {
         Status status = txn_mgr_->CommitTxn(txn);
-        EXPECT_EQ(status.code(), ErrorCode::kTxnConflict);
+        EXPECT_EQ(status.code(), ErrorCode::kTxnConflictNoRetry);
     };
 
     void InitTable(const String &db_name, const String &table_name, SharedPtr<TableDef> table_def, SizeT row_cnt) {

--- a/src/unit_test/storage/txn/txns_conflict.cpp
+++ b/src/unit_test/storage/txn/txns_conflict.cpp
@@ -95,6 +95,7 @@ INSTANTIATE_TEST_SUITE_P(TestWithDifferentParams,
 TEST_P(TestTxnsConflictTest, create_index_append) {
     LOG_INFO("--create_index_append--");
 
+    /*
     auto thread_create_index = [this]() {
         {
             String create_table_sql = "create table t1(c1 int, c2 varchar)";
@@ -164,8 +165,11 @@ TEST_P(TestTxnsConflictTest, create_index_append) {
         EXPECT_TRUE(ok);
         LOG_INFO(query_result.ToString());
     }
+    */
 }
 
+/* FIXME: We are not retrying query if it is conflicted with others right now.
+ * In this test, we expect query is retried and successful after conflicts.
 TEST_P(TestTxnsConflictTest, add_column_append) {
     LOG_INFO("--add_column_append--");
 
@@ -821,3 +825,4 @@ TEST_P(TestTxnsConflictTest, delete_append) {
         LOG_INFO(query_result.ToString());
     }
 }
+*/


### PR DESCRIPTION
### What problem does this PR solve?

1) Fix data race on BlockMeta::row_cnt_  and ObjState
2) Fix memory leak of NewTxn::~NewTxn()
3) Avoid query retry on conflicts.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)