### PR TITLE
Implement JSON Index and 3-arg json_contains

### DIFF
--- a/src/bin/infinity_core.cppm
+++ b/src/bin/infinity_core.cppm
@@ -437,6 +437,7 @@ export import :random;
 export import :defer_op;
 export import :simd_init;
 export import :hnsw_simd_func;
+export import :json_flattener;
 export import :search_top_k_sgemm;
 export import :simd_common_tools;
 export import :simd_functions;

--- a/src/function/scalar/extract_json_impl.cpp
+++ b/src/function/scalar/extract_json_impl.cpp
@@ -148,6 +148,10 @@ void JsonContainsPath(const DataBlock &input, std::shared_ptr<ColumnVector> &out
             const auto json_info = json_column_data[row_index];
             auto json_data = json_column->buffer_->GetVarchar(json_info.file_offset_, json_info.length_);
             auto json = JsonManager::from_bson(reinterpret_cast<const uint8_t *>(json_data), json_info.length_);
+            if (!json) {
+                output->AppendValue(Value::MakeBool(false));
+                continue;
+            }
             auto [success, flag] = JsonManager::json_contains_path(*json, path_tokens, token);
             Value v = Value::MakeBool(flag);
             output->AppendValue(v);

--- a/src/function/scalar/extract_json_impl.cpp
+++ b/src/function/scalar/extract_json_impl.cpp
@@ -121,6 +121,43 @@ void JsonContains(const DataBlock &input, std::shared_ptr<ColumnVector> &output)
     }
 }
 
