### PR TITLE
Fix: "Resource busy" causing RecoverMemIndex alignment error

### DIFF
--- a/src/storage/catalog/meta/segment_meta.cppm
+++ b/src/storage/catalog/meta/segment_meta.cppm
@@ -89,6 +89,7 @@ public:
     std::tuple<size_t, Status> GetRowCnt1();
 
     Status GetFirstDeleteTS(TxnTimeStamp &first_delete_ts);
+    Status GetAndSetFirstDeleteTS(TxnTimeStamp &first_delete_ts);
 
     std::tuple<std::shared_ptr<SegmentInfo>, Status> GetSegmentInfo();
 

--- a/src/storage/catalog/meta/segment_meta.cppm
+++ b/src/storage/catalog/meta/segment_meta.cppm
@@ -89,7 +89,7 @@ public:
     std::tuple<size_t, Status> GetRowCnt1();
 
     Status GetFirstDeleteTS(TxnTimeStamp &first_delete_ts);
-    Status GetAndSetFirstDeleteTS(TxnTimeStamp &first_delete_ts);
+    Status CommitFirstDeleteTS(const TxnTimeStamp &first_delete_ts);
 
     std::tuple<std::shared_ptr<SegmentInfo>, Status> GetSegmentInfo();
 

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -279,10 +279,30 @@ Status SegmentMeta::GetFirstDeleteTS(TxnTimeStamp &first_delete_ts) {
             return status;
         }
     }
-    if (*first_delete_ts_ > begin_ts_) {
-        first_delete_ts = UNCOMMIT_TS;
-    }
+    // if (*first_delete_ts_ > begin_ts_) {
+    //     first_delete_ts = UNCOMMIT_TS;
+    // }
     first_delete_ts = *first_delete_ts_;
+    return Status::OK();
+}
+
+Status SegmentMeta::GetAndSetFirstDeleteTS(TxnTimeStamp &first_delete_ts) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (!first_delete_ts_) {
+        Status status = LoadFirstDeleteTS();
+        if (!status.ok()) {
+            return status;
+        }
+    }
+    if (*first_delete_ts_ == UNCOMMIT_TS) {
+        std::string first_delete_ts_key = GetSegmentTag("first_delete_ts");
+        std::string first_delete_ts_str = fmt::format("{}", first_delete_ts);
+        Status status = kv_instance_.Put(first_delete_ts_key, first_delete_ts_str);
+        if (!status.ok()) {
+            return status;
+        }
+        first_delete_ts_ = first_delete_ts;
+    }
     return Status::OK();
 }
 

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -301,7 +301,7 @@ Status SegmentMeta::CommitFirstDeleteTS(const TxnTimeStamp &commit_ts) {
         if (!status.ok()) {
             return status;
         }
-        first_delete_ts_ = first_delete_ts;
+        first_delete_ts_ = commit_ts;
     }
     return Status::OK();
 }

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -294,7 +294,7 @@ Status SegmentMeta::CommitFirstDeleteTS(const TxnTimeStamp &commit_ts) {
             return status;
         }
     }
