### PR TITLE
Fix inflight tasks for fulltext index during cleanup

### DIFF
--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -42,6 +42,7 @@ import :scalar_function_set;
 import :special_function;
 import :meta_cache;
 import :utility;
+import :memory_indexer;
 
 import std;
 import third_party;
@@ -496,19 +497,6 @@ Status NewCatalog::CleanTable(TableMeta &table_meta, TxnTimeStamp begin_ts, Usag
 
     Status status;
 
-    std::vector<SegmentID> *segment_ids_ptr = nullptr;
-    std::tie(segment_ids_ptr, status) = table_meta.GetSegmentIDs1();
-    if (!status.ok()) {
-        return status;
-    }
-    for (SegmentID segment_id : *segment_ids_ptr) {
-        SegmentMeta segment_meta(segment_id, table_meta);
-        status = NewCatalog::CleanSegment(segment_meta, begin_ts, usage_flag);
-        if (!status.ok()) {
-            return status;
-        }
-    }
-
     std::vector<std::string> *index_id_strs_ptr = nullptr;
     std::vector<std::string> *index_names_ptr = nullptr;
     status = table_meta.GetIndexIDs(index_id_strs_ptr, &index_names_ptr);
@@ -520,6 +508,19 @@ Status NewCatalog::CleanTable(TableMeta &table_meta, TxnTimeStamp begin_ts, Usag
         const std::string &index_name_str = (*index_names_ptr)[i];
         TableIndexMeta table_index_meta(index_id_str, index_name_str, table_meta);
         status = NewCatalog::CleanTableIndex(table_index_meta, usage_flag);
+        if (!status.ok()) {
+            return status;
+        }
+    }
+
+    std::vector<SegmentID> *segment_ids_ptr = nullptr;
+    std::tie(segment_ids_ptr, status) = table_meta.GetSegmentIDs1();
+    if (!status.ok()) {
+        return status;
+    }
+    for (SegmentID segment_id : *segment_ids_ptr) {
+        SegmentMeta segment_meta(segment_id, table_meta);
+        status = NewCatalog::CleanSegment(segment_meta, begin_ts, usage_flag);
         if (!status.ok()) {
             return status;
         }
@@ -928,6 +929,22 @@ Status NewCatalog::CleanSegmentIndex(SegmentIndexMeta &segment_index_meta, Usage
         Status status = table_meta.InvalidateFtIndexCache();
         if (!status.ok()) {
             return status;
+        }
+    }
+
+    auto [index_base, index_status] = segment_index_meta.table_index_meta().GetIndexBase();
+    if (!index_status.ok()) {
+        return index_status;
+    }
+
+    // Wait for inflight tasks to complete for fulltext index
+    if (index_base->index_type_ == IndexType::kFullText) {
+        std::shared_ptr<MemIndex> mem_index = segment_index_meta.PopMemIndex();
+        if (mem_index != nullptr) {
+            std::shared_ptr<MemoryIndexer> memory_indexer = mem_index->GetFulltextIndex();
+            if (memory_indexer != nullptr) {
+                memory_indexer->WaitForTaskCompletion();
+            }
         }
     }
 

--- a/src/storage/invertedindex/memory_indexer.cppm
+++ b/src/storage/invertedindex/memory_indexer.cppm
@@ -134,6 +134,8 @@ public:
 
     size_t MemUsed() const;
 
+    void WaitForTaskCompletion();
+
 private:
     // call with write lock
     void IncreaseMemoryUsage(size_t mem);

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -371,6 +371,11 @@ size_t MemoryIndexer::CommitSync(size_t wait_if_empty_ms) {
     return num_generated;
 }
 
+void MemoryIndexer::WaitForTaskCompletion() {
+    std::unique_lock<std::mutex> task_lock(mutex_);
+    cv_.wait(task_lock, [this] { return inflight_tasks_ == 0; });
+}
+
 void MemoryIndexer::Dump(bool offline, bool spill) {
     if (offline) {
         assert(!spill);


### PR DESCRIPTION
### What problem does this PR solve?

" Error: Buffer: /var/infinity/data/db_1/tbl_78/seg_0/blk_8/1.col, Invalid status: Loaded, buffer type: Ephemeral, rc: 7@src/storage/buffer/buffer_obj_impl.cpp:297” during cleanup in debug_tsan_parallel_test of slow test.

If there are inflight AppendMemIndex tasks during cleanup, the status of buffer object might be Loaded, wait for inflight tasks to complete for fulltext index during cleaning segment index.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
