### PR TITLE
[Draft] Fix issue 3341: Chunk index row alignment error by modifying checkconflict

### DIFF
--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -4133,6 +4133,10 @@ bool NewTxn::CheckConflictTxnStore(const DumpMemIndexTxnStore &txn_store, NewTxn
 bool NewTxn::CheckConflictTxnStore(const DeleteTxnStore &txn_store, NewTxn *previous_txn, std::string &cause, bool &retry_query) {
     const std::string &db_name = txn_store.db_name_;
     const std::string &table_name = txn_store.table_name_;
+    std::set<SegmentID> segment_ids;
+    for (const auto &row_id : txn_store.row_ids_) {
+        segment_ids.insert(row_id.segment_id_);
+    }
     bool conflict = false;
     switch (previous_txn->base_txn_store_->type_) {
         case TransactionType::kCompact: {
@@ -4144,24 +4148,23 @@ bool NewTxn::CheckConflictTxnStore(const DeleteTxnStore &txn_store, NewTxn *prev
         }
         case TransactionType::kDelete: {
             DeleteTxnStore *delete_txn_store = static_cast<DeleteTxnStore *>(previous_txn->base_txn_store_.get());
-            if (delete_txn_store->db_name_ == db_name && delete_txn_store->table_name_ == table_name &&
-                std::find_first_of(txn_store.row_ids_.begin(),
-                                   txn_store.row_ids_.end(),
-                                   delete_txn_store->row_ids_.begin(),
-                                   delete_txn_store->row_ids_.end()) != txn_store.row_ids_.end()) {
-                conflict = true;
+            if (delete_txn_store->db_name_ == db_name && delete_txn_store->table_name_ == table_name) {
+                conflict = std::any_of(segment_ids.begin(), segment_ids.end(), [&](SegmentID segment_id) {
+                    return std::any_of(delete_txn_store->row_ids_.begin(), delete_txn_store->row_ids_.end(), [segment_id](const RowID &row_id) {
+                        return row_id.segment_id_ == segment_id;
+                    });
+                });
             }
             break;
         }
         case TransactionType::kUpdate: {
             UpdateTxnStore *update_txn_store = static_cast<UpdateTxnStore *>(previous_txn->base_txn_store_.get());
-            if (update_txn_store->db_name_ == db_name && update_txn_store->table_name_ == table_name &&
-                std::find_first_of(txn_store.row_ids_.begin(),
-                                   txn_store.row_ids_.end(),
-                                   update_txn_store->row_ids_.begin(),
-                                   update_txn_store->row_ids_.end()) != txn_store.row_ids_.end()) {
-
-                conflict = true;
+            if (update_txn_store->db_name_ == db_name && update_txn_store->table_name_ == table_name) {
+                conflict = std::any_of(segment_ids.begin(), segment_ids.end(), [&](SegmentID segment_id) {
+                    return std::any_of(update_txn_store->row_ids_.begin(), update_txn_store->row_ids_.end(), [segment_id](const RowID &row_id) {
+                        return row_id.segment_id_ == segment_id;
+                    });
+                });
             }
             break;
         }
@@ -4322,12 +4325,12 @@ bool NewTxn::CheckConflictTxnStore(const UpdateTxnStore &txn_store, NewTxn *prev
         }
         case TransactionType::kDelete: {
             auto *delete_txn_store = static_cast<DeleteTxnStore *>(previous_txn->base_txn_store_.get());
-            if (delete_txn_store->db_name_ == db_name && delete_txn_store->table_name_ == table_name &&
-                std::find_first_of(txn_store.row_ids_.begin(),
-                                   txn_store.row_ids_.end(),
-                                   delete_txn_store->row_ids_.begin(),
-                                   delete_txn_store->row_ids_.end()) != txn_store.row_ids_.end()) {
-                conflict = true;
+            if (delete_txn_store->db_name_ == db_name && delete_txn_store->table_name_ == table_name) {
+                conflict = std::any_of(segment_ids.begin(), segment_ids.end(), [&](SegmentID segment_id) {
+                    return std::any_of(delete_txn_store->row_ids_.begin(), delete_txn_store->row_ids_.end(), [segment_id](const RowID &row_id) {
+                        return row_id.segment_id_ == segment_id;
+                    });
+                });
             }
             break;
         }


### PR DESCRIPTION
Close #3341 

### Description

```
[19:12:20.181] [1704279] [critical]
[19:12:20.181] [1704279] [critical] Error: Chunk index row alignment error: Expected 12.3008192 but got 12.3008194@src/storage/new_txn/new_txn_index_impl.cpp:2663
[19:12:20.380] [1704279] [critical]    0# infinity::PrintStacktrace@infinity_core(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /home/weilongma/zpf/infinity/src/common/utility/exception_impl.cpp:47
   1# infinity::UnrecoverableError@infinity_core(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, unsigned int) at /home/weilongma/zpf/infinity/src/common/utility/exception_impl.cpp:81
   2# infinity::NewTxn@infinity_core::CountMemIndexGapInSegment(infinity::SegmentIndexMeta@infinity_core&, infinity::SegmentMeta@infinity_core&, std::vector<std::pair<infinity::RowID, unsigned long>, std::allocator<std::pair<infinity::RowID, unsigned long> > >&) at /home/weilongma/zpf/infinity/src/storage/new_txn/new_txn_index_impl.cpp:2663
   3# infinity::NewTxn@infinity_core::RecoverMemIndex(infinity::TableIndexMeta@infinity_core&) at /home/weilongma/zpf/infinity/src/storage/new_txn/new_txn_index_impl.cpp:2740
   4# infinity::NewCatalog@infinity_core::MemIndexRecover(infinity::NewTxn@infinity_core*)::$_0::operator()(infinity::TableMeta@infinity_core&) const at /home/weilongma/zpf/infinity/src/storage/catalog/new_catalog_static_impl.cpp:303
   5# infinity::Storage@infinity_core::RecoverMemIndex() at /home/weilongma/zpf/infinity/src/storage/storage_impl.cpp:883
   6# infinity::Storage@infinity_core::AdminToWriter() at /home/weilongma/zpf/infinity/src/storage/storage_impl.cpp:343
   7# infinity::Storage@infinity_core::SetStorageMode(infinity::StorageMode@infinity_core) at /home/weilongma/zpf/infinity/src/storage/storage_impl.cpp:764
   8# infinity::InfinityContext@infinity_core::ChangeServerRole(infinity::NodeRole, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned short) at /home/weilongma/zpf/infinity/src/main/infinity_context_impl.cpp:132
   9# infinity::InfinityContext@infinity_core::InitPhase2(bool) at /home/weilongma/zpf/infinity/src/main/infinity_context_impl.cpp:90
```

### Reproduce
1. Set test_multiple_index_types_import.py:
pytest.param("test/data/config/restart_test/test_insert/5.toml", MultiIndexTypesGenerator, 10, 600, 1800, marks=pytest.mark.slow)

2. uv run python3 tools/run_restart.py --infinity_path=./cmake-build-release/src/infinity --test_case=test_multiple_index_types_import.py --marker=slow | tee /tmp/test0326.log