### PR TITLE
Fix manually compact trigger new txn

### DIFF
--- a/src/main/query_context.cppm
+++ b/src/main/query_context.cppm
@@ -71,10 +71,6 @@ public:
 
     QueryResult QueryStatementInternal(const BaseStatement *statement);
 
-    bool ExecuteBGStatement(BaseStatement *statement, BGQueryState &state);
-
-    bool JoinBGStatement(BGQueryState &state, TxnTimeStamp &commit_ts, bool rollback = false);
-
     inline void set_current_schema(const std::string &current_schema) { session_ptr_->set_current_schema(current_schema); }
 
     [[nodiscard]] inline const std::string &schema_name() const { return session_ptr_->current_database(); }

--- a/src/storage/compaction_process.cppm
+++ b/src/storage/compaction_process.cppm
@@ -60,7 +60,7 @@ public:
 
     void NewDoCompact();
 
-    Status NewManualCompact(const std::string &db_name, const std::string &table_name);
+    Status NewManualCompact(NewTxn *new_txn, const std::string &db_name, const std::string &table_name);
 
     u64 RunningTaskCount() const { return task_count_; }
 


### PR DESCRIPTION
### What problem does this PR solve?

Compact command should use the txn created in the beginning of the query, but not create another txn.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