-    if (*first_delete_ts_ == UNCOMMIT_TS) {
+    if (*first_delete_ts_ == UNCOMMIT_TS && commit_ts != UNCOMMIT_TS) {
         std::string first_delete_ts_key = GetSegmentTag("first_delete_ts");
         std::string first_delete_ts_str = fmt::format("{}", commit_ts);
         Status status = kv_instance_.Put(first_delete_ts_key, first_delete_ts_str);

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -286,7 +286,7 @@ Status SegmentMeta::GetFirstDeleteTS(TxnTimeStamp &first_delete_ts) {
     return Status::OK();
 }
 
-Status SegmentMeta::GetAndSetFirstDeleteTS(TxnTimeStamp &first_delete_ts) {
+Status SegmentMeta::CommitFirstDeleteTS(const TxnTimeStamp &commit_ts) {
     std::lock_guard<std::mutex> lock(mtx_);
     if (!first_delete_ts_) {
         Status status = LoadFirstDeleteTS();
@@ -296,7 +296,7 @@ Status SegmentMeta::GetAndSetFirstDeleteTS(TxnTimeStamp &first_delete_ts) {
     }
     if (*first_delete_ts_ == UNCOMMIT_TS) {
         std::string first_delete_ts_key = GetSegmentTag("first_delete_ts");
-        std::string first_delete_ts_str = fmt::format("{}", first_delete_ts);
+        std::string first_delete_ts_str = fmt::format("{}", commit_ts);
         Status status = kv_instance_.Put(first_delete_ts_key, first_delete_ts_str);
         if (!status.ok()) {
             return status;

--- a/src/storage/catalog/meta/segment_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_meta_impl.cpp
@@ -44,6 +44,7 @@ SegmentMeta::SegmentMeta(SegmentID segment_id, TableMeta &table_meta)
       segment_id_(segment_id) {}
 
 Status SegmentMeta::SetFirstDeleteTS(TxnTimeStamp first_delete_ts) {
+    std::lock_guard<std::mutex> lock(mtx_);
     std::string first_delete_ts_key = GetSegmentTag("first_delete_ts");
     std::string first_delete_ts_str = fmt::format("{}", first_delete_ts);
     Status status = kv_instance_.Put(first_delete_ts_key, first_delete_ts_str);

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -644,6 +644,7 @@ private:
     Status PrepareCommitImport(WalCmdImportV2 *import_cmd);
     Status PrepareCommitReplayImport(WalCmdImportV2 *import_cmd);
     Status CommitBottomAppend(WalCmdAppendV2 *append_cmd);
+    Status PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd);
     Status CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd);
     Status RollbackDelete(const DeleteTxnStore *delete_txn_store);
     Status PrepareCommitCompact(WalCmdCompactV2 *compact_cmd);

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -645,6 +645,7 @@ private:
     Status PrepareCommitReplayImport(WalCmdImportV2 *import_cmd);
     Status CommitBottomAppend(WalCmdAppendV2 *append_cmd);
     Status PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd);
+    Status CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd);
     Status RollbackDelete(const DeleteTxnStore *delete_txn_store);
     Status PrepareCommitCompact(WalCmdCompactV2 *compact_cmd);
     Status PrepareCommitDumpIndex(const WalCmdDumpIndexV2 *dump_index_cmd, KVInstance *kv_instance);

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -644,7 +644,6 @@ private:
     Status PrepareCommitImport(WalCmdImportV2 *import_cmd);
     Status PrepareCommitReplayImport(WalCmdImportV2 *import_cmd);
     Status CommitBottomAppend(WalCmdAppendV2 *append_cmd);
-    Status PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd);
     Status CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd);
     Status RollbackDelete(const DeleteTxnStore *delete_txn_store);
     Status PrepareCommitCompact(WalCmdCompactV2 *compact_cmd);
@@ -659,7 +658,6 @@ private:
     Status PrepareCommitRestoreTableSnapshot(const WalCmdRestoreTableSnapshot *restore_table_snapshot_cmd, bool is_link_files = false);
     Status PrepareCommitRestoreDatabaseSnapshot(const WalCmdRestoreDatabaseSnapshot *restore_database_snapshot_cmd);
     Status PrepareCommitRestoreSystemSnapshot(const WalCmdRestoreSystemSnapshot *restore_system_snapshot_cmd);
-    Status CommitBottomCreateTableSnapshot(WalCmdCreateTableSnapshot *create_table_snapshot_cmd);
     Status CheckpointforSnapshot(TxnTimeStamp last_ckp_ts, CheckpointTxnStore *txn_store, SnapshotType snapshot_type);
 
     Status AddSegmentVersion(WalSegmentInfo &segment_info, SegmentMeta &segment_meta);

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1847,7 +1847,7 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
             }
         }
 
-        Status status = segment_meta->GetAndSetFirstDeleteTS(commit_ts);
+        Status status = segment_meta->CommitFirstDeleteTS(commit_ts);
         if (!status.ok()) {
             return status;
         }

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -559,7 +559,7 @@ Status NewTxn::ReplayDelete(WalCmdDeleteV2 *delete_cmd, TxnTimeStamp commit_ts, 
                                                 table_meta->table_id_str()));
     }
 
-    return PrepareCommitDelete(delete_cmd);
+    return Status::OK();
 }
 
 Status NewTxn::DeleteInner(const std::string &db_name, const std::string &table_name, TableMeta &table_meta, const std::vector<RowID> &row_ids) {
@@ -1812,7 +1812,8 @@ Status NewTxn::CommitBottomAppend(WalCmdAppendV2 *append_cmd) {
     return Status::OK();
 }
 
-Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
+Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
+    TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     const std::string &db_id_str = delete_cmd->db_id_;
     const std::string &table_id_str = delete_cmd->table_id_;
     const std::string &table_name = delete_cmd->table_name_;
@@ -1845,35 +1846,17 @@ Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
                 return status;
             }
         }
