### PR TITLE
Call FlushWal() when processing KV with wal enabled

### DIFF
--- a/src/storage/catalog/kv_store_impl.cpp
+++ b/src/storage/catalog/kv_store_impl.cpp
@@ -359,6 +359,10 @@ Status KVStore::Put(const std::string &key, const std::string &value, bool disab
     if (!s.ok()) {
         return Status::RocksDBError(std::move(s), fmt::format("rocksdb::TransactionDB::Put key: {}, value: {}", key, value));
     }
+
+    if (!disable_wal) {
+        transaction_db_->FlushWAL(false);
+    }
     return Status::OK();
 }
 
@@ -368,6 +372,10 @@ Status KVStore::Delete(const std::string &key, bool disable_wal) {
     rocksdb::Status s = transaction_db_->Delete(write_options, key);
     if (!s.ok()) {
         return Status::RocksDBError(std::move(s), fmt::format("rocksdb::TransactionDB::Delete key: {}", key));
+    }
+
+    if (!disable_wal) {
+        transaction_db_->FlushWAL(false);
     }
     return Status::OK();
 }
@@ -393,6 +401,10 @@ Status KVStore::Merge(const std::string &key, const std::string &value, bool dis
     rocksdb::Status s = transaction_db_->Merge(write_options, nullptr, key, value);
     if (!s.ok()) {
         return Status::RocksDBError(std::move(s), fmt::format("rocksdb::TransactionDB::Merge key: {}, value: {}", key, value));
+    }
+
+    if (!disable_wal) {
+        transaction_db_->FlushWAL(false);
     }
     return Status::OK();
 }


### PR DESCRIPTION
### What problem does this PR solve?

**Issue**
restart/test_insert_import.py failed with "Failed to find object for local path /var/infinity/data/db_1/tbl_0/seg_52/blk_0/version" during replaying import.  Key "pm|object|db_1/tbl_0/seg_52/blk_0/version" is not found in RocksDB. The version file  is persisted and the key is put to RocksDB before restart, but the key is lost after restart.

**Solution**
The kvs put to RocksDb with wal enabled might be lost after infinity restarts,  we need to call FlushWal() when processing KV with wal enabled.
.
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)