### PR TITLE
Fix issue of "create snapshot file for Varbuffer"

### DIFF
--- a/python/test_pysdk/test_table_snapshot.py
+++ b/python/test_pysdk/test_table_snapshot.py
@@ -130,6 +130,8 @@ class TestSnapshot:
                                                                                                    5).to_df()
             print(f"   Sparse vector search results: {len(sparse_result)} rows")
 
+            restored_table.optimize()
+
         except Exception as e:
             print(f"   ERROR in search operations: {e}")
             raise

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1523,7 +1523,11 @@ Status NewTxn::CreateTableSnapshotFile(std::shared_ptr<TableSnapshotInfo> table_
                     }
 
                     if (outline_buffer_obj) {
-                        outline_buffer_obj->SaveSnapshot(table_snapshot_info, use_memory, {}, row_cnt, data_size);
+                        // For outline buffer, we need to save it first and then save snapshot.
+                        // Sparse data is stored in outline buffer. It is difficult to get the sparse data of specified row count from memory
+                        // because there might be 1 or 2 buffer offsets for the same row.
+                        outline_buffer_obj->Save();
+                        outline_buffer_obj->SaveSnapshot(table_snapshot_info, false, {}, row_cnt, data_size);
                     }
                 }
             }


### PR DESCRIPTION
### What problem does this PR solve?

When Creating snapshot for var buffer (outline buffer), we need to save it first and then save snapshot.
Sparse data is stored in outline buffer.  It is difficult to get the sparse data of specified row count from memory because there might be 1 or 2 buffer offsets for the same row. (Check VectorBuffer::AppendSparse)

Issue link:#3103

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
