### PR TITLE
Fix cleanup issue

### DIFF
--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -4548,16 +4548,19 @@ Status NewTxn::Cleanup() {
     TxnTimeStamp oldest_txn_begin_ts = txn_mgr_->GetOldestAliveTS();
     TxnTimeStamp last_checkpoint_ts = InfinityContext::instance().storage()->wal_manager()->LastCheckpointTS();
 
-    if (last_cleanup_ts >= oldest_txn_begin_ts) {
-        LOG_TRACE(fmt::format("SKIP cleanup. last_cleanup_ts: {}, oldest_txn_begin_ts: {}", last_cleanup_ts, oldest_txn_begin_ts));
-
-        return Status::OK();
-    }
-
     // We will only clean up entities dropped before both the begin timestamp of active transactions and the latest checkpoint,
     // ensuring the entities are no longer needed.
     TxnTimeStamp visible_ts = std::min(oldest_txn_begin_ts, last_checkpoint_ts);
-    LOG_INFO(fmt::format("Cleaning ts < {} dropped entities...", visible_ts));
+    if (last_cleanup_ts < visible_ts) {
+        LOG_INFO(fmt::format("Cleaning ts < {} dropped entities...", visible_ts));
+    } else {
+        LOG_INFO(fmt::format("SKIP cleanup. last_cleanup_ts: {}, oldest_txn_begin_ts: {}, last_checkpoint_ts: {}",
+                             last_cleanup_ts,
+                             oldest_txn_begin_ts,
+                             last_checkpoint_ts));
+
+        return Status::OK();
+    }
 
     KVInstance *kv_instance = kv_instance_.get();
     std::vector<std::string> dropped_keys;


### PR DESCRIPTION
### What problem does this PR solve?
Issue:
In the following scenario, cleanup txn cleans the table dropped, but the entities are still needed by optimize.

```
*--Optimize------------------------------------------------------
              * -Drop table-*    *-Checkpoint-*   *-Cleanup-*
```

Solution:
We will only clean up entities dropped before both the begin timestamp of active transactions and the latest checkpoint, ensuring the entities are no longer needed.
### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
