### PR TITLE
Improve the `Read()` performance of `data_file_worker` and `var_file_worker`

### DIFF
--- a/src/storage/buffer/file_worker/data_file_worker_impl.cpp
+++ b/src/storage/buffer/file_worker/data_file_worker_impl.cpp
@@ -148,10 +148,10 @@ bool DataFileWorker::WriteSnapshot(std::span<char> data,
 void DataFileWorker::Read(std::shared_ptr<char[]> &data, std::unique_ptr<LocalFileHandle> &file_handle, size_t file_size) {
     // data = std::make_shared_for_overwrite<char[]>(buffer_size_);
     // std::unique_lock l(mutex_);
-    data = std::make_shared<char[]>(buffer_size_);
-
     if (!mmap_) {
+
         if (!file_handle) {
+            data = std::make_shared<char[]>(buffer_size_);
             return;
         }
         if (file_size < sizeof(u64) * 3) {
@@ -176,59 +176,30 @@ void DataFileWorker::Read(std::shared_ptr<char[]> &data, std::unique_ptr<LocalFi
         std::memcpy(&magic_number, (char *)mmap_ + offset, sizeof(magic_number));
         offset += sizeof(magic_number);
 
-        // // auto [nbytes1, status1] = file_handle->Read(&magic_number, sizeof(magic_number));
-        // if (!status1.ok()) {
-        //     RecoverableError(status1);
-        // }
-        // if (nbytes1 != sizeof(magic_number)) {
-        //     RecoverableError(Status::DataIOError(fmt::format("Read magic number which length isn't {}.", nbytes1)));
-        // }
         if (magic_number != 0x00dd3344) {
             RecoverableError(Status::DataIOError(fmt::format("Read magic error, {} != 0x00dd3344.", magic_number)));
         }
 
-        // u64 buffer_size_{};
-
         std::memcpy(&buffer_size_, (char *)mmap_ + offset, sizeof(buffer_size_));
         offset += sizeof(buffer_size_);
-
-        // auto [nbytes2, status2] = file_handle->Read(&buffer_size_, sizeof(buffer_size_));
-        // if (nbytes2 != sizeof(buffer_size_)) {
-        //     Status status = Status::DataIOError(fmt::format("Unmatched buffer length: {} / {}", nbytes2, buffer_size_));
-        //     RecoverableError(status2);
-        // }
 
         if (file_size != buffer_size_ + 3 * sizeof(u64)) {
             Status status = Status::DataIOError(fmt::format("File size: {} isn't matched with {}.", file_size, buffer_size_ + 3 * sizeof(u64)));
             RecoverableError(status);
         }
 
-        // file body
-        // data_ = static_cast<void *>(new char[buffer_size_]);
+        data = std::shared_ptr<char[]>(static_cast<char *>(mmap_) + offset, [](char *p) {});
 
         std::memcpy(data.get(), (char *)mmap_ + offset, buffer_size_);
         offset += buffer_size_;
 
-        // auto [nbytes3, status3] = file_handle->Read(data.get(), buffer_size_);
-        // if (nbytes3 != buffer_size_) {
-        //     Status status = Status::DataIOError(fmt::format("Expect to read buffer with size: {}, but {} bytes is read", buffer_size_, nbytes3));
-        //     RecoverableError(status);
-        // }
-
-        // file footer: checksum
+        // // file footer: checksum
         // u64 checksum{};
         // std::memcpy(&checksum, mmap_ + offset, sizeof(checksum));
         // offset += sizeof(checksum);
 
-        // auto [nbytes4, status4] = file_handle->Read(&checksum, sizeof(checksum));
-        // if (nbytes4 != sizeof(checksum)) {
-        //     Status status = Status::DataIOError(fmt::format("Incorrect file checksum length: {}.", nbytes4));
-        //     RecoverableError(status);
-        // }
-        //
-
     } else {
-        std::memcpy(data.get(), (char *)mmap_ + sizeof(u64) /* magic_num */ + sizeof(buffer_size_), buffer_size_);
+        data = std::shared_ptr<char[]>(static_cast<char *>(mmap_) + sizeof(u64) + sizeof(buffer_size_), [](char *) {});
     }
 }
 

--- a/src/storage/buffer/file_worker/var_file_worker_impl.cpp
+++ b/src/storage/buffer/file_worker/var_file_worker_impl.cpp
@@ -126,11 +126,6 @@ void VarFileWorker::Read(std::shared_ptr<VarBuffer> &data, std::unique_ptr<Local
         std::memcpy(buffer.get(), (char *)mmap_ + offset, mmap_size_);
         offset += mmap_size_;
 
-        // auto [nbytes, status] = file_handle->Read(buffer.get(), mmap_size_);
-        // if (!status.ok()) {
-        // UnrecoverableError(status.message());
-        // }
-
         data = std::make_shared<VarBuffer>(this, std::move(buffer), mmap_size_);
 
     } else {


### PR DESCRIPTION
### What problem does this PR solve?

1. When `mmap_` is unassigned, the branch now avoids using file_handle's read.
2. In `data_file_worker`, avoid the `memcpy` after `mmap`.

### Type of change

- [x] Refactoring
- [x] Performance Improvement
