### PR TITLE
Fix aggregate operator (count, sum...)

### DIFF
--- a/tools/generate_groupby1.py
+++ b/tools/generate_groupby1.py
@@ -30,7 +30,7 @@ def generate(generate_if_exists: bool, copy_dir: str):
         )
         return
 
-    row_n = 9000
+    row_n = 100000
     group_n1 = 150
     group_n2 = 100
     groupby_c1 = defaultdict(list)


### PR DESCRIPTION
### What problem does this PR solve?

aggregate operator issue for big data

The following queries are verified   in this PR.

```
select count(doc_id) from ragflow_68d3e5c2b4a111f081e5902e16919ed0_2ff85594b4a611f08591902e16919ed0;

select count(doc_id) from ragflow_68d3e5c2b4a111f081e5902e16919ed0_2ff85594b4a611f08591902e16919ed0 group by doc_id;

select min(create_timestamp_flt), max(create_timestamp_flt), sum(create_timestamp_flt) from ragflow_68d3e5c2b4a111f081e5902e16919ed0_2ff85594b4a611f08591902e16919ed0;

select doc_id, min(create_timestamp_flt), max(create_timestamp_flt), sum(create_timestamp_flt) from ragflow_68d3e5c2b4a111f081e5902e16919ed0_2ff85594b4a611f08591902e16919ed0 group by doc_id;
```

Tests test_big_groupby.slt covers similar queries.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)