### PR TITLE
Fix bug: Race Condition in MemIndex Dumping Protection - Non-atomic Check-and-Set Operation

### DIFF
--- a/src/storage/catalog/mem_index.cppm
+++ b/src/storage/catalog/mem_index.cppm
@@ -75,6 +75,7 @@ public:
 
     bool IsDumping() const;
     void SetIsDumping(bool is_dumping);
+    bool TrySetIsDumping();
     void UpdateBegin();
     void UpdateEnd();
     void WaitUpdate();

--- a/src/storage/catalog/mem_index_impl.cpp
+++ b/src/storage/catalog/mem_index_impl.cpp
@@ -182,6 +182,14 @@ void MemIndex::SetIsDumping(bool is_dumping) {
     std::unique_lock<std::mutex> lock(mtx_);
     is_dumping_ = is_dumping;
 }
+bool MemIndex::TrySetIsDumping() {
+    std::unique_lock<std::mutex> lock(mtx_);
+    if (is_dumping_) {
+        return false;
+    }
+    is_dumping_ = true;
+    return true;
+}
 
 void MemIndex::UpdateBegin() {
     std::unique_lock<std::mutex> lock(mtx_);

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -117,17 +117,20 @@ Status NewTxn::DumpMemIndex(const std::string &db_name, const std::string &table
         SegmentIndexMeta segment_index_meta(segment_id, *table_index_meta);
 
         std::shared_ptr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
-        if (mem_index == nullptr || mem_index->IsDumping() || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr)) {
+        if (mem_index == nullptr || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr)) {
+            continue;
+        }
+
+        if (!mem_index->TrySetIsDumping()) {
             continue;
         }
 
         ChunkID chunk_id = 0;
         std::tie(chunk_id, status) = segment_index_meta.GetAndSetNextChunkID();
         if (!status.ok()) {
+            mem_index->SetIsDumping(false);
             return status;
         }
-
-        mem_index->SetIsDumping(true);
 
         // Dump Mem Index
         status = this->DumpSegmentMemIndex(segment_index_meta, chunk_id);
@@ -162,15 +165,23 @@ Status NewTxn::DumpMemIndex(const std::string &db_name,
     std::shared_ptr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
 
     // Return when there is no mem index to dump.
-    if (mem_index == nullptr || mem_index->IsDumping() || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr) ||
+    if (mem_index == nullptr || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr) ||
         (begin_row_id != RowID() && mem_index->GetBaseMemIndex() != nullptr && begin_row_id != mem_index->GetBaseMemIndex()->GetBeginRowID())) {
-        LOG_WARN(fmt::format("NewTxn::DumpMemIndex skipped dumping MemIndex {}.{}.{}.{}.{} since it doesn't exist or it is dumped (is_dumping: {})",
+        LOG_WARN(fmt::format("NewTxn::DumpMemIndex skipped dumping MemIndex {}.{}.{}.{}.{} since it doesn't exist",
                              db_name,
                              table_name,
                              index_name,
                              segment_id,
-                             begin_row_id.ToUint64(),
-                             mem_index->IsDumping()));
+                             begin_row_id.ToUint64()));
+        return Status::OK();
+    }
+    if (!mem_index->TrySetIsDumping()) {
+        LOG_WARN(fmt::format("NewTxn::DumpMemIndex skipped dumping MemIndex {}.{}.{}.{}.{} since it is already being dumped",
+                             db_name,
+                             table_name,
+                             index_name,
+                             segment_id,
+                             begin_row_id.ToUint64()));
         return Status::OK();
     }
 
@@ -196,10 +207,9 @@ Status NewTxn::DumpMemIndex(const std::string &db_name,
     ChunkID chunk_id = 0;
     std::tie(chunk_id, status) = segment_index_meta.GetAndSetNextChunkID();
     if (!status.ok()) {
+        mem_index->SetIsDumping(false);
         return status;
     }
-
-    mem_index->SetIsDumping(true);
 
     // Dump Mem Index
     status = this->DumpSegmentMemIndex(segment_index_meta, chunk_id);
@@ -2628,11 +2638,14 @@ Status NewTxn::ManualDumpIndex(const std::string &db_name, const std::string &ta
 
             // 4. Get memory index for this segment
             std::shared_ptr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
-            if (mem_index == nullptr || mem_index->IsDumping() || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr)) {
+            if (mem_index == nullptr || (mem_index->GetBaseMemIndex() == nullptr && mem_index->GetEMVBIndex() == nullptr)) {
                 LOG_INFO(fmt::format("Skipping segment {} - no memory index to dump", segment_id));
                 continue;
             }
-            mem_index->SetIsDumping(true);
+            if (!mem_index->TrySetIsDumping()) {
+                LOG_INFO(fmt::format("Skipping segment {} - already being dumped by another thread", segment_id));
+                continue;
+            }
 
             // 4.5. Additional check for EMVB index - ensure it's built before dumping
 
@@ -2640,6 +2653,7 @@ Status NewTxn::ManualDumpIndex(const std::string &db_name, const std::string &ta
             ChunkID chunk_id = 0;
             std::tie(chunk_id, status) = segment_index_meta.GetAndSetNextChunkID();
             if (!status.ok()) {
+                mem_index->SetIsDumping(false);
                 return status;
             }
 


### PR DESCRIPTION
Close #3257


There is a race condition between checking IsDumping() and setting SetIsDumping(true) that allows two concurrent dump transactions to pass the check and both set the flag to true. This breaks the concurrency protection mechanism.

```
// Thread A and Thread B can both execute here simultaneously:
if (mem_index == nullptr || mem_index->IsDumping() || ...) {
    continue;  // Skip if already dumping
}
// Both threads passed the check!
mem_index->SetIsDumping(true);  // Both threads set to true
```