### PR TITLE
Bug Fix: buff obj state after save

### DIFF
--- a/src/storage/buffer/file_worker/version_file_worker.cpp
+++ b/src/storage/buffer/file_worker/version_file_worker.cpp
@@ -74,13 +74,20 @@ bool VersionFileWorker::WriteToFileImpl(bool to_spill, bool &prepare_success, co
     }
     auto *data = static_cast<BlockVersion *>(data_);
 
+    // if spill to file, return true if success
     if (to_spill) {
         data->SpillToFile(file_handle_.get());
+        return true;
     } else {
         const auto &ctx = static_cast<const VersionFileWorkerSaveCtx &>(base_ctx);
-        data->SaveToFile(ctx.checkpoint_ts_, *file_handle_);
+        bool is_full = data->SaveToFile(ctx.checkpoint_ts_, *file_handle_);
+        if (is_full) {
+            LOG_TRACE(fmt::format("Version file is full: {}", GetFilePath()));
+            // if the version file is full, return true to spill to file
+            return true;
+        }
     }
-    return true;
+    return false;
 }
 
 void VersionFileWorker::ReadFromFileImpl(SizeT file_size, bool from_spill) {

--- a/src/storage/catalog/meta/block_version.cppm
+++ b/src/storage/catalog/meta/block_version.cppm
@@ -55,7 +55,7 @@ export struct BlockVersion {
 
     Tuple<i32, Status> GetRowCountForUpdate(TxnTimeStamp begin_ts) const;
 
-    void SaveToFile(TxnTimeStamp checkpoint_ts, LocalFileHandle &file_handler) const;
+    bool SaveToFile(TxnTimeStamp checkpoint_ts, LocalFileHandle &file_handler) const;
 
     void SpillToFile(LocalFileHandle *file_handle) const;
     static UniquePtr<BlockVersion> LoadFromFile(LocalFileHandle *file_handle);


### PR DESCRIPTION
### What problem does this PR solve?

_Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR._

Issue link:(https://github.com/infiniflow/infinity/issues/2871)

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

Before: during save, the buffer obj will change from kephermal to kpersistent if it's saved whether it has later change or not. This will cause an issue as the timestamp for txn and actual implementation time are different. It's possible that an modification at a later timestamp happens at an earlier time thus it won't be recorded in the file. And if a file is deemed persistent and no modification is applied at a later time, at next save, the data won't be saved again leading to data loss.

After: during save check if there are any modification after checkpoint ts. If no we will make it kpersistent, or it will stay Kephermal. This will make sure no real time and timestamp conflict affect persisting data.
