### PR TITLE
Use `std::shared_ptr` to provide thread‑safe LRU management instead of ref_cnt

### DIFF
--- a/src/executor/operator/physical_scan/physical_knn_scan_impl.cpp
+++ b/src/executor/operator/physical_scan/physical_knn_scan_impl.cpp
@@ -958,11 +958,9 @@ void ExecuteHnswSearch(QueryContext *query_context,
         if (!status.ok()) {
             UnrecoverableError(status.message());
         }
-        HnswHandlerPtr hnsw_handler{};
+        std::shared_ptr<HnswHandler> hnsw_handler;
         index_file_worker->Read(hnsw_handler);
-        hnsw_search(hnsw_handler, false);
-        auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->hnsw_map_.cache_manager_;
-        cache_manager.UnPin(*index_file_worker->rel_file_path_);
+        hnsw_search(hnsw_handler.get(), false);
     }
     if (mem_index) {
         auto memory_hnsw_index = mem_index->GetHnswIndex();

--- a/src/storage/buffer/file_worker/file_worker.cppm
+++ b/src/storage/buffer/file_worker/file_worker.cppm
@@ -244,11 +244,12 @@ protected:
 
     virtual void Read(std::shared_ptr<EMVBIndex> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {}
 
-    virtual bool Write(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) {
+    virtual bool
+    Write(std::shared_ptr<HnswHandler> &data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) {
         return false;
     }
 
-    virtual void Read(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {}
+    virtual void Read(std::shared_ptr<HnswHandler> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {}
 
     virtual bool
     Write(std::span<IVFIndexInChunk> data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) {
@@ -281,11 +282,12 @@ protected:
 
     virtual void Read(std::shared_ptr<VarBuffer> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {}
 
-    virtual bool Write(BlockVersion *&data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) {
+    virtual bool
+    Write(std::shared_ptr<BlockVersion> &data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) {
         return false;
     }
 
-    virtual void Read(BlockVersion *&data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {}
+    virtual void Read(std::shared_ptr<BlockVersion> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {}
 
 public:
     // mutable boost::shared_mutex boost_rw_mutex_;

--- a/src/storage/buffer/file_worker/hnsw_file_worker.cppm
+++ b/src/storage/buffer/file_worker/hnsw_file_worker.cppm
@@ -42,9 +42,12 @@ public:
     FileWorkerType Type() const override { return FileWorkerType::kHNSWIndexFile; }
 
 protected:
-    bool Write(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) override;
+    bool Write(std::shared_ptr<HnswHandler> &data,
+               std::unique_ptr<LocalFileHandle> &file_handle,
+               bool &prepare_success,
+               const FileWorkerSaveCtx &ctx) override;
 
-    void Read(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) override;
+    void Read(std::shared_ptr<HnswHandler> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) override;
 
 private:
     mutable std::mutex mutex_;

--- a/src/storage/buffer/file_worker/hnsw_file_worker_impl.cpp
+++ b/src/storage/buffer/file_worker/hnsw_file_worker_impl.cpp
@@ -64,7 +64,10 @@ HnswFileWorker::~HnswFileWorker() {
     mmap_ = nullptr;
 }
 
-bool HnswFileWorker::Write(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) {
+bool HnswFileWorker::Write(std::shared_ptr<HnswHandler> &data,
+                           std::unique_ptr<LocalFileHandle> &file_handle,
+                           bool &prepare_success,
+                           const FileWorkerSaveCtx &ctx) {
     std::unique_lock l(mutex_);
     data->SaveToPtr(*file_handle);
 
@@ -76,24 +79,21 @@ bool HnswFileWorker::Write(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle
     }
     mmap_ = mmap(nullptr, mmap_size_, PROT_WRITE | PROT_READ, MAP_SHARED, fd, 0);
     auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->hnsw_map_.cache_manager_;
-    // cache_manager.Set(*rel_file_path_, data, mmap_size_);
     cache_manager.Set(*rel_file_path_, data, data->MemUsage());
-    cache_manager.UnPin(*rel_file_path_);
     prepare_success = true;
     return true;
 }
 
-void HnswFileWorker::Read(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {
+void HnswFileWorker::Read(std::shared_ptr<HnswHandler> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {
     std::unique_lock l(mutex_);
     if (!file_handle) {
         return;
     }
     auto &path = *rel_file_path_;
     auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->hnsw_map_.cache_manager_;
-    cache_manager.Pin(path);
     bool flag = cache_manager.Get(path, data);
     if (!flag) {
-        data = HnswHandlerPtr{HnswHandler::Make(index_base_.get(), column_def_).release()};
+        data = HnswHandler::Make(index_base_.get(), column_def_);
         auto fd = file_handle->fd();
 
         if (!mmap_) {
@@ -101,7 +101,6 @@ void HnswFileWorker::Read(HnswHandlerPtr &data, std::unique_ptr<LocalFileHandle>
             mmap_ = mmap(nullptr, mmap_size_, PROT_WRITE | PROT_READ, MAP_SHARED, fd, 0);
         }
         data->LoadFromPtr(mmap_, mmap_size_, *file_handle, file_size);
-        // cache_manager.Set(path, data, mmap_size_);
         cache_manager.Set(*rel_file_path_, data, data->MemUsage());
     }
 }

--- a/src/storage/buffer/file_worker/version_file_worker.cppm
+++ b/src/storage/buffer/file_worker/version_file_worker.cppm
@@ -29,16 +29,19 @@ export struct VersionFileWorkerSaveCtx : public FileWorkerSaveCtx {
 
 export class VersionFileWorker : public FileWorker {
 public:
-    static constexpr BlockVersion *has_cache_manager_{}; // now not used
+    static constexpr BlockVersion *has_cache_manager_{};
     explicit VersionFileWorker(std::shared_ptr<std::string> file_path, size_t capacity);
 
     virtual ~VersionFileWorker() override;
 
     FileWorkerType Type() const override { return FileWorkerType::kVersionDataFile; }
 
-    bool Write(BlockVersion *&data, std::unique_ptr<LocalFileHandle> &file_handle, bool &prepare_success, const FileWorkerSaveCtx &ctx) override;
+    bool Write(std::shared_ptr<BlockVersion> &data,
+               std::unique_ptr<LocalFileHandle> &file_handle,
+               bool &prepare_success,
+               const FileWorkerSaveCtx &ctx) override;
 
-    void Read(BlockVersion *&data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) override;
+    void Read(std::shared_ptr<BlockVersion> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) override;
 
 private:
     size_t capacity_{};

--- a/src/storage/catalog/kv_utility_impl.cpp
+++ b/src/storage/catalog/kv_utility_impl.cpp
@@ -155,8 +155,7 @@ size_t GetBlockRowCount(KVInstance *kv_instance,
         UnrecoverableError(fmt::format("Get version buffer failed: {}", rel_version_filepath));
     }
 
-    // std::shared_ptr<BlockVersion> block_version;
-    BlockVersion *block_version{};
+    std::shared_ptr<BlockVersion> block_version;
     static_cast<FileWorker *>(version_file_worker)->Read(block_version);
     size_t row_cnt = 0;
     if (block_version) {
@@ -165,12 +164,7 @@ size_t GetBlockRowCount(KVInstance *kv_instance,
             auto [offset, commit_cnt] = block_version->GetCommitRowCount(commit_ts);
             row_cnt += commit_cnt;
         }
-        // auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        // cache_manager.UnPin(*version_file_worker->rel_file_path_);
     }
-    // UnPin???
-    auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-    cache_manager.UnPin(*version_file_worker->rel_file_path_);
     return row_cnt;
 }
 

--- a/src/storage/catalog/meta/block_meta_impl.cpp
+++ b/src/storage/catalog/meta/block_meta_impl.cpp
@@ -78,12 +78,9 @@ Status BlockMeta::RestoreSetFromSnapshot() {
     auto *version_file_worker = fileworker_mgr->version_map_.EmplaceFileWorker(std::make_unique<VersionFileWorker>(rel_file_path, block_capacity()));
     version_file_worker_ = version_file_worker;
 
-    // std::shared_ptr<BlockVersion> block_version;
-    BlockVersion *block_version{};
+    std::shared_ptr<BlockVersion> block_version;
     static_cast<FileWorker *>(version_file_worker_)->Read(block_version);
     block_version->RestoreFromSnapshot(commit_ts_);
-    auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-    cache_manager.UnPin(*version_file_worker_->rel_file_path_);
     return Status::OK();
 }
 

--- a/src/storage/catalog/meta/block_version.cppm
+++ b/src/storage/catalog/meta/block_version.cppm
@@ -53,7 +53,7 @@ export struct BlockVersion {
     bool SaveToFile(void *&mmap, size_t &mmap_size, const std::string &rel_path, TxnTimeStamp checkpoint_ts, LocalFileHandle &file_handler);
     bool SaveToFile(TxnTimeStamp checkpoint_ts, LocalFileHandle &file_handle) const;
 
-    static void LoadFromFile(BlockVersion *&data, size_t &mmap_size, void *&mmap, LocalFileHandle *file_handle);
+    static void LoadFromFile(std::shared_ptr<BlockVersion> &data, size_t &mmap_size, void *&mmap, LocalFileHandle *file_handle);
 
     void GetCreateTS(size_t offset, size_t size, ColumnVector &res) const;
 

--- a/src/storage/catalog/meta/meta_tree_impl.cpp
+++ b/src/storage/catalog/meta/meta_tree_impl.cpp
@@ -706,14 +706,11 @@ size_t MetaTableObject::GetCurrentSegmentRowCount(Storage *storage_ptr) const {
     if (version_file_worker == nullptr) {
         UnrecoverableError(fmt::format("Can't get version from: {}", rel_version_path));
     }
-    // std::shared_ptr<BlockVersion> block_version;
-    BlockVersion *block_version{};
+    std::shared_ptr<BlockVersion> block_version;
     static_cast<FileWorker *>(version_file_worker)->Read(block_version);
     size_t row_cnt = block_version->GetRowCount();
 
     size_t segment_row_count = (block_count - 1) * DEFAULT_BLOCK_CAPACITY + row_cnt;
-    auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-    cache_manager.UnPin(*version_file_worker->rel_file_path_);
     return segment_row_count;
 }
 

--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -69,12 +69,9 @@ void NewTxnGetVisibleRangeState::Init(VersionFileWorker *version_file_worker, Tx
     begin_ts_ = begin_ts;
     commit_ts_ = commit_ts;
     {
-        // std::shared_ptr<BlockVersion> block_version;
-        BlockVersion *block_version{};
+        std::shared_ptr<BlockVersion> block_version;
         static_cast<FileWorker *>(version_file_worker_)->Read(block_version);
         block_offset_end_ = block_version->GetRowCount(begin_ts_);
-        auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        cache_manager.UnPin(*version_file_worker_->rel_file_path_);
     }
 }
 
@@ -83,8 +80,7 @@ bool NewTxnGetVisibleRangeState::Next(BlockOffset block_offset_begin, std::pair<
         return false;
     }
 
-    // std::shared_ptr<BlockVersion> block_version;
-    BlockVersion *block_version{};
+    std::shared_ptr<BlockVersion> block_version;
     static_cast<FileWorker *>(version_file_worker_)->Read(block_version);
 
     if (block_offset_begin == block_offset_end_) {
@@ -104,8 +100,6 @@ bool NewTxnGetVisibleRangeState::Next(BlockOffset block_offset_begin, std::pair<
         }
     }
     visible_range = {block_offset_begin, row_idx};
-    auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-    cache_manager.UnPin(*version_file_worker_->rel_file_path_);
     return block_offset_begin < row_idx;
 }
 
@@ -1118,14 +1112,11 @@ Status NewCatalog::GetCreateTSVector(BlockMeta &block_meta, size_t offset, size_
         return status;
     }
 
-    // std::shared_ptr<BlockVersion> block_version;
-    BlockVersion *block_version{};
+    std::shared_ptr<BlockVersion> block_version;
     static_cast<FileWorker *>(version_buffer)->Read(block_version);
     {
         block_version->GetCreateTS(offset, size, column_vector);
     }
-    auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-    cache_manager.UnPin(*version_buffer->rel_file_path_);
     return Status::OK();
 }
 
@@ -1138,14 +1129,11 @@ Status NewCatalog::GetDeleteTSVector(BlockMeta &block_meta, size_t offset, size_
         return status;
     }
 
-    // std::shared_ptr<BlockVersion> block_version;
-    BlockVersion *block_version{};
+    std::shared_ptr<BlockVersion> block_version;
     static_cast<FileWorker *>(version_file_worker)->Read(block_version);
     {
         block_version->GetDeleteTS(offset, size, column_vector);
     }
-    auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-    cache_manager.UnPin(*version_file_worker->rel_file_path_);
     return Status::OK();
 }
 

--- a/src/storage/knn_index/knn_hnsw/hnsw_handler_impl.cpp
+++ b/src/storage/knn_index/knn_hnsw/hnsw_handler_impl.cpp
@@ -628,7 +628,8 @@ void HnswIndexInMem::Dump(FileWorker *index_file_worker, size_t *dump_size_ptr) 
 
     own_memory_ = false;
     index_file_worker_ = std::move(index_file_worker);
-    index_file_worker_->Write(hnsw_handler_);
+    auto hnsw_handler = std::shared_ptr<HnswHandler>(hnsw_handler_);
+    index_file_worker_->Write(hnsw_handler);
 }
 
 size_t

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -899,8 +899,7 @@ Status NewTxn::AppendInBlock(BlockMeta &block_meta, size_t block_offset, size_t 
         }
 
         // append in version file.
-        BlockVersion *block_version{};
-        // auto *block_version = std::make_unique<BlockVersion>(block_meta.block_capacity()).release();
+        std::shared_ptr<BlockVersion> block_version;
         static_cast<FileWorker *>(version_file_worker)->Read(block_version);
         block_version->Append(commit_ts, block_offset + append_rows);
         // auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
@@ -968,8 +967,7 @@ Status NewTxn::DeleteInBlock(BlockMeta &block_meta, const std::vector<BlockOffse
         TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
 
         // delete in version file
-        // std::shared_ptr<BlockVersion> block_version;
-        BlockVersion *block_version{};
+        std::shared_ptr<BlockVersion> block_version;
         version_file_worker->Read(block_version);
         undo_block_offsets.reserve(block_offsets.size());
         for (BlockOffset block_offset : block_offsets) {
@@ -979,8 +977,6 @@ Status NewTxn::DeleteInBlock(BlockMeta &block_meta, const std::vector<BlockOffse
             }
             undo_block_offsets.push_back(block_offset);
         }
-        // auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        // cache_manager.UnPin(*version_file_worker->rel_file_path_);
         VersionFileWorkerSaveCtx version_file_worker_save_ctx{commit_ts};
         version_file_worker->Write(block_version, version_file_worker_save_ctx);
     }
@@ -1001,14 +997,11 @@ Status NewTxn::RollbackDeleteInBlock(BlockMeta &block_meta, const std::vector<Bl
 
     {
         // delete in version file
-        // std::shared_ptr<BlockVersion> block_version;
-        BlockVersion *block_version{};
+        std::shared_ptr<BlockVersion> block_version;
         version_file_worker->Read(block_version);
         for (BlockOffset block_offset : block_offsets) {
             block_version->RollbackDelete(block_offset);
         }
-        auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        cache_manager.UnPin(*version_file_worker->rel_file_path_);
     }
     return Status::OK();
 }
@@ -1025,8 +1018,7 @@ Status NewTxn::PrintVersionInBlock(BlockMeta &block_meta, const std::vector<Bloc
     TxnTimeStamp begin_ts = txn_context_ptr_->begin_ts_;
     {
         // delete in version file
-        // std::shared_ptr<BlockVersion> block_version;
-        BlockVersion *block_version{};
+        std::shared_ptr<BlockVersion> block_version;
         version_file_worker->Read(block_version);
         for (BlockOffset block_offset : block_offsets) {
             status = block_version->Print(begin_ts, block_offset, ignore_invisible);
@@ -1034,8 +1026,6 @@ Status NewTxn::PrintVersionInBlock(BlockMeta &block_meta, const std::vector<Bloc
                 return status;
             }
         }
-        auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        cache_manager.UnPin(*version_file_worker->rel_file_path_);
     }
     return Status::OK();
 }
@@ -1728,12 +1718,9 @@ Status NewTxn::AddSegmentVersion(WalSegmentInfo &segment_info, SegmentMeta &segm
         if (!status.ok()) {
             return status;
         }
-        // std::shared_ptr<BlockVersion> block_version;
-        BlockVersion *block_version{};
+        std::shared_ptr<BlockVersion> block_version;
         static_cast<FileWorker *>(version_file_worker)->Read(block_version);
         block_version->Append(save_ts, block_info.row_count_);
-        // auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        // cache_manager.UnPin(*version_file_worker->rel_file_path_);
 
         static_cast<FileWorker *>(version_file_worker)->Write(block_version, VersionFileWorkerSaveCtx{static_cast<u64>(-1)});
     }
@@ -1751,13 +1738,9 @@ Status NewTxn::CommitSegmentVersion(WalSegmentInfo &segment_info, SegmentMeta &s
         if (!status.ok()) {
             return status;
         }
-        // auto block_version = std::make_shared<BlockVersion>(block_meta.block_capacity());
-        // auto *block_version = std::make_unique<BlockVersion>(block_meta.block_capacity()).release();
-        BlockVersion *block_version{};
+        std::shared_ptr<BlockVersion> block_version;
         static_cast<FileWorker *>(version_file_worker)->Read(block_version);
         block_version->CommitAppend(save_ts, commit_ts);
-        // auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-        // cache_manager.UnPin(*version_file_worker->rel_file_path_);
 
         static_cast<FileWorker *>(version_file_worker)->Write(block_version, VersionFileWorkerSaveCtx(commit_ts));
     }

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -1871,11 +1871,8 @@ Status NewTxn::CreateTableSnapshotFile(std::shared_ptr<TableSnapshotInfo> table_
                 auto version_file_worker_ = fileworker_mgr->version_map_.EmplaceFileWorker(std::move(version_file_worker));
 
                 // Read version info
-                BlockVersion *block_version{};
+                std::shared_ptr<BlockVersion> block_version;
                 static_cast<FileWorker *>(version_file_worker_)->Read(block_version);
-
-                auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->version_map_.cache_manager_;
-                cache_manager.UnPin(*read_path);
 
                 // Write snapshot file
                 auto write_path = fmt::format("{}/{}/{}/{}", snapshot_dir, snapshot_name, *block_dir_ptr, BlockVersion::PATH);

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -1990,7 +1990,7 @@ Status NewTxn::AlterSegmentIndexByParams(SegmentIndexMeta &segment_index_meta, c
                 if (!status.ok()) {
                     return status;
                 }
-                HnswHandlerPtr hnsw_handler{};
+                std::shared_ptr<HnswHandler> hnsw_handler;
                 index_file_worker->Read(hnsw_handler);
                 if (params->compress_to_lvq) {
                     (hnsw_handler)->CompressToLVQ();
@@ -2000,8 +2000,6 @@ Status NewTxn::AlterSegmentIndexByParams(SegmentIndexMeta &segment_index_meta, c
                 if (params->lvq_avg) {
                     (hnsw_handler)->Optimize();
                 }
-                auto &cache_manager = InfinityContext::instance().storage()->fileworker_manager()->hnsw_map_.cache_manager_;
-                cache_manager.UnPin(*index_file_worker->rel_file_path_);
             }
             if (mem_index) {
                 std::shared_ptr<HnswIndexInMem> memory_hnsw_index = mem_index->GetHnswIndex();


### PR DESCRIPTION
### What problem does this PR solve?

Use `std::shared_ptr` to provide thread‑safe LRU management instead of ref_cnt.

### Type of change

- [x] Refactoring
