### PR TITLE
Align the result of rag analyzer to the python version

### DIFF
--- a/src/common/analyzer/rag_analyzer_impl.cpp
+++ b/src/common/analyzer/rag_analyzer_impl.cpp
@@ -1212,6 +1212,7 @@ void RAGAnalyzer::EnglishNormalize(const std::vector<std::string> &tokens, std::
 void RAGAnalyzer::TokenizeInner(std::vector<std::string> &res, const std::string &L) const {
     auto [tks, s] = MaxForward(L);
     auto [tks1, s1] = MaxBackward(L);
+
 #if 0
     std::size_t i = 0, j = 0, _i = 0, _j = 0, same = 0;
     while ((i + same < tks1.size()) && (j + same < tks.size()) && tks1[i + same] == tks[j + same]) {
@@ -1291,13 +1292,6 @@ void RAGAnalyzer::TokenizeInner(std::vector<std::string> &res, const std::string
 
     if (s1 > s) {
         tks = tks1;
-        // Recalculate diff array with the new tks size
-        diff.assign(std::max(tks.size(), tks1.size()), 0);
-        for (std::size_t i = 0; i < std::min(tks.size(), tks1.size()); ++i) {
-            if (tks[i] != tks1[i]) {
-                diff[i] = 1;
-            }
-        }
     }
 
     std::size_t i = 0;
@@ -1503,7 +1497,7 @@ std::string RAGAnalyzer::Tokenize(const std::string &line) {
     if (alpha_num > (std::size_t)(len * 0.9)) {
         std::vector<std::string> term_list;
         std::vector<std::string> sentences;
-        SentenceSplitter(line, sentences);
+        SentenceSplitter(processed_line, sentences);
         for (auto &sentence : sentences) {
             nltk_tokenizer_->Tokenize(sentence, term_list);
         }
@@ -1734,13 +1728,6 @@ void RAGAnalyzer::TokenizeInnerWithPosition(const std::string &L,
     }
     if (s1 > s) {
         tks = tks1;
-        // Recalculate diff array with the new tks size
-        diff.assign(std::max(tks.size(), tks1.size()), 0);
-        for (std::size_t i = 0; i < std::min(tks.size(), tks1.size()); ++i) {
-            if (tks[i] != tks1[i]) {
-                diff[i] = 1;
-            }
-        }
     }
 
     std::size_t i = 0;


### PR DESCRIPTION
### What problem does this PR solve?

```
Input: hello world!
Previously: hello world!
Currently: hello world

Input: 蓝月亮如何在外资夹击中生存,那是全宇宙最有意思的
Previously: 蓝月亮 如 何在 外资 夹 击中 生存 那 是 全宇宙 最 有意思 的
Currently: 蓝月亮 如何 在 外资 夹击 中 生存 , 那 是 全宇宙 最 有意思 的
```

Left issue:
The stemming algorithm is different:

```
NLTK porter stemmer behavior: loudly => loudli
Snowball behavior: loudly => loud
```

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
