### PR TITLE
Fix compact issue, modify testcases

### DIFF
--- a/python/infinity_http.py
+++ b/python/infinity_http.py
@@ -484,6 +484,13 @@ class table_http:
             res[col["name"]] = col["type"]
         return res
 
+    def compact(self):
+        url = f"databases/{self.database_name}/tables/{self.table_name}/compact"
+        h = self.net.set_up_header(["accept", "content-type"])
+        r = self.net.request(url, "put", h)
+        self.net.raise_exception(r)
+        return database_result()
+
     # index
     def create_index(
             self,

--- a/python/test_pysdk/test_compact.py
+++ b/python/test_pysdk/test_compact.py
@@ -1,0 +1,84 @@
+import importlib
+import sys
+import os
+import os
+import pytest
+from common import common_values
+import infinity
+from infinity.errors import ErrorCode
+from infinity.common import ConflictType, InfinityException
+
+from common.utils import generate_big_int_csv, copy_data, generate_big_rows_csv, generate_big_columns_csv, generate_fvecs, generate_commas_enwiki
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+from infinity_http import infinity_http
+
+@pytest.fixture(scope="class")
+def http(request):
+    return request.config.getoption("--http")
+@pytest.fixture(scope="class")
+def setup_class(request, http):
+    if http:
+        uri = common_values.TEST_LOCAL_HOST
+        request.cls.infinity_obj = infinity_http()
+    else:
+        uri = common_values.TEST_LOCAL_HOST
+        request.cls.infinity_obj = infinity.connect(uri)
+    request.cls.uri = uri
+    yield
+    request.cls.infinity_obj.disconnect()
+
+@pytest.mark.usefixtures("setup_class")
+@pytest.mark.usefixtures("suffix")
+class TestInfinity:
+    @pytest.fixture
+    def skip_setup_marker(self, request):
+        request.node.skip_setup = True
+
+    @pytest.mark.parametrize("check_data", [{"file_name": "embedding_int_dim3.csv",
+                                             "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
+    def test_compact(self, check_data, suffix):
+        db_obj = self.infinity_obj.get_database("default_db")
+        assert db_obj
+
+        if not check_data:
+            copy_data("embedding_int_dim3.csv")
+        db_obj.drop_table("test_compact"+suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table(
+            "test_compact"+suffix, {"c1": {"type": "int"}, "c2": {"type": "vector,3,int"}}, ConflictType.Error)
+
+        test_csv_dir = common_values.TEST_TMP_DIR + "embedding_int_dim3.csv"
+        assert os.path.exists(test_csv_dir)
+
+        # Import to create 4 segments
+        res = table_obj.import_data(test_csv_dir)
+        assert res.error_code == ErrorCode.OK
+
+        res = table_obj.import_data(test_csv_dir)
+        assert res.error_code == ErrorCode.OK
+
+        res = table_obj.import_data(test_csv_dir)
+        assert res.error_code == ErrorCode.OK
+
+        res = table_obj.import_data(test_csv_dir)
+        assert res.error_code == ErrorCode.OK
+
+        res, extra_result = table_obj.output(["count(*)"]).to_pl()
+        assert res.height == 1 and res.width == 1 and res.item(0, 0) == 12
+
+        # Compact
+        res = table_obj.compact()
+
+        # If compact is conflicted with background compact, sleep to wait for background compact to finish.
+        if res.error_code != ErrorCode.OK:
+            sleep(2)
+
+        assert len(table_obj.show_segments()) == 1
+
+        res, extra_result = table_obj.output(["count(*)"]).to_pl()
+        assert res.height == 1 and res.width == 1 and res.item(0, 0) == 12
+
+        res = db_obj.drop_table("test_compact"+suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK

--- a/src/executor/operator/physical_compact_impl.cpp
+++ b/src/executor/operator/physical_compact_impl.cpp
@@ -60,6 +60,7 @@ bool PhysicalCompact::Execute(QueryContext *query_context, OperatorState *operat
     compact_task->Wait();
 
     compact_operator_state->status_ = compact_task->result_status_;
+    compact_operator_state->result_msg_ = std::move(compact_operator_state->status_.msg_);
     compact_operator_state->SetComplete();
     return true;
 }

--- a/src/executor/operator/physical_sink_impl.cpp
+++ b/src/executor/operator/physical_sink_impl.cpp
@@ -429,8 +429,8 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(MessageSinkState *message_
             break;
         }
         case PhysicalOperatorType::kCompact: {
-            // auto *compact_output_state = static_cast<CompactOperatorState *>(task_operator_state);
-            message_sink_state->message_ = MakeUnique<String>("Tmp for test");
+            auto *compact_output_state = static_cast<CompactOperatorState *>(task_operator_state);
+            message_sink_state->message_ = std::move(compact_output_state->result_msg_);
             break;
         }
         default: {

--- a/src/executor/operator_state.cppm
+++ b/src/executor/operator_state.cppm
@@ -404,6 +404,7 @@ export struct CompactOperatorState : public OperatorState {
 
     SizeT compact_idx_{};
     SharedPtr<CompactStateData> compact_state_data_{};
+    UniquePtr<String> result_msg_{};
 };
 
 // Unnest

--- a/src/network/connection_impl.cpp
+++ b/src/network/connection_impl.cpp
@@ -421,7 +421,8 @@ void Connection::SendQueryResponse(const QueryResult &query_result) {
             break;
         }
         case LogicalNodeType::kImport:
-        case LogicalNodeType::kExport: {
+        case LogicalNodeType::kExport:
+        case LogicalNodeType::kCompact: {
             message = *query_result.result_table_->result_msg();
             break;
         }

--- a/src/network/http_server_impl.cpp
+++ b/src/network/http_server_impl.cpp
@@ -3256,12 +3256,8 @@ public:
         auto infinity = Infinity::RemoteConnect();
         DeferFn defer_fn([&]() { infinity->RemoteDisconnect(); });
 
-        String data_body = request->readBodyToString();
-        simdjson::padded_string json_pad(data_body);
-        simdjson::parser parser;
-        simdjson::document doc = parser.iterate(json_pad);
-        String db_name = doc["db_name"].get<String>();
-        String table_name = doc["table_name"].get<String>();
+        String db_name = request->getPathVariable("database_name");
+        String table_name = request->getPathVariable("table_name");
 
         nlohmann::json json_response;
         HTTPStatus http_status;
@@ -3683,6 +3679,7 @@ Thread HTTPServer::Start(const String &ip_address, u16 port) {
     router->route("POST", "/databases/{database_name}/tables/{table_name}/docs", MakeShared<InsertHandler>());
     router->route("DELETE", "/databases/{database_name}/tables/{table_name}/docs", MakeShared<DeleteHandler>());
     router->route("PUT", "/databases/{database_name}/tables/{table_name}/docs", MakeShared<UpdateHandler>());
+    router->route("PUT", "/databases/{database_name}/tables/{table_name}/compact", MakeShared<CompactTableHandler>());
 
     // DQL
     router->route("GET", "/databases/{database_name}/tables/{table_name}/docs", MakeShared<SelectHandler>());
@@ -3740,7 +3737,6 @@ Thread HTTPServer::Start(const String &ip_address, u16 port) {
     router->route("GET", "/instance/memory/objects", MakeShared<ShowMemoryObjectsHandler>());
     router->route("GET", "/instance/memory/allocations", MakeShared<ShowMemoryAllocationsHandler>());
     router->route("POST", "/instance/flush", MakeShared<ForceGlobalCheckpointHandler>());
-    router->route("POST", "/instance/table/compact", MakeShared<CompactTableHandler>());
 
     // variable
     router->route("GET", "/variables/global", MakeShared<ShowGlobalVariablesHandler>());

--- a/src/storage/catalog/meta/block_meta.cppm
+++ b/src/storage/catalog/meta/block_meta.cppm
@@ -46,8 +46,6 @@ public:
 
     Status GetBlockLock(SharedPtr<BlockLock> &block_lock);
 
-    // Status SetRowCnt(SizeT row_cnt);
-
     Status InitSet();
 
     Status LoadSet(TxnTimeStamp checkpoint_ts);

--- a/src/storage/catalog/meta/block_meta_impl.cpp
+++ b/src/storage/catalog/meta/block_meta_impl.cpp
@@ -57,12 +57,6 @@ Status BlockMeta::GetBlockLock(SharedPtr<BlockLock> &block_lock) {
 }
 
 Status BlockMeta::InitSet() {
-    // {
-    //     Status status = SetRowCnt(0);
-    //     if (!status.ok()) {
-    //         return status;
-    //     }
-    // }
     NewCatalog *new_catalog = InfinityContext::instance().storage()->new_catalog();
     {
         String block_lock_key = GetBlockTag("lock");

--- a/src/storage/catalog/meta/segment_meta.cppm
+++ b/src/storage/catalog/meta/segment_meta.cppm
@@ -71,8 +71,6 @@ public:
 
     Status SetNextBlockID(BlockID next_block_id);
 
-    // Status SetRowCnt(SizeT row_cnt);
-
     Status SetFirstDeleteTS(TxnTimeStamp first_delete_ts);
 
     Status InitSet();

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -77,17 +77,6 @@ Status SegmentMeta::SetNextBlockID(BlockID next_block_id) {
     return Status::OK();
 }
 
-// Status SegmentMeta::SetRowCnt(SizeT row_cnt) {
-//     row_cnt_ = row_cnt;
-//     String row_cnt_key = GetSegmentTag("row_cnt");
-//     String row_cnt_str = fmt::format("{}", row_cnt);
-//     Status status = kv_instance_.Put(row_cnt_key, row_cnt_str);
-//     if (!status.ok()) {
-//         return status;
-//     }
-//     return Status::OK();
-// }
-
 Status SegmentMeta::SetFirstDeleteTS(TxnTimeStamp first_delete_ts) {
     String first_delete_ts_key = GetSegmentTag("first_delete_ts");
     String first_delete_ts_str = fmt::format("{}", first_delete_ts);
@@ -112,12 +101,6 @@ Status SegmentMeta::InitSet() {
             return status;
         }
     }
-    // {
-    //     Status status = SetRowCnt(0);
-    //     if (!status.ok()) {
-    //         return status;
-    //     }
-    // }
     {
         Status status = SetFirstDeleteTS(UNCOMMIT_TS);
         if (!status.ok()) {

--- a/src/storage/catalog/meta/table_meeta.cppm
+++ b/src/storage/catalog/meta/table_meeta.cppm
@@ -59,30 +59,13 @@ public:
 
     Status UninitSet(UsageFlag usage_flag);
 
-    // Status GetNextSegmentID(SegmentID &next_segment_id) {
-    //     if (!next_segment_id_) {
-    //         Status status = LoadNextSegmentID();
-    //         if (!status.ok()) {
-    //             return status;
-    //         }
-    //     }
-    //     next_segment_id = *next_segment_id_;
-    //     return Status::OK();
-    // }
-
-    // Status SetNextSegmentID(SegmentID next_segment_id);
-
     Status GetUnsealedSegmentID(SegmentID &unsealed_segment_id);
 
     Status SetUnsealedSegmentID(SegmentID unsealed_segment_id);
 
     Status DelUnsealedSegmentID();
 
-    // Status SetSegmentIDs(const Vector<SegmentID> &segment_ids);
-
     Status RemoveSegmentIDs1(const Vector<SegmentID> &segment_ids);
-
-    // Status AddSegmentID(SegmentID segment_id);
 
     Pair<SegmentID, Status> AddSegmentID1(TxnTimeStamp commit_ts);
     Status AddSegmentWithID(TxnTimeStamp commit_ts, SegmentID segment_id);
@@ -92,7 +75,6 @@ public:
     Tuple<ColumnID, Status> GetColumnIDByColumnName(const String &column_name);
     Tuple<String, Status> GetColumnKeyByColumnName(const String &column_name) const;
     SharedPtr<String> GetTableDir();
-    // Tuple<SharedPtr<Vector<SegmentID>>, Status> GetSegmentIndexIDs1();
 
     Tuple<Vector<SegmentID> *, Status> GetSegmentIDs1();
     Status CheckSegments(const Vector<SegmentID> &segment_ids);
@@ -136,13 +118,9 @@ private:
 
     Status LoadColumnDefs();
 
-    // Status LoadSegmentIDs();
-
     Status LoadSegmentIDs1();
 
     Status LoadIndexIDs();
-
-    // Status LoadNextSegmentID();
 
     Status LoadUnsealedSegmentID();
 

--- a/src/storage/catalog/meta/table_meeta_impl.cpp
+++ b/src/storage/catalog/meta/table_meeta_impl.cpp
@@ -207,26 +207,6 @@ Status TableMeeta::RemoveSegmentIDs1(const Vector<SegmentID> &segment_ids) {
     return Status::OK();
 }
 
-// Status TableMeeta::AddSegmentID(SegmentID segment_id) {
-//     if (!segment_ids_) {
-//         Status status = LoadSegmentIDs();
-//         //        if (!status.ok() && status.code() != ErrorCode::kNotFound) {
-//         //            return status;
-//         //        }
-//         //        segment_ids_ = Vector<SegmentID>();
-//         if (!status.ok()) {
-//             return status;
-//         }
-//     }
-
-//     segment_ids_->emplace_back(segment_id);
-//     Status status = SetSegmentIDs(*segment_ids_);
-//     if (!status.ok()) {
-//         return status;
-//     }
-//     return Status::OK();
-// }
-
 Pair<SegmentID, Status> TableMeeta::AddSegmentID1(TxnTimeStamp commit_ts) {
     Status status;
 
@@ -644,18 +624,6 @@ Status TableMeeta::LoadColumnDefs() {
     return Status::OK();
 }
 
-// Status TableMeeta::LoadSegmentIDs() {
-//     String segment_ids_key = GetTableTag("segment_ids");
-//     String segment_ids_str;
-//     Status status = kv_instance_.Get(segment_ids_key, segment_ids_str);
-//     if (!status.ok()) {
-//         LOG_ERROR(fmt::format("Fail to get segment ids from kv store, key: {}, cause: {}", segment_ids_key, status.message()));
-//         return status;
-//     }
-//     segment_ids_ = nlohmann::json::parse(segment_ids_str).get<Vector<SegmentID>>();
-//     return Status::OK();
-// }
-
 Status TableMeeta::LoadSegmentIDs1() {
     segment_ids1_ = infinity::GetTableSegments(kv_instance_, db_id_str_, table_id_str_, begin_ts_, commit_ts_);
     return Status::OK();
@@ -837,20 +805,6 @@ Tuple<String, Status> TableMeeta::GetColumnKeyByColumnName(const String &column_
 }
 
 SharedPtr<String> TableMeeta::GetTableDir() { return {MakeShared<String>(table_id_str_)}; }
-
-// Tuple<SharedPtr<Vector<SegmentID>>, Status> TableMeeta::GetSegmentIndexIDs1() {
-//     if (!segment_ids_) {
-//         auto status = LoadSegmentIDs();
-//         if (!status.ok()) {
-//             //            if (status.code() == ErrorCode::kNotFound) {
-//             //                return {MakeShared<Vector<SegmentID>>(), Status::OK()};
-//             //            } else {
-//             return {nullptr, status};
-//             //            }
-//         }
-//     }
-//     return {MakeShared<Vector<SegmentID>>(segment_ids_.value()), Status::OK()};
-// }
 
 Tuple<Vector<SegmentID> *, Status> TableMeeta::GetSegmentIDs1() {
     std::lock_guard<std::mutex> lock(mtx_);

--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -917,13 +917,6 @@ Status NewCatalog::LoadFlushedBlock1(SegmentMeta &segment_meta, const WalBlockIn
             return status;
         }
     }
-    /*
-    status = block_meta.SetRowCnt(block_info.row_count_);
-    if (!status.ok()) {
-        return status;
-    }
-    */
-
     return Status::OK();
 }
 

--- a/src/storage/compaction/new_compaction_alg.cppm
+++ b/src/storage/compaction/new_compaction_alg.cppm
@@ -26,7 +26,7 @@ public:
 
     virtual void AddSegment(SegmentID segment_id, SizeT segment_row_cnt) = 0;
 
-    virtual Vector<SegmentID> GetCompactiableSegments() = 0;
+    virtual Vector<SegmentID> GetCompactableSegments() = 0;
 
     static UniquePtr<NewCompactionAlg> GetInstance();
 };

--- a/src/storage/compaction/new_compaction_alg_impl.cpp
+++ b/src/storage/compaction/new_compaction_alg_impl.cpp
@@ -59,7 +59,7 @@ public:
         segment_layers_[layer].emplace_back(segment_id, segment_row_cnt);
     }
 
-    Vector<SegmentID> GetCompactiableSegments() override {
+    Vector<SegmentID> GetCompactableSegments() override {
         int cur_layer_n = segment_layers_.size();
         for (int layer = 0; layer < cur_layer_n; ++layer) {
             auto &segment_layer = segment_layers_[layer];

--- a/src/storage/compaction_process.cppm
+++ b/src/storage/compaction_process.cppm
@@ -25,6 +25,7 @@ namespace infinity {
 
 class NewTxn;
 class BGTask;
+class TableMeeta;
 
 class TestCommander {
 public:
@@ -72,6 +73,8 @@ private:
     void NewScanAndOptimize();
 
     void Process();
+
+    Vector<SegmentID> GetCompactableSegments(TableMeeta &table_meta, const Vector<SegmentID> &segment_ids);
 
 private:
     BlockingQueue<SharedPtr<BGTask>> task_queue_{"CompactionProcessor"};

--- a/src/storage/compaction_process_impl.cpp
+++ b/src/storage/compaction_process_impl.cpp
@@ -186,19 +186,7 @@ void CompactionProcessor::NewDoCompact() {
             return;
         }
 
-        auto compaction_alg = NewCompactionAlg::GetInstance();
-
-        for (SegmentID segment_id : segment_ids) {
-            SegmentMeta segment_meta(segment_id, *table_meta);
-            auto [segment_row_cnt, segment_status] = segment_meta.GetRowCnt1();
-            if (!segment_status.ok()) {
-                UnrecoverableError(segment_status.message());
-            }
-
-            compaction_alg->AddSegment(segment_id, segment_row_cnt);
-        }
-        Vector<SegmentID> compactible_segment_ids = compaction_alg->GetCompactiableSegments();
-
+        Vector<SegmentID> compactible_segment_ids = GetCompactableSegments(*table_meta, segment_ids);
         if (!compactible_segment_ids.empty()) {
             status = new_txn_shared->Compact(db_name, table_name, compactible_segment_ids);
         }
@@ -218,6 +206,7 @@ void CompactionProcessor::NewDoCompact() {
 }
 
 Status CompactionProcessor::NewManualCompact(const String &db_name, const String &table_name) {
+    UniquePtr<String> result_msg;
     //    LOG_TRACE(fmt::format("Compact command triggered compaction: {}.{}", db_name, table_name));
     auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
     auto *new_txn = new_txn_mgr->BeginTxn(MakeUnique<String>(fmt::format("compact table {}.{}", db_name, table_name)), TransactionType::kNormal);
@@ -246,12 +235,22 @@ Status CompactionProcessor::NewManualCompact(const String &db_name, const String
             segment_ids.erase(std::remove(segment_ids.begin(), segment_ids.end(), unsealed_id), segment_ids.end());
         }
     }
-    status = new_txn->Compact(db_name, table_name, segment_ids);
-    if (!status.ok()) {
-        return status;
+
+    Vector<SegmentID> compactible_segment_ids = GetCompactableSegments(*table_meta, segment_ids);
+    if (!compactible_segment_ids.empty()) {
+        status = new_txn->Compact(db_name, table_name, compactible_segment_ids);
+        if (!status.ok()) {
+            return status;
+        }
+        status = new_txn_mgr->CommitTxn(new_txn);
+        if (!status.ok()) {
+            return status;
+        }
+        result_msg = MakeUnique<String>(fmt::format("Compact segments {} into new segment", fmt::join(compactible_segment_ids, ",")));
+    } else {
+        result_msg = MakeUnique<String>("No segment to compact");
     }
-    status = new_txn_mgr->CommitTxn(new_txn);
-    return status;
+    return Status(ErrorCode::kOk, std::move(result_msg));
 }
 
 void CompactionProcessor::NewScanAndOptimize() {
@@ -380,6 +379,21 @@ void CompactionProcessor::Process() {
         task_count_ -= tasks.size();
         tasks.clear();
     }
+}
+
+Vector<SegmentID> CompactionProcessor::GetCompactableSegments(TableMeeta &table_meta, const Vector<SegmentID> &segment_ids) {
+    auto compaction_alg = NewCompactionAlg::GetInstance();
+
+    for (SegmentID segment_id : segment_ids) {
+        SegmentMeta segment_meta(segment_id, table_meta);
+        auto [segment_row_cnt, segment_status] = segment_meta.GetRowCnt1();
+        if (!segment_status.ok()) {
+            UnrecoverableError(segment_status.message());
+        }
+        compaction_alg->AddSegment(segment_id, segment_row_cnt);
+    }
+
+    return compaction_alg->GetCompactableSegments();
 }
 
 } // namespace infinity

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -98,11 +98,6 @@ struct NewTxnCompactState {
         Status status;
 
         if (block_meta_) {
-            // status = block_meta_->SetRowCnt(cur_block_row_cnt_);
-            // if (!status.ok()) {
-            //     return status;
-            // }
-            // segment_row_cnt_ += cur_block_row_cnt_;
             block_row_cnts_.push_back(cur_block_row_cnt_);
             segment_row_cnt_ += cur_block_row_cnt_;
             block_meta_.reset();
@@ -140,10 +135,6 @@ struct NewTxnCompactState {
 
     Status FinalizeBlock() {
         if (block_meta_) {
-            // Status status = block_meta_->SetRowCnt(cur_block_row_cnt_);
-            // if (!status.ok()) {
-            //     return status;
-            // }
             block_row_cnts_.push_back(cur_block_row_cnt_);
             segment_row_cnt_ += cur_block_row_cnt_;
             for (ColumnID i = 0; i < column_cnt_; ++i) {
@@ -178,7 +169,6 @@ struct NewTxnCompactState {
         if (!status.ok()) {
             return status;
         }
-        // status = new_segment_meta_->SetRowCnt(segment_row_cnt_);
         return status;
     }
 
@@ -323,17 +313,9 @@ Status NewTxn::Import(const String &db_name, const String &table_name, const Vec
             }
         }
 
-        // status = block_meta->SetRowCnt(row_cnt);
-        // if (!status.ok()) {
-        //     return status;
-        // }
         block_row_cnts[segment_idx].push_back(row_cnt);
         segment_row_cnts[segment_idx] += row_cnt;
     }
-    // status = segment_meta->SetRowCnt(segment_row_cnt);
-    // if (!status.ok()) {
-    //     return status;
-    // }
     Vector<WalSegmentInfo> segment_infos;
     segment_infos.reserve(segment_count);
     for (SizeT segment_idx = 0; segment_idx < segment_count; ++segment_idx) {

--- a/src/unit_test/storage/column_vector/column_vector_decimal_ut.cpp
+++ b/src/unit_test/storage/column_vector/column_vector_decimal_ut.cpp
@@ -45,7 +45,6 @@ import decimal_info;
 import data_type;
 import compilation_config;
 
-#if 0
 using namespace infinity;
 
 class ColumnVectorDecimalTest : public BaseTest {
@@ -315,4 +314,3 @@ TEST_F(ColumnVectorDecimalTest, decimal_column_slice_init) {
         EXPECT_EQ(vx.value_.decimal.lower, static_cast<i64>(src_idx));
     }
 }
-#endif

--- a/tools/generate_many_import.py
+++ b/tools/generate_many_import.py
@@ -60,18 +60,8 @@ def generate(generate_if_exists: bool, copy_dir: str):
         slt_file.write("COMPACT TABLE {};\n".format(table_name))
         slt_file.write("\n")
 
-        for v in range(max_v):
-            slt_file.write("statement ok\n")
-            slt_file.write("DELETE FROM {} WHERE c1 = {};\n".format(table_name, v))
-            slt_file.write("\n")
-
         slt_file.write("statement ok\n")
         slt_file.write("COMPACT TABLE {};\n".format(table_name))
-        slt_file.write("\n")
-
-        slt_file.write("query I\n")
-        slt_file.write("SELECT * FROM {};\n".format(table_name))
-        slt_file.write("----\n")
         slt_file.write("\n")
 
         slt_file.write("statement ok\n")


### PR DESCRIPTION
### What problem does this PR solve?

1. We should use compaction algorithm to choose proper segments to compact.
2. Add result message for compact operation
e.g.
```
=> compact table test_compact_with_index;
No segment to compact for default_db.test_compact_with_index

=> compact table test_compact_with_index;
Compact segments 12,13,14,15 into new segment
```

3. Modify testcases

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
