### PR TITLE
Fix "wal.log does not exist" issue

### DIFF
--- a/src/unit_test/storage/new_catalog/delete_ut.cpp
+++ b/src/unit_test/storage/new_catalog/delete_ut.cpp
@@ -1598,8 +1598,6 @@ TEST_P(TestTxnDelete, test_delete_and_add_column) {
         status = new_txn_mgr->RollBackTxn(txn7);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_drop_column) {
@@ -2225,8 +2223,6 @@ TEST_P(TestTxnDelete, test_delete_and_drop_column) {
         status = new_txn_mgr->RollBackTxn(txn7);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_rename) {
@@ -2839,8 +2835,6 @@ TEST_P(TestTxnDelete, test_delete_and_rename) {
         status = new_txn_mgr->RollBackTxn(txn7);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_create_index) {
@@ -3469,8 +3463,6 @@ TEST_P(TestTxnDelete, test_delete_and_create_index) {
         status = new_txn_mgr->RollBackTxn(txn7);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_drop_index) {
@@ -4155,8 +4147,6 @@ TEST_P(TestTxnDelete, test_delete_and_drop_index) {
         status = new_txn_mgr->RollBackTxn(txn8);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_import) {
@@ -4909,8 +4899,6 @@ TEST_P(TestTxnDelete, test_delete_and_import) {
         status = new_txn_mgr->RollBackTxn(txn8);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_append) {
@@ -5646,8 +5634,6 @@ TEST_P(TestTxnDelete, test_delete_and_append) {
         status = new_txn_mgr->RollBackTxn(txn8);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_delete) {
@@ -6193,8 +6179,6 @@ TEST_P(TestTxnDelete, test_delete_and_delete) {
         status = new_txn_mgr->RollBackTxn(txn8);
         EXPECT_TRUE(status.ok());
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_compact) {
@@ -6607,8 +6591,6 @@ TEST_P(TestTxnDelete, test_delete_and_compact) {
 
         DropDB();
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnDelete, test_delete_and_optimize_index) {
@@ -7012,6 +6994,4 @@ TEST_P(TestTxnDelete, test_delete_and_optimize_index) {
 
         DropDB();
     }
-
-    RemoveDbDirs();
 }

--- a/src/unit_test/storage/new_catalog/update_ut.cpp
+++ b/src/unit_test/storage/new_catalog/update_ut.cpp
@@ -930,8 +930,6 @@ TEST_P(TestTxnUpdate, test_update_and_drop_table) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_drop_index) {
@@ -1081,8 +1079,6 @@ TEST_P(TestTxnUpdate, test_update_and_drop_index) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_dump_index) {
@@ -1198,8 +1194,6 @@ TEST_P(TestTxnUpdate, test_update_and_dump_index) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_add_drop_column_conflicts) {
@@ -1431,8 +1425,6 @@ TEST_P(TestTxnUpdate, test_update_and_add_drop_column_conflicts) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_compact_conflicts) {
@@ -1555,7 +1547,6 @@ TEST_P(TestTxnUpdate, test_update_and_compact_conflicts) {
 
         DropDatabase(setup);
     }
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_create_index_conflicts) {
@@ -1680,8 +1671,6 @@ TEST_P(TestTxnUpdate, test_update_and_create_index_conflicts) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_delete_conflicts) {
@@ -1841,8 +1830,6 @@ TEST_P(TestTxnUpdate, test_update_and_delete_conflicts) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }
 
 TEST_P(TestTxnUpdate, test_update_and_delete_no_conflicts) {
@@ -1934,6 +1921,4 @@ TEST_P(TestTxnUpdate, test_update_and_delete_no_conflicts) {
 
         DropDatabase(setup);
     }
-
-    RemoveDbDirs();
 }


### PR DESCRIPTION
### What problem does this PR solve?

delete_ut.cpp failed with error "wal.log is not found" intermittently. 

At the end of the testunit, db directory is removed explicitly. At the same time wal manager is still working in NewFlush(). 
wal.log is needed in NewFlush().
We should not call RemoveDbDirs() at the end of the testunit, db directory will be cleaned in TearDown().

### Type of change

- [x] Test cases

