### PR TITLE
Fix group by issue during PhysicalAggregate and PhysicalMergeAggregate

### DIFF
--- a/src/executor/hash_table.cppm
+++ b/src/executor/hash_table.cppm
@@ -39,6 +39,8 @@ export class HashTable : public HashTableBase {
 public:
     void Append(const std::vector<std::shared_ptr<ColumnVector>> &columns, size_t block_id, size_t row_count);
 
+    void Clear() { hash_table_.clear(); }
+
 public:
     // Key -> (block id -> row array)
     std::unordered_map<std::string, std::unordered_map<size_t, std::vector<size_t>>> hash_table_{};

--- a/src/executor/operator/physical_aggregate_impl.cpp
+++ b/src/executor/operator/physical_aggregate_impl.cpp
@@ -113,6 +113,8 @@ bool PhysicalAggregate::Execute(QueryContext *query_context, OperatorState *oper
     HashTable &hash_table = aggregate_operator_state->hash_table_;
     if (!hash_table.Initialized()) {
         hash_table.Init(groupby_types);
+    } else {
+        hash_table.Clear();
     }
 
     size_t block_count = groupby_table->DataBlockCount();

--- a/src/storage/data_block.cppm
+++ b/src/storage/data_block.cppm
@@ -89,15 +89,7 @@ public:
 public:
     [[nodiscard]] size_t column_count() const { return column_count_; }
 
-    [[nodiscard]] u16 row_count() const {
-        if (!finalized) {
-            if (row_count_ == 0) {
-                return 0;
-            }
-            UnrecoverableError("Not finalized data block");
-        }
-        return row_count_;
-    }
+    [[nodiscard]] u16 row_count() const { return row_count_; }
 
     [[nodiscard]] std::vector<std::shared_ptr<DataType>> types() const {
         std::vector<std::shared_ptr<DataType>> types;


### PR DESCRIPTION
### What problem does this PR solve?

"Error: offset 261696 is out of range 105408@src/storage/column_vector/var_buffer_impl.cpp:68" during query with group by option.

1)In PhysicalAggregate(), hash table is used to aggregate in a data block. We should clear data in the hash table for each PhysicalAggregate() .
2) In PhysicalMergeAggregate::GroupByMergeAggregateExecute(),  we get row count of a block during we append data to the block, the block is not finalized.

```
std::pair<size_t, size_t> block_row_id = {op_state->data_block_array_.size() - 1, last_data_block->row_count()};
```

Issue link: https://github.com/infiniflow/infinity/issues/3084

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
