### PR TITLE
Fix RoaringBitmap::SetTrue: row_index >= count_

### DIFF
--- a/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
@@ -736,7 +736,13 @@ struct TrunkReaderT final : TrunkReader<ColumnValueType, CardinalityTag> {
             const auto [key_ptr, offset_ptr] = index->GetKeyOffsetPointer();
             // output result
             for (u32 i = begin_pos; i < end_pos; ++i) {
-                selected_rows.SetTrue(offset_ptr[i]);
+                const u32 offset = offset_ptr[i];
+                // Bounds check: offset may exceed segment_row_count_ if mem index contains
+                // uncommitted entries from concurrent INSERT. These should not be visible to
+                // this transaction, so we skip them.
+                if (offset < segment_row_count_) {
+                    selected_rows.SetTrue(offset);
+                }
             }
         } else {
             // Low cardinality: use RoaringBitmap approach
@@ -765,8 +771,13 @@ struct TrunkReaderT final : TrunkReader<ColumnValueType, CardinalityTag> {
                     const uint8_t key_val = *it;
                     const auto *bitmap = static_cast<const Bitmap *>(index->GetOffsetsForKeyPtr(&key_val));
                     if (bitmap) {
-                        bitmap->RoaringBitmapApplyFunc([&selected_rows](u32 offset) -> bool {
-                            selected_rows.SetTrue(offset);
+                        // Bounds check: offset may exceed segment_row_count_ if mem index contains
+                        // uncommitted entries from concurrent INSERT. These should not be visible to
+                        // this transaction, so we skip them.
+                        bitmap->RoaringBitmapApplyFunc([&selected_rows, this](u32 offset) -> bool {
+                            if (offset < segment_row_count_) {
+                                selected_rows.SetTrue(offset);
+                            }
                             return true; // continue iteration
                         });
                     }
@@ -780,8 +791,13 @@ struct TrunkReaderT final : TrunkReader<ColumnValueType, CardinalityTag> {
                 for (auto it = begin_it; it != end_it; ++it) {
                     const auto *bitmap = static_cast<const Bitmap *>(index->GetOffsetsForKeyPtr(it));
                     if (bitmap) {
-                        bitmap->RoaringBitmapApplyFunc([&selected_rows](u32 offset) -> bool {
-                            selected_rows.SetTrue(offset);
+                        // Bounds check: offset may exceed segment_row_count_ if mem index contains
+                        // uncommitted entries from concurrent INSERT. These should not be visible to
+                        // this transaction, so we skip them.
+                        bitmap->RoaringBitmapApplyFunc([&selected_rows, this](u32 offset) -> bool {
+                            if (offset < segment_row_count_) {
+                                selected_rows.SetTrue(offset);
+                            }
                             return true;
                         });
                     }
@@ -897,7 +913,13 @@ struct TrunkReaderT<ColumnValueType, HighCardinalityTag> final : TrunkReader<Col
         const auto [key_ptr, offset_ptr] = index->GetKeyOffsetPointer();
         // output result
         for (u32 i = begin_pos; i < end_pos; ++i) {
-            selected_rows.SetTrue(offset_ptr[i]);
+            const u32 offset = offset_ptr[i];
+            // Bounds check: offset may exceed segment_row_count_ if mem index contains
+            // uncommitted entries from concurrent INSERT. These should not be visible to
+            // this transaction, so we skip them.
+            if (offset < segment_row_count_) {
+                selected_rows.SetTrue(offset);
+            }
         }
     }
 };

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -189,6 +189,9 @@ private:
         result_var.second.SetAllFalse();
 
         for (const u32 offset : result) {
+            // Bounds check: offset may exceed segment_row_count if mem index contains
+            // uncommitted entries from concurrent INSERT. These should not be visible to
+            // this transaction, so we skip them.
             if (offset < segment_row_count) {
                 result_var.second.SetTrue(offset);
             }


### PR DESCRIPTION
### What problem does this PR solve?

The issue occurs when INSERT and SELECT run concurrently.
The in-memory index returns entries from uncommitted transactions. The segment_row_count  is the committed row count at select start, but in-memory index has additional rows with larger offsets that are not yet committed.

Issue link:#https://github.com/infiniflow/infinity/issues/3359

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