-    }
-    return Status::OK();
-}
-
-Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
-    TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
-    const std::string &db_id_str = delete_cmd->db_id_;
-    const std::string &table_id_str = delete_cmd->table_id_;
-    const std::string &table_name = delete_cmd->table_name_;
-
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
-
-    std::optional<SegmentMeta> segment_meta;
-
-    NewTxnTableStore1 *txn_table_store = txn_store_.GetNewTxnTableStore1(db_id_str, table_id_str);
-    DeleteState &delete_state = txn_table_store->delete_state();
-    for (const auto &[segment_id, block_map] : delete_state.rows_) {
-        if (!segment_meta || segment_id != segment_meta->segment_id()) {
-            segment_meta.emplace(segment_id, table_meta);
-        }
-        TxnTimeStamp first_delete_ts = 0;
-        Status status = segment_meta->GetFirstDeleteTS(first_delete_ts);
-        if (!status.ok()) {
-            return status;
-        }
-        if (first_delete_ts == UNCOMMIT_TS) {
-            status = segment_meta->SetFirstDeleteTS(commit_ts);
+        {
+            TxnTimeStamp first_delete_ts = 0;
+            Status status = segment_meta->GetFirstDeleteTS(first_delete_ts);
             if (!status.ok()) {
                 return status;
+            }
+            if (first_delete_ts == UNCOMMIT_TS) {
+                status = segment_meta->SetFirstDeleteTS(commit_ts);
+                if (!status.ok()) {
+                    return status;
+                }
             }
         }
     }

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1866,6 +1866,8 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
         }
         Status status = segment_meta->CommitFirstDeleteTS(commit_ts);
         if (!status.ok()) {
+            // first_delete_ts is set-once; if another txn already wrote it after our snapshot,
+            // RocksDB returns "Resource busy" — this is expected and benign.
             LOG_WARN(fmt::format("NewTxn::CommitBottomDelete: {}", status.message()));
         }
     }

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -559,7 +559,7 @@ Status NewTxn::ReplayDelete(WalCmdDeleteV2 *delete_cmd, TxnTimeStamp commit_ts, 
                                                 table_meta->table_id_str()));
     }
 
-    return Status::OK();
+    return PrepareCommitDelete(delete_cmd);
 }
 
 Status NewTxn::DeleteInner(const std::string &db_name, const std::string &table_name, TableMeta &table_meta, const std::vector<RowID> &row_ids) {
@@ -1812,8 +1812,7 @@ Status NewTxn::CommitBottomAppend(WalCmdAppendV2 *append_cmd) {
     return Status::OK();
 }
 
-Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
-    TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
+Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
     const std::string &db_id_str = delete_cmd->db_id_;
     const std::string &table_id_str = delete_cmd->table_id_;
     const std::string &table_name = delete_cmd->table_name_;
@@ -1846,7 +1845,25 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
                 return status;
             }
         }
+    }
+    return Status::OK();
+}
 
+Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
+    TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
+    const std::string &db_id_str = delete_cmd->db_id_;
+    const std::string &table_id_str = delete_cmd->table_id_;
+    const std::string &table_name = delete_cmd->table_name_;
+    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+
+    std::optional<SegmentMeta> segment_meta;
+
+    NewTxnTableStore1 *txn_table_store = txn_store_.GetNewTxnTableStore1(db_id_str, table_id_str);
+    DeleteState &delete_state = txn_table_store->delete_state();
+    for (const auto &[segment_id, block_map] : delete_state.rows_) {
+        if (!segment_meta || segment_id != segment_meta->segment_id()) {
+            segment_meta.emplace(segment_id, table_meta);
+        }
         Status status = segment_meta->CommitFirstDeleteTS(commit_ts);
         if (!status.ok()) {
             return status;

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1861,7 +1861,6 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
 
     NewTxnTableStore1 *txn_table_store = txn_store_.GetNewTxnTableStore1(db_id_str, table_id_str);
     DeleteState &delete_state = txn_table_store->delete_state();
-    DeleteState &undo_delete_state = txn_table_store->undo_delete_state();
     for (const auto &[segment_id, block_map] : delete_state.rows_) {
         if (!segment_meta || segment_id != segment_meta->segment_id()) {
             segment_meta.emplace(segment_id, table_meta);

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1866,7 +1866,7 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
         }
         Status status = segment_meta->CommitFirstDeleteTS(commit_ts);
         if (!status.ok()) {
-            return status;
+            LOG_WARN(fmt::format("NewTxn::CommitBottomDelete: {}", status.message()));
         }
     }
     delete_state.rows_.clear();

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1813,7 +1813,6 @@ Status NewTxn::CommitBottomAppend(WalCmdAppendV2 *append_cmd) {
 }
 
 Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
-    TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     const std::string &db_id_str = delete_cmd->db_id_;
     const std::string &table_id_str = delete_cmd->table_id_;
     const std::string &table_name = delete_cmd->table_name_;

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1846,18 +1846,36 @@ Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
                 return status;
             }
         }
