### PR TITLE
fixing _split_by_lang in rag_tokenizer.py

### DIFF
--- a/python/infinity_sdk/infinity/rag_tokenizer.py
+++ b/python/infinity_sdk/infinity/rag_tokenizer.py
@@ -346,9 +346,8 @@ class RagTokenizer:
                 s = e
                 e = s + 1
                 zh = _zh
-            if s >= len(a):
-                continue
-            txt_lang_pairs.append((a[s:e], zh))
+            if s < len(a):  # Changed from s >= len(a) to be clearer
+                txt_lang_pairs.append((a[s:min(e, len(a))], zh))  # Ensure e doesn't exceed length of a
         return txt_lang_pairs
 
     def tokenize(self, line: str) -> str:


### PR DESCRIPTION
### What problem does this PR solve?

Guarding the final slice in _split_by_lang ensures we never run past the end of the segment when e can temporarily exceed len(a) (e.g., when the last run updates e = s + 1). The change now clamps the upper bound with min(e, len(a)), so we always append a valid substring and avoid the occasional “list index out of range” crash the tokenizer was seeing.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Python SDK impacted, Need to update PyPI
