### PR TITLE
Fix meta cache issue

### DIFF
--- a/src/storage/catalog/meta_cache_impl.cpp
+++ b/src/storage/catalog/meta_cache_impl.cpp
@@ -262,14 +262,17 @@ void MetaCache::Put(const std::vector<std::shared_ptr<MetaBaseCache>> &cache_ite
                 case CacheType::kDb: {
                     DBCacheInfo *db_cache_info = static_cast<DBCacheInfo *>(cache_info.get());
                     std::shared_ptr<MetaDbCache> db_cache = GetDbNolock(db_cache_info->db_name_, db_cache_info->begin_ts_);
-                    switch (db_cache_info->info_type_) {
-                        case DBCacheInfoType::kComment: {
-                            DBCacheCommentInfo *db_cache_info = static_cast<DBCacheCommentInfo *>(cache_info.get());
-                            db_cache->set_comment(db_cache_info->comment_);
-                            break;
-                        }
-                        default: {
-                            UnrecoverableError("Invalid db cache info type");
+                    // The cache might be erased from meta cache by TrimCacheNolock() while more caches are put to meta cache
+                    if (db_cache != nullptr) {
+                        switch (db_cache_info->info_type_) {
+                            case DBCacheInfoType::kComment: {
+                                DBCacheCommentInfo *db_cache_info = static_cast<DBCacheCommentInfo *>(cache_info.get());
+                                db_cache->set_comment(db_cache_info->comment_);
+                                break;
+                            }
+                            default: {
+                                UnrecoverableError("Invalid db cache info type");
+                            }
                         }
                     }
                     break;
@@ -278,31 +281,33 @@ void MetaCache::Put(const std::vector<std::shared_ptr<MetaBaseCache>> &cache_ite
                     TableCacheInfo *table_cache_info = static_cast<TableCacheInfo *>(cache_info.get());
                     std::shared_ptr<MetaTableCache> table_cache =
                         GetTableNolock(table_cache_info->db_id_, table_cache_info->table_name_, table_cache_info->begin_ts_);
-                    switch (table_cache_info->info_type_) {
-                        case TableCacheInfoType::kIndex: {
-                            TableCacheIndexInfo *table_cache_index_info = static_cast<TableCacheIndexInfo *>(cache_info.get());
-                            table_cache->set_index_ids(table_cache_index_info->index_ids_ptr_, table_cache_index_info->index_names_ptr_);
-                            break;
-                        }
-                        case TableCacheInfoType::kColumn: {
-                            TableCacheColumnInfo *table_cache_column_info = static_cast<TableCacheColumnInfo *>(cache_info.get());
-                            table_cache->set_columns(table_cache_column_info->columns_ptr_);
-                            break;
-                        }
-                        case TableCacheInfoType::kSegment: {
-                            TableCacheSegmentInfo *table_cache_segment_info = static_cast<TableCacheSegmentInfo *>(cache_info.get());
-                            table_cache->set_segments(table_cache_segment_info->segments_);
-                            break;
-                        }
-                        case TableCacheInfoType::kSegmentTag: {
-                            TableCacheSegmentTagInfo *table_cache_segment_tag_info = static_cast<TableCacheSegmentTagInfo *>(cache_info.get());
-                            table_cache->set_segment_tag(table_cache_segment_tag_info->segment_id_,
-                                                         table_cache_segment_tag_info->tag_,
-                                                         table_cache_segment_tag_info->value_);
-                            break;
-                        }
-                        default: {
-                            UnrecoverableError("Invalid table cache info type");
+                    if (table_cache != nullptr) {
+                        switch (table_cache_info->info_type_) {
+                            case TableCacheInfoType::kIndex: {
+                                TableCacheIndexInfo *table_cache_index_info = static_cast<TableCacheIndexInfo *>(cache_info.get());
+                                table_cache->set_index_ids(table_cache_index_info->index_ids_ptr_, table_cache_index_info->index_names_ptr_);
+                                break;
+                            }
+                            case TableCacheInfoType::kColumn: {
+                                TableCacheColumnInfo *table_cache_column_info = static_cast<TableCacheColumnInfo *>(cache_info.get());
+                                table_cache->set_columns(table_cache_column_info->columns_ptr_);
+                                break;
+                            }
+                            case TableCacheInfoType::kSegment: {
+                                TableCacheSegmentInfo *table_cache_segment_info = static_cast<TableCacheSegmentInfo *>(cache_info.get());
+                                table_cache->set_segments(table_cache_segment_info->segments_);
+                                break;
+                            }
+                            case TableCacheInfoType::kSegmentTag: {
+                                TableCacheSegmentTagInfo *table_cache_segment_tag_info = static_cast<TableCacheSegmentTagInfo *>(cache_info.get());
+                                table_cache->set_segment_tag(table_cache_segment_tag_info->segment_id_,
+                                                             table_cache_segment_tag_info->tag_,
+                                                             table_cache_segment_tag_info->value_);
+                                break;
+                            }
+                            default: {
+                                UnrecoverableError("Invalid table cache info type");
+                            }
                         }
                     }
                     break;
@@ -313,14 +318,16 @@ void MetaCache::Put(const std::vector<std::shared_ptr<MetaBaseCache>> &cache_ite
                                                                                  index_cache_info->table_id_,
                                                                                  index_cache_info->index_name_,
                                                                                  index_cache_info->begin_ts_);
-                    switch (index_cache_info->info_type_) {
-                        case IndexCacheInfoType::kIndexDef: {
-                            IndexCacheIndexDefInfo *index_cache_index_def_info = static_cast<IndexCacheIndexDefInfo *>(cache_info.get());
-                            index_cache->set_index_def(index_cache_index_def_info->index_def_);
-                            break;
-                        }
-                        default: {
-                            UnrecoverableError("Invalid index cache info type");
+                    if (index_cache != nullptr) {
+                        switch (index_cache_info->info_type_) {
+                            case IndexCacheInfoType::kIndexDef: {
+                                IndexCacheIndexDefInfo *index_cache_index_def_info = static_cast<IndexCacheIndexDefInfo *>(cache_info.get());
+                                index_cache->set_index_def(index_cache_index_def_info->index_def_);
+                                break;
+                            }
+                            default: {
+                                UnrecoverableError("Invalid index cache info type");
+                            }
                         }
                     }
                     break;

--- a/tools/run_pytest_parallel_continuous.py
+++ b/tools/run_pytest_parallel_continuous.py
@@ -12,7 +12,7 @@ commands = [
 
 LOG_PATH = "/var/infinity/log/infinity.log"
 # TEST_SEC = 3600 # 1 hour
-TEST_SEC = 10 # run once
+TEST_SEC = 10  # run once
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Pytest Parallel Continuous")
@@ -36,9 +36,13 @@ if __name__ == "__main__":
                         if stderr:
                             print(f"Command '{command}' error:\n{stderr}")
                             command_failed = True
+                            break
                     except RuntimeError as e:
                         print(e)
                         command_failed = True
+                        break
+                if command_failed:
+                    break
 
     except Exception as e:
         print(e)


### PR DESCRIPTION
### What problem does this PR solve?
python/test_show.py failed in test_show_big_databases during putting cache info in MetaCache::Put(), the db cache has been erased from meta cache by TrimCacheNolock(). We can skip putting cache info when cache is nullptr.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)