### PR TITLE
Enable periodical cleanup, fix cleanup issue

### DIFF
--- a/src/storage/catalog/new_catalog_impl.cpp
+++ b/src/storage/catalog/new_catalog_impl.cpp
@@ -343,24 +343,8 @@ Status NewCatalog::GetCleanedMeta(TxnTimeStamp ts,
     while (iter->Valid() && iter->Key().starts_with(drop_prefix)) {
         std::string drop_key = iter->Key().ToString();
         std::string commit_ts_str = iter->Value().ToString();
+        drop_ts = std::stoull(commit_ts_str);
 
-        auto keys = infinity::Partition(drop_key, '|');
-        const std::string &type_str = keys[1];
-        const std::string &meta_str = keys[2];
-        auto meta_infos = infinity::Partition(meta_str, '/');
-        if (type_str == "db") {
-            drop_ts = std::stoull(meta_infos[1]);
-        } else if (type_str == "tbl") {
-            drop_ts = std::stoull(meta_infos[2]);
-        } else if (type_str == "tbl_name") {
-            drop_ts = std::stoull(meta_infos[2]);
-        } else if (type_str == "tbl_col") {
-            drop_ts = std::stoull(meta_infos[3]);
-        } else if (type_str == "idx") {
-            drop_ts = std::stoull(meta_infos[3]);
-        } else {
-            drop_ts = std::stoull(commit_ts_str); // It might not be an integer
-        }
         if (drop_ts <= ts) {
             drop_keys.emplace_back(drop_key);
         }

--- a/src/storage/io/virtual_store_impl.cpp
+++ b/src/storage/io/virtual_store_impl.cpp
@@ -271,8 +271,8 @@ void VirtualStore::RecursiveCleanupAllEmptyDir(const std::string &path) {
     for (const auto &entry : std::filesystem::directory_iterator(path)) {
         auto entry_path = entry.path();
 
-        // Skip removing empty pos files of fulltext index, because they might be used.
-        if (std::filesystem::is_empty(entry_path) && entry_path.extension().string() != ".pos") {
+        // Skip removing empty files of fulltext index, because they might be used.
+        if (std::filesystem::is_empty(entry_path) && !entry_path.filename().string().starts_with("ft_")) {
             std::filesystem::remove(entry_path);
         }
     }

--- a/src/storage/periodic_trigger_thread_impl.cpp
+++ b/src/storage/periodic_trigger_thread_impl.cpp
@@ -68,7 +68,7 @@ void PeriodicTriggerThread::Run() {
         }
 
         if (new_cleanup_trigger_ != nullptr && new_cleanup_trigger_->Check()) {
-            // new_cleanup_trigger_->Trigger();
+            new_cleanup_trigger_->Trigger();
         }
     }
 }

--- a/src/unit_test/storage/bg_task/cleanup_task_ut.cpp
+++ b/src/unit_test/storage/bg_task/cleanup_task_ut.cpp
@@ -98,6 +98,14 @@ TEST_P(CleanupTaskTest, test_delete_db_simple) {
             EXPECT_TRUE(status.ok());
         }
 
+        {
+            auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("checkpoint"), TransactionType::kNewCheckpoint);
+            auto status = txn->Checkpoint(wal_manager->LastCheckpointTS(), false);
+            EXPECT_TRUE(status.ok());
+            status = new_txn_mgr->CommitTxn(txn);
+            EXPECT_TRUE(status.ok());
+        }
+
         std::vector<std::string> exist_file_paths;
         {
             auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("check table 1"), TransactionType::kRead);


### PR DESCRIPTION
### What problem does this PR solve?

1. Enable periodical cleanup
2. Cleanup decides which items to clean by the drop timestamp of the items, but the drop timestamp is not correct.
3. Skip removing empty files of fulltext index

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
