### PR TITLE
Fix KEY_EMPTY issue, uncommitted compact issue

### DIFF
--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -4688,7 +4688,8 @@ Status NewTxn::Cleanup() {
     TxnTimeStamp last_checkpoint_ts = InfinityContext::instance().storage()->wal_manager()->LastCheckpointTS();
 
     if (last_cleanup_ts >= oldest_txn_begin_ts) {
-        LOG_TRACE("SKIP cleanup");
+        LOG_TRACE(fmt::format("SKIP cleanup. last_cleanup_ts: {}, oldest_txn_begin_ts: {}", last_cleanup_ts, oldest_txn_begin_ts));
+
         return Status::OK();
     }
 

--- a/src/storage/new_txn/new_txn_manager_impl.cpp
+++ b/src/storage/new_txn/new_txn_manager_impl.cpp
@@ -426,7 +426,6 @@ void NewTxnManager::SetCurrentTransactionID(TransactionID current_transaction_id
 
 TxnTimeStamp NewTxnManager::GetOldestAliveTS() {
     std::lock_guard guard(locker_);
-    //    return begin_txns_.empty() ? current_ts_ + 1 : begin_txns_.begin()->first;
     return begin_txn_map_.empty() ? current_ts_ + 1 : begin_txn_map_.begin()->first;
 }
 

--- a/src/storage/persistence/obj_stat_accessor_impl.cpp
+++ b/src/storage/persistence/obj_stat_accessor_impl.cpp
@@ -146,6 +146,9 @@ std::unordered_map<std::string, std::shared_ptr<ObjStat>> ObjectStats::GetAllObj
 }
 
 void ObjectStats::AddObjStatToKVStore(const std::string &key, const std::shared_ptr<ObjStat> &obj_stat) {
+    if (key == "KEY_EMPTY") {
+        return;
+    }
     PersistenceManager *pm = InfinityContext::instance().persistence_manager();
     if (!pm) {
         return;


### PR DESCRIPTION
### What problem does this PR solve?
1) We don't need to dd object_state info of KEY_EMPTY to KV. 
2) Uncommitted compact txn is not cleaned up properly. It causes oldest_txn_begin_ts not updated. Later clean data is skipped when last_cleanup_ts >= oldest_txn_begin_ts.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