+    }
+    return Status::OK();
+}
 
-        {
-            TxnTimeStamp first_delete_ts = 0;
-            Status status = segment_meta->GetFirstDeleteTS(first_delete_ts);
+Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
+    TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
+    const std::string &db_id_str = delete_cmd->db_id_;
+    const std::string &table_id_str = delete_cmd->table_id_;
+    const std::string &table_name = delete_cmd->table_name_;
+
+    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+
+    std::optional<SegmentMeta> segment_meta;
+
+    NewTxnTableStore1 *txn_table_store = txn_store_.GetNewTxnTableStore1(db_id_str, table_id_str);
+    DeleteState &delete_state = txn_table_store->delete_state();
+    DeleteState &undo_delete_state = txn_table_store->undo_delete_state();
+    for (const auto &[segment_id, block_map] : delete_state.rows_) {
+        if (!segment_meta || segment_id != segment_meta->segment_id()) {
+            segment_meta.emplace(segment_id, table_meta);
+        }
+        TxnTimeStamp first_delete_ts = 0;
+        Status status = segment_meta->GetFirstDeleteTS(first_delete_ts);
+        if (!status.ok()) {
+            return status;
+        }
+        if (first_delete_ts == UNCOMMIT_TS) {
+            status = segment_meta->SetFirstDeleteTS(commit_ts);
             if (!status.ok()) {
                 return status;
-            }
-            if (first_delete_ts == UNCOMMIT_TS) {
-                status = segment_meta->SetFirstDeleteTS(commit_ts);
-                if (!status.ok()) {
-                    return status;
-                }
             }
         }
     }

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1856,18 +1856,21 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
     const std::string &table_name = delete_cmd->table_name_;
     TableMeta table_meta(db_id_str, table_id_str, table_name, this);
 
-    std::optional<SegmentMeta> segment_meta;
-
     NewTxnTableStore1 *txn_table_store = txn_store_.GetNewTxnTableStore1(db_id_str, table_id_str);
     DeleteState &delete_state = txn_table_store->delete_state();
-    for (const auto &[segment_id, block_map] : delete_state.rows_) {
-        if (!segment_meta || segment_id != segment_meta->segment_id()) {
-            segment_meta.emplace(segment_id, table_meta);
-        }
-        Status status = segment_meta->CommitFirstDeleteTS(commit_ts);
+
+    std::set<SegmentID> segment_ids;
+    for (const auto &[segment_id, _] : delete_state.rows_) {
+        segment_ids.insert(segment_id);
+    }
+    for (const SegmentID &segment_id : segment_ids) {
+        SegmentMeta segment_meta(segment_id, table_meta);
+        Status status = segment_meta.CommitFirstDeleteTS(commit_ts);
         if (!status.ok()) {
-            // first_delete_ts is set-once; if another txn already wrote it after our snapshot,
-            // RocksDB returns "Resource busy" — this is expected and benign.
+            // Our RocksDB snapshot is frozen at BeginTxn time. If another txn has already
+            // committed first_delete_ts for this segment after our snapshot, RocksDB detects
+            // a write-write conflict and returns "Resource busy". Since first_delete_ts only
+            // needs to be set once (by whichever txn commits first), this error is benign.
             LOG_WARN(fmt::format("NewTxn::CommitBottomDelete: {}", status.message()));
         }
     }

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1846,18 +1846,10 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
                 return status;
             }
         }
