### PR TITLE
Modify test_memindex, fix lock-order-inversion

### DIFF
--- a/python/restart_test/test_memidx.py
+++ b/python/restart_test/test_memidx.py
@@ -539,7 +539,7 @@ class TestMemIdx:
             table_obj2.insert([{"c1": 4, "c2": [0.2, 0.1, 0.3, 0.4]} for i in range(6)])
 
             # wait for mem index dump
-            time.sleep(3)
+            time.sleep(10)
 
             # 2 chunk indexes for each index
             db1_dir = data_dir + "/db_2"
@@ -554,7 +554,7 @@ class TestMemIdx:
         @decorator2
         def part2(infinity_obj):
             # wait for optimize
-            time.sleep(3)
+            time.sleep(20)
 
             # new chunk index is generated after optimize for each index
             db1_dir = data_dir + "/db_2"

--- a/python/restart_test/test_memidx.py
+++ b/python/restart_test/test_memidx.py
@@ -539,7 +539,7 @@ class TestMemIdx:
             table_obj2.insert([{"c1": 4, "c2": [0.2, 0.1, 0.3, 0.4]} for i in range(6)])
 
             # wait for mem index dump
-            time.sleep(10)
+            time.sleep(3)
 
             # 2 chunk indexes for each index
             db1_dir = data_dir + "/db_2"

--- a/src/storage/catalog/meta/block_meta_impl.cpp
+++ b/src/storage/catalog/meta/block_meta_impl.cpp
@@ -268,19 +268,24 @@ std::string BlockMeta::GetBlockTag(const std::string &tag) const {
 }
 
 std::tuple<size_t, Status> BlockMeta::GetRowCnt1() {
-    std::lock_guard<std::mutex> lock(mtx_);
-    if (row_cnt_) {
-        return {*row_cnt_, Status::OK()};
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        if (row_cnt_) {
+            return {*row_cnt_, Status::OK()};
+        }
     }
 #if 1
     TableMeeta &table_meta = segment_meta_.table_meta();
-    row_cnt_ = infinity::GetBlockRowCount(&kv_instance_,
-                                          table_meta.db_id_str(),
-                                          table_meta.table_id_str(),
-                                          segment_meta_.segment_id(),
-                                          block_id_,
-                                          begin_ts_,
-                                          commit_ts_);
+    auto row_cnt = infinity::GetBlockRowCount(&kv_instance_,
+                                              table_meta.db_id_str(),
+                                              table_meta.table_id_str(),
+                                              segment_meta_.segment_id(),
+                                              block_id_,
+                                              begin_ts_,
+                                              commit_ts_);
+
+    std::lock_guard<std::mutex> lock(mtx_);
+    row_cnt_ = row_cnt;
     return {*row_cnt_, Status::OK()};
 #else
     Status status;


### PR DESCRIPTION
### What problem does this PR solve?
1) test_memidx.py failed with ENABLE_SANITIZER_THREAD=ON, optimize index needs longer time, we need to sleep more.

2) "ThreadSanitizer: lock-order-inversion (potential deadlock) ", we need to avoid holding multiple locks at the same time if possible.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Test cases