### PR TITLE
Fix DocListFormat::Init bug

### DIFF
--- a/src/storage/invertedindex/format/doc_list_format_option.cppm
+++ b/src/storage/invertedindex/format/doc_list_format_option.cppm
@@ -161,9 +161,10 @@ private:
             offset += sizeof(u32);
         }
         if (option.HasDocPayload()) {
-            PostingField *doc_payload_value = new TypedPostingField<u16>;
+            TypedPostingField<u16> *doc_payload_value = new TypedPostingField<u16>;
             doc_payload_value->location_ = row_count++;
             doc_payload_value->offset_ = offset;
+            doc_payload_value->encoder_ = GetDocPayloadEncoder();
             values_.push_back(doc_payload_value);
         }
         if (skiplist_format_) {


### PR DESCRIPTION
Close #3321


**Description**
A null pointer dereference bug was discovered in the FullText index implementation when processing DocPayload fields. **The bug causes a crash during index building and querying operations with UBSAN mode.**

**Error Message**
`member call on null pointer of type 'infinity::IntEncoder<unsigned short, indexlib::NewPForDeltaCompressor>'`

**Reproduce**
uv run python3 tools/run_restart_test.py --infinity_path=cmake-build-debug/src/infinity --slow SLOW
