### PR TITLE
Fix deadlock of append and dump in bottom executor

### DIFF
--- a/src/common/blocking_queue.cppm
+++ b/src/common/blocking_queue.cppm
@@ -68,6 +68,22 @@ public:
         return true;
     }
 
+    bool TryEnqueue(T &&task) {
+        {
+            if (!allow_enqueue_) {
+                return false;
+            }
+
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            if (queue_.size() >= capacity_) {
+                return false;
+            }
+            queue_.push_back(std::forward<T>(task));
+        }
+        empty_cv_.notify_one();
+        return true;
+    }
+
     void EnqueueBulk(std::vector<T> &input_array) {
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);

--- a/src/storage/dump_index_process.cppm
+++ b/src/storage/dump_index_process.cppm
@@ -43,7 +43,7 @@ private:
     void Process();
 
 private:
-    BlockingQueue<std::shared_ptr<BGTask>> task_queue_{"DumpIndexProcessor"};
+    BlockingQueue<std::shared_ptr<BGTask>> task_queue_{"DumpIndexProcessor", 1024 * 1024};
 
     std::thread processor_thread_{};
 

--- a/src/storage/dump_index_process_impl.cpp
+++ b/src/storage/dump_index_process_impl.cpp
@@ -67,8 +67,11 @@ void DumpIndexProcessor::Stop() {
 }
 
 void DumpIndexProcessor::Submit(std::shared_ptr<BGTask> bg_task) {
-    task_queue_.Enqueue(std::move(bg_task));
-    ++task_count_;
+    if (task_queue_.TryEnqueue(std::move(bg_task))) {
+        ++task_count_;
+    } else {
+        LOG_WARN(fmt::format("Task queue of DumpIndexProcessor is full, skip the task. Queue size is {}", task_queue_.Size()));
+    }
 }
 
 void DumpIndexProcessor::DoDump(DumpMemIndexTask *dump_task) {


### PR DESCRIPTION
### What problem does this PR solve?
**Issue**
Multiple Append operations are executed and lots of dump tasks are triggered in bottom executor as the row count exceeds quota. Then  the dump  task queue is full and append  is waiting for the queue in bottom executor.
While dump  wants to do CommitBottom in bottom executor.  There is deadlock.

**Solution**
1) Increase the dump task queue capacity to 1024 * 1024
2) When the dump task queue is full, skip the task.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
