### PR TITLE
Fix: Double free bug when using 'Import'

### DIFF
--- a/src/storage/buffer/buffer_obj_impl.cpp
+++ b/src/storage/buffer/buffer_obj_impl.cpp
@@ -184,6 +184,14 @@ bool BufferObj::Free() {
     if (!locker.try_lock()) {
         return false; // when other thread is loading or cleaning, return false
     }
+    // Buffer already freed by GC, skip.
+    // This can happen when:
+    // 1. GC triggers due to memory pressure between Save() and Free() in Import operations
+    // 2. Import creates temporary buffers in TempDir, which are freed by GC
+    if (status_ == BufferStatus::kFreed) {
+        LOG_WARN(fmt::format("Buffer already freed by GC, file: {}", GetFilename()));
+        return true;
+    }
     if (status_ != BufferStatus::kUnloaded) {
         UnrecoverableError(fmt::format("attempt to free {} buffer object", BufferStatusToString(status_)));
     }


### PR DESCRIPTION
Close #3333

### Description

A race condition causes a critical error "attempt to free Freed buffer object" during CSV import operations when background garbage collection (GC) processes buffers before the import code explicitly frees them.

### Error Message

```
Txn ID: 1083, Text: compact table default_db.test_multi_index_types, Begin TS: 1237, Commit TS: 18446744073709551615, KV Commit TS: 18446744073709551615, State: Started

Txn ID: 1081, Text: COPY: default_db.test_multi_index_types FROM /home/infiniflow/runners_work/inf24-5478793f71f2/infinity/infinity/test/data/csv/enwiki_embedding_plus_9999.csv WITH CSV delimiter: 	, Begin TS: 1233, Commit TS: 18446744073709551615, KV Commit TS: 18446744073709551615, State: Started


[17:31:47.273] [2339751] [critical] Error: attempt to free Freed buffer object@src/storage/buffer/buffer_obj_impl.cpp:188
[17:31:47.443] [2340109] [info] SKIP cleanup. last_cleanup_ts: 1251, oldest_txn_begin_ts: 1233, last_checkpoint_ts: 1253
[17:31:47.443] [2340111] [info] Optimize all indexes begin ts: 1257
[17:31:48.390] [2339751] [critical]    0# infinity::PrintStacktrace@infinity_core(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /infinity/src/common/utility/exception_impl.cpp:47
   1# infinity::UnrecoverableError@infinity_core(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, unsigned int) at /infinity/src/common/utility/exception_impl.cpp:81
   2# infinity::BufferObj@infinity_core::Free() at /infinity/src/storage/buffer/buffer_obj_impl.cpp:188
   3# infinity::NewImportCtx@infinity_core::FinalizeAndWriteDataBlock() at /infinity/src/executor/operator/physical_import_impl.cpp:143
   4# infinity::PhysicalImport@infinity_core::NewImportCSV(infinity::QueryContext@infinity_core*, infinity::ImportOperatorState@infinity_core*) at /infinity/src/executor/operator/physical_import_impl.cpp:520
   5# infinity::PhysicalImport@infinity_core::Execute(infinity::QueryContext@infinity_core*, infinity::OperatorState@infinity_core*) at /infinity/src/executor/operator/physical_import_impl.cpp:221
   6# infinity::FragmentTask@infinity_core::OnExecute() at /infinity/src/scheduler/fragment_task_impl.cpp:84
   7# infinity::TaskScheduler@infinity_core::RunTask(infinity::FragmentTask@infinity_core*) at /infinity/src/scheduler/task_scheduler_impl.cpp:186
   8# infinity::TaskScheduler@infinity_core::Schedule(infinity::PlanFragment@infinity_core*, infinity::BaseStatement const*) at /infinity/src/scheduler/task_scheduler_impl.cpp:154
   9# infinity::QueryContext@infinity_core::QueryStatementInternal(infinity::BaseStatement const*) at /infinity/src/main/query_context_impl.cpp:258
  10# infinity::QueryContext@infinity_core::QueryStatement(infinity::BaseStatement const*) at /infinity/src/main/query_context_impl.cpp:116
  11# infinity::Infinity@infinity_core::Import(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, infinity::ImportOptions@infinity_core) at /infinity/src/main/infinity_impl.cpp:955
  12# infinity::InfinityThriftService@infinity_core::Import(infinity_thrift_rpc::CommonResponse&, infinity_thrift_rpc::ImportRequest const&) at /infinity/src/network/infinity_thrift_service_impl.cpp:411
  13# infinity_thrift_rpc::InfinityServiceProcessor::process_Import(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) at /infinity/src/network/infinity_thrift/InfinityService.cpp:11535
  14# infinity_thrift_rpc::InfinityServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, void*) at /infinity/src/network/infinity_thrift/InfinityService.cpp:11058
  15# apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*) at vcpkg_installed/x64-linux/include/thrift/TDispatchProcessor.h:121
  16# apache::thrift::server::TConnectedClient::run() at :0
  17# apache::thrift::concurrency::ThreadManager::Task::run() at :0
  18# apache::thrift::concurrency::ThreadManager::Worker::run() at :0
  19# apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>) at :0
  20# std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> > > >::_M_run() at :0
  21# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:104
  22#      at :0
  23#      at :0
  24# 
```

### How to Reproduce

1. Create a table with multiple indexes
2. Import a large CSV file (e.g., 10k+ rows with embedding columns)
3. While import is running, trigger an index optimization (e.g., manually run `optimize` command)
4. The import operation fails with the above error

uv run python3 tools/run_restart_test.py --test_case=test_multiple_indexes_types_import.py --infinity_path=./cmake-build-release/src/infinity --marker=slow

### Fix

Modified Free() in buffer_obj_impl.cpp to handle the case where buffer is already freed by GC:

```
if (status_ == BufferStatus::kFreed) {
    LOG_DEBUG(fmt::format("BufferObj::Free: buffer already freed by GC, file: {}", GetFilename()));
    return true; // already freed by GC, skip
}
```