### PR TITLE
Fix meta cache issue

### DIFF
--- a/src/storage/catalog/meta/db_meeta_impl.cpp
+++ b/src/storage/catalog/meta/db_meeta_impl.cpp
@@ -122,8 +122,8 @@ Status DBMeeta::GetComment(std::string *&comment) {
         }
         comment_ = std::move(comment_str);
 
-        if (db_cache.get() != nullptr) {
-            db_cache->set_comment(std::make_shared<std::string>(*comment_));
+        if (db_cache.get() != nullptr && txn_ != nullptr) {
+            txn_->AddCacheInfo(std::make_shared<DBCacheCommentInfo>(db_name_, txn_begin_ts_, std::make_shared<std::string>(*comment_)));
         }
     }
     comment = &*comment_;

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -29,6 +29,8 @@ import :fast_rough_filter;
 import :kv_utility;
 import :snapshot_info;
 import :meta_cache;
+import :new_txn;
+import :new_txn_manager;
 
 import std;
 import third_party;
@@ -269,7 +271,8 @@ Status SegmentMeta::LoadFirstDeleteTS() {
     }
     first_delete_ts_ = std::stoull(first_delete_ts_str);
 
-    if (table_cache.get() != nullptr) {
+    if (table_cache.get() != nullptr && table_meta_.txn() != nullptr && begin_ts_ > table_meta_.txn()->txn_mgr()->LastKVCommitTS()) {
+        LOG_DEBUG(fmt::format("Set segment_tag to table cache, table_name: {}, segment_id: {}", table_name, segment_id_));
         table_cache->set_segment_tag(segment_id_, first_delete_ts_key, *first_delete_ts_);
     }
     return Status::OK();

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -271,9 +271,9 @@ Status SegmentMeta::LoadFirstDeleteTS() {
     }
     first_delete_ts_ = std::stoull(first_delete_ts_str);
 
-    if (table_cache.get() != nullptr && table_meta_.txn() != nullptr && begin_ts_ > table_meta_.txn()->txn_mgr()->LastKVCommitTS()) {
-        LOG_DEBUG(fmt::format("Set segment_tag to table cache, table_name: {}, segment_id: {}", table_name, segment_id_));
-        table_cache->set_segment_tag(segment_id_, first_delete_ts_key, *first_delete_ts_);
+    if (table_cache.get() != nullptr && table_meta_.txn() != nullptr) {
+        table_meta_.txn()->AddCacheInfo(
+            std::make_shared<TableCacheSegmentTagInfo>(db_id, table_name, begin_ts_, segment_id_, first_delete_ts_key, *first_delete_ts_));
     }
     return Status::OK();
 }

--- a/src/storage/catalog/meta/table_index_meeta_impl.cpp
+++ b/src/storage/catalog/meta/table_index_meeta_impl.cpp
@@ -72,8 +72,9 @@ std::tuple<std::shared_ptr<IndexBase>, Status> TableIndexMeeta::GetIndexBase() {
     index_def_ =
         infinity::GetTableIndexDef(&kv_instance_, table_meta_.db_id_str(), table_meta_.table_id_str(), index_id_str_, table_meta_.begin_ts());
 
-    if (index_cache.get() != nullptr) {
-        index_cache->set_index_def(index_def_);
+    if (index_cache.get() != nullptr && table_meta_.txn() != nullptr) {
+        table_meta_.txn()->AddCacheInfo(
+            std::make_shared<IndexCacheIndexDefInfo>(db_id, table_id, index_name_str_, table_meta_.begin_ts(), index_def_));
     }
 
     return {index_def_, Status::OK()};

--- a/src/storage/catalog/meta/table_meeta_impl.cpp
+++ b/src/storage/catalog/meta/table_meeta_impl.cpp
@@ -650,7 +650,8 @@ Status TableMeeta::LoadColumnDefs() {
         return a->id_ < b->id_;
     });
     column_defs_ = std::move(column_defs);
-    if (table_cache.get() != nullptr) {
+    if (table_cache.get() != nullptr && txn_ != nullptr && begin_ts_ > txn_->txn_mgr()->LastKVCommitTS()) {
+        LOG_DEBUG(fmt::format("Set column defs to table cache, table_name: {}, column_defs size: {}", table_name_, column_defs_->size()));
         table_cache->set_columns(column_defs_);
     }
     return Status::OK();
@@ -730,7 +731,8 @@ Status TableMeeta::LoadIndexIDs() {
         }
     }
 
-    if (table_cache.get() != nullptr) {
+    if (table_cache.get() != nullptr && txn_ != nullptr && begin_ts_ > txn_->txn_mgr()->LastKVCommitTS()) {
+        LOG_DEBUG(fmt::format("Set index_ids to table cache, table_name: {}, index_ids size: {}", table_name_, index_ids_ptr->size()));
         table_cache->set_index_ids(index_ids_ptr, index_names_ptr);
     }
 
@@ -885,7 +887,8 @@ std::tuple<std::vector<SegmentID> *, Status> TableMeeta::GetSegmentIDs1() {
         segment_ids1_ = infinity::GetTableSegments(kv_instance_, db_id_str_, table_id_str_, begin_ts_, commit_ts_);
     }
 
-    if (table_cache.get() != nullptr) {
+    if (table_cache.get() != nullptr && txn_ != nullptr && begin_ts_ > txn_->txn_mgr()->LastKVCommitTS()) {
+        LOG_DEBUG(fmt::format("Set segments to table cache, table name: {}, segment_ids size: {}", table_name_, segment_ids1_->size()));
         table_cache->set_segments(segment_ids1_);
     }
 

--- a/src/storage/catalog/meta_cache.cppm
+++ b/src/storage/catalog/meta_cache.cppm
@@ -360,16 +360,20 @@ private:
 public:
     explicit MetaCache(size_t capacity) : capacity_(capacity) {};
 
-    void Put(const std::vector<std::shared_ptr<MetaBaseCache>> &cache_items, TxnTimeStamp begin_ts);
+    void Put(const std::vector<std::shared_ptr<MetaBaseCache>> &cache_items,
+             const std::vector<std::shared_ptr<CacheInfo>> &cache_infos,
+             TxnTimeStamp begin_ts);
 
     Status Erase(const std::vector<std::shared_ptr<EraseBaseCache>> &cache_items, KVInstance *kv_instance, TxnTimeStamp commit_ts);
 
     Status PutOrErase(const std::vector<std::shared_ptr<MetaBaseCache>> &cache_items, KVInstance *kv_instance);
 
+    std::shared_ptr<MetaDbCache> GetDbNolock(const std::string &db_name, TxnTimeStamp begin_ts);
+    std::shared_ptr<MetaTableCache> GetTableNolock(u64 db_id, const std::string &table_name, TxnTimeStamp begin_ts);
+    std::shared_ptr<MetaIndexCache> GetIndexNolock(u64 db_id, u64 table_id, const std::string &index_name, TxnTimeStamp begin_ts);
+
     std::shared_ptr<MetaDbCache> GetDb(const std::string &db_name, TxnTimeStamp begin_ts);
-
     std::shared_ptr<MetaTableCache> GetTable(u64 db_id, const std::string &table_name, TxnTimeStamp begin_ts);
-
     std::shared_ptr<MetaIndexCache> GetIndex(u64 db_id, u64 table_id, const std::string &index_name, TxnTimeStamp begin_ts);
 
     CacheStatus GetCacheStatus(MetaCacheType type) const;

--- a/src/storage/catalog/meta_cache.cppm
+++ b/src/storage/catalog/meta_cache.cppm
@@ -205,6 +205,122 @@ export struct MetaEraseIndexCache : public EraseBaseCache {
     std::string index_name_{};
 };
 
+export enum class CacheType {
+    kInvalid,
+    kDb,
+    kTable,
+    kIndex,
+};
+
+export struct CacheInfo {
+    explicit CacheInfo(CacheType type) : cache_type_(type) {}
+    virtual ~CacheInfo() = default;
+    CacheType cache_type_{CacheType::kInvalid};
+};
+
+export enum class DBCacheInfoType {
+    kInvalid,
+    kComment,
+};
+
+export struct DBCacheInfo : public CacheInfo {
+    explicit DBCacheInfo(DBCacheInfoType type, const std::string &db_name, TxnTimeStamp begin_ts)
+        : CacheInfo(CacheType::kDb), info_type_(type), db_name_(db_name), begin_ts_(begin_ts) {}
+    virtual ~DBCacheInfo() = default;
+    DBCacheInfoType info_type_{DBCacheInfoType::kInvalid};
+    std::string db_name_{};
+    TxnTimeStamp begin_ts_{};
+};
+
+export struct DBCacheCommentInfo : public DBCacheInfo {
+    explicit DBCacheCommentInfo(const std::string &db_name, TxnTimeStamp begin_ts, std::shared_ptr<std::string> comment)
+        : DBCacheInfo(DBCacheInfoType::kComment, db_name, begin_ts), comment_(comment) {}
+    std::shared_ptr<std::string> comment_{};
+};
+
+export enum class TableCacheInfoType {
+    kInvalid,
+    kIndex,
+    kColumn,
+    kSegment,
+    kSegmentTag,
+};
+
+export struct TableCacheInfo : public CacheInfo {
+    explicit TableCacheInfo(TableCacheInfoType type, u64 db_id, const std::string &table_name, TxnTimeStamp begin_ts)
+        : CacheInfo(CacheType::kTable), info_type_(type), db_id_(db_id), table_name_(table_name), begin_ts_(begin_ts) {}
+    virtual ~TableCacheInfo() = default;
+    TableCacheInfoType info_type_{TableCacheInfoType::kInvalid};
+    u64 db_id_{};
+    std::string table_name_{};
+    TxnTimeStamp begin_ts_{};
+};
+
+export struct TableCacheIndexInfo : public TableCacheInfo {
+    explicit TableCacheIndexInfo(u64 db_id,
+                                 const std::string &table_name,
+                                 TxnTimeStamp begin_ts,
+                                 std::shared_ptr<std::vector<std::string>> index_ids_ptr,
+                                 std::shared_ptr<std::vector<std::string>> index_names_ptr)
+        : TableCacheInfo(TableCacheInfoType::kIndex, db_id, table_name, begin_ts), index_ids_ptr_(index_ids_ptr), index_names_ptr_(index_names_ptr) {}
+    std::shared_ptr<std::vector<std::string>> index_ids_ptr_{};
+    std::shared_ptr<std::vector<std::string>> index_names_ptr_{};
+};
+
+export struct TableCacheColumnInfo : public TableCacheInfo {
+    explicit TableCacheColumnInfo(u64 db_id,
+                                  const std::string &table_name,
+                                  TxnTimeStamp begin_ts,
+                                  std::shared_ptr<std::vector<std::shared_ptr<ColumnDef>>> columns_ptr)
+        : TableCacheInfo(TableCacheInfoType::kColumn, db_id, table_name, begin_ts), columns_ptr_(columns_ptr) {}
+    std::shared_ptr<std::vector<std::shared_ptr<ColumnDef>>> columns_ptr_{};
+};
+
+export struct TableCacheSegmentInfo : public TableCacheInfo {
+    explicit TableCacheSegmentInfo(u64 db_id, const std::string &table_name, TxnTimeStamp begin_ts, std::shared_ptr<std::vector<SegmentID>> segments)
+        : TableCacheInfo(TableCacheInfoType::kSegment, db_id, table_name, begin_ts), segments_(segments) {}
+    std::shared_ptr<std::vector<SegmentID>> segments_{};
+};
+
+export struct TableCacheSegmentTagInfo : public TableCacheInfo {
+    explicit TableCacheSegmentTagInfo(u64 db_id,
+                                      const std::string &table_name,
+                                      TxnTimeStamp begin_ts,
+                                      SegmentID segment_id,
+                                      const std::string &tag,
+                                      u64 value)
+        : TableCacheInfo(TableCacheInfoType::kSegmentTag, db_id, table_name, begin_ts), segment_id_(segment_id), tag_(tag), value_(value) {}
+    SegmentID segment_id_;
+    std::string tag_;
+    u64 value_;
+};
+
+export enum class IndexCacheInfoType {
+    kInvalid,
+    kIndexDef,
+};
+
+export struct IndexCacheInfo : public CacheInfo {
+    explicit IndexCacheInfo(IndexCacheInfoType type, u64 db_id, u64 table_id, const std::string &index_name, TxnTimeStamp begin_ts)
+        : CacheInfo(CacheType::kIndex), info_type_(type), db_id_(db_id), table_id_(table_id), index_name_(index_name), begin_ts_(begin_ts) {}
+    virtual ~IndexCacheInfo() = default;
+    IndexCacheInfoType info_type_{IndexCacheInfoType::kInvalid};
+    u64 db_id_{};
+    u64 table_id_{};
+    std::string index_name_{};
+    TxnTimeStamp begin_ts_{};
+};
+
+export struct IndexCacheIndexDefInfo : public IndexCacheInfo {
+    explicit IndexCacheIndexDefInfo(u64 db_id,
+                                    u64 table_id,
+                                    const std::string &index_name,
+                                    TxnTimeStamp begin_ts,
+                                    std::shared_ptr<IndexBase> index_def)
+        : IndexCacheInfo(IndexCacheInfoType::kIndexDef, db_id, table_id, index_name, begin_ts), index_def_(index_def) {}
+    std::shared_ptr<IndexBase> index_def_;
+};
+
 struct CacheItem {
     std::string name_;
     std::shared_ptr<MetaBaseCache> meta_cache_;

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -711,12 +711,9 @@ public:
     void AddMetaKeyForBufferObject(std::unique_ptr<MetaKey> object_meta_key);
 
     void AddMetaCache(const std::shared_ptr<MetaBaseCache> &meta_base_cache);
-    void ResetMetaCache();
-    void SaveMetaCache();
-
     void AddCacheInfo(const std::shared_ptr<CacheInfo> &cache_info);
-    void ResetCacheInfo();
-    void SaveCacheInfo();
+    void ResetMetaCacheAndCacheInfo();
+    void SaveMetaCacheAndCacheInfo();
 
 private:
     // Reference to external class

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -117,6 +117,7 @@ struct TableDetail;
 struct CheckpointTxnStore;
 struct MetaKey;
 struct MetaBaseCache;
+struct CacheInfo;
 
 export struct CheckpointOption {
     TxnTimeStamp checkpoint_ts_ = 0;
@@ -713,6 +714,10 @@ public:
     void ResetMetaCache();
     void SaveMetaCache();
 
+    void AddCacheInfo(const std::shared_ptr<CacheInfo> &cache_info);
+    void ResetCacheInfo();
+    void SaveCacheInfo();
+
 private:
     // Reference to external class
     NewTxnManager *txn_mgr_{};
@@ -760,6 +765,8 @@ private:
 
     // Meta cache
     std::vector<std::shared_ptr<MetaBaseCache>> meta_cache_items_{}; // cache item to store
+
+    std::vector<std::shared_ptr<CacheInfo>> cache_infos_{};
 
 private:
     std::shared_ptr<TxnContext> txn_context_ptr_{};

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -1969,7 +1969,7 @@ Status NewTxn::Commit() {
         TxnTimeStamp commit_ts = txn_mgr_->GetReadCommitTS(this);
         this->SetTxnCommitting(commit_ts);
         this->SetTxnCommitted();
-        this->SaveMetaCache(); // Load the meta used in this txn to cache.
+        txn_mgr_->SaveOrResetMetaCacheForReadTxn(this);
         LOG_TRACE(fmt::format("Commit READ txn: {}. begin ts: {}, Command: {}", txn_context_ptr_->txn_id_, BeginTS(), *GetTxnText()));
         return Status::OK();
     }

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -6325,9 +6325,6 @@ void NewTxn::ResetMetaCacheAndCacheInfo() {
 }
 
 void NewTxn::SaveMetaCacheAndCacheInfo() {
-    if (meta_cache_items_.empty() && cache_infos_.empty()) {
-        return;
-    }
     MetaCache *meta_cache_ptr = txn_mgr_->storage()->meta_cache();
     meta_cache_ptr->Put(meta_cache_items_, cache_infos_, this->BeginTS());
 }

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -1969,7 +1969,10 @@ Status NewTxn::Commit() {
         TxnTimeStamp commit_ts = txn_mgr_->GetReadCommitTS(this);
         this->SetTxnCommitting(commit_ts);
         this->SetTxnCommitted();
-        txn_mgr_->SaveOrResetMetaCacheForReadTxn(this);
+        if (!meta_cache_items_.empty() || !cache_infos_.empty()) {
+            txn_mgr_->SaveOrResetMetaCacheForReadTxn(this);
+        }
+
         LOG_TRACE(fmt::format("Commit READ txn: {}. begin ts: {}, Command: {}", txn_context_ptr_->txn_id_, BeginTS(), *GetTxnText()));
         return Status::OK();
     }
@@ -6325,6 +6328,87 @@ void NewTxn::SaveMetaCache() {
     }
     MetaCache *meta_cache_ptr = txn_mgr_->storage()->meta_cache();
     meta_cache_ptr->Put(meta_cache_items_, this->BeginTS());
+}
+
+void NewTxn::AddCacheInfo(const std::shared_ptr<CacheInfo> &cache_info) { cache_infos_.emplace_back(cache_info); }
+
+void NewTxn::ResetCacheInfo() { cache_infos_.clear(); }
+
+void NewTxn::SaveCacheInfo() {
+    MetaCache *meta_cache = txn_mgr_->storage()->meta_cache();
+    for (auto &cache_info : cache_infos_) {
+        switch (cache_info->cache_type_) {
+            case CacheType::kDb: {
+                DBCacheInfo *db_cache_info = static_cast<DBCacheInfo *>(cache_info.get());
+                std::shared_ptr<MetaDbCache> db_cache = meta_cache->GetDb(db_cache_info->db_name_, db_cache_info->begin_ts_);
+                switch (db_cache_info->info_type_) {
+                    case DBCacheInfoType::kComment: {
+                        DBCacheCommentInfo *db_cache_info = static_cast<DBCacheCommentInfo *>(cache_info.get());
+                        db_cache->set_comment(db_cache_info->comment_);
+                        break;
+                    }
+                    default: {
+                        UnrecoverableError("Invalid db cache info type");
+                    }
+                }
+                break;
+            }
+            case CacheType::kTable: {
+                TableCacheInfo *table_cache_info = static_cast<TableCacheInfo *>(cache_info.get());
+                std::shared_ptr<MetaTableCache> table_cache =
+                    meta_cache->GetTable(table_cache_info->db_id_, table_cache_info->table_name_, table_cache_info->begin_ts_);
+                switch (table_cache_info->info_type_) {
+                    case TableCacheInfoType::kIndex: {
+                        TableCacheIndexInfo *table_cache_index_info = static_cast<TableCacheIndexInfo *>(cache_info.get());
+                        table_cache->set_index_ids(table_cache_index_info->index_ids_ptr_, table_cache_index_info->index_names_ptr_);
+                        break;
+                    }
+                    case TableCacheInfoType::kColumn: {
+                        TableCacheColumnInfo *table_cache_column_info = static_cast<TableCacheColumnInfo *>(cache_info.get());
+                        table_cache->set_columns(table_cache_column_info->columns_ptr_);
+                        break;
+                    }
+                    case TableCacheInfoType::kSegment: {
+                        TableCacheSegmentInfo *table_cache_segment_info = static_cast<TableCacheSegmentInfo *>(cache_info.get());
+                        table_cache->set_segments(table_cache_segment_info->segments_);
+                        break;
+                    }
+                    case TableCacheInfoType::kSegmentTag: {
+                        TableCacheSegmentTagInfo *table_cache_segment_tag_info = static_cast<TableCacheSegmentTagInfo *>(cache_info.get());
+                        table_cache->set_segment_tag(table_cache_segment_tag_info->segment_id_,
+                                                     table_cache_segment_tag_info->tag_,
+                                                     table_cache_segment_tag_info->value_);
+                        break;
+                    }
+                    default: {
+                        UnrecoverableError("Invalid table cache info type");
+                    }
+                }
+                break;
+            }
+            case CacheType::kIndex: {
+                IndexCacheInfo *index_cache_info = static_cast<IndexCacheInfo *>(cache_info.get());
+                std::shared_ptr<MetaIndexCache> index_cache = meta_cache->GetIndex(index_cache_info->db_id_,
+                                                                                   index_cache_info->table_id_,
+                                                                                   index_cache_info->index_name_,
+                                                                                   index_cache_info->begin_ts_);
+                switch (index_cache_info->info_type_) {
+                    case IndexCacheInfoType::kIndexDef: {
+                        IndexCacheIndexDefInfo *index_cache_index_def_info = static_cast<IndexCacheIndexDefInfo *>(cache_info.get());
+                        index_cache->set_index_def(index_cache_index_def_info->index_def_);
+                        break;
+                    }
+                    default: {
+                        UnrecoverableError("Invalid index cache info type");
+                    }
+                }
+                break;
+            }
+            default: {
+                UnrecoverableError("Invalid cache type");
+            }
+        }
+    }
 }
 
 } // namespace infinity

--- a/src/storage/new_txn/new_txn_manager.cppm
+++ b/src/storage/new_txn/new_txn_manager.cppm
@@ -71,6 +71,7 @@ public:
     // std::optional<std::string> CheckTxnConflict(NewTxn *txn);
 
     bool CheckConflict1(NewTxn *txn, std::string &conflict_reason, bool &retry_query);
+    void SaveOrResetMetaCacheForReadTxn(NewTxn *txn);
 
     void SendToWAL(NewTxn *txn);
 
@@ -157,6 +158,11 @@ public:
     void RemoveMapElementForRollbackNoLock(TxnTimeStamp commit_ts, NewTxn *txn_ptr);
 
     SystemCache *GetSystemCachePtr() const;
+
+    TxnTimeStamp LastKVCommitTS() const {
+        std::lock_guard guard(locker_);
+        return last_kv_commit_ts_;
+    }
 
 private:
     mutable std::mutex locker_{};

--- a/src/storage/new_txn/new_txn_manager_impl.cpp
+++ b/src/storage/new_txn/new_txn_manager_impl.cpp
@@ -254,8 +254,7 @@ void NewTxnManager::SaveOrResetMetaCacheForReadTxn(NewTxn *txn) {
             } else {
                 // Writable Txn
                 LOG_DEBUG(fmt::format("Reset meta cache and cache info for read txn {}", txn->TxnID()));
-                txn->ResetMetaCache();
-                txn->ResetCacheInfo();
+                txn->ResetMetaCacheAndCacheInfo();
                 all_read_txns = false;
                 break;
             }
@@ -263,8 +262,7 @@ void NewTxnManager::SaveOrResetMetaCacheForReadTxn(NewTxn *txn) {
 
         if (all_read_txns) {
             LOG_DEBUG(fmt::format("Save meta cache and cache info for read txn {}", txn->TxnID()));
-            txn->SaveMetaCache();
-            txn->SaveCacheInfo();
+            txn->SaveMetaCacheAndCacheInfo();
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
**Issue**
The scenario with error is as below.  Create index erases table cache, and then show index adds a new table cache. Optimize index intends to add index info to table cache, but it can not see index1, so the index info in table cache is not latest. Then snapshot reads the wong index info in table cache. 

create  index (idx1)-------show index ------snapshot
  ** |---------------optimize-------------------------------|

**Solution**
   
We allow  txn to change the table cache only when the txn begins after all committed write txns.
If it is conflicted with any committed write txn, the info it intends to change to the table cache may be not correct.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
