### PR TITLE
Fix total_hits_count issue for PhysicalTop

### DIFF
--- a/src/executor/operator/physical_sink_impl.cpp
+++ b/src/executor/operator/physical_sink_impl.cpp
@@ -481,7 +481,7 @@ void PhysicalSink::FillSinkStateFromLastOperatorState(FragmentContext *fragment_
                                                             output_data_block_count,
                                                             task_operator_state->Complete(),
                                                             task_operator_state->total_hits_count_flag_,
-                                                            task_operator_state->total_hits_count_);
+                                                            idx == 0 ? task_operator_state->total_hits_count_ : 0);
         if (task_operator_state->Complete() && !fragment_context->IsMaterialize()) {
             fragment_data->data_idx_ = std::nullopt;
         }

--- a/src/executor/operator/physical_top_impl.cpp
+++ b/src/executor/operator/physical_top_impl.cpp
@@ -390,11 +390,11 @@ bool PhysicalTop::Execute(QueryContext *, OperatorState *operator_state) {
     top_solver.Solve(input_data_block_array, output_data_block_array);
     execution_count++;
     input_data_block_array.clear();
+    if (total_hits_count_flag_) {
+        top_operator_state->total_hits_count_flag_ = true;
+        top_operator_state->total_hits_count_ += total_hits_row_count;
+    }
     if (prev_op_state->Complete()) {
-        if (total_hits_count_flag_) {
-            top_operator_state->total_hits_count_flag_ = true;
-            top_operator_state->total_hits_count_ += total_hits_row_count;
-        }
         top_solver.Finalize(output_data_block_array, execution_count, offset_);
         top_operator_state->SetComplete();
         return true;


### PR DESCRIPTION
### What problem does this PR solve?

'total_his_count' of query with limit and sort is wrong.
```
builder = table_object.output(selectFields)
builder.sort([("create_time", 1)])
builder.offset(offset).limit(limit)
kb_res1, extra_result = builder.option({"total_hits_count": True}).to_df()
```

Issue link:https://github.com/infiniflow/infinity/issues/3076

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
