### PR TITLE
Simplify concurrent checkpoint handling

### DIFF
--- a/src/executor/operator/physical_flush_impl.cpp
+++ b/src/executor/operator/physical_flush_impl.cpp
@@ -85,12 +85,6 @@ void PhysicalFlush::FlushCatalog(QueryContext *query_context, OperatorState *ope
 
 void PhysicalFlush::FlushData(QueryContext *query_context, OperatorState *operator_state) {
     auto *wal_manager = query_context->storage()->wal_manager();
-    if (wal_manager->IsCheckpointing()) {
-        LOG_ERROR("There is a running checkpoint task, skip this checkpoint triggered by command");
-        Status status = Status::Checkpointing();
-        RecoverableError(status);
-    }
-
     TxnTimeStamp max_commit_ts{};
     i64 wal_size{};
     std::tie(max_commit_ts, wal_size) = wal_manager->GetCommitState();

--- a/src/storage/bg_task/periodic_trigger_impl.cpp
+++ b/src/storage/bg_task/periodic_trigger_impl.cpp
@@ -79,7 +79,7 @@ void CheckpointPeriodicTrigger::Trigger() {
         LOG_DEBUG("No write txn after last checkpoint");
         return;
     }
-    if (wal_manager->IsCheckpointing()) {
+    if (new_txn_mgr->IsCheckpointing()) {
         LOG_INFO("There is a running checkpoint task, skip this checkpoint triggered by periodic timer");
         return;
     }

--- a/src/storage/new_txn/new_txn_manager.cppm
+++ b/src/storage/new_txn/new_txn_manager.cppm
@@ -162,6 +162,10 @@ public:
 
     void UpdateTxnBeginTSAndKVInstance(NewTxn *txn);
 
+    bool SetCheckpointBeginTS(TxnTimeStamp checkpoint_ts);
+
+    bool IsCheckpointing() const;
+
 private:
     mutable std::mutex locker_{};
     Storage *storage_{};

--- a/src/storage/wal/wal_manager.cppm
+++ b/src/storage/wal/wal_manager.cppm
@@ -81,10 +81,6 @@ public:
 
     void FlushLogByReplication(const std::vector<std::string> &synced_logs, bool on_startup);
 
-    bool SetCheckpointing();
-    bool UnsetCheckpoint();
-    bool IsCheckpointing() const;
-
     void SwapWalFile(TxnTimeStamp max_commit_ts, bool error_if_duplicate);
 
     std::string GetWalFilename() const;

--- a/src/storage/wal/wal_manager_impl.cpp
+++ b/src/storage/wal/wal_manager_impl.cpp
@@ -436,24 +436,6 @@ void WalManager::FlushLogByReplication(const std::vector<std::string> &synced_lo
     ofs_.flush();
 }
 
-bool WalManager::SetCheckpointing() {
-    bool expect = false;
-    if (checkpoint_in_progress_.compare_exchange_strong(expect, true)) {
-        return true;
-    }
-    return false;
-}
-
-bool WalManager::UnsetCheckpoint() {
-    bool expect = true;
-    if (checkpoint_in_progress_.compare_exchange_strong(expect, false)) {
-        return true;
-    }
-    return false;
-}
-
-bool WalManager::IsCheckpointing() const { return checkpoint_in_progress_; }
-
 /*****************************************************************************
  * CHECKPOINT WAL FILE
  *****************************************************************************/


### PR DESCRIPTION
### What problem does this PR solve?

Simplify concurrent checkpoint handling.

Current logic to detect concurrent checkpoint :  
Use ckp_begin_ts_ in NewTxnManager. 
In BeginTxnShared(), if another checkpoint is already started,  nullptr is returned.


```
=> flush data;
System is checkpointing@src/main/query_context_impl.cpp:562
```

### Type of change

- [x] Refactoring
