### PR TITLE
Fix dump rollback issue

### DIFF
--- a/python/restart_test/test_memidx.py
+++ b/python/restart_test/test_memidx.py
@@ -97,6 +97,9 @@ class TestMemIdx:
                 data_dict, data_type_dict, _ = table_obj.output(["count(*)"]).to_result()
                 assert data_dict["count(star)"] == [13]
 
+            # Wait for memindex dump
+            # If search is processed during memindex dump, it is possible to get partial results.
+            time.sleep(5)
             check()
             table_obj.optimize()
             check()

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -121,13 +121,14 @@ Status NewTxn::DumpMemIndex(const std::string &db_name, const std::string &table
         if (mem_index == nullptr || mem_index->IsDumping() || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr)) {
             continue;
         }
-        mem_index->SetIsDumping(true);
 
         ChunkID chunk_id = 0;
         std::tie(chunk_id, status) = segment_index_meta.GetAndSetNextChunkID();
         if (!status.ok()) {
             return status;
         }
+
+        mem_index->SetIsDumping(true);
 
         // Dump Mem Index
         status = this->DumpSegmentMemIndex(segment_index_meta, chunk_id);
@@ -175,7 +176,6 @@ Status NewTxn::DumpMemIndex(const std::string &db_name,
                              mem_index->IsDumping()));
         return Status::OK();
     }
-    mem_index->SetIsDumping(true);
 
     // Put the data into local txn store
     DumpMemIndexTxnStore *txn_store;
@@ -201,6 +201,8 @@ Status NewTxn::DumpMemIndex(const std::string &db_name,
     if (!status.ok()) {
         return status;
     }
+
+    mem_index->SetIsDumping(true);
 
     // Dump Mem Index
     status = this->DumpSegmentMemIndex(segment_index_meta, chunk_id);


### PR DESCRIPTION
### What problem does this PR solve?

1. During mem index dump, we should set base_txn_store_ before is_dumping_ is set to true, so that we can set is_dumping_ to false in PostRollback().

2. test_memindex.py fails in slow test. Search might be processed during mem index dump and get partial result. We should sleep for a while to wait for the dump completes.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
