### PR TITLE
Fix_seg_fault_in OutputToDataBlock

### DIFF
--- a/src/executor/physical_operator_impl.cpp
+++ b/src/executor/physical_operator_impl.cpp
@@ -158,6 +158,9 @@ void OutputToDataBlockHelper::OutputToDataBlock(BufferManager *buffer_mgr,
                 continue;
             }
         }
+        if (cached_block_meta == nullptr) {
+            continue;
+        }
         if (column_id != cache_column_id) {
             // LOG_TRACE(fmt::format("Get column vector from segment_id: {}, block_id: {}, column_id: {}", segment_id, block_id, column_id));
             ColumnMeta column_meta(column_id, *cached_block_meta);

--- a/test/data/config/restart_test/test_insert/1.toml
+++ b/test/data/config/restart_test/test_insert/1.toml
@@ -5,7 +5,7 @@ time_zone = "utc-8"
 [network]
 [log]
 log_to_stdout = true
-log_level = "info"
+log_level = "trace"
 
 [storage]
 mem_index_capacity       = 8192


### PR DESCRIPTION
### What problem does this PR solve?

Segment fault in OutputToDataBlock() during python/restart_test/test_insert.py::TestInsert::test_index of reldeb_restart_test in slow test.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
