### PR TITLE
Fix issue #3235 

### DIFF
--- a/src/storage/column_vector/vector_buffer_impl.cpp
+++ b/src/storage/column_vector/vector_buffer_impl.cpp
@@ -351,7 +351,6 @@ void VectorBuffer::WriteAdv(char *&ptr, const DataType *data_type) const {
             break;
         }
         default: {
-            UnrecoverableError("VectorBuffer not support this data type");
             break;
         }
     }
@@ -372,7 +371,6 @@ void VectorBuffer::ReadAdv(const char *&ptr, const DataType *data_type) {
             break;
         }
         default: {
-            UnrecoverableError("VectorBuffer not support this data type");
             break;
         }
     }


### PR DESCRIPTION
**Problem**
JSON data failed to be read after database restart with error "offset 0 is out of range 0", while VARCHAR data worked correctly.

**Root Cause**
JSON data was not being serialized to the WAL during INSERT operations.

When serializing DataBlock to the WAL, the VectorBuffer::WriteAdv method only handled certain data types (Varchar, Array, Sparse, MultiVector, Tensor, TensorArray) but omitted LogicalType::kJson.