### PR TITLE
Invalidate reader cache on DropIndex and CreateIndex

### DIFF
--- a/src/executor/operator/physical_match.cpp
+++ b/src/executor/operator/physical_match.cpp
@@ -108,7 +108,7 @@ QueryIterators CreateQueryIterators(QueryBuilder &query_builder,
                 iter = std::move(new_iter);
             }
         } else {
-            LOG_WARN("physical_match: iter is nullptr");
+            // LOG_WARN("physical_match: iter is nullptr");
         }
         return iter;
     };

--- a/src/storage/catalog/meta/table_index_meeta.cpp
+++ b/src/storage/catalog/meta/table_index_meeta.cpp
@@ -176,19 +176,6 @@ Status TableIndexMeeta::GetSegmentUpdateTS(SharedPtr<SegmentUpdateTS> &segment_u
     return Status::OK();
 }
 
-Status TableIndexMeeta::UpdateFulltextSegmentTS(TxnTimeStamp ts) {
-    SharedPtr<SegmentUpdateTS> segment_update_ts;
-    Status status = GetSegmentUpdateTS(segment_update_ts);
-    if (!status.ok()) {
-        return status;
-    }
-    status = table_meta_.UpdateFulltextSegmentTS(ts, *segment_update_ts);
-    if (!status.ok()) {
-        return status;
-    }
-    return Status::OK();
-}
-
 Status TableIndexMeeta::InitSet1(const SharedPtr<IndexBase> &index_base, NewCatalog *new_catalog) {
     {
         Status status = SetIndexBase(index_base);

--- a/src/storage/catalog/meta/table_index_meeta.cppm
+++ b/src/storage/catalog/meta/table_index_meeta.cppm
@@ -73,8 +73,6 @@ private:
     Status GetSegmentUpdateTS(SharedPtr<SegmentUpdateTS> &segment_update_ts);
 
 public:
-    Status UpdateFulltextSegmentTS(TxnTimeStamp ts);
-
     Status InitSet1(const SharedPtr<IndexBase> &index_base, NewCatalog *new_catalog);
 
     Status UninitSet1(UsageFlag usage_flag);

--- a/src/storage/catalog/meta/table_meeta.cpp
+++ b/src/storage/catalog/meta/table_meeta.cpp
@@ -339,8 +339,6 @@ Status TableMeeta::LoadSet() {
             if (!status.ok()) {
                 return status;
             }
-
-            table_index_meta.UpdateFulltextSegmentTS(commit_ts_);
             break;
         }
     }
@@ -547,7 +545,7 @@ Status TableMeeta::RemoveFtIndexCache() {
     return Status::OK();
 }
 
-Status TableMeeta::InvalidateFtIndexCache(SegmentID segment_id) {
+Status TableMeeta::InvalidateFtIndexCache() {
     String ft_index_cache_key = GetTableTag("ft_index_cache");
     NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
     SharedPtr<TableIndexReaderCache> ft_index_cache;
@@ -558,14 +556,7 @@ Status TableMeeta::InvalidateFtIndexCache(SegmentID segment_id) {
         }
         return status;
     }
-    ColumnID next_column_id;
-    status = GetNextColumnID(next_column_id);
-    if (!status.ok()) {
-        return status;
-    }
-    for (ColumnID column_id = 0; column_id < next_column_id; ++column_id) {
-        ft_index_cache->InvalidateSegmentColumn(column_id, segment_id);
-    }
+    ft_index_cache->Invalidate();
     return Status::OK();
 }
 
@@ -588,17 +579,6 @@ Status TableMeeta::SetNextColumnID(ColumnID next_column_id) {
         return status;
     }
     next_column_id_ = next_column_id;
-    return Status::OK();
-}
-
-Status TableMeeta::UpdateFulltextSegmentTS(TxnTimeStamp ts, SegmentUpdateTS &segment_update_ts) {
-    SharedPtr<TableIndexReaderCache> ft_index_cache;
-    Status status = GetFtIndexCache(ft_index_cache);
-    if (!status.ok()) {
-        return status;
-    }
-    ft_index_cache->UpdateKnownUpdateTs(ts, segment_update_ts.mtx_, segment_update_ts.ts_);
-
     return Status::OK();
 }
 

