### PR TITLE
Fix: Update operation fails for MultiVector column with HNSW index

### DIFF
--- a/src/expression/cast_expression_impl.cpp
+++ b/src/expression/cast_expression_impl.cpp
@@ -167,8 +167,18 @@ bool CastExpression::CanCast(const DataType &source, const DataType &target) {
                     return false;
             }
         }
+        case LogicalType::kTensor: {
+            switch (target.type()) {
+                case LogicalType::kTensor:
+                case LogicalType::kMultiVector:
+                    return true;
+                default:
+                    return false;
+            }
+        }
         case LogicalType::kJson: {
             switch (target.type()) {
+                case LogicalType::kJson:
                 case LogicalType::kVarchar:
                     return true;
                 default:


### PR DESCRIPTION
Close #3305.


**Description:**
Using the update operation on a table with a MultiVector column that has an HNSW index causes a type cast error. The error occurs even when the data types appear to match.

**Error Message:**
[critical] Error: Invalid cast from Tensor(double,1024) to MultiVector(float,1024)
@src/expression/cast_expression_impl.cpp:179

**Steps to Reproduce:**
uv run python3 tools/run_restart_test.py --infinity_path=cmake-build-release/src/infinity --test_case=test_multiple_index_types_import.py --slow SLOW 2>&1 | tee /tmp/restart_test_output2.log
