### PR TITLE
Add cache mutex

### DIFF
--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -674,6 +674,7 @@ public:
 
     void AddMetaCache(const std::shared_ptr<MetaBaseCache> &meta_base_cache);
     void AddCacheInfo(const std::shared_ptr<CacheInfo> &cache_info);
+    bool MetaCacheAndCacheInfoEmpty();
     void ResetMetaCacheAndCacheInfo();
     void SaveMetaCacheAndCacheInfo();
 
@@ -729,9 +730,8 @@ private:
     // Use for commit and rollback
     std::vector<std::unique_ptr<std::binary_semaphore>> semas_{};
 
-    // Meta cache
+    std::mutex cache_mtx_{};
     std::vector<std::shared_ptr<MetaBaseCache>> meta_cache_items_{}; // cache item to store
-
     std::vector<std::shared_ptr<CacheInfo>> cache_infos_{};
 
 private:

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -670,7 +670,7 @@ Status NewTxn::Compact(const std::string &db_name, const std::string &table_name
         return status;
     }
 
-    LOG_TRACE(fmt::format("To compact segments {}", segment_ids.size()));
+    LOG_TRACE(fmt::format("To compact segments size: {}", segment_ids.size()));
     for (SegmentID segment_id : segment_ids) {
         SegmentMeta segment_meta(segment_id, table_meta);
 

--- a/test/data/config/test_new_bg_on.toml
+++ b/test/data/config/test_new_bg_on.toml
@@ -8,6 +8,7 @@ server_address           = "0.0.0.0"
 [log]
 log_filename             = "infinity.log"
 log_dir                  = "/var/infinity/log"
+log_level                = "trace"
 
 [storage]
 compact_interval         = "2s"

--- a/test/data/config/test_new_vfs_off_bg_on.toml
+++ b/test/data/config/test_new_vfs_off_bg_on.toml
@@ -8,6 +8,7 @@ server_address           = "0.0.0.0"
 [log]
 log_filename             = "infinity.log"
 log_dir                  = "/var/infinity/log"
+log_level                = "trace"
 
 [storage]
 data_dir                 = "/var/infinity/data"


### PR DESCRIPTION
### What problem does this PR solve?

heap-buffer-overflow occurs while calling AddCacheInfo(). It seems 2 threads are writing to vector at the same time.

```
   #5 0x560339e634b5 in infinity::NewTxn@infinity_core::AddCacheInfo(std::shared_ptr<infinity::CacheInfo@infinity_core> const&) /infinity/src/storage/new_txn/new_txn_impl.cpp:5474:88
    #6 0x560338c97366 in infinity::SegmentMeta@infinity_core::LoadFirstDeleteTS() /infinity/src/storage/catalog/meta/segment_meta_impl.cpp:157:28
```

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