-        {
-            TxnTimeStamp first_delete_ts = 0;
-            Status status = segment_meta->GetFirstDeleteTS(first_delete_ts);
-            if (!status.ok()) {
-                return status;
-            }
-            if (first_delete_ts == UNCOMMIT_TS) {
-                status = segment_meta->SetFirstDeleteTS(commit_ts);
-                if (!status.ok()) {
-                    return status;
-                }
-            }
+
+        Status status = segment_meta->GetAndSetFirstDeleteTS(commit_ts);
+        if (!status.ok()) {
+            return status;
         }
     }
     delete_state.rows_.clear();

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -4584,6 +4584,14 @@ void NewTxn::CommitBottom() {
                 }
                 break;
             }
+            case WalCommandType::DELETE_V2: {
+                auto *delete_cmd = static_cast<WalCmdDeleteV2 *>(command.get());
+                auto status = CommitBottomAppend(delete_cmd);
+                if (!status.ok()) {
+                    UnrecoverableError(fmt::format("CommitBottomDelete failed: {}", status.message()));
+                }
+                break;
+            }
             default: {
                 break;
             }

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -4586,7 +4586,7 @@ void NewTxn::CommitBottom() {
             }
             case WalCommandType::DELETE_V2: {
                 auto *delete_cmd = static_cast<WalCmdDeleteV2 *>(command.get());
-                auto status = CommitBottomAppend(delete_cmd);
+                auto status = CommitBottomDelete(delete_cmd);
                 if (!status.ok()) {
                     UnrecoverableError(fmt::format("CommitBottomDelete failed: {}", status.message()));
                 }

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -2301,16 +2301,6 @@ Status NewTxn::PrepareCommit() {
                 break;
             }
             case WalCommandType::DELETE_V2: {
-                if (IsReplay()) {
-                    // Skip replay of DROP_INDEX_V2 command.
-                    break;
-                }
-                auto *delete_cmd = static_cast<WalCmdDeleteV2 *>(command.get());
-
-                Status status = PrepareCommitDelete(delete_cmd);
-                if (!status.ok()) {
-                    return status;
-                }
                 break;
             }
             case WalCommandType::IMPORT_V2: {

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -2301,6 +2301,14 @@ Status NewTxn::PrepareCommit() {
                 break;
             }
             case WalCommandType::DELETE_V2: {
+                if (IsReplay()) {
+                    break;
+                }
+                auto *delete_cmd = static_cast<WalCmdDeleteV2 *>(command.get());
+                Status status = PrepareCommitDelete(delete_cmd);
+                if (!status.ok()) {
+                    return status;
+                }
                 break;
             }
             case WalCommandType::IMPORT_V2: {

--- a/src/unit_test/storage/new_catalog/kv_store_ut.cpp
+++ b/src/unit_test/storage/new_catalog/kv_store_ut.cpp
@@ -513,3 +513,62 @@ TEST_F(TestTxnKVStoreTest, wal) {
     status = kv_store->Destroy(rocksdb_tmp_path);
     EXPECT_TRUE(status.ok());
 }
+
+TEST_F(TestTxnKVStoreTest, txn_conflict_same_key_snapshot_isolation) {
+    using namespace infinity;
+    const auto rocksdb_tmp_path = fmt::format("{}/rocksdb_snapshot_isolation", GetFullTmpDir());
+
+    std::unique_ptr<KVStore> kv_store = std::make_unique<KVStore>();
+    Status status = kv_store->Init(rocksdb_tmp_path);
+    EXPECT_TRUE(status.ok());
+
+    const std::string key = "seg|2|0|0|first_delete_ts";
+
+    // Step 1: Create TX_A (simulates update txn), snapshot = T0
+    std::unique_ptr<KVInstance> tx_a = kv_store->GetInstance();
+
+    // Step 2: Create TX_B (simulates delete txn), snapshot = T0
+    std::unique_ptr<KVInstance> tx_b = kv_store->GetInstance();
+
+    // Step 3: TX_A reads the key from snapshot T0 → not found (expected, key doesn't exist yet)
+    std::string value;
+    status = tx_a->Get(key, value);
+    EXPECT_FALSE(status.ok()); // key doesn't exist in T0 snapshot
+
+    // Step 4: TX_B writes the key and commits first
+    status = tx_b->Put(key, "14");
+    EXPECT_TRUE(status.ok());
+    status = tx_b->Commit();
+    EXPECT_TRUE(status.ok());
+
+    // Now RocksDB has: seg|2|0|0|first_delete_ts = 14
+    // But TX_A's snapshot is still T0!
+
+    // Step 5: TX_A reads from its stale snapshot → still not found
+    value.clear();
+    status = tx_a->Get(key, value);
+    EXPECT_FALSE(status.ok());
+
+    // Step 6: TX_A tries to write the same key → "Resource busy"!
+    status = tx_a->Put(key, "16");
+    EXPECT_FALSE(status.ok()); // Resource busy!
+    std::cout << "Snapshot isolation conflict: " << status.message() << std::endl;
+
+    // Step 7: TX_A can still commit (the failed Put is just skipped)
+    status = tx_a->Commit();
+    EXPECT_TRUE(status.ok());
+
+    // Step 8: Verify — only TX_B's write persists (TX_A's Put was rejected)
+    {
+        std::unique_ptr<KVInstance> tx_verify = kv_store->GetInstance();
+        status = tx_verify->Get(key, value);
+        EXPECT_TRUE(status.ok());
+        EXPECT_EQ(value, "14"); // TX_B's value, not TX_A's "16"
+        tx_verify->Commit();
+    }
+
+    status = kv_store->Uninit();
+    EXPECT_TRUE(status.ok());
+    status = kv_store->Destroy(rocksdb_tmp_path);
+    EXPECT_TRUE(status.ok());
+}

--- a/src/unit_test/storage/new_catalog/update_ut.cpp
+++ b/src/unit_test/storage/new_catalog/update_ut.cpp
@@ -1913,11 +1913,7 @@ TEST_P(TestTxnUpdate, test_update_and_delete_no_conflicts) {
         EXPECT_TRUE(status.ok());
 
         status = setup.new_txn_mgr->CommitTxn(txn4);
-        EXPECT_FALSE(status.ok());
-        // false due to delete conflict
-
-        // Verify that both operations succeeded
-        // setup.check_data_no_conflicts();
+        EXPECT_TRUE(status.ok());
 
         DropDatabase(setup);
     }


### PR DESCRIPTION
Closes #3341

---

## Diagram 1: Why "Resource busy" happens

Each txn creates a RocksDB transaction with a frozen snapshot at `BeginTxn` time. The snapshot is never refreshed.

```mermaid
sequenceDiagram
    participant A as Update TX
    participant R as RocksDB
    participant B as Delete TX

    Note right of R: Both get snapshot T0
    A->>R: BeginTxn (snapshot T0)
    B->>R: BeginTxn (snapshot T0)

    Note right of R: TX_B commits first
    B->>R: Put(first_delete_ts=14)
    R-->>B: OK
    B->>R: Commit

    Note right of R: TX_A tries same key
    A->>R: Get(first_delete_ts)
    R-->>A: NOT FOUND (stale snapshot)
    A->>R: Put(first_delete_ts=16)
    R-->>A: Resource busy!
```

---

## Diagram 2: How the bug causes alignment error

There are **two problems** with the old approach:

1. **`first_delete_ts` can be incorrect**: It was set in `PrepareCommitDelete` (top half, concurrent). When multiple txns delete from the same segment concurrently, the value depends on who runs first — but the top half is not serialized, so the result can be incorrect.

2. **"Resource busy" causes rollback, leaving gaps in append ranges**: When `SetFirstDeleteTS` fails with "Resource busy", the error is returned directly from `PrepareCommitDelete`. This triggers a txn rollback, but append rows were already allocated before `PrepareCommit`. The rollback leaves gaps in append ranges. Most index types do not handle these gaps, leading to the alignment error on restart.

### Before (broken)

```mermaid
flowchart TD
    A[Update TX: allocate append rows] --> B[PrepareCommitDelete]
    B --> C[SetFirstDeleteTS: Resource busy]
    C --> D[Error returned -> txn ROLLBACK]
    D --> E[Append rows rolled back but GAP left]
    E --> F[Most indexes cannot handle the gap]
    F --> G[Restart: RecoverMemIndex]
    G --> H[Alignment error]

    style C fill:#f66,color:#fff
    style D fill:#f66,color:#fff
    style H fill:#f66,color:#fff
```

### After (fixed)

```mermaid
flowchart TD
    A[Update TX: allocate append rows] --> B[CommitBottomDelete - serialized]
    B --> C[CommitFirstDeleteTS: Resource busy]
    C --> D[LOG_WARN - benign continue]
    D --> E[Append rows committed no gap]
    E --> F[Restart: RecoverMemIndex]
    F --> G[No error]

    style C fill:#f90,color:#fff
    style E fill:#4a4,color:#fff
    style G fill:#4a4,color:#fff
```