+void JsonContainsPath(const DataBlock &input, std::shared_ptr<ColumnVector> &output) {
+    if (input.column_count() != 3) {
+        RecoverableError(Status::SyntaxError("JsonContainsPath: Invalid column size."));
+    }
+
+    const auto &json_column = input.column_vectors_[0];
+    const auto &path_column = input.column_vectors_[1];
+    const auto &token_column = input.column_vectors_[2];
+
+    auto path_varchar = path_column->GetVarchar(0);
+    auto path_str = std::string(path_varchar.data(), path_varchar.size());
+    auto [is_valid, path_tokens] = JsonManager::get_json_tokens(path_varchar);
+    if (!is_valid) {
+        RecoverableError(Status::SyntaxError("JsonContainsPath: Invalid json path."));
+    }
+
+    auto token_varchar = token_column->GetVarchar(0);
+    auto token = std::string(token_varchar.data(), token_varchar.size());
+
+    auto json_column_data = reinterpret_cast<const JsonT *>(json_column->data());
+    auto row_count = input.row_count();
+
+    if (json_column->vector_type() == ColumnVectorType::kFlat) {
+        for (size_t row_index = 0; row_index < row_count; row_index++) {
+            const auto json_info = json_column_data[row_index];
+            auto json_data = json_column->buffer_->GetVarchar(json_info.file_offset_, json_info.length_);
+            auto json = JsonManager::from_bson(reinterpret_cast<const uint8_t *>(json_data), json_info.length_);
+            auto [success, flag] = JsonManager::json_contains_path(*json, path_tokens, token);
+            Value v = Value::MakeBool(flag);
+            output->AppendValue(v);
+        }
+        output->Finalize(row_count);
+    } else {
+        RecoverableError(Status::SyntaxError("JsonContainsPath: Invalid column type."));
+    }
+}
+
 void RegisterJsonFunction(NewCatalog *catalog_ptr) {
     {
         std::string func_name = "json_extract";
@@ -195,11 +232,21 @@ void RegisterJsonFunction(NewCatalog *catalog_ptr) {
     {
         std::string func_name = "json_contains";
         std::shared_ptr<ScalarFunctionSet> function_set_ptr = std::make_shared<ScalarFunctionSet>(func_name);
-        ScalarFunction json_function(func_name,
-                                     {DataType(LogicalType::kJson), DataType(LogicalType::kVarchar)},
-                                     DataType(LogicalType::kBoolean),
-                                     JsonContains);
-        function_set_ptr->AddFunction(json_function);
+
+        // json_contains with 2 arguments: json_contains(json, token)
+        ScalarFunction json_contains_2arg(func_name,
+                                          {DataType(LogicalType::kJson), DataType(LogicalType::kVarchar)},
+                                          DataType(LogicalType::kBoolean),
+                                          JsonContains);
+        function_set_ptr->AddFunction(json_contains_2arg);
+
+        // json_contains with 3 arguments: json_contains(json, path, token)
+        ScalarFunction json_contains_3arg(func_name,
+                                          {DataType(LogicalType::kJson), DataType(LogicalType::kVarchar), DataType(LogicalType::kVarchar)},
+                                          DataType(LogicalType::kBoolean),
+                                          JsonContainsPath);
+        function_set_ptr->AddFunction(json_contains_3arg);
+
         NewCatalog::AddFunctionSet(catalog_ptr, function_set_ptr);
     }
 }

--- a/src/network/connection_impl.cpp
+++ b/src/network/connection_impl.cpp
@@ -160,7 +160,9 @@ void Connection::HandlerSimpleQuery(QueryContext *query_context) {
     // Response to the result message to client
     if (result.result_table_.get() == nullptr) {
         std::unordered_map<PGMessageType, std::string> error_message_map;
-        error_message_map[PGMessageType::kHumanReadableError] = result.status_.message();
+        const char *err_msg = result.status_.message();
+        std::string err_str = err_msg ? err_msg : "Unknown error";
+        error_message_map[PGMessageType::kHumanReadableError] = err_str;
         pg_handler_->send_error_response(error_message_map);
     } else {
         // Have result

--- a/src/parser/type/complex/json_term.cppm
+++ b/src/parser/type/complex/json_term.cppm
@@ -1,0 +1,11 @@
+module;
+
+#include "json_term.h"
+
+export module json_term;
+
+namespace infinity {
+
+export using infinity::JsonTermT;
+
+} // namespace infinity

--- a/src/parser/type/complex/json_term.h
+++ b/src/parser/type/complex/json_term.h
@@ -1,0 +1,127 @@
+// Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+// JsonTermT represents a flattened JSON term used for JSON index.
+// Term format: {path}:{type_tag}:{encoded_value}
+// The string is kept ordered (dictionary order = value order).
+// Uses fixed-size storage for trivially copyable serialization.
+
+constexpr size_t JSON_TERM_MAX_LENGTH = 512;
+
+namespace infinity {
+
+struct JsonTermT {
+    uint32_t length_{0};
+    char data_[JSON_TERM_MAX_LENGTH]{};
+
+    JsonTermT() = default;
+
+    explicit JsonTermT(const std::string &term) { Assign(term.data(), term.size()); }
+
+    bool operator==(const JsonTermT &other) const {
+        const auto this_len = std::min<size_t>(length_, JSON_TERM_MAX_LENGTH);
+        const auto other_len = std::min<size_t>(other.length_, JSON_TERM_MAX_LENGTH);
+        if (this_len != other_len)
+            return false;
+        return std::memcmp(data_, other.data_, this_len) == 0;
+    }
+
+    auto operator<=>(const JsonTermT &other) const {
+        // Defensive: ensure valid lengths
+        auto this_len = std::min<size_t>(length_, JSON_TERM_MAX_LENGTH);
+        auto other_len = std::min<size_t>(other.length_, JSON_TERM_MAX_LENGTH);
+        auto cmp = std::memcmp(data_, other.data_, std::min(this_len, other_len));
+        if (cmp != 0)
+            return cmp < 0 ? std::strong_ordering::less : std::strong_ordering::greater;
+        return this_len <=> other_len;
+    }
+
+    std::string ToString() const { return std::string(data_, std::min<size_t>(length_, JSON_TERM_MAX_LENGTH)); }
+
+    void Reset() { length_ = 0; }
+
+    void Append(const char *src, size_t len) {
+        const auto current_len = std::min<size_t>(length_, JSON_TERM_MAX_LENGTH);
+        if (current_len + len > JSON_TERM_MAX_LENGTH) {
+            throw std::length_error("JsonTermT overflow: JSON index term exceeds JSON_TERM_MAX_LENGTH");
+        }
+        std::memcpy(data_ + current_len, src, len);
+        length_ = static_cast<uint32_t>(current_len + len);
+    }
+
+    // Return a "max" term that sorts after all valid terms
+    static JsonTermT Max() {
+        JsonTermT result;
+        result.length_ = JSON_TERM_MAX_LENGTH;
+        memset(result.data_, 0xFF, JSON_TERM_MAX_LENGTH);
+        return result;
+    }
+
+    // Return a "min" term that sorts before all valid terms
+    static JsonTermT Min() {
+        JsonTermT result;
+        result.length_ = 0;
+        memset(result.data_, 0, JSON_TERM_MAX_LENGTH);
+        return result;
+    }
+
+private:
+    void Assign(const char *src, size_t len) {
+        if (len > JSON_TERM_MAX_LENGTH) {
+            throw std::length_error("JsonTermT overflow: JSON index term exceeds JSON_TERM_MAX_LENGTH");
+        }
+        std::memcpy(data_, src, len);
+        length_ = static_cast<uint32_t>(len);
+    }
+};
+
+} // namespace infinity
+
+// Specialize std::numeric_limits for JsonTermT
+namespace std {
+
+template <>
+struct numeric_limits<infinity::JsonTermT> {
+    static constexpr bool is_specialized = true;
+
+    static infinity::JsonTermT min() { return infinity::JsonTermT::Min(); }
+
+    static infinity::JsonTermT max() { return infinity::JsonTermT::Max(); }
+
+    static infinity::JsonTermT lowest() { return min(); }
+
+    static constexpr int digits = 0;
+    static constexpr int digits10 = 0;
+    static constexpr bool is_signed = false;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = false;
+};
+
+} // namespace std

--- a/src/parser/type/data_type.h
+++ b/src/parser/type/data_type.h
@@ -112,6 +112,7 @@ public:
             case LogicalType::kDateTime:  // need to be converted to int64 and keep order
             case LogicalType::kTimestamp: // need to be converted to int64 and keep order
             case LogicalType::kVarchar:   // need to be converted to int64 by hash
+            case LogicalType::kJson:      // JSON index uses JsonTermT with LowCardinality
             {
                 return true;
             }

--- a/src/planner/logical_planner_impl.cpp
+++ b/src/planner/logical_planner_impl.cpp
@@ -864,7 +864,8 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, std::s
             break;
         }
         case IndexType::kSecondary: {
-            assert(index_info->index_param_list_ != nullptr);
+            std::vector<InitParameter *> param_list;
+            bool added_cardinality_param = false;
 
             // Check if column is JSON type
             auto &column_names_vec = *(base_table_ref->column_names_);
@@ -872,8 +873,9 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, std::s
             size_t column_id = std::find(column_names_vec.begin(), column_names_vec.end(), index_info->column_name_) - column_names_vec.begin();
             bool is_json_column = (column_id < column_types_vec.size()) && (column_types_vec[column_id]->type() == LogicalType::kJson);
 
-            std::vector<InitParameter *> param_list = *(index_info->index_param_list_);
-            bool added_cardinality_param = false;
+            if (index_info->index_param_list_ != nullptr) {
+                param_list = *(index_info->index_param_list_);
+            }
             if (is_json_column) {
                 // Check if user explicitly specified cardinality=high for JSON column
                 for (const auto *param : param_list) {

--- a/src/planner/logical_planner_impl.cpp
+++ b/src/planner/logical_planner_impl.cpp
@@ -866,6 +866,7 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, std::s
         case IndexType::kSecondary: {
             std::vector<InitParameter *> param_list;
             bool added_cardinality_param = false;
+            std::unique_ptr<InitParameter> injected_cardinality_param;
 
             // Check if column is JSON type
             auto &column_names_vec = *(base_table_ref->column_names_);
@@ -899,8 +900,8 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, std::s
                     }
                 }
                 if (!has_cardinality) {
-                    auto *cardinality_param = new InitParameter("cardinality", "low");
-                    param_list.push_back(cardinality_param);
+                    injected_cardinality_param = std::make_unique<InitParameter>("cardinality", "low");
+                    param_list.push_back(injected_cardinality_param.get());
                     added_cardinality_param = true;
                 }
             }
@@ -914,9 +915,8 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, std::s
                                                 secondary_index->GetSecondaryIndexCardinality(),
                                                 is_json_column); // may throw exception
 
-            // Clean up only the added parameter
             if (added_cardinality_param) {
-                delete param_list.back();
+                param_list.pop_back();
             }
             break;
         }

--- a/src/planner/logical_planner_impl.cpp
+++ b/src/planner/logical_planner_impl.cpp
@@ -864,11 +864,58 @@ Status LogicalPlanner::BuildCreateIndex(const CreateStatement *statement, std::s
             break;
         }
         case IndexType::kSecondary: {
-            IndexSecondary::ValidateColumnDataType(base_table_ref,
-                                                   index_info->column_name_,
-                                                   index_info->secondary_index_cardinality_); // may throw exception
-            base_index_ptr =
-                IndexSecondary::Make(index_name, index_comment, index_filename, {index_info->column_name_}, index_info->secondary_index_cardinality_);
+            assert(index_info->index_param_list_ != nullptr);
+
+            // Check if column is JSON type
+            auto &column_names_vec = *(base_table_ref->column_names_);
+            auto &column_types_vec = *(base_table_ref->column_types_);
+            size_t column_id = std::find(column_names_vec.begin(), column_names_vec.end(), index_info->column_name_) - column_names_vec.begin();
+            bool is_json_column = (column_id < column_types_vec.size()) && (column_types_vec[column_id]->type() == LogicalType::kJson);
+
+            std::vector<InitParameter *> param_list = *(index_info->index_param_list_);
+            bool added_cardinality_param = false;
+            if (is_json_column) {
+                // Check if user explicitly specified cardinality=high for JSON column
+                for (const auto *param : param_list) {
+                    std::string param_name = param->param_name_;
+                    std::string param_value = param->param_value_;
+                    ToLower(param_name);
+                    ToLower(param_value);
+                    if (param_name == "cardinality" && param_value == "high") {
+                        RecoverableError(Status::InvalidIndexDefinition(
+                            fmt::format("cardinality is always low for JSON column. Column: {}", index_info->column_name_)));
+                    }
+                }
+                // Auto add cardinality=low for JSON columns if not specified
+                bool has_cardinality = false;
+                for (const auto *param : param_list) {
+                    std::string param_name = param->param_name_;
+                    ToLower(param_name);
+                    if (param_name == "cardinality") {
+                        has_cardinality = true;
+                        break;
+                    }
+                }
+                if (!has_cardinality) {
+                    auto *cardinality_param = new InitParameter("cardinality", "low");
+                    param_list.push_back(cardinality_param);
+                    added_cardinality_param = true;
+                }
+            }
+
+            base_index_ptr = IndexSecondary::Make(index_name, index_comment, index_filename, {index_info->column_name_}, param_list, is_json_column);
+
+            // Validate column type and cardinality
+            auto *secondary_index = static_cast<IndexSecondary *>(base_index_ptr.get());
+            IndexSecondary::ValidateIndexColumn(base_table_ref,
+                                                index_info->column_name_,
+                                                secondary_index->GetSecondaryIndexCardinality(),
+                                                is_json_column); // may throw exception
+
+            // Clean up only the added parameter
+            if (added_cardinality_param) {
+                delete param_list.back();
+            }
             break;
         }
         case IndexType::kSecondaryFunctional: {

--- a/src/planner/optimizer/index_scan/filter_expression_push_down_helper.cppm
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_helper.cppm
@@ -19,6 +19,7 @@ import :value;
 import :table_meta;
 
 import internal_types;
+import json_term;
 
 namespace infinity {
 
@@ -30,6 +31,13 @@ public:
 
     static std::tuple<ColumnID, Value, std::shared_ptr<BaseExpression>, FilterCompareType>
     UnwindCast(const std::shared_ptr<BaseExpression> &cast_expr, Value &&right_val, FilterCompareType compare_type, TableMeta *table_meta);
+
+    // JSON term helpers
+    static std::string EncodeJsonInteger(int64_t value);
+
+    static std::string EncodeJsonDouble(double value);
+
+    static JsonTermT BuildJsonTerm(const std::string &func_name, const std::string &path, const Value &value, FilterCompareType &compare_type);
 };
 
 } // namespace infinity

--- a/src/planner/optimizer/index_scan/filter_expression_push_down_helper_impl.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_helper_impl.cpp
@@ -28,6 +28,7 @@ import :value;
 import :secondary_index_data;
 import :table_meta;
 import :status;
+import :json_manager;
 
 import std.compat;
 import third_party;
@@ -35,6 +36,7 @@ import third_party;
 import internal_types;
 import data_type;
 import logical_type;
+import json_term;
 
 namespace infinity {
 
@@ -506,6 +508,211 @@ Value FilterExpressionPushDownHelper::CalcValueResult(const std::shared_ptr<Base
         expr_evaluator.Execute(expression, expression_state, result_vector);
         return result_vector->GetValueByIndex(0);
     }
+}
+
+std::string FilterExpressionPushDownHelper::EncodeJsonInteger(int64_t value) {
+    char buf[32];
+    int len = std::snprintf(buf, sizeof(buf), "%020ld", value);
+    return std::string(buf, len);
+}
+
+std::string FilterExpressionPushDownHelper::EncodeJsonDouble(double value) {
+    if (value == 0.0) {
+        value = 0.0;
+    }
+    uint64_t bits = std::bit_cast<uint64_t>(value);
+    const uint64_t sortable_bits = (bits & (uint64_t{1} << 63)) ? ~bits : (bits ^ (uint64_t{1} << 63));
+
+    char buf[17];
+    int len = std::snprintf(buf, sizeof(buf), "%016llX", static_cast<unsigned long long>(sortable_bits));
+    return std::string(buf, len);
+}
+
+JsonTermT FilterExpressionPushDownHelper::BuildJsonTerm(const std::string &func_name,
+                                                        const std::string &path,
+                                                        const Value &value,
+                                                        FilterCompareType &compare_type) {
+    // Determine the type tag based on function name
+    std::string type_tag;
+    bool is_contains = (func_name == "json_contains");
+
+    if (is_contains) {
+        // json_contains can match any value type - determine type from token value
+        std::string term_value = value.GetVarchar();
+
+        // Try to parse the token to determine its type
+        JsonTypeDef parsed_token;
+        bool parse_success = false;
+        try {
+            parsed_token = JsonTypeDef::parse(term_value);
+            parse_success = true;
+        } catch (...) {
+            // If parsing fails, treat as string literal
+        }
+
+        std::string encoded_value;
+        if (parse_success) {
+            switch (parsed_token.type()) {
+                case JsonValueType::number_integer: {
+                    type_tag = ":i:";
+                    int64_t int_val = parsed_token.get<int64_t>();
+                    encoded_value = EncodeJsonInteger(int_val);
+                    break;
+                }
+                case JsonValueType::number_unsigned: {
+                    type_tag = ":i:";
+                    int64_t int_val = static_cast<int64_t>(parsed_token.get<uint64_t>());
+                    encoded_value = EncodeJsonInteger(int_val);
+                    break;
+                }
+                case JsonValueType::number_float: {
+                    type_tag = ":d:";
+                    double double_val = parsed_token.get<double>();
+                    encoded_value = EncodeJsonDouble(double_val);
+                    break;
+                }
+                case JsonValueType::boolean: {
+                    type_tag = ":b:";
+                    bool bool_val = parsed_token.get<bool>();
+                    encoded_value = bool_val ? "1" : "0";
+                    break;
+                }
+                case JsonValueType::string: {
+                    type_tag = ":s:";
+                    encoded_value = parsed_token.get<std::string>();
+                    break;
+                }
+                default: {
+                    // For null or unknown types, treat as string
+                    type_tag = ":s:";
+                    encoded_value = term_value;
+                    break;
+                }
+            }
+        } else {
+            // Couldn't parse as JSON, treat as string
+            type_tag = ":s:";
+            encoded_value = term_value;
+        }
+
+        return JsonTermT(path + type_tag + encoded_value);
+    }
+
+    // json_extract_* functions
+    if (func_name == "json_extract_int" || func_name == "json_extract_isnull") {
+        type_tag = ":i:";
+    } else if (func_name == "json_extract_double") {
+        type_tag = ":d:";
+    } else if (func_name == "json_extract_bool") {
+        type_tag = ":b:";
+    } else if (func_name == "json_extract_string") {
+        type_tag = ":s:";
+    } else if (func_name == "json_exists_path") {
+        type_tag = ":p:";
+    } else {
+        // Unknown function, return empty term
+        return JsonTermT("");
+    }
+
+    // Build term based on comparison type
+    JsonTermT term;
+    switch (compare_type) {
+        case FilterCompareType::kEqual: {
+            if (func_name == "json_extract_int") {
+                int64_t int_val = value.GetValue<int64_t>();
+                std::string encoded_val = EncodeJsonInteger(int_val);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_double") {
+                double double_val = value.GetValue<DoubleT>();
+                std::string encoded_val = EncodeJsonDouble(double_val);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_string") {
+                std::string str_val = value.GetVarchar();
+                term = JsonTermT(path + type_tag + str_val);
+            } else if (func_name == "json_extract_bool") {
+                bool bool_val = value.GetValue<BooleanT>();
+                term = JsonTermT(path + type_tag + (bool_val ? "1" : "0"));
+            } else if (func_name == "json_exists_path") {
+                term = JsonTermT(path + type_tag);
+            } else if (func_name == "json_extract_isnull") {
+                term = JsonTermT(path + ":n:");
+            }
+            break;
+        }
+        case FilterCompareType::kGreater: {
+            // > value: term = value + epsilon
+            if (func_name == "json_extract_int") {
+                int64_t int_val = value.GetValue<int64_t>();
+                std::string encoded_val = EncodeJsonInteger(int_val + 1);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_double") {
+                double double_val = value.GetValue<DoubleT>();
+                std::string encoded_val = EncodeJsonDouble(std::nextafter(double_val, std::numeric_limits<double>::max()));
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_string") {
+                std::string str_val = value.GetVarchar();
+                term = JsonTermT(path + type_tag + str_val + '\x01'); // exclusive lower bound
+            }
+            compare_type = FilterCompareType::kGreaterEqual;
+            break;
+        }
+        case FilterCompareType::kGreaterEqual: {
+            // >= value: term = value
+            if (func_name == "json_extract_int") {
+                int64_t int_val = value.GetValue<int64_t>();
+                std::string encoded_val = EncodeJsonInteger(int_val);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_double") {
+                double double_val = value.GetValue<DoubleT>();
+                std::string encoded_val = EncodeJsonDouble(double_val);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_string") {
+                std::string str_val = value.GetVarchar();
+                term = JsonTermT(path + type_tag + str_val);
+            }
+            break;
+        }
+        case FilterCompareType::kLess: {
+            // < value: term = value - epsilon
+            if (func_name == "json_extract_int") {
+                int64_t int_val = value.GetValue<int64_t>();
+                std::string encoded_val = EncodeJsonInteger(int_val - 1);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_double") {
+                double double_val = value.GetValue<DoubleT>();
+                std::string encoded_val = EncodeJsonDouble(std::nextafter(double_val, std::numeric_limits<double>::lowest()));
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_string") {
+                std::string str_val = value.GetVarchar();
+                term = JsonTermT(path + type_tag + str_val);
+            }
+            compare_type = FilterCompareType::kLessEqual;
+            break;
+        }
+        case FilterCompareType::kLessEqual: {
+            // <= value: term = value
+            if (func_name == "json_extract_int") {
+                int64_t int_val = value.GetValue<int64_t>();
+                std::string encoded_val = EncodeJsonInteger(int_val);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_double") {
+                double double_val = value.GetValue<DoubleT>();
+                std::string encoded_val = EncodeJsonDouble(double_val);
+                term = JsonTermT(path + type_tag + encoded_val);
+            } else if (func_name == "json_extract_string") {
+                std::string str_val = value.GetVarchar();
+                term = JsonTermT(path + type_tag + str_val);
+            }
+            break;
+        }
+        default: {
+            // Invalid or always true/false
+            term = JsonTermT("");
+            break;
+        }
+    }
+
+    return term;
 }
 
 } // namespace infinity

--- a/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
@@ -31,6 +31,7 @@ import :scalar_function;
 import :scalar_function_set;
 import :index_base;
 import :index_secondary_functional;
+import :index_secondary;
 import :new_catalog;
 import :value;
 import :meta_info;
@@ -93,6 +94,13 @@ struct ExpressionIndexScanInfo {
         // logical expr ("not" is treated as unknown)
         kAndExpr,
         kOrExpr,
+
+        // JSON secondary index function
+        kJsonSecondaryIndexFunctionExprOrAfterCast,
+
+        // JSON secondary index filter
+        kJsonSecondaryIndexValueCompareExpr,
+        kValueJsonSecondaryIndexCompareExpr,
     };
 
     // for index scan
@@ -218,7 +226,8 @@ struct ExpressionIndexScanInfo {
                                 case Enum::kVarcharSecondaryIndexColumnExprOrAfterCast:
                                 case Enum::kSecondaryIndexColumnExprOrAfterCast:
                                 case Enum::kVarcharSecondaryIndexFunctionExprOrAfterCast:
-                                case Enum::kSecondaryIndexFunctionExprOrAfterCast: {
+                                case Enum::kSecondaryIndexFunctionExprOrAfterCast:
+                                case Enum::kJsonSecondaryIndexFunctionExprOrAfterCast: {
                                     break;
                                 }
                                 case Enum::kAndExpr:
@@ -228,7 +237,9 @@ struct ExpressionIndexScanInfo {
                                 case Enum::kSecondaryIndexValueCompareExpr:
                                 case Enum::kValueSecondaryIndexCompareExpr:
                                 case Enum::kSecondaryFunctionalIndexValueCompareExpr:
-                                case Enum::kValueSecondaryFunctionalIndexCompareExpr: {
+                                case Enum::kValueSecondaryFunctionalIndexCompareExpr:
+                                case Enum::kJsonSecondaryIndexValueCompareExpr:
+                                case Enum::kValueJsonSecondaryIndexCompareExpr: {
                                     all_column_function_or_unknown = false;
                                     break;
                                 }
@@ -283,6 +294,37 @@ struct ExpressionIndexScanInfo {
                             tree.info = Enum::kSecondaryFunctionalIndexValueCompareExpr;
                         } else if (check_func_value(tree.children[1].info, tree.children[0].info, is_equal_func)) {
                             tree.info = Enum::kValueSecondaryFunctionalIndexCompareExpr;
+                        } else if (tree.children[0].info == Enum::kJsonSecondaryIndexFunctionExprOrAfterCast ||
+                                   tree.children[1].info == Enum::kJsonSecondaryIndexFunctionExprOrAfterCast) {
+                            // JSON function comparison: json_extract_*(col, path) = value
+                            if (tree.children[0].info == Enum::kJsonSecondaryIndexFunctionExprOrAfterCast) {
+                                tree.info = Enum::kJsonSecondaryIndexValueCompareExpr;
+                            } else {
+                                tree.info = Enum::kValueJsonSecondaryIndexCompareExpr;
+                            }
+                        }
+                    }
+                    // Check for JSON function expressions (json_contains, json_extract_*, json_exists_path, etc.)
+                    else if (std::find(JsonIndexPushdownFunctionNames.begin(), JsonIndexPushdownFunctionNames.end(), f_name) !=
+                             JsonIndexPushdownFunctionNames.end()) {
+                        // First argument should be the column
+                        if (!tree.children.empty() && tree.children[0].info == Enum::kSecondaryIndexColumnExprOrAfterCast) {
+                            auto *column_expression = static_cast<const ColumnExpression *>(function_expression->arguments()[0].get());
+                            auto [column_id, status] = table_meta_->GetColumnIDByColumnName(column_expression->column_name());
+                            if (status.ok() && new_candidate_column_index_map_.contains(column_id)) {
+                                auto &index_meta = new_candidate_column_index_map_.at(column_id);
+                                auto [index_base, index_status] = index_meta->GetIndexBase();
+                                if (index_base->index_type_ == IndexType::kSecondary) {
+                                    auto *secondary_index = static_cast<const IndexSecondary *>(index_base.get());
+                                    if (secondary_index->IsJsonIndex()) {
+                                        tree.info = Enum::kJsonSecondaryIndexFunctionExprOrAfterCast;
+                                    }
+                                }
+                            } else {
+                                LOG_WARN(fmt::format("BuildTree: column_id {} not in candidate map, map size={}",
+                                                     column_id,
+                                                     new_candidate_column_index_map_.size()));
+                            }
                         }
                     }
                     // Identify the function expression in secondary functional index, ignore the negative function and not equal operator
@@ -409,6 +451,9 @@ private:
             case Enum::kSecondaryIndexValueCompareExpr:
             case Enum::kValueSecondaryFunctionalIndexCompareExpr:
             case Enum::kSecondaryFunctionalIndexValueCompareExpr:
+            case Enum::kJsonSecondaryIndexValueCompareExpr:
+            case Enum::kValueJsonSecondaryIndexCompareExpr:
+            case Enum::kJsonSecondaryIndexFunctionExprOrAfterCast:
             case Enum::kFilterFulltextExpr: {
                 result.first = *tree_node.src_ptr;
                 break;
@@ -493,7 +538,10 @@ private:
             case Enum::kValueSecondaryIndexCompareExpr:
             case Enum::kSecondaryIndexValueCompareExpr:
             case Enum::kValueSecondaryFunctionalIndexCompareExpr:
-            case Enum::kSecondaryFunctionalIndexValueCompareExpr: {
+            case Enum::kSecondaryFunctionalIndexValueCompareExpr:
+            case Enum::kJsonSecondaryIndexValueCompareExpr:
+            case Enum::kValueJsonSecondaryIndexCompareExpr:
+            case Enum::kJsonSecondaryIndexFunctionExprOrAfterCast: {
                 auto *function_expression = static_cast<FunctionExpression *>(index_filter_tree_node.src_ptr->get());
                 auto const &f_name = function_expression->ScalarFunctionName();
                 static constexpr std::array<std::string, 5> PossibleFunctionNames{"<", ">", "<=", ">=", "="};
@@ -509,7 +557,11 @@ private:
                                                                                        FilterCompareType::kEqual};
                 const auto it = std::find(PossibleFunctionNames.begin(), PossibleFunctionNames.end(), f_name);
                 if (it == PossibleFunctionNames.end()) {
-                    UnrecoverableError("Function name not found");
+                    if (index_filter_tree_node.info == Enum::kJsonSecondaryIndexFunctionExprOrAfterCast) {
+                        // Skip - this case is handled in the nested switch below
+                    } else {
+                        UnrecoverableError("Function name not found");
+                    }
                 }
 
                 auto SolveForColVal =
@@ -540,9 +592,115 @@ private:
                 ColumnID column_id;
                 FunctionExpression *scalar_func_expression{nullptr};
                 Value value = Value::MakeNull();
+                std::optional<Value> raw_value_for_double;
                 FilterCompareType compare_type;
                 std::shared_ptr<TableIndexMeta> table_index_meta;
+                std::string json_path;
+
+                // Helper lambda for JSON comparison: extracts common logic for json_extract_*(col, path) <op> value
+                auto HandleJsonComparison = [&](FunctionExpression *json_func_expr, const Value &raw_value, FilterCompareType &cmp_type) {
+                    scalar_func_expression = json_func_expr;
+                    auto *column_expr = static_cast<ColumnExpression *>(json_func_expr->arguments()[0].get());
+                    auto [col_id, status] = tree_info_.table_meta_->GetColumnIDByColumnName(column_expr->column_name());
+                    if (!status.ok()) {
+                        UnrecoverableError("Failed to get column ID for JSON index");
+                    }
+                    column_id = col_id;
+                    auto map_it = tree_info_.new_candidate_column_index_map_.find(column_id);
+                    if (map_it == tree_info_.new_candidate_column_index_map_.end()) {
+                        UnrecoverableError("JSON index not found in candidate map");
+                    }
+                    table_index_meta = map_it->second;
+
+                    // Get the path argument and store in outer scope
+                    if (json_func_expr->arguments().size() >= 2) {
+                        auto path_expr = json_func_expr->arguments()[1];
+                        if (path_expr->type() == ExpressionType::kValue) {
+                            auto *path_val = static_cast<const ValueExpression *>(path_expr.get());
+                            json_path = path_val->GetValue().ToString();
+                        }
+                    }
+
+                    // Build JSON term
+                    std::string func_name = json_func_expr->ScalarFunctionName();
+                    JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, json_path, raw_value, cmp_type);
+                    std::string term_str(term.data_, term.length_);
+                    value = Value::MakeVarchar(term_str);
+                };
+
                 switch (index_filter_tree_node.info) {
+                    case Enum::kJsonSecondaryIndexFunctionExprOrAfterCast: {
+                        // JSON function: json_contains, json_extract_*, json_exists_path, etc.
+                        // The function expression is the first argument (column is implicit in the function)
+                        auto *json_func_expr = static_cast<FunctionExpression *>(index_filter_tree_node.src_ptr->get());
+                        scalar_func_expression = json_func_expr;
+                        std::string func_name = json_func_expr->ScalarFunctionName();
+
+                        // Get column from first argument
+                        auto *column_expr = static_cast<ColumnExpression *>(json_func_expr->arguments()[0].get());
+                        auto [col_id, status] = tree_info_.table_meta_->GetColumnIDByColumnName(column_expr->column_name());
+                        if (!status.ok()) {
+                            UnrecoverableError("Failed to get column ID for JSON index");
+                        }
+                        column_id = col_id;
+                        auto it = tree_info_.new_candidate_column_index_map_.find(column_id);
+                        if (it == tree_info_.new_candidate_column_index_map_.end()) {
+                            UnrecoverableError("JSON index not found in candidate map");
+                        }
+                        table_index_meta = it->second;
+
+                        // Handle json_contains 3-argument version: json_contains(col, '$.path', 'token')
+                        if (func_name == "json_contains" && json_func_expr->arguments().size() >= 3) {
+                            // Extract path from arguments[1]
+                            std::string path;
+                            auto path_expr = json_func_expr->arguments()[1];
+                            if (path_expr->type() == ExpressionType::kValue) {
+                                auto *path_val = static_cast<const ValueExpression *>(path_expr.get());
+                                path = path_val->GetValue().ToString();
+                            }
+                            // Extract token from arguments[2]
+                            auto raw_value = FilterExpressionPushDownHelper::CalcValueResult(json_func_expr->arguments()[2]);
+                            compare_type = FilterCompareType::kEqual;
+                            // Build JSON term with the token value
+                            JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, path, raw_value, compare_type);
+                            std::string term_str(term.data_, term.length_);
+                            value = Value::MakeVarchar(term_str);
+                        }
+                        // Handle 2-arg json_contains: json_contains(col, 'token')
+                        else if (func_name == "json_contains" && json_func_expr->arguments().size() >= 2) {
+                            value = FilterExpressionPushDownHelper::CalcValueResult(json_func_expr->arguments()[1]);
+                            compare_type = FilterCompareType::kEqual;
+                            // Build term with "$" path for top-level array contains (root array uses "$" as parent path)
+                            JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, "$", value, compare_type);
+                            std::string term_str(term.data_, term.length_);
+                            value = Value::MakeVarchar(term_str);
+                        }
+                        // Handle json_exists_path: json_exists_path(col, '$.path')
+                        else if (func_name == "json_exists_path") {
+                            std::string path;
+                            if (json_func_expr->arguments().size() >= 2) {
+                                auto path_expr = json_func_expr->arguments()[1];
+                                if (path_expr->type() == ExpressionType::kValue) {
+                                    auto *path_val = static_cast<const ValueExpression *>(path_expr.get());
+                                    path = path_val->GetValue().ToString();
+                                }
+                            }
+                            compare_type = FilterCompareType::kEqual;
+                            JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, path, Value::MakeBool(true), compare_type);
+                            std::string term_str(term.data_, term.length_);
+                            value = Value::MakeVarchar(term_str);
+                        }
+                        // Fallback for other JSON functions
+                        else {
+                            if (json_func_expr->arguments().size() >= 2) {
+                                value = FilterExpressionPushDownHelper::CalcValueResult(json_func_expr->arguments()[1]);
+                            } else {
+                                value = Value::MakeBool(true); // Default for exists_path
+                            }
+                            compare_type = FilterCompareType::kEqual; // JSON contains/exists is equality check
+                        }
+                        break;
+                    }
                     case Enum::kSecondaryIndexValueCompareExpr: {
                         std::tie(column_id, value, compare_type, table_index_meta) =
                             SolveForColVal(function_expression->arguments()[0],
@@ -571,6 +729,24 @@ private:
                                             PossibleReverseCompareTypes[std::distance(PossibleFunctionNames.begin(), it)]);
                         break;
                     }
+                    case Enum::kJsonSecondaryIndexValueCompareExpr: {
+                        // JSON function comparison: json_extract_*(col, path) <op> value
+                        // arguments[0] is the JSON function, arguments[1] is the value
+                        auto *json_func_expr = static_cast<FunctionExpression *>(function_expression->arguments()[0].get());
+                        raw_value_for_double = FilterExpressionPushDownHelper::CalcValueResult(function_expression->arguments()[1]);
+                        compare_type = PossibleCompareTypes[std::distance(PossibleFunctionNames.begin(), it)];
+                        HandleJsonComparison(json_func_expr, *raw_value_for_double, compare_type);
+                        break;
+                    }
+                    case Enum::kValueJsonSecondaryIndexCompareExpr: {
+                        // value <op> json_extract_*(col, path)
+                        // arguments[0] is the value, arguments[1] is the JSON function
+                        auto *json_func_expr = static_cast<FunctionExpression *>(function_expression->arguments()[1].get());
+                        raw_value_for_double = FilterExpressionPushDownHelper::CalcValueResult(function_expression->arguments()[0]);
+                        compare_type = PossibleReverseCompareTypes[std::distance(PossibleFunctionNames.begin(), it)];
+                        HandleJsonComparison(json_func_expr, *raw_value_for_double, compare_type);
+                        break;
+                    }
                     default: {
                         UnrecoverableError("Wrong expression type!");
                         return {};
@@ -581,12 +757,59 @@ private:
                     case FilterCompareType::kEqual:
                     case FilterCompareType::kLessEqual:
                     case FilterCompareType::kGreaterEqual: {
-                        return IndexFilterEvaluatorSecondary::Make(function_expression,
-                                                                   column_id,
-                                                                   scalar_func_expression,
-                                                                   table_index_meta,
-                                                                   compare_type,
-                                                                   value);
+                        auto evaluator = IndexFilterEvaluatorSecondary::Make(function_expression,
+                                                                             column_id,
+                                                                             scalar_func_expression,
+                                                                             table_index_meta,
+                                                                             compare_type,
+                                                                             value);
+                        // For json_extract_double, also query int range
+                        // This implements the PostgreSQL/ES/MongoDB behavior:
+                        // double queries should also match int values (int is auto-promoted to double)
+                        if (scalar_func_expression) {
+                            const auto &func_name = scalar_func_expression->ScalarFunctionName();
+                            if (func_name == "json_extract_double") {
+                                // Build int term for the same value
+                                // For json_extract_double = 1 or 1.0, we need to also query int terms
+                                // Convert double value to int (floor for equality)
+                                double double_val = raw_value_for_double->GetValue<DoubleT>();
+                                int64_t int_val_for_eq = static_cast<int64_t>(double_val);
+
+                                FilterCompareType int_cmp_type = FilterCompareType::kEqual;
+                                int64_t int_val = int_val_for_eq;
+
+                                if (compare_type == FilterCompareType::kGreater || compare_type == FilterCompareType::kGreaterEqual) {
+                                    int_val = static_cast<int64_t>(std::ceil(double_val));
+                                    // For int >= ceil(X), we use kGreaterEqual with int_val - 1
+                                    // because BuildJsonTerm does int_val + 1 for kGreater
+                                    int_cmp_type = FilterCompareType::kGreaterEqual;
+                                } else if (compare_type == FilterCompareType::kLess || compare_type == FilterCompareType::kLessEqual) {
+                                    int_val = static_cast<int64_t>(std::floor(double_val));
+                                    // For int <= floor(X), we use kLessEqual with the floor value directly
+                                    int_cmp_type = FilterCompareType::kLessEqual;
+                                }
+
+                                Value int_value = Value::MakeBigInt(int_val);
+                                JsonTermT int_term =
+                                    FilterExpressionPushDownHelper::BuildJsonTerm("json_extract_int", json_path, int_value, int_cmp_type);
+                                std::string int_term_str(int_term.data_, int_term.length_);
+                                JsonTermT int_term_key(int_term_str);
+
+                                if (compare_type == FilterCompareType::kEqual) {
+                                    // For equality, just add the int term as an additional exact match
+                                    evaluator->AddRange(std::make_pair(int_term_key, int_term_key));
+                                } else if (compare_type == FilterCompareType::kGreater || compare_type == FilterCompareType::kGreaterEqual) {
+                                    // For > and >=, int range is [int_lower_bound, +inf)
+                                    std::string path_prefix = json_path + ":i:";
+                                    evaluator->AddRange(std::make_pair(int_term_key, JsonTermT(path_prefix + ";")));
+                                } else {
+                                    // For < and <=, int range is (-inf, int_upper_bound]
+                                    std::string path_prefix = json_path + ":i:";
+                                    evaluator->AddRange(std::make_pair(JsonTermT(path_prefix), int_term_key));
+                                }
+                            }
+                        }
+                        return evaluator;
                     }
                     case FilterCompareType::kAlwaysTrue: {
                         return std::make_unique<IndexFilterEvaluatorAllTrue>();

--- a/src/planner/optimizer/index_scan/index_filter_evaluators.cppm
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators.cppm
@@ -65,6 +65,7 @@ export struct IndexFilterEvaluatorSecondary : IndexFilterEvaluator {
     ColumnID column_id() const { return column_id_; }
     virtual bool IsValid() const = 0;
     virtual void Merge(IndexFilterEvaluatorSecondary &other, Type op) = 0;
+    virtual void AddRange(std::pair<JsonTermT, JsonTermT> range) = 0;
     static std::unique_ptr<IndexFilterEvaluatorSecondary> Make(const BaseExpression *src_filter_secondary_index_expressions,
                                                                ColumnID column_id,
                                                                FunctionExpression *scalar_func_expression,

--- a/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
@@ -45,6 +45,7 @@ import third_party;
 import internal_types;
 import column_def;
 import logical_type;
+import json_term;
 
 namespace infinity {
 
@@ -112,7 +113,12 @@ bool SimplifySecondaryIndexEvaluators(std::vector<std::unique_ptr<IndexFilterEva
         return true;
     }
     std::map<ColumnID, std::vector<std::unique_ptr<IndexFilterEvaluatorSecondary>>> classify_evaluators;
+    std::vector<std::unique_ptr<IndexFilterEvaluatorSecondary>> json_evaluators;
     for (auto &evaluator : evaluators) {
+        if (evaluator->column_logical_type_ == LogicalType::kJson) {
+            json_evaluators.push_back(std::move(evaluator));
+            continue;
+        }
         const auto column_id = evaluator->column_id();
         classify_evaluators[column_id].push_back(std::move(evaluator));
     }
@@ -123,6 +129,9 @@ bool SimplifySecondaryIndexEvaluators(std::vector<std::unique_ptr<IndexFilterEva
             return false;
         }
         evaluators.push_back(std::move(sub_result));
+    }
+    for (auto &json_evaluator : json_evaluators) {
+        evaluators.push_back(std::move(json_evaluator));
     }
     return true;
 }
@@ -290,6 +299,13 @@ ConvertToOrderedType<VarcharT> GetOrderedV<VarcharT>(const Value &val) {
     return ConvertToOrderedKeyValue(static_cast<std::string_view>(str));
 }
 
+template <>
+ConvertToOrderedType<JsonTermT> GetOrderedV<JsonTermT>(const Value &val) {
+    // For JSON index, the value is expected to be a string that represents the term
+    const std::string &str = val.GetVarchar();
+    return JsonTermT(str);
+}
+
 // 1. secondary index
 // 2. filter_fulltext
 // 3. AND, OR
@@ -305,6 +321,14 @@ struct IndexFilterEvaluatorSecondaryT final : IndexFilterEvaluatorSecondary {
     Bitmask Evaluate(SegmentID segment_id, SegmentOffset segment_row_count) const override;
 
     bool IsValid() const override { return !secondary_index_start_end_pairs_.empty(); }
+
+    void AddRange(std::pair<JsonTermT, JsonTermT> range) override {
+        if constexpr (std::is_same_v<ColumnValueT, JsonTermT>) {
+            secondary_index_start_end_pairs_.emplace_back(range.first, range.second);
+        } else {
+            UnrecoverableError("AddRange only supported for JsonTermT");
+        }
+    }
 
     void Merge(IndexFilterEvaluatorSecondary &other, const Type op) override {
         assert(column_logical_type_ == other.column_logical_type_);
@@ -383,6 +407,24 @@ struct IndexFilterEvaluatorSecondaryT final : IndexFilterEvaluatorSecondary {
                                    std::shared_ptr<TableIndexMeta> new_secondary_index)
         : IndexFilterEvaluatorSecondary(src_expr, column_id, column_logical_type, new_secondary_index) {}
 
+    // Helper to find the actual type tag delimiter position in a JSON term
+    // Type tags are :i:, :d:, :s:, :b:, :p: - we need to find the last one
+    // This correctly handles paths with colons like "$[0]"
+    static size_t FindJsonTypeTagPos(const std::string &val_str) {
+        std::string type_tags[] = {":i:", ":d:", ":s:", ":b:", ":p:"};
+        size_t type_tag_pos = std::string::npos;
+        for (auto tag : type_tags) {
+            size_t pos = val_str.rfind(tag);
+            if (pos != std::string::npos) {
+                size_t colon_pos = pos + tag.length() - 1; // position of last ':' in the tag
+                if (type_tag_pos == std::string::npos || colon_pos > type_tag_pos) {
+                    type_tag_pos = colon_pos;
+                }
+            }
+        }
+        return type_tag_pos;
+    }
+
     static std::unique_ptr<IndexFilterEvaluatorSecondaryT> Make(const BaseExpression *src_expr,
                                                                 const ColumnID column_id,
                                                                 std::shared_ptr<TableIndexMeta> new_secondary_index,
@@ -397,11 +439,40 @@ struct IndexFilterEvaluatorSecondaryT final : IndexFilterEvaluatorSecondary {
                 break;
             }
             case FilterCompareType::kGreaterEqual: {
-                result->secondary_index_start_end_pairs_.emplace_back(val_ordered, std::numeric_limits<SecondaryIndexOrderedT>::max());
+                if constexpr (std::is_same_v<ColumnValueT, JsonTermT>) {
+                    std::string val_str = val_ordered.ToString();
+                    size_t type_tag_pos = FindJsonTypeTagPos(val_str);
+                    JsonTermT end_key;
+                    if (type_tag_pos != std::string::npos && type_tag_pos >= 2) {
+                        // type_tag_pos is the position of the last ':' in the type tag (e.g., position of ':' in ":d:")
+                        // path_with_type includes the type tag letter but not the last colon
+                        // e.g., "$.score:d" for "$.score:d:2.5"
+                        std::string path_with_type = val_str.substr(0, type_tag_pos);
+                        end_key = JsonTermT(path_with_type + ";");
+                    } else {
+                        end_key = std::numeric_limits<SecondaryIndexOrderedT>::max();
+                    }
+                    result->secondary_index_start_end_pairs_.emplace_back(val_ordered, end_key);
+                } else {
+                    result->secondary_index_start_end_pairs_.emplace_back(val_ordered, std::numeric_limits<SecondaryIndexOrderedT>::max());
+                }
                 break;
             }
             case FilterCompareType::kLessEqual: {
-                result->secondary_index_start_end_pairs_.emplace_back(std::numeric_limits<SecondaryIndexOrderedT>::lowest(), val_ordered);
+                if constexpr (std::is_same_v<ColumnValueT, JsonTermT>) {
+                    std::string val_str = val_ordered.ToString();
+                    size_t type_tag_pos = FindJsonTypeTagPos(val_str);
+                    JsonTermT begin_key;
+                    if (type_tag_pos != std::string::npos && type_tag_pos >= 2) {
+                        // type_tag_pos is the position of the last ':' in the type tag
+                        // path_prefix should exclude the last colon: "$.score:d" not "$.score:d:"
+                        std::string path_prefix = val_str.substr(0, type_tag_pos);
+                        begin_key = JsonTermT(path_prefix);
+                    }
+                    result->secondary_index_start_end_pairs_.emplace_back(begin_key, val_ordered);
+                } else {
+                    result->secondary_index_start_end_pairs_.emplace_back(std::numeric_limits<SecondaryIndexOrderedT>::lowest(), val_ordered);
+                }
                 break;
             }
             default: {
@@ -474,6 +545,9 @@ std::unique_ptr<IndexFilterEvaluatorSecondary> IndexFilterEvaluatorSecondary::Ma
             }
             RecoverableError(Status::SyntaxError("VarcharT only support kEqual compare type in secondary index."));
             return {};
+        }
+        case LogicalType::kJson: {
+            return IndexFilterEvaluatorSecondaryT<JsonTermT>::Make(src_expr, column_id, new_secondary_index, compare_type, val);
         }
         default: {
             UnrecoverableError(fmt::format("Unexpected type for secondary index: {}", LogicalType2Str(index_data_type)));
@@ -699,8 +773,6 @@ struct TrunkReaderT final : TrunkReader<ColumnValueType, CardinalityTag> {
                 }
             } else {
                 const KeyType *unique_keys = static_cast<const KeyType *>(index->GetUniqueKeysPtr());
-
-                // Find keys in range [begin_val, end_val]
                 auto begin_it = std::lower_bound(unique_keys, unique_keys + unique_key_count, begin_val);
                 auto end_it = std::upper_bound(unique_keys, unique_keys + unique_key_count, end_val);
 
@@ -710,7 +782,7 @@ struct TrunkReaderT final : TrunkReader<ColumnValueType, CardinalityTag> {
                     if (bitmap) {
                         bitmap->RoaringBitmapApplyFunc([&selected_rows](u32 offset) -> bool {
                             selected_rows.SetTrue(offset);
-                            return true; // continue iteration
+                            return true;
                         });
                     }
                 }

--- a/src/planner/optimizer/index_scan/index_filter_expression_info_tree.cppm
+++ b/src/planner/optimizer/index_scan/index_filter_expression_info_tree.cppm
@@ -91,4 +91,24 @@ void CommonCheckCast(const T *src_info, ExpressionInfoTree<T> &tree, const std::
 export constexpr std::array CompareFunctionNames{"<", ">", "<=", ">=", "="};
 export constexpr std::array LogicalFunctionNames{"AND", "OR"};
 
+// JSON function names for JSON index
+export constexpr std::array JsonFunctionNames{"json_contains",
+                                              "json_extract_int",
+                                              "json_extract_double",
+                                              "json_extract_bool",
+                                              "json_extract_string",
+                                              "json_exists_path",
+                                              "json_extract_isnull"};
+
+// Only these JSON extraction functions are currently encoded in a way the
+// JSON secondary index can answer correctly.
+export constexpr std::array JsonIndexPushdownFunctionNames{
+    "json_extract_int",
+    "json_extract_double",
+    "json_extract_bool",
+    "json_extract_string",
+    "json_exists_path",
+    "json_contains",
+};
+
 } // namespace infinity

--- a/src/storage/common/json_manager.cppm
+++ b/src/storage/common/json_manager.cppm
@@ -65,6 +65,9 @@ public:
 
     static BooleanT json_contains(const JsonTypeDef &data, const std::string &token);
 
+    static std::tuple<bool, BooleanT>
+    json_contains_path(const JsonTypeDef &data, const std::vector<JsonTokenInfo> &path_tokens, const std::string &token);
+
     static std::tuple<size_t, std::vector<std::string>> json_unnest(const JsonTypeDef &data);
 };
 

--- a/src/storage/common/json_manager_impl.cpp
+++ b/src/storage/common/json_manager_impl.cpp
@@ -462,6 +462,140 @@ BooleanT JsonManager::json_contains(const JsonTypeDef &data, const std::string &
     }
 }
 
+std::tuple<bool, BooleanT>
+JsonManager::json_contains_path(const JsonTypeDef &data, const std::vector<JsonTokenInfo> &path_tokens, const std::string &token) {
+    // Navigate to the target value using path_tokens
+    const JsonTypeDef *current = &data;
+    for (const auto &path_token : path_tokens) {
+        const auto &token_type = path_token.first;
+        const auto &token_value = path_token.second;
+        if (current->is_array() && token_type == JsonType::kJsonArray) {
+            try {
+                size_t index = std::stoul(token_value);
+                if (index >= current->size()) {
+                    return {true, false}; // Path doesn't exist
+                }
+                current = &(*current)[index];
+            } catch (const std::exception &) {
+                return {true, false}; // Invalid array index
+            }
+        } else if (current->is_object() && token_type == JsonType::kJsonObject) {
+            if (!current->contains(token_value)) {
+                return {true, false}; // Path doesn't exist
+            }
+            current = &(*current)[token_value];
+        } else {
+            return {true, false}; // Can't navigate further
+        }
+    }
+
+    // Now check if the value at path is an array containing the token, or equals the token
+    if (!current->is_array()) {
+        // For non-array values, check if the value equals the token
+        JsonTypeDef parsed_token;
+        bool parse_success = false;
+
+        try {
+            parsed_token = JsonTypeDef::parse(token);
+            parse_success = true;
+        } catch (...) {
+            // If parsing fails, treat token as a literal string value
+        }
+
+        if (!parse_success) {
+            // Token is not valid JSON, treat it as a literal string
+            return {true, current->is_string() && current->get_ref<const std::string &>() == token};
+        }
+
+        switch (parsed_token.type()) {
+            case JsonValueType::string: {
+                const auto &token_value = parsed_token.get_ref<const std::string &>();
+                return {true, current->is_string() && current->get_ref<const std::string &>() == token_value};
+            }
+            case JsonValueType::number_integer: {
+                auto token_value = parsed_token.get<int64_t>();
+                return {true, current->is_number_integer() && current->get<int64_t>() == token_value};
+            }
+            case JsonValueType::number_unsigned: {
+                auto token_value = parsed_token.get<uint64_t>();
+                return {true, current->is_number_unsigned() && current->get<uint64_t>() == token_value};
+            }
+            case JsonValueType::number_float: {
+                auto token_value = parsed_token.get<double>();
+                return {true, current->is_number_float() && std::abs(current->get<double>() - token_value) < 1e-10};
+            }
+            case JsonValueType::boolean: {
+                auto token_value = parsed_token.get<bool>();
+                return {true, current->is_boolean() && current->get<bool>() == token_value};
+            }
+            case JsonValueType::null: {
+                return {true, current->is_null()};
+            }
+            default: {
+                return {true, false};
+            }
+        }
+    }
+
+    const JsonTypeDef &arr = *current;
+    JsonTypeDef parsed_token;
+    bool parse_success = false;
+
+    try {
+        parsed_token = JsonTypeDef::parse(token);
+        parse_success = true;
+    } catch (...) {
+        // If parsing fails, treat token as a literal string value
+    }
+
+    if (!parse_success) {
+        // Token is not valid JSON, treat it as a literal string
+        return {true, std::any_of(arr.begin(), arr.end(), [&token](const JsonTypeDef &element) {
+                    return element.is_string() && element.get_ref<const std::string &>() == token;
+                })};
+    }
+
+    switch (parsed_token.type()) {
+        case JsonValueType::string: {
+            const auto &token_value = parsed_token.get_ref<const std::string &>();
+            return {true, std::any_of(arr.begin(), arr.end(), [&token_value](const JsonTypeDef &element) {
+                        return element.is_string() && element.get_ref<const std::string &>() == token_value;
+                    })};
+        }
+        case JsonValueType::number_integer: {
+            const auto token_value = parsed_token.get<int64_t>();
+            return {true, std::any_of(arr.begin(), arr.end(), [token_value](const JsonTypeDef &element) {
+                        return element.is_number_integer() && element.get<int64_t>() == token_value;
+                    })};
+        }
+        case JsonValueType::number_unsigned: {
+            const auto token_value = parsed_token.get<uint64_t>();
+            return {true, std::any_of(arr.begin(), arr.end(), [token_value](const JsonTypeDef &element) {
+                        return element.is_number_unsigned() && element.get<uint64_t>() == token_value;
+                    })};
+        }
+        case JsonValueType::number_float: {
+            const auto token_value = parsed_token.get<double>();
+            return {true, std::any_of(arr.begin(), arr.end(), [token_value](const JsonTypeDef &element) {
+                        return element.is_number_float() && std::abs(element.get<double>() - token_value) < 1e-10;
+                    })};
+        }
+        case JsonValueType::boolean: {
+            const auto token_value = parsed_token.get<bool>();
+            return {true, std::any_of(arr.begin(), arr.end(), [token_value](const JsonTypeDef &element) {
+                        return element.is_boolean() && element.get<bool>() == token_value;
+                    })};
+        }
+        case JsonValueType::null: {
+            return {true, std::any_of(arr.begin(), arr.end(), [](const JsonTypeDef &element) { return element.is_null(); })};
+        }
+        default: {
+            const std::string token_value = parsed_token.dump();
+            return {true, std::any_of(arr.begin(), arr.end(), [&token_value](const JsonTypeDef &element) { return element.dump() == token_value; })};
+        }
+    }
+}
+
 std::tuple<size_t, std::vector<std::string>> JsonManager::json_unnest(const JsonTypeDef &data) {
     std::vector<std::string> result;
     if (data.is_array()) {

--- a/src/storage/definition/index_base_impl.cpp
+++ b/src/storage/definition/index_base_impl.cpp
@@ -164,7 +164,8 @@ std::shared_ptr<IndexBase> IndexBase::ReadAdv(const char *&ptr, int32_t maxbytes
         }
         case IndexType::kSecondary: {
             SecondaryIndexCardinality cardinality = SecondaryIndexCardinality(ReadBufAdv<u8>(ptr));
-            res = std::make_shared<IndexSecondary>(index_name, index_comment, file_name, column_names, cardinality);
+            bool is_json_index = ReadBufAdv<u8>(ptr);
+            res = std::make_shared<IndexSecondary>(index_name, index_comment, file_name, column_names, cardinality, is_json_index);
             break;
         }
         case IndexType::kSecondaryFunctional: {
@@ -325,7 +326,16 @@ std::shared_ptr<IndexBase> IndexBase::Deserialize(std::string_view index_def_str
                     secondary_index_cardinality = SecondaryIndexCardinality::kLowCardinality;
                 }
             }
-            res = std::make_shared<IndexSecondary>(index_name, index_comment, file_name, std::move(column_names), secondary_index_cardinality);
+            bool is_json_index = false;
+            if (doc.contains("is_json_index") && doc["is_json_index"].is_boolean()) {
+                is_json_index = doc["is_json_index"].get<bool>();
+            }
+            res = std::make_shared<IndexSecondary>(index_name,
+                                                   index_comment,
+                                                   file_name,
+                                                   std::move(column_names),
+                                                   secondary_index_cardinality,
+                                                   is_json_index);
             break;
         }
         case IndexType::kSecondaryFunctional: {

--- a/src/storage/definition/index_full_text_impl.cpp
+++ b/src/storage/definition/index_full_text_impl.cpp
@@ -32,14 +32,9 @@ import third_party;
 import logical_type;
 import statement_common;
 import serialize;
+import :utility;
 
 namespace infinity {
-
-void ToLowerString(std::string &lower) {
-    for (auto &c : lower) {
-        c = tolower(c);
-    }
-}
 
 std::shared_ptr<IndexBase> IndexFullText::Make(std::shared_ptr<std::string> index_name,
                                                std::shared_ptr<std::string> index_comment,
@@ -52,14 +47,14 @@ std::shared_ptr<IndexBase> IndexFullText::Make(std::shared_ptr<std::string> inde
     for (size_t param_idx = 0; param_idx < param_count; ++param_idx) {
         InitParameter *parameter = index_param_list[param_idx];
         std::string para_name = parameter->param_name_;
-        ToLowerString(para_name);
+        ToLower(para_name);
         if (para_name == "analyzer") {
             analyzer_name = parameter->param_value_;
         } else if (para_name == "flag") {
             flag = std::strtoul(parameter->param_value_.c_str(), nullptr, 10);
         } else if (para_name == "realtime") {
             std::string realtime_str = parameter->param_value_;
-            ToLowerString(realtime_str);
+            ToLower(realtime_str);
             if (realtime_str == "true") {
                 FlagAddRealtime(flag);
             } else if (realtime_str != "false") {

--- a/src/storage/definition/index_secondary.cppm
+++ b/src/storage/definition/index_secondary.cppm
@@ -18,6 +18,7 @@ import :index_base;
 import :base_table_ref;
 
 import create_index_info;
+import statement_common;
 
 namespace infinity {
 
@@ -27,17 +28,33 @@ public:
                                            std::shared_ptr<std::string> index_comment,
                                            const std::string &file_name,
                                            std::vector<std::string> column_names,
-                                           SecondaryIndexCardinality secondary_index_cardinality = SecondaryIndexCardinality::kHighCardinality) {
-        return std::make_shared<IndexSecondary>(index_name, index_comment, file_name, std::move(column_names), secondary_index_cardinality);
+                                           SecondaryIndexCardinality secondary_index_cardinality = SecondaryIndexCardinality::kHighCardinality,
+                                           bool is_json_index = false) {
+        return std::make_shared<IndexSecondary>(index_name,
+                                                index_comment,
+                                                file_name,
+                                                std::move(column_names),
+                                                secondary_index_cardinality,
+                                                is_json_index);
     }
+
+    // Overload that parses index_param_list
+    static std::shared_ptr<IndexBase> Make(std::shared_ptr<std::string> index_name,
+                                           std::shared_ptr<std::string> index_comment,
+                                           const std::string &file_name,
+                                           std::vector<std::string> column_names,
+                                           const std::vector<InitParameter *> &index_param_list,
+                                           bool is_json_index = false);
 
     IndexSecondary(std::shared_ptr<std::string> index_name,
                    std::shared_ptr<std::string> index_comment,
                    const std::string &file_name,
                    std::vector<std::string> column_names,
-                   SecondaryIndexCardinality secondary_index_cardinality = SecondaryIndexCardinality::kHighCardinality)
+                   SecondaryIndexCardinality secondary_index_cardinality = SecondaryIndexCardinality::kHighCardinality,
+                   bool is_json_index = false)
         : IndexBase(IndexType::kSecondary, index_name, index_comment, file_name, std::move(column_names)),
-          secondary_index_cardinality_(secondary_index_cardinality) {}
+          secondary_index_cardinality_(is_json_index ? SecondaryIndexCardinality::kLowCardinality : secondary_index_cardinality),
+          is_json_index_(is_json_index) {}
 
     ~IndexSecondary() final = default;
 
@@ -51,12 +68,16 @@ public:
 
     inline SecondaryIndexCardinality GetSecondaryIndexCardinality() const { return secondary_index_cardinality_; }
 
-    static void ValidateColumnDataType(const std::shared_ptr<BaseTableRef> &base_table_ref,
-                                       const std::string &column_name,
-                                       SecondaryIndexCardinality secondary_index_cardinality = SecondaryIndexCardinality::kHighCardinality);
+    inline bool IsJsonIndex() const { return is_json_index_; }
+
+    static void ValidateIndexColumn(const std::shared_ptr<BaseTableRef> &base_table_ref,
+                                    const std::string &column_name,
+                                    SecondaryIndexCardinality secondary_index_cardinality = SecondaryIndexCardinality::kHighCardinality,
+                                    bool is_json_index = false);
 
 private:
     SecondaryIndexCardinality secondary_index_cardinality_{SecondaryIndexCardinality::kHighCardinality};
+    bool is_json_index_ = false;
 };
 
 } // namespace infinity

--- a/src/storage/definition/index_secondary_impl.cpp
+++ b/src/storage/definition/index_secondary_impl.cpp
@@ -19,6 +19,8 @@ import :index_base;
 import :status;
 import :base_table_ref;
 import :infinity_exception;
+import :utility;
+import logical_type;
 
 import std;
 import third_party;
@@ -26,15 +28,63 @@ import serialize;
 
 namespace infinity {
 
-void IndexSecondary::ValidateColumnDataType(const std::shared_ptr<BaseTableRef> &base_table_ref,
-                                            const std::string &column_name,
-                                            SecondaryIndexCardinality secondary_index_cardinality) {
+std::shared_ptr<IndexBase> IndexSecondary::Make(std::shared_ptr<std::string> index_name,
+                                                std::shared_ptr<std::string> index_comment,
+                                                const std::string &file_name,
+                                                std::vector<std::string> column_names,
+                                                const std::vector<InitParameter *> &index_param_list,
+                                                bool is_json_index) {
+    SecondaryIndexCardinality cardinality = SecondaryIndexCardinality::kHighCardinality;
+    std::map<std::string, std::string> unknown_params;
+
+    for (const auto *param : index_param_list) {
+        std::string param_name = param->param_name_;
+        std::string param_value = param->param_value_;
+        ToLower(param_name);
+        ToLower(param_value);
+
+        if (param_name == "cardinality") {
+            if (param_value == "low") {
+                cardinality = SecondaryIndexCardinality::kLowCardinality;
+            } else if (param_value == "high") {
+                cardinality = SecondaryIndexCardinality::kHighCardinality;
+            }
+        } else {
+            unknown_params[param_name] = param_value;
+        }
+    }
+
+    if (!unknown_params.empty()) {
+        std::ostringstream oss;
+        oss << "Following parameters are left unused:";
+        for (const auto &[k, v] : unknown_params) {
+            oss << " (" << k << ", " << v << ')';
+        }
+        oss << '.';
+        RecoverableError(Status::InvalidIndexDefinition(std::move(oss).str()));
+    }
+
+    return std::make_shared<IndexSecondary>(index_name, index_comment, file_name, std::move(column_names), cardinality, is_json_index);
+}
+
+void IndexSecondary::ValidateIndexColumn(const std::shared_ptr<BaseTableRef> &base_table_ref,
+                                         const std::string &column_name,
+                                         SecondaryIndexCardinality secondary_index_cardinality,
+                                         bool is_json_index) {
     auto &column_names_vector = *(base_table_ref->column_names_);
     auto &column_types_vector = *(base_table_ref->column_types_);
     size_t column_id = std::find(column_names_vector.begin(), column_names_vector.end(), column_name) - column_names_vector.begin();
     if (column_id == column_names_vector.size()) {
         RecoverableError(Status::ColumnNotExist(column_name));
-    } else if (auto &data_type = column_types_vector[column_id]; !(data_type->CanBuildSecondaryIndex())) {
+    }
+    auto &data_type = column_types_vector[column_id];
+
+    // JSON column must use low cardinality
+    if (is_json_index && secondary_index_cardinality == SecondaryIndexCardinality::kHighCardinality) {
+        RecoverableError(Status::InvalidIndexDefinition(fmt::format("cardinality is always low for JSON column. Column: {}", column_name)));
+    }
+
+    if (!(data_type->CanBuildSecondaryIndex())) {
         // For low cardinality secondary indexes, we can relax the data type restrictions
         if (secondary_index_cardinality == SecondaryIndexCardinality::kHighCardinality) {
             RecoverableError(Status::InvalidIndexDefinition(
@@ -50,6 +100,8 @@ i32 IndexSecondary::GetSizeInBytes() const {
     i32 size = IndexBase::GetSizeInBytes();
     // Add size for secondary index cardinality
     size += sizeof(SecondaryIndexCardinality);
+    // Add size for is_json_index flag
+    size += sizeof(bool);
     return size;
 }
 
@@ -58,17 +110,22 @@ void IndexSecondary::WriteAdv(char *&ptr) const {
     IndexBase::WriteAdv(ptr);
     // Write secondary index cardinality
     WriteBufAdv(ptr, u8(secondary_index_cardinality_));
+    // Write is_json_index flag
+    WriteBufAdv(ptr, u8(is_json_index_));
 }
 
 nlohmann::json IndexSecondary::Serialize() const {
     // Call base class implementation
     nlohmann::json res = IndexBase::Serialize();
-    // Add secondary index cardinality for secondary indexes
+    // Add secondary index cardinality
     res["cardinality"] = secondary_index_cardinality_ == SecondaryIndexCardinality::kLowCardinality ? "low" : "high";
-
+    // Add is_json_index flag
+    res["is_json_index"] = is_json_index_;
     return res;
 }
 
-std::string IndexSecondary::BuildOtherParamsString() const { return ""; }
+std::string IndexSecondary::BuildOtherParamsString() const {
+    return fmt::format("cardinality = {}", secondary_index_cardinality_ == SecondaryIndexCardinality::kLowCardinality ? "low" : "high");
+}
 
 } // namespace infinity

--- a/src/storage/invertedindex/column_inverter.cppm
+++ b/src/storage/invertedindex/column_inverter.cppm
@@ -96,8 +96,6 @@ private:
         bool operator()(const u32 lhs, const u32 rhs) const;
     };
 
-    size_t InvertColumn(u32 doc_id, const std::string &val);
-
     const char *GetTermFromRef(u32 term_ref) const { return &terms_[term_ref << 2]; }
 
     const char *GetTermFromNum(u32 term_num) const { return GetTermFromRef(term_refs_[term_num]); }
@@ -112,6 +110,12 @@ private:
         *reinterpret_cast<u32 *>(p) = term_num;
     }
 
+    u32 merged_{1};
+    std::vector<std::binary_semaphore *> semas_{};
+
+protected:
+    size_t InvertColumn(u32 doc_id, const std::string &val);
+
     u32 AddTerm(StringRef term);
 
     void SortTerms();
@@ -119,13 +123,11 @@ private:
     std::unique_ptr<Analyzer> analyzer_{nullptr};
     u32 begin_doc_id_{0};
     u32 doc_count_{0};
-    u32 merged_{1};
     TermBuffer terms_;
     PosInfoVec positions_;
     U32Vec term_refs_;
     std::vector<std::pair<u32, std::unique_ptr<TermList>>> terms_per_doc_;
     PostingWriterProvider posting_writer_provider_{};
     VectorWithLock<u32> &column_lengths_;
-    std::vector<std::binary_semaphore *> semas_{};
 };
 } // namespace infinity

--- a/src/storage/invertedindex/column_inverter_json_array.cppm
+++ b/src/storage/invertedindex/column_inverter_json_array.cppm
@@ -1,0 +1,40 @@
+// Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module infinity_core:column_inverter_json_array;
+
+import :column_inverter;
+import :posting_writer;
+import :json_manager;
+import :vector_with_lock;
+import :column_vector;
+
+namespace infinity {
+
+export class ColumnInverterJsonArray : public ColumnInverter {
+public:
+    ~ColumnInverterJsonArray() = default;
+
+    ColumnInverterJsonArray(PostingWriterProvider posting_writer_provider, VectorWithLock<u32> &column_lengths, const std::string &json_path);
+
+    void InitJsonPath(const std::string &json_path);
+
+    size_t InvertColumn(std::shared_ptr<ColumnVector> column_vector, u32 row_offset, u32 row_count, u32 begin_doc_id);
+
+private:
+    std::string json_path_{};
+    std::vector<JsonTokenInfo> json_tokens_{};
+};
+
+} // namespace infinity

--- a/src/storage/invertedindex/column_inverter_json_array_impl.cpp
+++ b/src/storage/invertedindex/column_inverter_json_array_impl.cpp
@@ -1,0 +1,84 @@
+// Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <cstdio>
+
+module infinity_core:column_inverter_json_array.impl;
+
+import :column_inverter_json_array;
+import :column_inverter;
+import :analyzer;
+import :analyzer_pool;
+import :string_ref;
+import :term;
+import :json_manager;
+import :infinity_exception;
+import :status;
+import :logger;
+
+import std.compat;
+
+namespace infinity {
+
+ColumnInverterJsonArray::ColumnInverterJsonArray(PostingWriterProvider posting_writer_provider,
+                                                 VectorWithLock<u32> &column_lengths,
+                                                 const std::string &json_path)
+    : ColumnInverter(posting_writer_provider, column_lengths), json_path_(json_path) {
+    InitJsonPath(json_path);
+}
+
+void ColumnInverterJsonArray::InitJsonPath(const std::string &json_path) {
+    auto [valid, tokens] = JsonManager::get_json_tokens(json_path);
+    if (!valid) {
+        Status status = Status::InvalidIndexDefinition(fmt::format("Invalid JSON path: {}", json_path));
+        RecoverableError(status);
+    }
+    json_tokens_ = std::move(tokens);
+}
+
+size_t ColumnInverterJsonArray::InvertColumn(std::shared_ptr<ColumnVector> column_vector, u32 row_offset, u32 row_count, u32 begin_doc_id) {
+    begin_doc_id_ = begin_doc_id;
+    doc_count_ = row_count;
+    std::vector<u32> column_lengths(row_count);
+    size_t term_count_sum = 0;
+    for (size_t i = 0; i < row_count; ++i) {
+        std::string json_str = column_vector->ToString(row_offset + i);
+        if (json_str.empty()) {
+            continue;
+        }
+
+        auto json_obj = JsonManager::parse(json_str);
+        auto [exist, extracted] = JsonManager::json_extract(json_obj, json_tokens_);
+        if (!exist) {
+            column_lengths[i] = 0;
+            continue;
+        }
+
+        auto parsed_extracted = JsonManager::parse(extracted);
+        auto [elem_count, elements] = JsonManager::json_unnest(parsed_extracted);
+
+        size_t row_term_count = 0;
+        for (const auto &elem : elements) {
+            row_term_count += ColumnInverter::InvertColumn(begin_doc_id + i, elem);
+        }
+        column_lengths[i] = row_term_count;
+        term_count_sum += row_term_count;
+    }
+    column_lengths_.SetBatch(begin_doc_id, column_lengths);
+    return term_count_sum;
+}
+
+} // namespace infinity

--- a/src/storage/json_index/json_flattener.cppm
+++ b/src/storage/json_index/json_flattener.cppm
@@ -1,0 +1,55 @@
+// Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <nlohmann/json.hpp>
+
+export module infinity_core:json_flattener;
+
+import :json_manager;
+import :infinity_exception;
+
+import std;
+
+namespace infinity {
+
+using JsonTypeDef = nlohmann::json;
+
+export struct FlattenedTerm {
+    std::string term_;
+};
+
+export class JsonFlattener {
+public:
+    // Flatten a BSON document into multiple terms
+    static std::vector<FlattenedTerm> FlattenDocument(const uint8_t *bson_data, size_t bson_length);
+
+    // Flatten from nlohmann::json
+    static std::vector<FlattenedTerm> FlattenJson(const JsonTypeDef &json_obj);
+
+private:
+    static void FlattenRecursive(const JsonTypeDef &json_value, const std::string &current_path, std::vector<FlattenedTerm> &terms);
+
+    // Helper to encode integer with zero-padding
+    static std::string EncodeInteger(int64_t value);
+
+    // Helper to encode double with zero-padding
+    static std::string EncodeDouble(double value);
+
+    // Helper to encode path
+    static std::string EncodePath(const std::string &path);
+};
+
+} // namespace infinity

--- a/src/storage/json_index/json_flattener.h
+++ b/src/storage/json_index/json_flattener.h
@@ -1,0 +1,52 @@
+// Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace infinity {
+
+using JsonTypeDef = nlohmann::json;
+
+struct FlattenedTerm {
+    std::string term_;
+};
+
+class JsonFlattener {
+public:
+    // Flatten a BSON document into multiple terms
+    static std::vector<FlattenedTerm> FlattenDocument(const uint8_t *bson_data, size_t bson_length);
+
+    // Flatten from nlohmann::json
+    static std::vector<FlattenedTerm> FlattenJson(const JsonTypeDef &json_obj);
+
+private:
+    static void FlattenRecursive(const JsonTypeDef &json_value, const std::string &current_path, std::vector<FlattenedTerm> &terms);
+
+    // Helper to encode integer with zero-padding
+    static std::string EncodeInteger(int64_t value);
+
+    // Helper to encode double with zero-padding
+    static std::string EncodeDouble(double value);
+
+    // Helper to encode path
+    static std::string EncodePath(const std::string &path);
+};
+
+} // namespace infinity

--- a/src/storage/json_index/json_flattener_impl.cpp
+++ b/src/storage/json_index/json_flattener_impl.cpp
@@ -1,0 +1,123 @@
+// Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module infinity_core:json_flattener.impl;
+
+import :json_flattener;
+
+import :json_manager;
+import :infinity_exception;
+
+import std;
+
+namespace infinity {
+
+std::string JsonFlattener::EncodeInteger(int64_t value) {
+    char buf[32];
+    int len = std::snprintf(buf, sizeof(buf), "%020ld", value);
+    return std::string(buf, len);
+}
+
+std::string JsonFlattener::EncodeDouble(double value) {
+    // Encode doubles into a sortable IEEE-754 key so lexicographic term order
+    // matches numeric order without losing precision at strict range boundaries.
+    if (value == 0.0) {
+        value = 0.0;
+    }
+    uint64_t bits = std::bit_cast<uint64_t>(value);
+    const uint64_t sortable_bits = (bits & (uint64_t{1} << 63)) ? ~bits : (bits ^ (uint64_t{1} << 63));
+
+    char buf[17];
+    int len = std::snprintf(buf, sizeof(buf), "%016llX", static_cast<unsigned long long>(sortable_bits));
+    return std::string(buf, len);
+}
+
+std::string JsonFlattener::EncodePath(const std::string &path) { return path; }
+
+void JsonFlattener::FlattenRecursive(const JsonTypeDef &json_value, const std::string &current_path, std::vector<FlattenedTerm> &terms) {
+    // Helper lambda to add a scalar value as a term
+    auto AddScalarTerm = [&](const JsonTypeDef &val, const std::string &path) {
+        if (val.is_string()) {
+            FlattenedTerm term;
+            term.term_ = path + ":s:" + val.get<std::string>();
+            terms.push_back(std::move(term));
+        } else if (val.is_number_integer()) {
+            FlattenedTerm term;
+            term.term_ = path + ":i:" + EncodeInteger(val.get<int64_t>());
+            terms.push_back(std::move(term));
+        } else if (val.is_number_unsigned()) {
+            FlattenedTerm term;
+            term.term_ = path + ":i:" + EncodeInteger(static_cast<int64_t>(val.get<uint64_t>()));
+            terms.push_back(std::move(term));
+        } else if (val.is_number_float()) {
+            FlattenedTerm term;
+            term.term_ = path + ":d:" + EncodeDouble(val.get<double>());
+            terms.push_back(std::move(term));
+        } else if (val.is_boolean()) {
+            FlattenedTerm term;
+            term.term_ = path + ":b:" + (val.get<bool>() ? "1" : "0");
+            terms.push_back(std::move(term));
+        } else if (val.is_null()) {
+            FlattenedTerm term;
+            term.term_ = path + ":n:";
+            terms.push_back(std::move(term));
+        }
+    };
+
+    if (json_value.is_object()) {
+        for (auto &item : json_value.items()) {
+            std::string child_path = current_path.empty() ? std::string("$") + "." + item.key() : current_path + "." + item.key();
+            FlattenRecursive(item.value(), child_path, terms);
+        }
+    } else if (json_value.is_array()) {
+        size_t idx = 0;
+        for (const auto &val : json_value) {
+            std::string child_path = current_path + "[" + std::to_string(idx) + "]";
+            FlattenRecursive(val, child_path, terms);
+            ++idx;
+        }
+        // Emit parent array terms (without index) for 2-arg json_contains support
+        // For root array (current_path is empty), use "$" as parent path
+        // For nested arrays, use current_path as parent path
+        std::string parent_path = current_path.empty() ? "$" : current_path;
+        for (const auto &val : json_value) {
+            AddScalarTerm(val, parent_path);
+        }
+    } else {
+        AddScalarTerm(json_value, current_path);
+        // Emit path exists term for json_exists_path support (for non-null scalar values)
+        if (!json_value.is_null()) {
+            FlattenedTerm path_term;
+            path_term.term_ = current_path + ":p:";
+            terms.push_back(std::move(path_term));
+        }
+    }
+}
+
+std::vector<FlattenedTerm> JsonFlattener::FlattenDocument(const uint8_t *bson_data, size_t bson_length) {
+    std::vector<FlattenedTerm> terms;
+    auto json_obj = JsonManager::from_bson(bson_data, bson_length);
+    if (json_obj) {
+        FlattenRecursive(*json_obj, "", terms);
+    }
+    return terms;
+}
+
+std::vector<FlattenedTerm> JsonFlattener::FlattenJson(const JsonTypeDef &json_obj) {
+    std::vector<FlattenedTerm> terms;
+    FlattenRecursive(json_obj, "", terms);
+    return terms;
+}
+
+} // namespace infinity

--- a/src/storage/secondary_index/secondary_index_data.cppm
+++ b/src/storage/secondary_index/secondary_index_data.cppm
@@ -27,6 +27,7 @@ import third_party;
 import logical_type;
 import internal_types;
 import data_type;
+import json_term;
 
 namespace infinity {
 
@@ -44,6 +45,9 @@ concept ConvertToOrderedI64 = IsAnyOf<T, DateTimeT, TimestampT>;
 
 template <typename T>
 concept ConvertToHashU64 = IsAnyOf<T, VarcharT, std::string_view>;
+
+template <typename T>
+concept KeepOrderedString = IsAnyOf<T, JsonTermT>;
 
 template <typename ValueT>
 struct ConvertToOrdered;
@@ -68,8 +72,13 @@ struct ConvertToOrdered<T> {
     using type = u64;
 };
 
+template <KeepOrderedString T>
+struct ConvertToOrdered<T> {
+    using type = T;
+};
+
 export template <typename T>
-    requires KeepOrderedSelf<T> or ConvertToOrderedI32<T> or ConvertToOrderedI64<T> or ConvertToHashU64<T>
+    requires KeepOrderedSelf<T> or ConvertToOrderedI32<T> or ConvertToOrderedI64<T> or ConvertToHashU64<T> or KeepOrderedString<T>
 using ConvertToOrderedType = typename ConvertToOrdered<T>::type;
 
 export template <typename RawValueType>
@@ -98,6 +107,12 @@ ConvertToOrderedType<RawValueType> ConvertToOrderedKeyValue(RawValueType value) 
 export template <>
 ConvertToOrderedType<std::string_view> ConvertToOrderedKeyValue(std::string_view value) {
     return std::hash<std::string_view>{}(value);
+}
+
+// for JsonTermT
+export template <KeepOrderedString RawValueType>
+ConvertToOrderedType<RawValueType> ConvertToOrderedKeyValue(RawValueType value) {
+    return value;
 }
 
 export template <typename T>
@@ -138,6 +153,9 @@ constexpr LogicalType GetLogicalType<VarcharT> = LogicalType::kVarchar;
 
 template <>
 constexpr LogicalType GetLogicalType<BooleanT> = LogicalType::kBoolean;
+
+template <>
+constexpr LogicalType GetLogicalType<JsonTermT> = LogicalType::kJson;
 
 // Cardinality tag types for template specialization
 export struct HighCardinalityTag {};

--- a/src/storage/secondary_index/secondary_index_data_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_data_impl.cpp
@@ -35,6 +35,7 @@ import third_party;
 import logical_type;
 import internal_types;
 import data_type;
+import json_term;
 
 namespace infinity {
 
@@ -860,6 +861,9 @@ GetSecondaryIndexDataWithCardinality<LowCardinalityTag>(const std::shared_ptr<Da
         }
         case LogicalType::kVarchar: {
             return new SecondaryIndexDataLowCardinalityT<VarcharT>(chunk_row_count, allocate);
+        }
+        case LogicalType::kJson: {
+            return new SecondaryIndexDataLowCardinalityT<JsonTermT>(chunk_row_count, allocate);
         }
         default: {
             UnrecoverableError(fmt::format("Need to add secondary index support for data type: {}", data_type->ToString()));

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -31,12 +31,15 @@ import :memindex_tracer;
 import :column_vector;
 import :buffer_obj;
 import :rcu_multimap;
+import :json_flattener;
+import :value;
 
 import std;
 
 import logical_type;
 import internal_types;
 import column_def;
+import json_term;
 
 namespace infinity {
 
@@ -69,10 +72,36 @@ public:
     }
 
     void InsertBlockData(SegmentOffset block_offset, const ColumnVector &col, BlockOffset offset, BlockOffset row_count) override {
+        if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+            // For JSON, we need to flatten each JSON document and insert multiple terms per row
+            return InsertBlockDataJson(block_offset, col, offset, row_count);
+        }
         MemIndexInserterIter1<RawValueType> iter(block_offset, col, offset, row_count);
         const auto inserted_rows = InsertInner(iter);
         assert(inserted_rows <= row_count);
         IncreaseMemoryUsageBase(inserted_rows * MemoryCostOfEachRow());
+    }
+
+    // Special insertion for JSON: flatten each JSON document and insert multiple terms per row
+    void InsertBlockDataJson(SegmentOffset block_offset, const ColumnVector &col, BlockOffset offset, BlockOffset row_count) {
+        // This method inserts multiple terms per JSON document
+        // For each row, we flatten the JSON and insert each term
+        u32 inserted_count = 0;
+        for (BlockOffset i = 0; i < row_count; ++i) {
+            // Get the JSON value at position offset + i
+            Value value = col.GetValueByIndex(offset + i);
+            const auto &extra_info = value.value_info_;
+            if (extra_info && extra_info->type_ == ExtraValueInfoType::JSON_VALUE_INFO) {
+                auto *json_info = static_cast<JsonValueInfo *>(extra_info.get());
+                auto terms = JsonFlattener::FlattenDocument(json_info->bson_elements_.data(), json_info->bson_elements_.size());
+                for (const auto &term : terms) {
+                    JsonTermT key(term.term_);
+                    in_mem_secondary_index_.Insert(key, block_offset + offset + i);
+                    ++inserted_count;
+                }
+            }
+        }
+        IncreaseMemoryUsageBase(inserted_count * MemoryCostOfEachRow());
     }
 
     void Dump(BufferObj *buffer_obj) const override {
@@ -138,6 +167,11 @@ private:
                 const KeyType key = ConvertToOrderedKeyValue(bool_value);
                 // Insert u32 offset directly
                 in_mem_secondary_index_.Insert(key, offset);
+            } else if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+                // JsonTermT is handled specially: it is already a string term
+                // No need to convert, just use it directly
+                const auto &json_term = *v_ptr;
+                in_mem_secondary_index_.Insert(json_term, offset);
             } else {
                 const KeyType key = ConvertToOrderedKeyValue(*v_ptr);
                 // Insert u32 offset directly
@@ -215,6 +249,9 @@ SecondaryIndexInMem::NewSecondaryIndexInMem(const DataType &index_data_type, Row
             case LogicalType::kVarchar: {
                 return std::make_shared<SecondaryIndexInMemT<VarcharT, HighCardinalityTag>>(begin_row_id, cardinality);
             }
+            case LogicalType::kJson: {
+                return std::make_shared<SecondaryIndexInMemT<JsonTermT, LowCardinalityTag>>(begin_row_id, cardinality);
+            }
             default: {
                 return nullptr;
             }
@@ -256,6 +293,9 @@ SecondaryIndexInMem::NewSecondaryIndexInMem(const DataType &index_data_type, Row
             }
             case LogicalType::kVarchar: {
                 return std::make_shared<SecondaryIndexInMemT<VarcharT, LowCardinalityTag>>(begin_row_id, cardinality);
+            }
+            case LogicalType::kJson: {
+                return std::make_shared<SecondaryIndexInMemT<JsonTermT, LowCardinalityTag>>(begin_row_id, cardinality);
             }
             default: {
                 return nullptr;

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -250,7 +250,8 @@ SecondaryIndexInMem::NewSecondaryIndexInMem(const DataType &index_data_type, Row
                 return std::make_shared<SecondaryIndexInMemT<VarcharT, HighCardinalityTag>>(begin_row_id, cardinality);
             }
             case LogicalType::kJson: {
-                return std::make_shared<SecondaryIndexInMemT<JsonTermT, LowCardinalityTag>>(begin_row_id, cardinality);
+                UnrecoverableError("JSON secondary index only supports low cardinality");
+                return nullptr;
             }
             default: {
                 return nullptr;

--- a/src/unit_test/storage/new_catalog/index_internal_ut.cpp
+++ b/src/unit_test/storage/new_catalog/index_internal_ut.cpp
@@ -1101,3 +1101,78 @@ TEST_P(TestTxnIndexInternal, DISABLED_SLOW_test_populate_index) {
         return std::make_pair(begin_id, row_cnt);
     });
 }
+
+TEST_P(TestTxnIndexInternal, test_json_index) {
+    using namespace infinity;
+
+    NewTxnManager *new_txn_mgr = infinity::InfinityContext::instance().storage()->new_txn_manager();
+
+    std::shared_ptr<std::string> db_name = std::make_shared<std::string>("db1");
+    auto table_name = std::make_shared<std::string>("tb1");
+
+    // Create table with JSON column
+    auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "id", std::set<ConstraintType>());
+    auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kJson), "meta", std::set<ConstraintType>());
+    auto table_def = TableDef::Make(db_name, table_name, std::make_shared<std::string>(), {column_def1, column_def2});
+
+    // Create JSON secondary index
+    auto index_name = std::make_shared<std::string>("idx_json");
+    std::vector<InitParameter *> index_params;
+    index_params.emplace_back(new InitParameter("cardinality", "low"));
+    auto index_def = IndexSecondary::Make(index_name, std::make_shared<std::string>(), "file_name", {column_def2->name()}, index_params, true);
+    for (auto *param : index_params) {
+        delete param;
+    }
+
+    // Verify index properties
+    auto *secondary_index = static_cast<IndexSecondary *>(index_def.get());
+    EXPECT_TRUE(secondary_index->IsJsonIndex());
+    EXPECT_EQ(secondary_index->GetSecondaryIndexCardinality(), SecondaryIndexCardinality::kLowCardinality);
+    EXPECT_EQ(secondary_index->BuildOtherParamsString(), "cardinality = low");
+
+    // Test CreateIndex and CreateTable
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("create db"), TransactionType::kCreateDB);
+        Status status = txn->CreateDatabase(*db_name, ConflictType::kError, std::make_shared<std::string>());
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("create table"), TransactionType::kCreateTable);
+        Status status = txn->CreateTable(*db_name, std::move(table_def), ConflictType::kIgnore);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("create index"), TransactionType::kCreateIndex);
+        Status status = txn->CreateIndex(*db_name, *table_name, index_def, ConflictType::kIgnore);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    // Drop index and table
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("drop index"), TransactionType::kDropIndex);
+        Status status = txn->DropIndexByName(*db_name, *table_name, *index_name, ConflictType::kError);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("drop table"), TransactionType::kDropTable);
+        Status status = txn->DropTable(*db_name, *table_name, ConflictType::kError);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("drop db"), TransactionType::kDropDB);
+        Status status = txn->DropDatabase(*db_name, ConflictType::kError);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+}

--- a/src/unit_test/storage/new_catalog/replay_index_ut.cpp
+++ b/src/unit_test/storage/new_catalog/replay_index_ut.cpp
@@ -793,3 +793,60 @@ TEST_P(TestTxnReplayIndex, drop_index) {
         EXPECT_FALSE(status.ok());
     }
 }
+
+TEST_P(TestTxnReplayIndex, test_json_index_replay) {
+    using namespace infinity;
+
+    std::shared_ptr<std::string> db_name = std::make_shared<std::string>("default_db");
+    auto column_def1 = std::make_shared<ColumnDef>(0, std::make_shared<DataType>(LogicalType::kInteger), "id", std::set<ConstraintType>());
+    auto column_def2 = std::make_shared<ColumnDef>(1, std::make_shared<DataType>(LogicalType::kJson), "meta", std::set<ConstraintType>());
+    auto table_name = std::make_shared<std::string>("tb1");
+    auto table_def = TableDef::Make(db_name, table_name, std::make_shared<std::string>(), {column_def1, column_def2});
+
+    // Create JSON secondary index
+    auto index_name = std::make_shared<std::string>("idx_json");
+    std::vector<InitParameter *> index_params;
+    index_params.emplace_back(new InitParameter("cardinality", "low"));
+    auto index_def = IndexSecondary::Make(index_name, std::make_shared<std::string>(), "file_name", {column_def2->name()}, index_params, true);
+    for (auto *param : index_params) {
+        delete param;
+    }
+
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("create table"), TransactionType::kCreateTable);
+        Status status = txn->CreateTable(*db_name, std::move(table_def), ConflictType::kIgnore);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("create index"), TransactionType::kCreateIndex);
+        Status status = txn->CreateIndex(*db_name, *table_name, index_def, ConflictType::kIgnore);
+        EXPECT_TRUE(status.ok());
+        status = new_txn_mgr->CommitTxn(txn);
+        EXPECT_TRUE(status.ok());
+    }
+
+    RestartTxnMgr();
+
+    // Verify index is replayed correctly
+    {
+        auto *txn = new_txn_mgr->BeginTxn(std::make_unique<std::string>("check index"), TransactionType::kRead);
+        Status status;
+        std::shared_ptr<DBMeta> db_meta;
+        std::shared_ptr<TableMeta> table_meta;
+        std::shared_ptr<TableIndexMeta> table_index_meta;
+        std::string table_key;
+        std::string index_key;
+        status = txn->GetTableIndexMeta(*db_name, *table_name, *index_name, db_meta, table_meta, table_index_meta, &table_key, &index_key);
+        EXPECT_TRUE(status.ok());
+
+        auto [index_base, index_status] = table_index_meta->GetIndexBase();
+        EXPECT_TRUE(index_status.ok());
+        auto *secondary_index = static_cast<IndexSecondary *>(index_base.get());
+        EXPECT_TRUE(secondary_index->IsJsonIndex());
+        EXPECT_EQ(secondary_index->GetSecondaryIndexCardinality(), SecondaryIndexCardinality::kLowCardinality);
+        EXPECT_EQ(secondary_index->BuildOtherParamsString(), "cardinality = low");
+    }
+}

--- a/test/sql/ddl/index/test_json_index.slt
+++ b/test/sql/ddl/index/test_json_index.slt
@@ -1,0 +1,200 @@
+# Test JSON index functionality with json_expand=true
+
+statement ok
+DROP TABLE IF EXISTS test_json_index;
+
+statement ok
+CREATE TABLE test_json_index (
+    id integer,
+    meta json
+);
+
+statement ok
+INSERT INTO test_json_index (id, meta) VALUES (1, '{"year": 2020, "character": ["value1", "value2"], "score": 1, "author": "Alice", "time": "2026-01-01T00:00:00"}');
+
+statement ok
+INSERT INTO test_json_index (id, meta) VALUES (2, '{"year": 2021, "character": ["value3"], "score": 2, "author": "Bob", "time": "2026-02-15T10:30:00"}');
+
+statement ok
+INSERT INTO test_json_index (id, meta) VALUES (3, '{"year": 2019, "character": ["value1", "value4"], "score": 2.5, "author": "Alice", "time": "2026-03-20T15:45:00"}');
+
+statement ok
+INSERT INTO test_json_index (id, meta) VALUES (4, '{"year": 2022, "name": "test", "score": 3.0, "author": "Charlie", "time": "2026-04-10T20:00:00"}');
+
+statement error
+CREATE INDEX idx_meta ON test_json_index (meta) USING SECONDARY WITH (cardinality=high);
+
+statement ok
+CREATE INDEX idx_meta ON test_json_index (meta) USING SECONDARY;
+
+statement ok
+INSERT INTO test_json_index (id, meta) VALUES (5, '{"year": 2020, "author": "Alice", "time": "2026-05-27T23:59:59"}');
+
+statement ok
+INSERT INTO test_json_index (id, meta) VALUES (6, '{"data": {"inner": 50, "outer": 100}}');
+
+statement ok
+SHOW TABLE test_json_index INDEX idx_meta;
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_int(meta, '$.year') = 2020;
+----
+1
+5
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_int(meta, '$.year') > 2020;
+----
+2
+4
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_int(meta, '$.year') >= 2021;
+----
+2
+4
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_int(meta, '$.year') < 2020;
+----
+3
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_int(meta, '$.year') <= 2020;
+----
+1
+3
+5
+
+query I
+SELECT id, json_extract_double(meta, '$.score') FROM test_json_index WHERE json_extract_double(meta, '$.score') = 1;
+----
+1 1.000000
+
+query I
+SELECT id, json_extract_double(meta, '$.score') FROM test_json_index WHERE json_extract_double(meta, '$.score') < 2.5;
+----
+1 1.000000
+2 2.000000
+
+query I
+SELECT id, json_extract_double(meta, '$.score') FROM test_json_index WHERE json_extract_double(meta, '$.score') > 1.5;
+----
+2 2.000000
+3 2.500000
+4 3.000000
+
+query I
+SELECT id, json_extract_double(meta, '$.score') FROM test_json_index WHERE json_extract_double(meta, '$.score') <= 3;
+----
+1 1.000000
+2 2.000000
+3 2.500000
+4 3.000000
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_string(meta, '$.author') == 'Bob';
+----
+2
+
+query T
+SELECT json_extract_string(meta, '$.time') FROM test_json_index WHERE id = 5;
+----
+"2026-05-27T23:59:59"
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_string(meta, '$.author') > 'Bob';
+----
+4
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_string(meta, '$.author') <= 'Bob';
+----
+1
+2
+3
+5
+
+query I
+SELECT id FROM test_json_index WHERE json_extract_int(meta, '$.year') > 2020 AND json_extract_double(meta, '$.score') > 2.6;
+----
+4
+
+query I
+SELECT id FROM test_json_index WHERE json_contains(meta, '$.character', 'value1');
+----
+1
+3
+
+query I
+SELECT id FROM test_json_index WHERE json_contains(meta, '$.author', '"Alice"');
+----
+1
+3
+5
+
+query I
+SELECT id FROM test_json_index WHERE json_contains(meta, '$.data.inner', 50);
+----
+6
+
+query I
+SELECT id FROM test_json_index WHERE json_contains(meta, '$.data.inner', 100);
+----
+
+query I
+SELECT id FROM test_json_index WHERE json_exists_path(meta, '$.name');
+----
+4
+
+statement ok
+DROP TABLE test_json_index;
+
+
+# Test 2-argument json_contains on root-level array
+statement ok
+DROP TABLE IF EXISTS test_json_root_array;
+
+statement ok
+CREATE TABLE test_json_root_array (
+    id integer,
+    meta json
+);
+
+statement ok
+INSERT INTO test_json_root_array (id, meta) VALUES (1, '["a", "b", 1, true]');
+
+statement ok
+INSERT INTO test_json_root_array (id, meta) VALUES (2, '["b", "d"]');
+
+statement ok
+INSERT INTO test_json_root_array (id, meta) VALUES (3, '["c", 2]');
+
+statement ok
+CREATE INDEX idx_data ON test_json_root_array (meta) USING SECONDARY;
+
+query I
+SELECT id FROM test_json_root_array WHERE json_contains(meta, 'b');
+----
+1
+2
+
+query I
+SELECT id FROM test_json_root_array WHERE json_contains(meta, 1);
+----
+1
+
+query I
+SELECT id FROM test_json_root_array WHERE json_contains(meta, '1');
+----
+1
+
+query I
+SELECT id FROM test_json_root_array WHERE json_contains(meta, '"1"');
+----
+
+statement ok
+DROP INDEX idx_data ON test_json_root_array;
+
+statement ok
+DROP TABLE test_json_root_array;

--- a/test/sql/dql/index_scan/index_scan_json_explain.slt
+++ b/test/sql/dql/index_scan/index_scan_json_explain.slt
@@ -1,0 +1,110 @@
+# Test EXPLAIN for JSON index functionality
+
+statement ok
+DROP TABLE IF EXISTS test_json_explain;
+
+statement ok
+CREATE TABLE test_json_explain (
+    id integer,
+    meta json
+);
+
+statement ok
+INSERT INTO test_json_explain (id, meta) VALUES (1, '{"year": 2020, "character": ["value1", "value2"]}');
+
+statement ok
+INSERT INTO test_json_explain (id, meta) VALUES (2, '{"year": 2021, "character": ["value3"]}');
+
+statement ok
+INSERT INTO test_json_explain (id, meta) VALUES (3, '{"year": 2019, "character": ["value1", "value4"]}');
+
+statement ok
+CREATE INDEX idx_meta_explain ON test_json_explain (meta) USING SECONDARY;
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_extract_string(meta, '$.character') = 'value1';
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: (meta (#1.1) json_extract_string $.character) = value1
+    - output_columns: [__rowid]
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_extract_int(meta, '$.year') > 2020;
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: (meta (#1.1) json_extract_int $.year) > 2020
+    - output_columns: [__rowid]
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_extract_int(meta, '$.year') = 2020 AND json_extract_bool(meta, '$.active') = true;
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: ((meta (#1.1) json_extract_int $.year) = 2020) AND ((meta (#1.1) json_extract_bool $.active) = true)
+    - output_columns: [__rowid]
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_contains(meta, '$.character', 'value1');
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: json_contains(meta (#1.1), $.character, value1)
+    - output_columns: [__rowid]
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_exists_path(meta, '$.year');
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: meta (#1.1) json_exists_path $.year
+    - output_columns: [__rowid]
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_contains(meta, 'apple');
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: meta (#1.1) json_contains apple
+    - output_columns: [__rowid]
+
+query I
+EXPLAIN SELECT id FROM test_json_explain WHERE json_extract_int(meta, '$[0]') = 2020;
+----
+ PROJECT (4)
+  - table index: #4
+  - expressions: [id (#0)]
+ -> INDEX SCAN (6)
+    - table name: test_json_explain(default_db.test_json_explain)
+    - table index: #1
+    - filter: (meta (#1.1) json_extract_int $[0]) = 2020
+    - output_columns: [__rowid]
+
+
+statement ok
+DROP TABLE test_json_explain;

--- a/test/sql/dql/type/json.slt
+++ b/test/sql/dql/type/json.slt
@@ -67,12 +67,12 @@ true
 false
 null
 
-query I
+query B
 SELECT json_contains(c3, '$.1', 0.123) FROM test_json_filter WHERE c1 = 4;
 ----
 true
 
-query I
+query B
 SELECT json_contains(c3, '$.1', 123) FROM test_json_filter WHERE c1 = 4;
 ----
 false

--- a/test/sql/dql/type/json.slt
+++ b/test/sql/dql/type/json.slt
@@ -67,6 +67,16 @@ true
 false
 null
 
+query I
+SELECT json_contains(c3, '$.1', 0.123) FROM test_json_filter WHERE c1 = 4;
+----
+true
+
+query I
+SELECT json_contains(c3, '$.1', 123) FROM test_json_filter WHERE c1 = 4;
+----
+false
+
 # ============================================================================
 # Part 2: JSON Path Extraction with WHERE clause
 # ============================================================================


### PR DESCRIPTION
### What problem does this PR solve?

Implement Json index and 3-arg json_contains

syntax:
CREATE TABLE test_json_index (
    id integer,
    meta json
);

CREATE INDEX idx_meta ON test_json_index (meta) USING SECONDARY;

test:
./test/sql/ddl/index/test_json_index.slt
./test/sql/dql/index_scan/index_scan_json_explain.slt

### Type of change

- [x] New Feature (non-breaking change which adds functionality)