--- a/src/storage/catalog/meta/table_meeta.cpp
+++ b/src/storage/catalog/meta/table_meeta.cpp
@@ -528,6 +528,7 @@ Status TableMeeta::GetFtIndexCache(SharedPtr<TableIndexReaderCache> &ft_index_ca
     String ft_index_cache_key = GetTableTag("ft_index_cache");
     NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
 
+    ft_index_cache = MakeShared<TableIndexReaderCache>(db_id_str_, table_id_str_);
     Status status = new_catalog->GetFtIndexCache(ft_index_cache_key, ft_index_cache);
     if (!status.ok()) {
         return status;
@@ -548,7 +549,7 @@ Status TableMeeta::RemoveFtIndexCache() {
 Status TableMeeta::InvalidateFtIndexCache() {
     String ft_index_cache_key = GetTableTag("ft_index_cache");
     NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
-    SharedPtr<TableIndexReaderCache> ft_index_cache;
+    SharedPtr<TableIndexReaderCache> ft_index_cache = MakeShared<TableIndexReaderCache>(db_id_str_, table_id_str_);
     Status status = new_catalog->GetFtIndexCache(ft_index_cache_key, ft_index_cache);
     if (!status.ok()) {
         if (status.code() == ErrorCode::kCatalogError) {

--- a/src/storage/catalog/meta/table_meeta.cppm
+++ b/src/storage/catalog/meta/table_meeta.cppm
@@ -120,13 +120,11 @@ public:
 
     Status RemoveFtIndexCache();
 
-    Status InvalidateFtIndexCache(SegmentID segment_id);
+    Status InvalidateFtIndexCache();
 
     Status GetNextColumnID(ColumnID &next_column_id);
 
     Status SetNextColumnID(ColumnID next_column_id);
-
-    Status UpdateFulltextSegmentTS(TxnTimeStamp ts, SegmentUpdateTS &segment_update_ts);
 
     Status GetNextRowID(RowID &next_row_id);
 

--- a/src/storage/catalog/new_catalog.cpp
+++ b/src/storage/catalog/new_catalog.cpp
@@ -24,7 +24,6 @@ import new_txn;
 import status;
 import extra_ddl_info;
 import kv_store;
-import third_party;
 import logger;
 import infinity_exception;
 import default_values;
@@ -224,15 +223,11 @@ Status NewCatalog::AddFtIndexCache(String ft_index_cache_key, SharedPtr<TableInd
 }
 
 Status NewCatalog::GetFtIndexCache(const String &ft_index_cache_key, SharedPtr<TableIndexReaderCache> &ft_index_cache) {
-    ft_index_cache = nullptr;
-    {
-        std::shared_lock<std::shared_mutex> lck(ft_index_cache_mtx_);
-        if (auto iter = ft_index_cache_map_.find(ft_index_cache_key); iter != ft_index_cache_map_.end()) {
-            ft_index_cache = iter->second;
-        }
-    }
-    if (ft_index_cache == nullptr) {
-        return Status::CatalogError(fmt::format("FtIndexCache key: {} not found", ft_index_cache_key));
+    std::unique_lock<std::shared_mutex> lck(ft_index_cache_mtx_);
+    if (auto iter = ft_index_cache_map_.find(ft_index_cache_key); iter != ft_index_cache_map_.end()) {
+        ft_index_cache = iter->second;
+    } else {
+        ft_index_cache_map_.emplace(ft_index_cache_key, ft_index_cache);
     }
     return Status::OK();
 }

--- a/src/storage/catalog/new_catalog_static.cpp
+++ b/src/storage/catalog/new_catalog_static.cpp
@@ -1041,7 +1041,7 @@ Status NewCatalog::CleanSegmentIndex(SegmentIndexMeta &segment_index_meta, Usage
     if (usage_flag != UsageFlag::kTransform) {
         // Invalidate the fulltext index cache for this segment
         TableMeeta &table_meta = segment_index_meta.table_index_meta().table_meta();
-        Status status = table_meta.InvalidateFtIndexCache(segment_index_meta.segment_id());
+        Status status = table_meta.InvalidateFtIndexCache();
         if (!status.ok()) {
             return status;
         }

--- a/src/storage/invertedindex/column_index_reader.cpp
+++ b/src/storage/invertedindex/column_index_reader.cpp
@@ -233,131 +233,70 @@ void TableIndexReaderCache::UpdateKnownUpdateTs(TxnTimeStamp ts, std::shared_mut
         return;
     }
     segment_update_ts = ts;
-    first_known_update_ts_ = std::min(first_known_update_ts_, ts);
-    last_known_update_ts_ = std::max(last_known_update_ts_, ts);
 }
 
 SharedPtr<IndexReader> TableIndexReaderCache::GetIndexReader(NewTxn *txn) {
     TxnTimeStamp begin_ts = txn->BeginTS();
     SharedPtr<IndexReader> index_reader = MakeShared<IndexReader>();
     std::scoped_lock lock(mutex_);
-    assert(cache_ts_ <= first_known_update_ts_);
-    assert(first_known_update_ts_ == MAX_TIMESTAMP || first_known_update_ts_ <= last_known_update_ts_);
-    if (first_known_update_ts_ != 0 && begin_ts >= cache_ts_ && begin_ts < first_known_update_ts_) [[likely]] {
+    if (begin_ts >= cache_ts_) [[likely]] {
         // no need to build, use cache
         index_reader->column_index_readers_ = cache_column_readers_;
-        // result.column2analyzer_ = column2analyzer_;
-    } else {
-        FlatHashMap<u64, TxnTimeStamp, detail::Hash<u64>> cache_column_ts;
-        index_reader->column_index_readers_ = MakeShared<FlatHashMap<u64, SharedPtr<Map<String, SharedPtr<ColumnIndexReader>>>, detail::Hash<u64>>>();
-        // result.column2analyzer_ = MakeShared<Map<String, String>>();
+        return index_reader;
+    }
 
-        TableMeeta table_meta(db_id_str_, table_id_str_, txn);
-        Vector<String> *index_id_strs = nullptr;
-        {
-            Status status = table_meta.GetIndexIDs(index_id_strs, nullptr);
-            if (!status.ok()) {
-                UnrecoverableError("GetIndexIDs failed");
-            }
+    index_reader->column_index_readers_ = MakeShared<FlatHashMap<u64, SharedPtr<Map<String, SharedPtr<ColumnIndexReader>>>, detail::Hash<u64>>>();
+
+    TableMeeta table_meta(db_id_str_, table_id_str_, txn);
+    Vector<String> *index_id_strs = nullptr;
+    {
+        Status status = table_meta.GetIndexIDs(index_id_strs, nullptr);
+        if (!status.ok()) {
+            UnrecoverableError("GetIndexIDs failed");
         }
-        for (const String &index_id_str : *index_id_strs) {
-            TableIndexMeeta table_index_meta(index_id_str, table_meta);
-            auto [index_base, index_status] = table_index_meta.GetIndexBase();
-            if (!index_status.ok()) {
-                UnrecoverableError("Fail to get index definition");
-            }
-            if (index_base->index_type_ != IndexType::kFullText) {
-                // non-fulltext index
-                continue;
-            }
-
-            String column_name = index_base->column_name();
-            auto [column_def, col_def_status] = table_index_meta.GetColumnDef();
-            u64 column_id = column_def->id();
-            if (index_reader->column_index_readers_->find(column_id) == index_reader->column_index_readers_->end()) {
-                (*index_reader->column_index_readers_)[column_id] = MakeShared<Map<String, SharedPtr<ColumnIndexReader>>>();
-            }
-            auto column_index_map = (*index_reader->column_index_readers_)[column_id];
-
-            // assert(table_index_entry->GetFulltextSegmentUpdateTs() <= last_known_update_ts_);
-            if (auto &target_ts = cache_column_ts[column_id]; target_ts < begin_ts) {
-                // need update result
-                target_ts = begin_ts;
-                const IndexFullText *index_full_text = reinterpret_cast<const IndexFullText *>(index_base.get());
-                // update column2analyzer_
-                // (*result.column2analyzer_)[column_name] = index_full_text->analyzer_;
-                if (auto it = cache_column_ts_.find(column_id); it != cache_column_ts_.end() and it->second == begin_ts) {
-                    // reuse cache
-                    (*column_index_map)[index_id_str] = cache_column_readers_->at(column_id)->at(index_id_str);
-                } else {
-                    // new column_index_reader
-                    auto column_index_reader = MakeShared<ColumnIndexReader>();
-                    optionflag_t flag = index_full_text->flag_;
-                    column_index_reader->Open(flag, table_index_meta);
-                    column_index_reader->analyzer_ = index_full_text->analyzer_;
-                    column_index_reader->column_name_ = column_name;
-                    (*column_index_map)[index_id_str] = std::move(column_index_reader);
-                }
-            }
-            if (begin_ts >= last_known_update_ts_) {
-                // need to update cache
-                cache_ts_ = last_known_update_ts_;
-                first_known_update_ts_ = MAX_TIMESTAMP;
-                last_known_update_ts_ = 0;
-                cache_column_ts_ = std::move(cache_column_ts);
-                cache_column_readers_ = index_reader->column_index_readers_;
-                // column2analyzer_ = result.column2analyzer_;
-            }
+    }
+    for (const String &index_id_str : *index_id_strs) {
+        TableIndexMeeta table_index_meta(index_id_str, table_meta);
+        auto [index_base, index_status] = table_index_meta.GetIndexBase();
+        if (!index_status.ok()) {
+            UnrecoverableError("Fail to get index definition");
         }
+        if (index_base->index_type_ != IndexType::kFullText) {
+            // non-fulltext index
+            continue;
+        }
+
+        String column_name = index_base->column_name();
+        auto [column_def, col_def_status] = table_index_meta.GetColumnDef();
+        u64 column_id = column_def->id();
+        if (index_reader->column_index_readers_->find(column_id) == index_reader->column_index_readers_->end()) {
+            (*index_reader->column_index_readers_)[column_id] = MakeShared<Map<String, SharedPtr<ColumnIndexReader>>>();
+        }
+        auto column_index_map = (*index_reader->column_index_readers_)[column_id];
+
+        // assert(table_index_entry->GetFulltextSegmentUpdateTs() <= last_known_update_ts_);
+        const IndexFullText *index_full_text = reinterpret_cast<const IndexFullText *>(index_base.get());
+        // new column_index_reader
+        auto column_index_reader = MakeShared<ColumnIndexReader>();
+        optionflag_t flag = index_full_text->flag_;
+        column_index_reader->Open(flag, table_index_meta);
+        column_index_reader->analyzer_ = index_full_text->analyzer_;
+        column_index_reader->column_name_ = column_name;
+        (*column_index_map)[index_id_str] = std::move(column_index_reader);
+    }
+
+    if (cache_ts_ == UNCOMMIT_TS || begin_ts > cache_ts_) {
+        // need to update cache
+        cache_ts_ = begin_ts;
+        cache_column_readers_ = index_reader->column_index_readers_;
     }
     return index_reader;
 }
 
 void TableIndexReaderCache::Invalidate() {
     std::scoped_lock lock(mutex_);
-    first_known_update_ts_ = 0;
-    last_known_update_ts_ = std::max(last_known_update_ts_, cache_ts_);
-    cache_ts_ = 0;
-    cache_column_ts_.clear();
+    cache_ts_ = UNCOMMIT_TS;
     cache_column_readers_.reset();
-    // column2analyzer_.reset();
-}
-
-void TableIndexReaderCache::InvalidateColumn(u64 column_id, const String &column_name) {
-    std::scoped_lock lock(mutex_);
-    cache_column_ts_.erase(column_id);
-    if (cache_column_readers_.get() != nullptr) {
-        cache_column_readers_->erase(column_id);
-    }
-    // if (column2analyzer_.get() != nullptr) {
-    //     column2analyzer_->erase(column_name);
-    // }
-}
-
-void TableIndexReaderCache::InvalidateSegmentColumn(u64 column_id, SegmentID segment_id) {
-    std::scoped_lock lock(mutex_);
-    if (!cache_column_readers_.get()) {
-        return;
-    }
-    auto iter = cache_column_readers_->find(column_id);
-    if (iter != cache_column_readers_->end()) {
-        for (auto index_reader : (*iter->second)) {
-            index_reader.second->InvalidateSegment(segment_id);
-        }
-    }
-}
-
-void TableIndexReaderCache::InvalidateChunkColumn(u64 column_id, SegmentID segment_id, ChunkID chunk_id) {
-    std::scoped_lock lock(mutex_);
-    if (!cache_column_readers_.get()) {
-        return;
-    }
-    auto iter = cache_column_readers_->find(column_id);
-    if (iter != cache_column_readers_->end()) {
-        for (auto index_reader : (*iter->second)) {
-            index_reader.second->InvalidateChunk(segment_id, chunk_id);
-        }
-    }
 }
 
 } // namespace infinity

--- a/src/storage/invertedindex/column_index_reader.cpp
+++ b/src/storage/invertedindex/column_index_reader.cpp
@@ -225,16 +225,6 @@ void ColumnIndexReader::InvalidateChunk(SegmentID segment_id, ChunkID chunk_id) 
     }
 }
 
-void TableIndexReaderCache::UpdateKnownUpdateTs(TxnTimeStamp ts, std::shared_mutex &segment_update_ts_mutex, TxnTimeStamp &segment_update_ts) {
-    std::scoped_lock lock1(mutex_);
-    std::unique_lock lock2(segment_update_ts_mutex);
-    if (ts < segment_update_ts) {
-        // Optimize txn begin ts may be less than Insert txn commit ts
-        return;
-    }
-    segment_update_ts = ts;
-}
-
 SharedPtr<IndexReader> TableIndexReaderCache::GetIndexReader(NewTxn *txn) {
     TxnTimeStamp begin_ts = txn->BeginTS();
     SharedPtr<IndexReader> index_reader = MakeShared<IndexReader>();

--- a/src/storage/invertedindex/column_index_reader.cppm
+++ b/src/storage/invertedindex/column_index_reader.cppm
@@ -132,8 +132,6 @@ export class TableIndexReaderCache {
 public:
     TableIndexReaderCache(String db_id_str, String table_id_str) : db_id_str_(db_id_str), table_id_str_(table_id_str) {}
 
-    void UpdateKnownUpdateTs(TxnTimeStamp ts, std::shared_mutex &segment_update_ts_mutex, TxnTimeStamp &segment_update_ts);
-
     SharedPtr<IndexReader> GetIndexReader(NewTxn *txn);
 
     // User shall call this function only once when all transactions using `GetIndexReader()` have finished.

--- a/src/storage/invertedindex/column_index_reader.cppm
+++ b/src/storage/invertedindex/column_index_reader.cppm
@@ -26,6 +26,7 @@ import index_defines;
 import internal_types;
 import logger;
 import status;
+import default_values;
 
 namespace infinity {
 class TermDocIterator;
@@ -138,21 +139,12 @@ public:
     // User shall call this function only once when all transactions using `GetIndexReader()` have finished.
     void Invalidate();
 
-    void InvalidateColumn(u64 column_id, const String &column_name);
-
-    void InvalidateSegmentColumn(u64 column_id, SegmentID segment_id);
-
-    void InvalidateChunkColumn(u64 column_id, SegmentID segment_id, ChunkID chunk_id);
-
 private:
     std::mutex mutex_;
     String db_id_str_;
     String table_id_str_;
 
-    TxnTimeStamp first_known_update_ts_ = 0;
-    TxnTimeStamp last_known_update_ts_ = 0;
-    TxnTimeStamp cache_ts_ = 0;
-    FlatHashMap<u64, TxnTimeStamp, detail::Hash<u64>> cache_column_ts_;
+    TxnTimeStamp cache_ts_ = UNCOMMIT_TS;
     SharedPtr<FlatHashMap<u64, SharedPtr<Map<String, SharedPtr<ColumnIndexReader>>>, detail::Hash<u64>>> cache_column_readers_;
 };
 

--- a/src/storage/new_txn/new_txn_index.cpp
+++ b/src/storage/new_txn/new_txn_index.cpp
@@ -2036,16 +2036,7 @@ Status NewTxn::GetFullTextIndexReader(const String &db_name, const String &table
     SharedPtr<TableIndexReaderCache> ft_index_cache;
     status = table_meta->GetFtIndexCache(ft_index_cache);
     if (!status.ok()) {
-        // Add cache if not exist
-        if (status.code() == ErrorCode::kCatalogError) {
-            ft_index_cache = MakeShared<TableIndexReaderCache>(table_meta->db_id_str(), table_meta->table_id_str());
-            status = table_meta->AddFtIndexCache(ft_index_cache);
-            if (!status.ok()) {
-                return status;
-            }
-        } else {
-            return status;
-        }
+        return status;
     }
     index_reader = ft_index_cache->GetIndexReader(this);
     return Status::OK();


### PR DESCRIPTION
### What problem does this PR solve?

Invalidate reader cache on DropIndex and CreateIndex, simplify TableIndexReaderCache

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring
