### PR TITLE
Fix error search expression leading error on resource releasing

### DIFF
--- a/src/network/http/http_search_impl.cpp
+++ b/src/network/http/http_search_impl.cpp
@@ -849,7 +849,6 @@ SearchExpr *HTTPSearch::ParseSearchExpr(std::string_view json_sv, HTTPStatus &ht
     auto search_expr = new SearchExpr();
     try {
         search_expr->SetExprs(child_expr);
-        child_expr = nullptr;
     } catch (std::exception &e) {
         delete search_expr;
         search_expr = nullptr;

--- a/src/network/infinity_thrift_service_impl.cpp
+++ b/src/network/infinity_thrift_service_impl.cpp
@@ -597,9 +597,13 @@ void InfinityThriftService::Select(infinity_thrift_rpc::SelectResponse &response
             search_expr_list->emplace_back(fusion_expr);
         }
 
-        search_expr = new SearchExpr();
-        search_expr->SetExprs(search_expr_list);
-        search_expr_list = nullptr;
+        try {
+            search_expr = new SearchExpr();
+            search_expr->SetExprs(search_expr_list);
+        } catch (std::exception &e) {
+            ProcessStatus(response, Status::SyntaxError(e.what()));
+            return;
+        }
     }
 
     // filter
@@ -913,7 +917,6 @@ void InfinityThriftService::Explain(infinity_thrift_rpc::SelectResponse &respons
 
         search_expr = new SearchExpr();
         search_expr->SetExprs(search_expr_list);
-        search_expr_list = nullptr;
     }
 
     // filter

--- a/src/parser/expr/search_expr.cpp
+++ b/src/parser/expr/search_expr.cpp
@@ -48,7 +48,7 @@ std::string SearchExpr::ToString() const {
     return oss.str();
 }
 
-void SearchExpr::SetExprs(std::vector<infinity::ParsedExpr *> *exprs) {
+void SearchExpr::SetExprs(std::vector<infinity::ParsedExpr *> *& exprs) {
     if (exprs == nullptr) {
         ParserError("SearchExpr::SetExprs parameter is nullptr");
     }
@@ -59,6 +59,7 @@ void SearchExpr::SetExprs(std::vector<infinity::ParsedExpr *> *exprs) {
     for (ParsedExpr *expr : *exprs) {
         AddExpr(expr);
     }
+    exprs = nullptr;
     Validate();
 }
 

--- a/src/parser/expr/search_expr.h
+++ b/src/parser/expr/search_expr.h
@@ -31,7 +31,7 @@ public:
 
     [[nodiscard]] std::string ToString() const override;
 
-    void SetExprs(std::vector<infinity::ParsedExpr *> *exprs);
+    void SetExprs(std::vector<infinity::ParsedExpr *> *&exprs);
     void AddExpr(infinity::ParsedExpr *expr);
     void Validate() const;
 

--- a/src/storage/wal/wal_manager_impl.cpp
+++ b/src/storage/wal/wal_manager_impl.cpp
@@ -258,6 +258,8 @@ void WalManager::NewFlush() {
             continue;
         }
 
+        LOG_TRACE(fmt::format("Attempt to write {} logs", txn_batch.size()));
+
         for (const auto &txn : txn_batch) {
             if (txn == nullptr) {
                 // terminate entry


### PR DESCRIPTION
### What problem does this PR solve?

* Added exception handling to the creation and setup of `SearchExpr` in `InfinityThriftService::Select`, returning a syntax error status to the response in case of failure.
* This pull request primarily refactors the handling of ownership and memory management for the `exprs` parameter in the `SearchExpr::SetExprs` method, improving code safety and consistency

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
