### PR TITLE
Update KVInstance for manual optimize when updating begin_ts

### DIFF
--- a/src/storage/compaction_process_impl.cpp
+++ b/src/storage/compaction_process_impl.cpp
@@ -211,7 +211,7 @@ void CompactionProcessor::NewNotifyCompact() {
 
 Status CompactionProcessor::NewManualCompact(NewTxn *new_txn, const std::string &db_name, const std::string &table_name) {
     auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
-    new_txn_mgr->UpdateTxnBeginTS(new_txn);
+    new_txn_mgr->UpdateTxnBeginTSAndKVInstance(new_txn);
 
     std::unique_ptr<std::string> result_msg;
     LOG_TRACE(fmt::format("Compact command triggered compaction: {}.{}", db_name, table_name));

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -165,6 +165,7 @@ public:
     //    void Begin();
 
     void SetBeginTS(TxnTimeStamp begin_ts);
+    void UpdateKVInstance(std::unique_ptr<KVInstance> kv_instance);
 
     Status Commit();
 

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -1864,6 +1864,11 @@ void NewTxn::SetBeginTS(TxnTimeStamp begin_ts) {
     txn_context_ptr_->begin_ts_ = begin_ts;
 }
 
+void NewTxn::UpdateKVInstance(std::unique_ptr<KVInstance> kv_instance) {
+    kv_instance_->Commit();
+    kv_instance_ = std::move(kv_instance);
+}
+
 Status NewTxn::Commit() {
     if (base_txn_store_ == nullptr or this->readonly()) {
         if (base_txn_store_ != nullptr) {

--- a/src/storage/new_txn/new_txn_manager.cppm
+++ b/src/storage/new_txn/new_txn_manager.cppm
@@ -159,7 +159,7 @@ public:
         return last_kv_commit_ts_;
     }
 
-    void UpdateTxnBeginTS(NewTxn *txn);
+    void UpdateTxnBeginTSAndKVInstance(NewTxn *txn);
 
 private:
     mutable std::mutex locker_{};

--- a/src/storage/optimization_process_impl.cpp
+++ b/src/storage/optimization_process_impl.cpp
@@ -84,7 +84,7 @@ void OptimizationProcessor::Submit(const std::shared_ptr<BGTask> &bg_task) {
 
 Status OptimizationProcessor::NewManualOptimize(NewTxn *new_txn, const std::string &db_name, const std::string &table_name) {
     auto *new_txn_mgr = InfinityContext::instance().storage()->new_txn_manager();
-    new_txn_mgr->UpdateTxnBeginTS(new_txn);
+    new_txn_mgr->UpdateTxnBeginTSAndKVInstance(new_txn);
     return new_txn->OptimizeTableIndexes(db_name, table_name);
 }
 


### PR DESCRIPTION
### What problem does this PR solve

In https://github.com/infiniflow/infinity/pull/3059,  we set begin ts of manual optimize when NewManualOptimize() is actually called. We should not only set begin ts but update kv_instance to avoid "resource busy" completely.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
