### PR TITLE
Implement ColBERTSaR based on Plaid

### DIFF
--- a/src/storage/buffer/file_worker/plaid_index_file_worker_impl.cpp
+++ b/src/storage/buffer/file_worker/plaid_index_file_worker_impl.cpp
@@ -58,8 +58,9 @@ void PlaidIndexFileWorker::AllocateInMemory() {
     const auto *index_plaid = static_cast<IndexPLAID *>(index_base_.get());
     const auto nbits = index_plaid->nbits_;
     const auto n_centroids = index_plaid->n_centroids_;
+    const auto colbertsar_mode = index_plaid->colbertsar_mode_;
     // Allocate PlaidIndex object directly (like EMVB)
-    data_ = static_cast<void *>(new PlaidIndex(start_segment_offset_, column_embedding_dim, nbits, n_centroids));
+    data_ = static_cast<void *>(new PlaidIndex(start_segment_offset_, column_embedding_dim, nbits, n_centroids, colbertsar_mode));
 }
 
 void PlaidIndexFileWorker::FreeInMemory() {
@@ -98,7 +99,8 @@ void PlaidIndexFileWorker::ReadFromFileImpl(size_t file_size, bool from_spill) {
     const auto *index_plaid = static_cast<IndexPLAID *>(index_base_.get());
     const auto nbits = index_plaid->nbits_;
     const auto n_centroids = index_plaid->n_centroids_;
-    auto *index = new PlaidIndex(start_segment_offset_, column_embedding_dim, nbits, n_centroids);
+    const auto colbertsar_mode = index_plaid->colbertsar_mode_;
+    auto *index = new PlaidIndex(start_segment_offset_, column_embedding_dim, nbits, n_centroids, colbertsar_mode);
     data_ = static_cast<void *>(index);
     index->ReadIndexInner(*file_handle_);
 }
@@ -112,10 +114,12 @@ bool PlaidIndexFileWorker::ReadFromMmapImpl(const void *ptr, size_t size) {
     }
     const auto column_embedding_dim = GetEmbeddingInfo()->Dimension();
 
-    // Read header from the mmap data (first 4 fields: start_segment_offset, embedding_dimension, nbits, n_centroids)
+    // Read header from the mmap data (format_version + 4 fields)
     const char *src = static_cast<const char *>(ptr);
-    u32 stored_start_segment_offset, stored_embedding_dimension, stored_nbits, stored_n_centroids;
+    u32 format_version, stored_start_segment_offset, stored_embedding_dimension, stored_nbits, stored_n_centroids;
     size_t offset = 0;
+    std::memcpy(&format_version, src + offset, sizeof(format_version));
+    offset += sizeof(format_version);
     std::memcpy(&stored_start_segment_offset, src + offset, sizeof(stored_start_segment_offset));
     offset += sizeof(stored_start_segment_offset);
     std::memcpy(&stored_embedding_dimension, src + offset, sizeof(stored_embedding_dimension));
@@ -143,7 +147,8 @@ bool PlaidIndexFileWorker::ReadFromMmapImpl(const void *ptr, size_t size) {
         stored_n_centroids));
 
     // Allocate PlaidIndex object with correct nbits from file
-    auto *index = new PlaidIndex(start_segment_offset_, column_embedding_dim, nbits, n_centroids);
+    const bool colbertsar_mode = (format_version == 2);
+    auto *index = new PlaidIndex(start_segment_offset_, column_embedding_dim, nbits, n_centroids, colbertsar_mode);
 
     LOG_INFO(fmt::format("PlaidIndexFileWorker::ReadFromMmapImpl: Created PlaidIndex with nbits={}, n_centroids={}", nbits, n_centroids));
 

--- a/src/storage/catalog/meta/segment_index_meta_impl.cpp
+++ b/src/storage/catalog/meta/segment_index_meta_impl.cpp
@@ -434,9 +434,10 @@ Status SegmentIndexMeta::LoadPlaidGlobalCentroids() {
     // Get nbits from index base
     const auto *index_plaid = static_cast<const IndexPLAID *>(index_base.get());
     const u32 nbits = index_plaid->nbits_;
+    const bool colbertsar_mode = index_plaid->colbertsar_mode_;
 
     // Create and load centroids
-    plaid_global_centroids_ = std::make_shared<PlaidGlobalCentroids>(embedding_dimension, nbits);
+    plaid_global_centroids_ = std::make_shared<PlaidGlobalCentroids>(embedding_dimension, nbits, colbertsar_mode);
 
     auto [file_handle, status] = VirtualStore::Open(centroids_file, FileAccessMode::kRead);
     if (!status.ok()) {

--- a/src/storage/definition/index_plaid.cppm
+++ b/src/storage/definition/index_plaid.cppm
@@ -31,9 +31,10 @@ public:
                const std::string &file_name,
                std::vector<std::string> column_names,
                const u32 nbits,
-               const u32 n_centroids)
+               const u32 n_centroids,
+               const bool colbertsar_mode = false)
         : IndexBase(IndexType::kPLAID, std::move(index_name), index_comment, file_name, std::move(column_names)), nbits_(nbits),
-          n_centroids_(n_centroids) {}
+          n_centroids_(n_centroids), colbertsar_mode_(colbertsar_mode) {}
 
     static std::shared_ptr<IndexBase> Make(std::shared_ptr<std::string> index_name,
                                            std::shared_ptr<std::string> index_comment,
@@ -55,8 +56,9 @@ public:
 
     nlohmann::json Serialize() const override;
 
-    const u32 nbits_ = 4;       // Quantization bits (2 or 4)
-    const u32 n_centroids_ = 0; // Number of centroids (0 = auto: sqrt(N))
+    const u32 nbits_ = 4;                // Quantization bits (2 or 4)
+    const u32 n_centroids_ = 0;          // Number of centroids (0 = auto: sqrt(N))
+    const bool colbertsar_mode_ = false; // true: residual-free ColBERTSaR mode
 };
 
 } // namespace infinity

--- a/src/storage/definition/index_plaid_impl.cpp
+++ b/src/storage/definition/index_plaid_impl.cpp
@@ -52,7 +52,12 @@ void IndexPLAID::ValidateColumnDataType(const std::shared_ptr<BaseTableRef> &bas
     }
 }
 
-std::string IndexPLAID::BuildOtherParamsString() const { return fmt::format("nbits = {}, n_centroids = {}.", nbits_, n_centroids_); }
+std::string IndexPLAID::BuildOtherParamsString() const {
+    if (colbertsar_mode_) {
+        return fmt::format("colbertsar_mode = true, n_centroids = {}.", n_centroids_);
+    }
+    return fmt::format("nbits = {}, n_centroids = {}.", nbits_, n_centroids_);
+}
 
 constexpr std::array<u32, 2> acceptable_nbits = {2, 4};
 
@@ -63,6 +68,7 @@ std::shared_ptr<IndexBase> IndexPLAID::Make(std::shared_ptr<std::string> index_n
                                             const std::vector<InitParameter *> &index_param_list) {
     u32 nbits = 4;       // default: 4-bit quantization
     u32 n_centroids = 0; // default: auto (sqrt(N))
+    bool colbertsar_mode = false;
 
     for (auto para : index_param_list) {
         if (para->param_name_ == "nbits") {
@@ -79,24 +85,35 @@ std::shared_ptr<IndexBase> IndexPLAID::Make(std::shared_ptr<std::string> index_n
                 RecoverableError(status);
             }
             n_centroids = u32(val);
+        } else if (para->param_name_ == "colbertsar_mode") {
+            const std::string val = para->param_value_;
+            if (val == "true" || val == "1") {
+                colbertsar_mode = true;
+            } else if (val == "false" || val == "0") {
+                colbertsar_mode = false;
+            } else {
+                Status status = Status::InvalidIndexParam("colbertsar_mode must be 'true' or 'false'");
+                RecoverableError(status);
+            }
         } else {
             Status status = Status::InvalidIndexParam(para->param_name_);
             RecoverableError(status);
         }
     }
 
-    if (std::find(acceptable_nbits.begin(), acceptable_nbits.end(), nbits) == acceptable_nbits.end()) {
+    if (!colbertsar_mode && std::find(acceptable_nbits.begin(), acceptable_nbits.end(), nbits) == acceptable_nbits.end()) {
         Status status = Status::InvalidIndexParam("nbits must be 2 or 4");
         RecoverableError(status);
     }
 
-    return std::make_shared<IndexPLAID>(index_name, index_comment, file_name, std::move(column_names), nbits, n_centroids);
+    return std::make_shared<IndexPLAID>(index_name, index_comment, file_name, std::move(column_names), nbits, n_centroids, colbertsar_mode);
 }
 
 i32 IndexPLAID::GetSizeInBytes() const {
     size_t size = IndexBase::GetSizeInBytes();
     size += sizeof(nbits_);
     size += sizeof(n_centroids_);
+    size += sizeof(colbertsar_mode_);
     return size;
 }
 
@@ -104,6 +121,7 @@ void IndexPLAID::WriteAdv(char *&ptr) const {
     IndexBase::WriteAdv(ptr);
     WriteBufAdv(ptr, nbits_);
     WriteBufAdv(ptr, n_centroids_);
+    WriteBufAdv(ptr, colbertsar_mode_);
 }
 
 std::string IndexPLAID::ToString() const {
@@ -116,6 +134,7 @@ nlohmann::json IndexPLAID::Serialize() const {
     nlohmann::json res = IndexBase::Serialize();
     res["nbits"] = nbits_;
     res["n_centroids"] = n_centroids_;
+    res["colbertsar_mode"] = colbertsar_mode_;
     return res;
 }
 

--- a/src/storage/knn_index/plaid/plaid_global_centroids.cppm
+++ b/src/storage/knn_index/plaid/plaid_global_centroids.cppm
@@ -31,7 +31,7 @@ class LocalFileHandle;
 // 3. Low memory footprint (chunks share centroids)
 export class PlaidGlobalCentroids {
 public:
-    PlaidGlobalCentroids(u32 embedding_dimension, u32 nbits);
+    PlaidGlobalCentroids(u32 embedding_dimension, u32 nbits, bool colbertsar_mode = false);
     ~PlaidGlobalCentroids();
 
     // Disable copy

--- a/src/storage/knn_index/plaid/plaid_global_centroids_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_global_centroids_impl.cpp
@@ -29,8 +29,9 @@ import std.compat;
 
 namespace infinity {
 
-PlaidGlobalCentroids::PlaidGlobalCentroids(const u32 embedding_dimension, const u32 nbits)
-    : embedding_dimension_(embedding_dimension), nbits_(nbits), quantizer_(std::make_unique<PlaidQuantizer>(nbits, embedding_dimension)) {}
+PlaidGlobalCentroids::PlaidGlobalCentroids(const u32 embedding_dimension, const u32 nbits, const bool colbertsar_mode)
+    : embedding_dimension_(embedding_dimension), nbits_(nbits),
+      quantizer_(colbertsar_mode ? nullptr : std::make_unique<PlaidQuantizer>(nbits, embedding_dimension)) {}
 
 PlaidGlobalCentroids::~PlaidGlobalCentroids() = default;
 
@@ -123,6 +124,12 @@ void PlaidGlobalCentroids::Train(const u32 n_centroids, const f32 *embedding_dat
     ComputeCentroidNorms();
 
     LOG_INFO(fmt::format("PlaidGlobalCentroids::Train: Trained {} centroids from {} samples", n_centroids_, training_num));
+
+    if (quantizer_ == nullptr) {
+        // ColBERTSaR mode: skip quantizer training
+        LOG_INFO("PlaidGlobalCentroids::Train: ColBERTSaR mode, skipping quantizer training.");
+        return;
+    }
 
     // Sample residuals for quantizer training
     constexpr u64 MAX_SAMPLE_FOR_QUANTIZER = 50000;
@@ -325,8 +332,10 @@ void PlaidGlobalCentroids::Save(LocalFileHandle &file_handle) const {
     file_handle.Append(centroids_data_.data(), centroids_data_.size() * sizeof(f32));
     file_handle.Append(centroid_norms_neg_half_.data(), centroid_norms_neg_half_.size() * sizeof(f32));
 
-    // Quantizer
-    quantizer_->Save(file_handle);
+    // Quantizer (not saved in ColBERTSaR mode)
+    if (quantizer_) {
+        quantizer_->Save(file_handle);
+    }
 }
 
 void PlaidGlobalCentroids::Load(LocalFileHandle &file_handle) {
@@ -349,8 +358,10 @@ void PlaidGlobalCentroids::Load(LocalFileHandle &file_handle) {
     file_handle.Read(centroids_data_.data(), centroids_data_.size() * sizeof(f32));
     file_handle.Read(centroid_norms_neg_half_.data(), centroid_norms_neg_half_.size() * sizeof(f32));
 
-    // Read quantizer
-    quantizer_->Load(file_handle);
+    // Read quantizer (not saved in ColBERTSaR mode)
+    if (quantizer_) {
+        quantizer_->Load(file_handle);
+    }
 }
 
 size_t PlaidGlobalCentroids::MemUsage() const {
@@ -359,7 +370,9 @@ size_t PlaidGlobalCentroids::MemUsage() const {
     size_t size = sizeof(PlaidGlobalCentroids);
     size += centroids_data_.size() * sizeof(f32);
     size += centroid_norms_neg_half_.size() * sizeof(f32);
-    size += quantizer_->MemUsage();
+    if (quantizer_) {
+        size += quantizer_->MemUsage();
+    }
 
     return size;
 }

--- a/src/storage/knn_index/plaid/plaid_global_centroids_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_global_centroids_impl.cpp
@@ -327,13 +327,15 @@ void PlaidGlobalCentroids::Save(LocalFileHandle &file_handle) const {
     file_handle.Append(&embedding_dimension_, sizeof(embedding_dimension_));
     file_handle.Append(&nbits_, sizeof(nbits_));
     file_handle.Append(&n_centroids_, sizeof(n_centroids_));
+    const bool has_quantizer = (quantizer_ != nullptr);
+    file_handle.Append(&has_quantizer, sizeof(has_quantizer));
 
     // Centroids data
     file_handle.Append(centroids_data_.data(), centroids_data_.size() * sizeof(f32));
     file_handle.Append(centroid_norms_neg_half_.data(), centroid_norms_neg_half_.size() * sizeof(f32));
 
     // Quantizer (not saved in ColBERTSaR mode)
-    if (quantizer_) {
+    if (has_quantizer) {
         quantizer_->Save(file_handle);
     }
 }
@@ -351,6 +353,8 @@ void PlaidGlobalCentroids::Load(LocalFileHandle &file_handle) {
     }
 
     file_handle.Read(&n_centroids_, sizeof(n_centroids_));
+    bool has_quantizer = false;
+    file_handle.Read(&has_quantizer, sizeof(has_quantizer));
 
     // Read centroids data
     centroids_data_.resize(n_centroids_ * embedding_dimension_);
@@ -358,8 +362,11 @@ void PlaidGlobalCentroids::Load(LocalFileHandle &file_handle) {
     file_handle.Read(centroids_data_.data(), centroids_data_.size() * sizeof(f32));
     file_handle.Read(centroid_norms_neg_half_.data(), centroid_norms_neg_half_.size() * sizeof(f32));
 
-    // Read quantizer (not saved in ColBERTSaR mode)
-    if (quantizer_) {
+    // Read quantizer (driven by file marker, not by instance state)
+    if (has_quantizer) {
+        if (!quantizer_) {
+            UnrecoverableError("PlaidGlobalCentroids::Load: file has quantizer but instance was created without one");
+        }
         quantizer_->Load(file_handle);
     }
 }

--- a/src/storage/knn_index/plaid/plaid_index.cppm
+++ b/src/storage/knn_index/plaid/plaid_index.cppm
@@ -37,10 +37,16 @@ using PlaidQueryResultType = std::tuple<u32, std::unique_ptr<f32[]>, std::unique
 export class PlaidIndex {
 public:
     // Constructor for memory-based index
-    PlaidIndex(u32 start_segment_offset, u32 embedding_dimension, u32 nbits, u32 n_centroids = 0);
+    PlaidIndex(u32 start_segment_offset, u32 embedding_dimension, u32 nbits, u32 n_centroids = 0, bool colbertsar_mode = false);
 
     // Constructor for mmap-based index
-    PlaidIndex(u32 start_segment_offset, u32 embedding_dimension, u32 nbits, u32 n_centroids, void *mmap_addr, size_t mmap_size);
+    PlaidIndex(u32 start_segment_offset,
+               u32 embedding_dimension,
+               u32 nbits,
+               u32 n_centroids,
+               void *mmap_addr,
+               size_t mmap_size,
+               bool colbertsar_mode = false);
 
     ~PlaidIndex();
 
@@ -110,6 +116,7 @@ public:
     u32 GetNCentroids() const { return n_centroids_; }
     u32 GetEmbeddingDimension() const { return embedding_dimension_; }
     bool IsMmap() const { return is_mmap_; }
+    bool IsColBERTSaRMode() const { return colbertsar_mode_; }
 
     // Access centroids (for global centroids sharing)
     const std::vector<f32> &centroids_data() const { return global_centroids_ref_ ? global_centroids_ref_->centroids_data() : centroids_data_; }
@@ -233,6 +240,9 @@ public:
 
     // Quantizer
     std::unique_ptr<PlaidQuantizer> quantizer_;
+
+    // ColBERTSaR mode (residual-free)
+    bool colbertsar_mode_ = false;
 
     // Mmap support
     void *mmap_addr_ = nullptr;

--- a/src/storage/knn_index/plaid/plaid_index.cppm
+++ b/src/storage/knn_index/plaid/plaid_index.cppm
@@ -315,6 +315,16 @@ public:
     // Static helper: compute auto n_centroids using next-plaid formula
     static u32 ComputeAutoNCentroids(u64 embedding_count);
 
+    // ColBERTSaR query-aware centroid training via SGD
+    // Uses in-batch document embeddings as pseudo-queries when no external queries provided
+    // Optimizes: min_C ||Q·C[assignments]^T - Q·D^T||  (MaxSim approximation error)
+    void TrainQueryAwareCentroids(u32 n_centroids,
+                                  const f32 *embedding_data,
+                                  u64 embedding_num,
+                                  u32 batch_size = 2048,
+                                  u32 n_epochs = 50,
+                                  f32 learning_rate = 1e-4f);
+
     // Ensure IVF is in mutable (nested vector) form.
     // If currently flattened, reconstructs ivf_lists_ from ivf_data_ and clears
     // the flattened arrays. Must be called at the start of any IVF-mutating

--- a/src/storage/knn_index/plaid/plaid_index_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_index_impl.cpp
@@ -1141,11 +1141,13 @@ void PlaidIndex::TrainQueryAwareCentroids(const u32 n_centroids,
     // Gradient accumulation buffer for centroids (one per batch)
     auto grad_accum = std::make_unique<f32[]>(K * dim);
 
+    // Single RNG for all epochs (avoid recreating per iteration)
+    std::random_device rd;
+    std::mt19937 gen(rd());
+
     for (u32 epoch = 0; epoch < n_epochs; ++epoch) {
         // Shuffle indices for this epoch
-        std::random_device rd;
-        std::mt19937 gen_epoch(rd());
-        std::shuffle(indices.begin(), indices.end(), gen_epoch);
+        std::shuffle(indices.begin(), indices.end(), gen);
 
         f64 epoch_loss = 0.0; // Use double for stable accumulation
         u64 epoch_samples = 0;

--- a/src/storage/knn_index/plaid/plaid_index_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_index_impl.cpp
@@ -514,13 +514,14 @@ void PlaidIndex::AddMultipleDocsEmbeddings(const f32 *embedding_data, const std:
                                                            dist_table_chunk.get());
 
             for (u32 i = 0; i < chunk_count; ++i) {
-                f32 max_neg_distance = std::numeric_limits<f32>::lowest();
+                f32 max_dot = std::numeric_limits<f32>::lowest();
                 u32 max_id = 0;
                 const f32 *dist_ptr = dist_table_chunk.get() + i * n_centroids_;
 
                 for (u32 k = 0; k < n_centroids_; ++k) {
-                    if (const f32 neg_distance = dist_ptr[k] + centroid_norms_neg_half_[k]; neg_distance > max_neg_distance) {
-                        max_neg_distance = neg_distance;
+                    // ColBERTSaR: pure dot product (no L2 norm correction)
+                    if (dist_ptr[k] > max_dot) {
+                        max_dot = dist_ptr[k];
                         max_id = k;
                     }
                 }
@@ -1041,12 +1042,15 @@ std::unique_ptr<f32[]> PlaidIndex::ComputeQueryCentroidScores(const f32 *query_p
     const auto &norms = centroid_norms_neg_half();
     matrixA_multiply_transpose_matrixB_output_to_C(query_ptr, centroids.data(), n_query_tokens, n_centroids_, embedding_dimension_, sc);
 
-    // Add centroid_norms_neg_half for L2 distance computation
-    for (u32 i = 0; i < n_query_tokens; ++i) {
-        for (u32 j = 0; j < n_centroids_; ++j) {
-            sc[i * n_centroids_ + j] += norms[j];
+    if (!colbertsar_mode_) {
+        // PLAID: add centroid_norms_neg_half for L2 distance computation
+        for (u32 i = 0; i < n_query_tokens; ++i) {
+            for (u32 j = 0; j < n_centroids_; ++j) {
+                sc[i * n_centroids_ + j] += norms[j];
+            }
         }
     }
+    // ColBERTSaR: use pure dot product scores (no L2 norm correction)
 
     return scores;
 }
@@ -1143,8 +1147,8 @@ void PlaidIndex::TrainQueryAwareCentroids(const u32 n_centroids,
         std::mt19937 gen_epoch(rd());
         std::shuffle(indices.begin(), indices.end(), gen_epoch);
 
-        f32 epoch_loss = 0.0f;
-        u32 n_batches = 0;
+        f64 epoch_loss = 0.0; // Use double for stable accumulation
+        u64 epoch_samples = 0;
 
         // Process data in mini-batches
         for (u64 offset = 0; offset < embedding_num; offset += batch_size) {
@@ -1192,21 +1196,29 @@ void PlaidIndex::TrainQueryAwareCentroids(const u32 n_centroids,
             matrixA_multiply_transpose_matrixB_output_to_C(batch.get(), batch.get(), cur_batch, cur_batch, dim, qd.get());
 
             // 5. diff = qc - qd  [cur_batch, cur_batch]
-            //    Compute loss = mean_i(||diff[i,:]||) = mean_i(sqrt(sum_j diff[i][j]²))
+            //    Loss = mean_i(||diff[i,:]||)  where ||·|| is L2 norm
+            //    d(loss)/d(A_j) = mean_i(diff[i][j] * Q_i / N_i)   where N_i = ||diff[i,:]||
+            //    See: d/dx sqrt(sum x²) = x / sqrt(sum x²)
+            //    Store normalized diff^T: diff_T[j][i] = diff[i][j] / N_i
             f32 batch_loss = 0.0f;
-            auto diff_T = std::make_unique<f32[]>(cur_batch * cur_batch); // Stored as [cur_batch, cur_batch] but as diff^T layout
+            auto diff_T = std::make_unique<f32[]>(cur_batch * cur_batch);
             for (u32 i = 0; i < cur_batch; ++i) {
                 f32 norm_sq = 0.0f;
                 for (u32 j = 0; j < cur_batch; ++j) {
                     const f32 d = qc[i * cur_batch + j] - qd[i * cur_batch + j];
-                    // Store in diff^T layout: diff_T[j][i] = diff[i][j]
-                    diff_T[j * cur_batch + i] = d;
+                    diff_T[j * cur_batch + i] = d; // temporary, will normalize
                     norm_sq += d * d;
                 }
-                batch_loss += std::sqrt(norm_sq);
+                const f32 norm_i = std::sqrt(norm_sq);
+                batch_loss += norm_i;
+                // Normalize: gradient factor = 1/N_i, with epsilon for numerical stability
+                const f32 inv_norm = (norm_i > 1e-12f) ? (1.0f / norm_i) : 0.0f;
+                for (u32 j = 0; j < cur_batch; ++j) {
+                    diff_T[j * cur_batch + i] *= inv_norm;
+                }
             }
-            epoch_loss += batch_loss;
-            ++n_batches;
+            epoch_loss += static_cast<f64>(batch_loss);
+            epoch_samples += cur_batch;
 
             // 6. Compute gradient: grad_contrib = diff_T @ Q  [cur_batch, dim]
             //    diff_T is [cur_batch, cur_batch], Q = batch is [cur_batch, dim]
@@ -1232,8 +1244,9 @@ void PlaidIndex::TrainQueryAwareCentroids(const u32 n_centroids,
             auto grad_contrib = std::make_unique<f32[]>(cur_batch * dim);
             matrixA_multiply_transpose_matrixB_output_to_C(diff_T.get(), batch_T.get(), cur_batch, dim, cur_batch, grad_contrib.get());
 
-            // Scale: 2/(Nq * B) where Nq = B = cur_batch (in-batch mode)
-            const f32 scale = 2.0f / (static_cast<f32>(cur_batch) * static_cast<f32>(cur_batch));
+            // Gradient scale: 1/Nq for mean over queries (Nq = cur_batch in in-batch mode)
+            // The diff is already divided by N_i in step 5, so only the 1/Nq factor remains
+            const f32 scale = 1.0f / static_cast<f32>(cur_batch);
 
             // 7. Scatter-add gradients to centroids
             for (u32 j = 0; j < cur_batch; ++j) {
@@ -1256,7 +1269,9 @@ void PlaidIndex::TrainQueryAwareCentroids(const u32 n_centroids,
             centroid_norms_neg_half_[k] = -0.5f * L2NormSquare<f32, f32, u32>(centroids_data_.data() + k * dim, dim);
         }
 
-        const f32 avg_loss = (n_batches > 0) ? epoch_loss / static_cast<f32>(n_batches) : 0.0f;
+        // epoch_loss = sum over all queries of ||diff_i|| across all batches
+        // avg_loss = mean_i(||diff_i||) = epoch_loss / epoch_samples
+        const f32 avg_loss = (epoch_samples > 0) ? static_cast<f32>(epoch_loss / static_cast<f64>(epoch_samples)) : 0.0f;
         LOG_TRACE(fmt::format("TrainQueryAwareCentroids: Epoch {}/{} avg_loss={:.6f}", epoch + 1, n_epochs, avg_loss));
     }
 
@@ -1304,10 +1319,12 @@ void PlaidIndex::BatchedIVFProbe(const f32 *query_ptr,
                                                        embedding_dimension_,
                                                        batch_scores.get());
 
-        // Add centroid_norms_neg_half for L2 distance computation
-        for (u32 i = 0; i < n_query_tokens; ++i) {
-            for (u32 j = 0; j < current_batch_size; ++j) {
-                batch_scores[i * current_batch_size + j] += norms[batch_start + j];
+        // Add centroid_norms_neg_half for L2 distance computation (PLAID only)
+        if (!colbertsar_mode_) {
+            for (u32 i = 0; i < n_query_tokens; ++i) {
+                for (u32 j = 0; j < current_batch_size; ++j) {
+                    batch_scores[i * current_batch_size + j] += norms[batch_start + j];
+                }
             }
         }
 
@@ -1396,11 +1413,15 @@ void PlaidIndex::BatchedIVFProbe(const f32 *query_ptr,
                                                        embedding_dimension_,
                                                        sparse_batch_scores.get());
 
-        // Add norms and store
+        // Add norms and store (PLAID only adds centroid norms; ColBERTSaR uses pure dot product)
         for (u32 q = 0; q < n_query_tokens; ++q) {
             for (u32 i = 0; i < current_batch; ++i) {
                 const u32 cid = probed_centroids[batch_start + i];
-                sparse_centroid_scores[(batch_start + i) * n_query_tokens + q] = sparse_batch_scores[q * current_batch + i] + norms[cid];
+                f32 val = sparse_batch_scores[q * current_batch + i];
+                if (!colbertsar_mode_) {
+                    val += norms[cid];
+                }
+                sparse_centroid_scores[(batch_start + i) * n_query_tokens + q] = val;
             }
         }
     }

--- a/src/storage/knn_index/plaid/plaid_index_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_index_impl.cpp
@@ -110,19 +110,24 @@ inline f32 simd_hmax(const f32 *data, u32 len) {
 }
 #endif
 
-PlaidIndex::PlaidIndex(const u32 start_segment_offset, const u32 embedding_dimension, const u32 nbits, const u32 n_centroids)
+PlaidIndex::PlaidIndex(const u32 start_segment_offset,
+                       const u32 embedding_dimension,
+                       const u32 nbits,
+                       const u32 n_centroids,
+                       const bool colbertsar_mode)
     : start_segment_offset_(start_segment_offset), embedding_dimension_(embedding_dimension), nbits_(nbits), requested_n_centroids_(n_centroids),
-      quantizer_(std::make_unique<PlaidQuantizer>(nbits, embedding_dimension)) {}
+      quantizer_(colbertsar_mode ? nullptr : std::make_unique<PlaidQuantizer>(nbits, embedding_dimension)), colbertsar_mode_(colbertsar_mode) {}
 
 PlaidIndex::PlaidIndex(const u32 start_segment_offset,
                        const u32 embedding_dimension,
                        const u32 nbits,
                        const u32 n_centroids,
                        void *mmap_addr,
-                       const size_t mmap_size)
+                       const size_t mmap_size,
+                       const bool colbertsar_mode)
     : start_segment_offset_(start_segment_offset), embedding_dimension_(embedding_dimension), nbits_(nbits), requested_n_centroids_(n_centroids),
-      quantizer_(std::make_unique<PlaidQuantizer>(nbits, embedding_dimension)), mmap_addr_(mmap_addr), mmap_size_(mmap_size), is_mmap_(true),
-      owns_data_(false) {}
+      quantizer_(colbertsar_mode ? nullptr : std::make_unique<PlaidQuantizer>(nbits, embedding_dimension)), colbertsar_mode_(colbertsar_mode),
+      mmap_addr_(mmap_addr), mmap_size_(mmap_size), is_mmap_(true), owns_data_(false) {}
 
 PlaidIndex::~PlaidIndex() = default;
 
@@ -135,8 +140,8 @@ PlaidIndex::PlaidIndex(PlaidIndex &&other)
       owned_centroid_ids_(std::move(other.owned_centroid_ids_)), mmap_centroid_ids_(other.mmap_centroid_ids_),
       mmap_centroid_ids_size_(other.mmap_centroid_ids_size_), packed_residuals_(std::move(other.packed_residuals_)),
       packed_residuals_size_(other.packed_residuals_size_), packed_residuals_capacity_(other.packed_residuals_capacity_),
-      ivf_lists_(std::move(other.ivf_lists_)), quantizer_(std::move(other.quantizer_)), mmap_addr_(other.mmap_addr_), mmap_size_(other.mmap_size_),
-      is_mmap_(other.is_mmap_), owns_data_(other.owns_data_) {
+      ivf_lists_(std::move(other.ivf_lists_)), quantizer_(std::move(other.quantizer_)), colbertsar_mode_(other.colbertsar_mode_),
+      mmap_addr_(other.mmap_addr_), mmap_size_(other.mmap_size_), is_mmap_(other.is_mmap_), owns_data_(other.owns_data_) {
     other.mmap_addr_ = nullptr;
     other.mmap_size_ = 0;
     other.n_docs_ = 0;
@@ -154,6 +159,7 @@ PlaidIndex &PlaidIndex::operator=(PlaidIndex &&other) {
         std::unique_lock other_lock(other.rw_mutex_);
 
         n_centroids_ = other.n_centroids_;
+        colbertsar_mode_ = other.colbertsar_mode_;
         centroids_data_ = std::move(other.centroids_data_);
         centroid_norms_neg_half_ = std::move(other.centroid_norms_neg_half_);
         global_centroids_ref_ = std::move(other.global_centroids_ref_);
@@ -190,7 +196,12 @@ PlaidIndex &PlaidIndex::operator=(PlaidIndex &&other) {
     return *this;
 }
 
-u64 PlaidIndex::ExpectLeastTrainingDataNum() const { return std::max<u64>(32ul * n_centroids_, 32ul * quantizer_->n_buckets()); }
+u64 PlaidIndex::ExpectLeastTrainingDataNum() const {
+    if (colbertsar_mode_) {
+        return std::max<u64>(32ul * n_centroids_, 256ul);
+    }
+    return std::max<u64>(32ul * n_centroids_, 32ul * quantizer_->n_buckets());
+}
 
 void PlaidIndex::Train(const u32 centroids_num, const f32 *embedding_data, const u64 embedding_num, const u32 iter_cnt) {
     std::unique_lock lock(rw_mutex_);
@@ -286,6 +297,13 @@ void PlaidIndex::Train(const u32 centroids_num, const f32 *embedding_data, const
         sampled_data.reset();
         LOG_INFO(fmt::format("PlaidIndex::TrainWithSampling: Freed K-means sampling data, saved ~{} MB",
                              actual_sample_size * embedding_dimension_ * sizeof(f32) / (1024 * 1024)));
+    }
+
+    if (colbertsar_mode_) {
+        LOG_INFO("PlaidIndex::TrainWithSampling: ColBERTSaR mode, skipping residual quantizer training.");
+        auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_1 - time_0).count();
+        LOG_INFO(fmt::format("PlaidIndex::Train: Finish train, total time cost: {} ms", total_ms));
+        return;
     }
 
     // Sample residuals for quantizer training (following next-plaid's strategy)
@@ -396,35 +414,76 @@ void PlaidIndex::AddMultipleDocsEmbeddings(const f32 *embedding_data, const std:
     for (u32 len : doc_lens)
         total_embedding_num += len;
 
-    // Assign to centroids and quantize residuals using STREAMING processing
-    // Following next-plaid's strategy: compute residuals -> quantize immediately -> release memory
+    // Assign to centroids and (optionally) quantize residuals using STREAMING processing
     std::vector<u32> centroid_id_assignments(total_embedding_num);
 
-    // Get packed dimension from quantizer (constant for all chunks)
-    // Use ceiling division to match PlaidQuantizer::packed_dim() computation
     const u32 packed_dim = (embedding_dimension_ * nbits_ + 7) / 8;
-    const size_t new_data_size = total_embedding_num * packed_dim;
-    const size_t old_packed_size = packed_residuals_size_;
 
-    // IMPORTANT: First release old packed_residuals_ to temporary, then allocate new memory
-    // This minimizes peak memory: at any point we only have old OR new, not both
-    auto old_packed = std::move(packed_residuals_);
-    packed_residuals_size_ = 0; // Reset size since we're moving ownership
+    if (!colbertsar_mode_) {
+        // PLAID mode: compute residuals -> quantize immediately -> release memory
+        const size_t new_data_size = total_embedding_num * packed_dim;
+        const size_t old_packed_size = packed_residuals_size_;
 
-    // Now allocate new buffer (old memory is in 'old_packed', will be freed after copy)
-    auto new_packed = std::make_unique<u8[]>(old_packed_size + new_data_size);
+        // IMPORTANT: First release old packed_residuals_ to temporary, then allocate new memory
+        auto old_packed = std::move(packed_residuals_);
+        packed_residuals_size_ = 0;
 
-    // Copy old data first (if any), then immediately release old memory
-    if (old_packed_size > 0 && old_packed) {
-        std::copy_n(old_packed.get(), old_packed_size, new_packed.get());
-        old_packed.reset(); // IMMEDIATELY release old memory
-    }
+        auto new_packed = std::make_unique<u8[]>(old_packed_size + new_data_size);
 
-    // Process in chunks and write new data directly to the buffer
-    {
-        // Process in chunks to limit memory usage
-        // Target: keep distance table under ~256MB (64M floats)
-        // For n_centroids=4096, chunk_size = 64M / 4096 = 16384
+        if (old_packed_size > 0 && old_packed) {
+            std::copy_n(old_packed.get(), old_packed_size, new_packed.get());
+            old_packed.reset();
+        }
+
+        {
+            constexpr u32 CHUNK_SIZE = 16384;
+            const auto dist_table_chunk = std::make_unique_for_overwrite<f32[]>(CHUNK_SIZE * n_centroids_);
+
+            for (u64 chunk_start = 0; chunk_start < total_embedding_num; chunk_start += CHUNK_SIZE) {
+                const u32 chunk_end = std::min(static_cast<u32>(chunk_start + CHUNK_SIZE), static_cast<u32>(total_embedding_num));
+                const u32 chunk_count = chunk_end - chunk_start;
+
+                matrixA_multiply_transpose_matrixB_output_to_C(embedding_data + chunk_start * embedding_dimension_,
+                                                               centroids_data_.data(),
+                                                               chunk_count,
+                                                               n_centroids_,
+                                                               embedding_dimension_,
+                                                               dist_table_chunk.get());
+
+                const auto chunk_residuals = std::make_unique_for_overwrite<f32[]>(chunk_count * embedding_dimension_);
+
+                for (u32 i = 0; i < chunk_count; ++i) {
+                    const f32 *embedding_data_ptr = embedding_data + (chunk_start + i) * embedding_dimension_;
+                    f32 *output_ptr = chunk_residuals.get() + i * embedding_dimension_;
+                    f32 max_neg_distance = std::numeric_limits<f32>::lowest();
+                    u32 max_id = 0;
+                    const f32 *dist_ptr = dist_table_chunk.get() + i * n_centroids_;
+
+                    for (u32 k = 0; k < n_centroids_; ++k) {
+                        if (const f32 neg_distance = dist_ptr[k] + centroid_norms_neg_half_[k]; neg_distance > max_neg_distance) {
+                            max_neg_distance = neg_distance;
+                            max_id = k;
+                        }
+                    }
+
+                    centroid_id_assignments[chunk_start + i] = max_id;
+                    const f32 *centroids_data_ptr = centroids_data_.data() + max_id * embedding_dimension_;
+                    for (u32 j = 0; j < embedding_dimension_; ++j) {
+                        output_ptr[j] = embedding_data_ptr[j] - centroids_data_ptr[j];
+                    }
+                }
+
+                u32 chunk_packed_dim = 0;
+                auto chunk_packed = quantizer_->Quantize(chunk_residuals.get(), chunk_count, chunk_packed_dim);
+                std::copy_n(chunk_packed.get(), chunk_count * chunk_packed_dim, new_packed.get() + old_packed_size + chunk_start * packed_dim);
+            }
+        }
+
+        packed_residuals_size_ = old_packed_size + new_data_size;
+        packed_residuals_capacity_ = packed_residuals_size_;
+        packed_residuals_ = std::move(new_packed);
+    } else {
+        // ColBERTSaR mode: only centroid assignment, no residuals
         constexpr u32 CHUNK_SIZE = 16384;
         const auto dist_table_chunk = std::make_unique_for_overwrite<f32[]>(CHUNK_SIZE * n_centroids_);
 
@@ -432,7 +491,6 @@ void PlaidIndex::AddMultipleDocsEmbeddings(const f32 *embedding_data, const std:
             const u32 chunk_end = std::min(static_cast<u32>(chunk_start + CHUNK_SIZE), static_cast<u32>(total_embedding_num));
             const u32 chunk_count = chunk_end - chunk_start;
 
-            // Compute distances for this chunk
             matrixA_multiply_transpose_matrixB_output_to_C(embedding_data + chunk_start * embedding_dimension_,
                                                            centroids_data_.data(),
                                                            chunk_count,
@@ -440,12 +498,7 @@ void PlaidIndex::AddMultipleDocsEmbeddings(const f32 *embedding_data, const std:
                                                            embedding_dimension_,
                                                            dist_table_chunk.get());
 
-            // Compute residuals for this chunk (STREAMING: only allocate chunk-sized residuals)
-            const auto chunk_residuals = std::make_unique_for_overwrite<f32[]>(chunk_count * embedding_dimension_);
-
             for (u32 i = 0; i < chunk_count; ++i) {
-                const f32 *embedding_data_ptr = embedding_data + (chunk_start + i) * embedding_dimension_;
-                f32 *output_ptr = chunk_residuals.get() + i * embedding_dimension_;
                 f32 max_neg_distance = std::numeric_limits<f32>::lowest();
                 u32 max_id = 0;
                 const f32 *dist_ptr = dist_table_chunk.get() + i * n_centroids_;
@@ -456,27 +509,10 @@ void PlaidIndex::AddMultipleDocsEmbeddings(const f32 *embedding_data, const std:
                         max_id = k;
                     }
                 }
-
                 centroid_id_assignments[chunk_start + i] = max_id;
-                const f32 *centroids_data_ptr = centroids_data_.data() + max_id * embedding_dimension_;
-                for (u32 j = 0; j < embedding_dimension_; ++j) {
-                    output_ptr[j] = embedding_data_ptr[j] - centroids_data_ptr[j];
-                }
             }
-
-            // Quantize this chunk immediately (STREAMING: quantize then release residuals memory)
-            u32 chunk_packed_dim = 0;
-            auto chunk_packed = quantizer_->Quantize(chunk_residuals.get(), chunk_count, chunk_packed_dim);
-
-            // Write new data after the old data
-            std::copy_n(chunk_packed.get(), chunk_count * chunk_packed_dim, new_packed.get() + old_packed_size + chunk_start * packed_dim);
         }
     }
-
-    // Update size and move new data to storage
-    packed_residuals_size_ = old_packed_size + new_data_size;
-    packed_residuals_capacity_ = packed_residuals_size_;
-    packed_residuals_ = std::move(new_packed);
 
     // Store centroid assignments
     // Reserve space first to avoid multiple reallocations
@@ -535,15 +571,6 @@ void PlaidIndex::AddMultipleDocsEmbeddingsWithCentroids(const f32 *embedding_dat
     for (u32 len : doc_lens)
         total_embedding_num += len;
 
-    // Get expected packed dimension from quantizer
-    // Use ceiling division to match PlaidQuantizer::packed_dim() computation
-    const u32 expected_packed_dim = (embedding_dimension_ * nbits_ + 7) / 8;
-    if (packed_dim != expected_packed_dim) {
-        UnrecoverableError(fmt::format("PlaidIndex::AddMultipleDocsEmbeddingsWithCentroids: packed_dim mismatch. Expected {}, got {}",
-                                       expected_packed_dim,
-                                       packed_dim));
-    }
-
     // Copy centroid IDs
     const size_t old_centroid_ids_size = owned_centroid_ids_.size();
     owned_centroid_ids_.reserve(old_centroid_ids_size + total_embedding_num);
@@ -551,25 +578,34 @@ void PlaidIndex::AddMultipleDocsEmbeddingsWithCentroids(const f32 *embedding_dat
         owned_centroid_ids_.push_back(centroid_ids[i]);
     }
 
-    // Copy packed residuals
-    const size_t new_data_size = total_embedding_num * packed_dim;
-    const size_t old_packed_size = packed_residuals_size_;
+    if (!colbertsar_mode_) {
+        // PLAID mode: copy packed residuals
+        const u32 expected_packed_dim = (embedding_dimension_ * nbits_ + 7) / 8;
+        if (packed_dim != expected_packed_dim) {
+            UnrecoverableError(fmt::format("PlaidIndex::AddMultipleDocsEmbeddingsWithCentroids: packed_dim mismatch. Expected {}, got {}",
+                                           expected_packed_dim,
+                                           packed_dim));
+        }
 
-    auto old_packed = std::move(packed_residuals_);
-    packed_residuals_size_ = 0;
+        const size_t new_data_size = total_embedding_num * packed_dim;
+        const size_t old_packed_size = packed_residuals_size_;
 
-    auto new_packed = std::make_unique<u8[]>(old_packed_size + new_data_size);
+        auto old_packed = std::move(packed_residuals_);
+        packed_residuals_size_ = 0;
 
-    if (old_packed_size > 0 && old_packed) {
-        std::copy_n(old_packed.get(), old_packed_size, new_packed.get());
-        old_packed.reset();
+        auto new_packed = std::make_unique<u8[]>(old_packed_size + new_data_size);
+
+        if (old_packed_size > 0 && old_packed) {
+            std::copy_n(old_packed.get(), old_packed_size, new_packed.get());
+            old_packed.reset();
+        }
+
+        std::copy_n(packed_residuals, new_data_size, new_packed.get() + old_packed_size);
+
+        packed_residuals_size_ = old_packed_size + new_data_size;
+        packed_residuals_capacity_ = packed_residuals_size_;
+        packed_residuals_ = std::move(new_packed);
     }
-
-    std::copy_n(packed_residuals, new_data_size, new_packed.get() + old_packed_size);
-
-    packed_residuals_size_ = old_packed_size + new_data_size;
-    packed_residuals_capacity_ = packed_residuals_size_;
-    packed_residuals_ = std::move(new_packed);
 
     // Update IVF lists
     u64 offset = 0;
@@ -618,8 +654,8 @@ void PlaidIndex::CopyCentroidsFrom(const std::vector<f32> &centroids_data,
     centroids_data_ = centroids_data;
     centroid_norms_neg_half_ = centroid_norms_neg_half;
 
-    // Copy quantizer if provided
-    if (quantizer != nullptr) {
+    // Copy quantizer if provided (null in ColBERTSaR mode)
+    if (quantizer != nullptr && quantizer_) {
         quantizer_->CopyFrom(*quantizer);
     }
 
@@ -645,8 +681,10 @@ void PlaidIndex::ShareGlobalCentroids(std::shared_ptr<PlaidGlobalCentroids> glob
     global_centroids_ref_ = std::move(global_centroids);
     n_centroids_ = global_centroids_ref_->n_centroids();
 
-    // Copy quantizer from global centroids (still needed for dequantization)
-    quantizer_->CopyFrom(*global_centroids_ref_->quantizer());
+    // Copy quantizer from global centroids if not in ColBERTSaR mode
+    if (quantizer_) {
+        quantizer_->CopyFrom(*global_centroids_ref_->quantizer());
+    }
 
     // Resize IVF lists
     ivf_lists_.clear();
@@ -808,6 +846,19 @@ PlaidQueryResultType PlaidIndex::GetQueryResultWithBitmask(const f32 *query_ptr,
         doc_scores.emplace_back(score, doc_id);
     }
 
+    if (colbertsar_mode_) {
+        // ColBERTSaR: no residual rerank, approximate score is final
+        std::partial_sort(doc_scores.begin(), doc_scores.begin() + std::min(top_k, (u32)doc_scores.size()), doc_scores.end(), std::greater<>());
+        const u32 result_count = std::min(top_k, (u32)doc_scores.size());
+        auto scores = std::make_unique<f32[]>(result_count);
+        auto ids = std::make_unique<u32[]>(result_count);
+        for (u32 i = 0; i < result_count; ++i) {
+            scores[i] = doc_scores[i].first;
+            ids[i] = doc_scores[i].second + start_segment_offset_;
+        }
+        return std::make_tuple(result_count, std::move(scores), std::move(ids));
+    }
+
     std::partial_sort(doc_scores.begin(), doc_scores.begin() + std::min(n_doc_to_score, (u32)doc_scores.size()), doc_scores.end(), std::greater<>());
 
     const u32 n_to_rerank = std::min(n_full_scores, std::min(n_doc_to_score, (u32)doc_scores.size()));
@@ -920,6 +971,19 @@ PlaidQueryResultType PlaidIndex::GetQueryResultBatched(const f32 *query_ptr,
                                            n_sparse_centroids,
                                            query_embedding_num);
         doc_scores.emplace_back(score, doc_id);
+    }
+
+    if (colbertsar_mode_) {
+        // ColBERTSaR: no residual rerank, approximate score is final
+        std::partial_sort(doc_scores.begin(), doc_scores.begin() + std::min(top_k, (u32)doc_scores.size()), doc_scores.end(), std::greater<>());
+        const u32 result_count = std::min(top_k, (u32)doc_scores.size());
+        auto scores = std::make_unique<f32[]>(result_count);
+        auto ids = std::make_unique<u32[]>(result_count);
+        for (u32 i = 0; i < result_count; ++i) {
+            scores[i] = doc_scores[i].first;
+            ids[i] = doc_scores[i].second + start_segment_offset_;
+        }
+        return std::make_tuple(result_count, std::move(scores), std::move(ids));
     }
 
     std::partial_sort(doc_scores.begin(), doc_scores.begin() + std::min(n_doc_to_score, (u32)doc_scores.size()), doc_scores.end(), std::greater<>());
@@ -1370,6 +1434,8 @@ void PlaidIndex::SaveIndexInner(LocalFileHandle &file_handle) const {
     std::shared_lock lock(rw_mutex_);
 
     // Header
+    const u32 format_version = colbertsar_mode_ ? 2 : 1; // 1=PLAID, 2=ColBERTSaR
+    file_handle.Append(&format_version, sizeof(format_version));
     file_handle.Append(&start_segment_offset_, sizeof(start_segment_offset_));
     file_handle.Append(&embedding_dimension_, sizeof(embedding_dimension_));
     file_handle.Append(&nbits_, sizeof(nbits_));
@@ -1414,17 +1480,21 @@ void PlaidIndex::SaveIndexInner(LocalFileHandle &file_handle) const {
         }
     }
 
-    // Residual codes
-    u32 packed_residuals_size_u32 = packed_residuals_size_;
-    file_handle.Append(&packed_residuals_size_u32, sizeof(packed_residuals_size_u32));
-    file_handle.Append(packed_residuals_.get(), packed_residuals_size_);
-
-    // Quantizer
-    quantizer_->Save(file_handle);
+    if (!colbertsar_mode_) {
+        // PLAID: write residual codes and quantizer
+        u32 packed_residuals_size_u32 = packed_residuals_size_;
+        file_handle.Append(&packed_residuals_size_u32, sizeof(packed_residuals_size_u32));
+        file_handle.Append(packed_residuals_.get(), packed_residuals_size_);
+        quantizer_->Save(file_handle);
+    }
 }
 
 void PlaidIndex::ReadIndexInner(LocalFileHandle &file_handle) {
     std::unique_lock lock(rw_mutex_);
+
+    // Read format version
+    u32 format_version;
+    file_handle.Read(&format_version, sizeof(format_version));
 
     // Verify header
     u32 stored_start_segment_offset, stored_embedding_dimension, stored_nbits;
@@ -1435,6 +1505,8 @@ void PlaidIndex::ReadIndexInner(LocalFileHandle &file_handle) {
     if (stored_start_segment_offset != start_segment_offset_ || stored_embedding_dimension != embedding_dimension_ || stored_nbits != nbits_) {
         UnrecoverableError("PlaidIndex::ReadIndexInner: header mismatch");
     }
+
+    colbertsar_mode_ = (format_version == 2);
 
     file_handle.Read(&n_centroids_, sizeof(n_centroids_));
     file_handle.Read(&n_docs_, sizeof(u32));
@@ -1473,22 +1545,31 @@ void PlaidIndex::ReadIndexInner(LocalFileHandle &file_handle) {
         file_handle.Read(ivf_lists_[i].data(), list_size * sizeof(u32));
     }
 
-    // Read residual codes
-    u32 packed_residuals_size_u32;
-    file_handle.Read(&packed_residuals_size_u32, sizeof(packed_residuals_size_u32));
-    packed_residuals_size_ = packed_residuals_size_u32;
-    packed_residuals_capacity_ = packed_residuals_size_;
-    packed_residuals_ = std::make_unique<u8[]>(packed_residuals_size_);
-    file_handle.Read(packed_residuals_.get(), packed_residuals_size_);
+    // Read residual codes (only in PLAID mode, format_version == 1)
+    if (format_version == 1) {
+        u32 packed_residuals_size_u32;
+        file_handle.Read(&packed_residuals_size_u32, sizeof(packed_residuals_size_u32));
+        packed_residuals_size_ = packed_residuals_size_u32;
+        packed_residuals_capacity_ = packed_residuals_size_;
+        packed_residuals_ = std::make_unique<u8[]>(packed_residuals_size_);
+        file_handle.Read(packed_residuals_.get(), packed_residuals_size_);
 
-    // Read quantizer
-    quantizer_->Load(file_handle);
+        // Read quantizer
+        if (quantizer_) {
+            quantizer_->Load(file_handle);
+        }
+    } else {
+        packed_residuals_ = nullptr;
+        packed_residuals_size_ = 0;
+        packed_residuals_capacity_ = 0;
+    }
 }
 
 size_t PlaidIndex::CalcSize() const {
     std::shared_lock lock(rw_mutex_);
     size_t size = 0;
 
+    size += sizeof(u32); // format_version
     size += sizeof(start_segment_offset_);
     size += sizeof(embedding_dimension_);
     size += sizeof(nbits_);
@@ -1514,14 +1595,16 @@ size_t PlaidIndex::CalcSize() const {
         }
     }
 
-    size += sizeof(u32) + packed_residuals_size_;
+    if (!colbertsar_mode_) {
+        size += sizeof(u32) + packed_residuals_size_;
 
-    // Quantizer size (now includes nbits_ and embedding_dim_ to match SaveToPtr format)
-    size += sizeof(u32);                                               // nbits_
-    size += sizeof(u32);                                               // embedding_dim_
-    size += sizeof(f32);                                               // avg_residual_
-    size += sizeof(u32) + (quantizer_->n_buckets() - 1) * sizeof(f32); // bucket_cutoffs (n_buckets - 1)
-    size += sizeof(u32) + quantizer_->n_buckets() * sizeof(f32);       // bucket_weights
+        // Quantizer size (now includes nbits_ and embedding_dim_ to match SaveToPtr format)
+        size += sizeof(u32);                                               // nbits_
+        size += sizeof(u32);                                               // embedding_dim_
+        size += sizeof(f32);                                               // avg_residual_
+        size += sizeof(u32) + (quantizer_->n_buckets() - 1) * sizeof(f32); // bucket_cutoffs
+        size += sizeof(u32) + quantizer_->n_buckets() * sizeof(f32);       // bucket_weights
+    }
 
     return size;
 }
@@ -1537,6 +1620,8 @@ void PlaidIndex::SaveToPtr(void *ptr, size_t &offset) const {
         offset += len;
     };
 
+    const u32 format_version = colbertsar_mode_ ? 2 : 1;
+    append(&format_version, sizeof(format_version));
     append(&start_segment_offset_, sizeof(start_segment_offset_));
     append(&embedding_dimension_, sizeof(embedding_dimension_));
     append(&nbits_, sizeof(nbits_));
@@ -1579,12 +1664,14 @@ void PlaidIndex::SaveToPtr(void *ptr, size_t &offset) const {
         }
     }
 
-    u32 packed_size = packed_residuals_size_;
-    append(&packed_size, sizeof(packed_size));
-    append(packed_residuals_.get(), packed_residuals_size_);
+    if (!colbertsar_mode_) {
+        u32 packed_size = packed_residuals_size_;
+        append(&packed_size, sizeof(packed_size));
+        append(packed_residuals_.get(), packed_residuals_size_);
 
-    // Save quantizer data
-    quantizer_->SaveToPtr(ptr, offset);
+        // Save quantizer data
+        quantizer_->SaveToPtr(ptr, offset);
+    }
 }
 
 void PlaidIndex::LoadFromPtr(void *ptr, size_t mmap_size, size_t file_size) {
@@ -1596,6 +1683,10 @@ void PlaidIndex::LoadFromPtr(void *ptr, size_t mmap_size, size_t file_size) {
         std::memcpy(dst, src + offset, len);
         offset += len;
     };
+
+    u32 format_version;
+    read(&format_version, sizeof(format_version));
+    colbertsar_mode_ = (format_version == 2);
 
     u32 stored_start_segment_offset, stored_embedding_dimension, stored_nbits;
     read(&stored_start_segment_offset, sizeof(stored_start_segment_offset));
@@ -1645,15 +1736,25 @@ void PlaidIndex::LoadFromPtr(void *ptr, size_t mmap_size, size_t file_size) {
         read(ivf_lists_[i].data(), list_size * sizeof(u32));
     }
 
-    u32 packed_size;
-    read(&packed_size, sizeof(packed_size));
-    packed_residuals_size_ = packed_size;
-    packed_residuals_capacity_ = packed_size;
-    packed_residuals_ = std::make_unique<u8[]>(packed_residuals_size_);
-    read(packed_residuals_.get(), packed_residuals_size_);
+    if (format_version == 1) {
+        // PLAID: read residual codes and quantizer
+        u32 packed_size;
+        read(&packed_size, sizeof(packed_size));
+        packed_residuals_size_ = packed_size;
+        packed_residuals_capacity_ = packed_size;
+        packed_residuals_ = std::make_unique<u8[]>(packed_residuals_size_);
+        read(packed_residuals_.get(), packed_residuals_size_);
 
-    // Load quantizer data
-    quantizer_->LoadFromPtr(ptr, offset);
+        // Load quantizer data
+        if (quantizer_) {
+            quantizer_->LoadFromPtr(ptr, offset);
+        }
+    } else {
+        // ColBERTSaR: no residuals or quantizer
+        packed_residuals_ = nullptr;
+        packed_residuals_size_ = 0;
+        packed_residuals_capacity_ = 0;
+    }
 }
 
 u32 PlaidIndex::GetDocLen(u32 doc_id) const {
@@ -1690,8 +1791,11 @@ void PlaidIndex::MergeChunks(const std::vector<std::pair<u32, const PlaidIndex *
     std::vector<u32> merged_doc_lens;
     std::vector<u32> merged_doc_offsets;
     std::vector<u32> merged_centroid_ids;
-    auto merged_packed = std::make_unique<u8[]>(total_embeddings * packed_dim);
+    std::unique_ptr<u8[]> merged_packed;
     size_t merged_packed_offset = 0;
+    if (!colbertsar_mode_) {
+        merged_packed = std::make_unique<u8[]>(total_embeddings * packed_dim);
+    }
 
     merged_doc_lens.reserve(total_docs);
     merged_doc_offsets.reserve(total_docs);
@@ -1717,12 +1821,14 @@ void PlaidIndex::MergeChunks(const std::vector<std::pair<u32, const PlaidIndex *
         const auto &chunk_centroid_ids = chunk->centroid_ids();
         merged_centroid_ids.insert(merged_centroid_ids.end(), chunk_centroid_ids.begin(), chunk_centroid_ids.end());
 
-        // Merge packed_residuals
-        const u8 *chunk_residuals = chunk->packed_residuals();
-        size_t chunk_residuals_size = chunk->packed_residuals_size();
-        if (chunk_residuals && chunk_residuals_size > 0) {
-            std::copy_n(chunk_residuals, chunk_residuals_size, merged_packed.get() + merged_packed_offset);
-            merged_packed_offset += chunk_residuals_size;
+        // Merge packed_residuals (PLAID mode only)
+        if (!colbertsar_mode_) {
+            const u8 *chunk_residuals = chunk->packed_residuals();
+            size_t chunk_residuals_size = chunk->packed_residuals_size();
+            if (chunk_residuals && chunk_residuals_size > 0) {
+                std::copy_n(chunk_residuals, chunk_residuals_size, merged_packed.get() + merged_packed_offset);
+                merged_packed_offset += chunk_residuals_size;
+            }
         }
 
         current_embedding_offset += chunk_embedding_num;
@@ -1749,9 +1855,11 @@ void PlaidIndex::MergeChunks(const std::vector<std::pair<u32, const PlaidIndex *
     // MergeChunks always produces owned data
     EnsureMutableCentroidIDs();
     owned_centroid_ids_ = std::move(merged_centroid_ids);
-    packed_residuals_ = std::move(merged_packed);
-    packed_residuals_size_ = total_embeddings * packed_dim;
-    packed_residuals_capacity_ = packed_residuals_size_;
+    if (!colbertsar_mode_) {
+        packed_residuals_ = std::move(merged_packed);
+        packed_residuals_size_ = total_embeddings * packed_dim;
+        packed_residuals_capacity_ = packed_residuals_size_;
+    }
     ivf_lists_ = std::move(merged_ivf_lists);
 
     LOG_INFO(fmt::format("PlaidIndex::MergeChunks: Merged successfully. Total docs: {}, embeddings: {}, IVF entries: {}",
@@ -1816,30 +1924,29 @@ void PlaidIndex::MergeOneChunk(const PlaidIndex *chunk, u32 doc_offset) {
     auto chunk_centroid_ids = chunk->centroid_ids();
     owned_centroid_ids_.insert(owned_centroid_ids_.end(), chunk_centroid_ids.begin(), chunk_centroid_ids.end());
 
-    // Extend packed_residuals_ with amortized O(1) reallocation (2x growth strategy)
-    const u8 *chunk_residuals = chunk->packed_residuals();
-    size_t chunk_residuals_size = chunk->packed_residuals_size();
-    if (chunk_residuals && chunk_residuals_size > 0) {
-        const size_t new_size = packed_residuals_size_ + chunk_residuals_size;
+    // Extend packed_residuals_ (PLAID mode only)
+    if (!colbertsar_mode_) {
+        const u8 *chunk_residuals = chunk->packed_residuals();
+        size_t chunk_residuals_size = chunk->packed_residuals_size();
+        if (chunk_residuals && chunk_residuals_size > 0) {
+            const size_t new_size = packed_residuals_size_ + chunk_residuals_size;
 
-        if (new_size <= packed_residuals_capacity_) {
-            // Existing buffer has enough capacity — just append in place
-            std::copy_n(chunk_residuals, chunk_residuals_size, packed_residuals_.get() + packed_residuals_size_);
-        } else if (packed_residuals_ && packed_residuals_size_ > 0) {
-            // Need to grow: allocate max(new_size, capacity * 2) to amortize reallocation
-            const size_t alloc_size = std::max(new_size, packed_residuals_capacity_ * 2);
-            auto new_packed = std::make_unique<u8[]>(alloc_size);
-            std::copy_n(packed_residuals_.get(), packed_residuals_size_, new_packed.get());
-            std::copy_n(chunk_residuals, chunk_residuals_size, new_packed.get() + packed_residuals_size_);
-            packed_residuals_ = std::move(new_packed);
-            packed_residuals_capacity_ = alloc_size;
-        } else {
-            // First allocation
-            packed_residuals_ = std::make_unique<u8[]>(new_size);
-            std::copy_n(chunk_residuals, chunk_residuals_size, packed_residuals_.get());
-            packed_residuals_capacity_ = new_size;
+            if (new_size <= packed_residuals_capacity_) {
+                std::copy_n(chunk_residuals, chunk_residuals_size, packed_residuals_.get() + packed_residuals_size_);
+            } else if (packed_residuals_ && packed_residuals_size_ > 0) {
+                const size_t alloc_size = std::max(new_size, packed_residuals_capacity_ * 2);
+                auto new_packed = std::make_unique<u8[]>(alloc_size);
+                std::copy_n(packed_residuals_.get(), packed_residuals_size_, new_packed.get());
+                std::copy_n(chunk_residuals, chunk_residuals_size, new_packed.get() + packed_residuals_size_);
+                packed_residuals_ = std::move(new_packed);
+                packed_residuals_capacity_ = alloc_size;
+            } else {
+                packed_residuals_ = std::make_unique<u8[]>(new_size);
+                std::copy_n(chunk_residuals, chunk_residuals_size, packed_residuals_.get());
+                packed_residuals_capacity_ = new_size;
+            }
+            packed_residuals_size_ = new_size;
         }
-        packed_residuals_size_ = new_size;
     }
 
     // Update IVF lists for this chunk
@@ -2169,12 +2276,14 @@ void PlaidIndex::AcceptMergedData(std::vector<u32> &&doc_lens,
                                        total_embeddings));
     }
 
-    // Validate packed_residuals_size matches expected size
-    size_t expected_packed_size = total_embeddings * ((embedding_dimension_ * nbits_ + 7) / 8);
-    if (packed_residuals_size != expected_packed_size) {
-        UnrecoverableError(fmt::format("PlaidIndex::AcceptMergedData: packed_residuals_size {} doesn't match expected {}",
-                                       packed_residuals_size,
-                                       expected_packed_size));
+    if (!colbertsar_mode_) {
+        // Validate packed_residuals_size matches expected size
+        size_t expected_packed_size = total_embeddings * ((embedding_dimension_ * nbits_ + 7) / 8);
+        if (packed_residuals_size != expected_packed_size) {
+            UnrecoverableError(fmt::format("PlaidIndex::AcceptMergedData: packed_residuals_size {} doesn't match expected {}",
+                                           packed_residuals_size,
+                                           expected_packed_size));
+        }
     }
 
     // Move all data efficiently — AcceptMergedData always receives owned data
@@ -2182,9 +2291,11 @@ void PlaidIndex::AcceptMergedData(std::vector<u32> &&doc_lens,
     doc_lens_ = std::move(doc_lens);
     doc_offsets_ = std::move(doc_offsets);
     owned_centroid_ids_ = std::move(centroid_ids);
-    packed_residuals_ = std::move(packed_residuals);
-    packed_residuals_size_ = packed_residuals_size;
-    packed_residuals_capacity_ = packed_residuals_size_;
+    if (!colbertsar_mode_) {
+        packed_residuals_ = std::move(packed_residuals);
+        packed_residuals_size_ = packed_residuals_size;
+        packed_residuals_capacity_ = packed_residuals_size_;
+    }
     ivf_lists_ = std::move(ivf_lists);
     // AcceptMergedData receives nested ivf_lists, so clear flattened state
     ivf_data_.clear();
@@ -2205,8 +2316,10 @@ void PlaidIndex::AcceptMergedData(std::vector<u32> &&doc_lens,
         centroids_data_ = global_centroids_data;
         centroid_norms_neg_half_ = global_norms;
 
-        // Copy quantizer
-        quantizer_->CopyFrom(*global_centroids_ref_->quantizer());
+        // Copy quantizer if available
+        if (quantizer_ && global_centroids_ref_->quantizer()) {
+            quantizer_->CopyFrom(*global_centroids_ref_->quantizer());
+        }
 
         // Clear global centroids reference since we now have local copies
         // This makes the index self-contained and safe for mmap

--- a/src/storage/knn_index/plaid/plaid_index_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_index_impl.cpp
@@ -266,6 +266,21 @@ void PlaidIndex::Train(const u32 centroids_num, const f32 *embedding_data, const
     centroid_norms_neg_half_.resize(n_centroids_);
     ivf_lists_.resize(n_centroids_);
 
+    if (colbertsar_mode_) {
+        // ColBERTSaR: query-aware centroid training via SGD
+        const auto time_0 = std::chrono::high_resolution_clock::now();
+        TrainQueryAwareCentroids(n_centroids_, training_data, training_num);
+        const auto time_1 = std::chrono::high_resolution_clock::now();
+        auto train_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_1 - time_0).count();
+        LOG_INFO(fmt::format("PlaidIndex::Train: ColBERTSaR query-aware training done, time cost: {} ms", train_ms));
+
+        if (sampled_data) {
+            sampled_data.reset();
+        }
+        LOG_INFO(fmt::format("PlaidIndex::Train: Finish train, total time cost: {} ms", train_ms));
+        return;
+    }
+
     const auto time_0 = std::chrono::high_resolution_clock::now();
 
     // Train centroids using K-means on sampled data
@@ -1060,6 +1075,192 @@ u32 PlaidIndex::ComputeAutoNCentroids(const u64 embedding_count) {
     n_centroids = ((n_centroids + 7) / 8) * 8;
     n_centroids = std::max(8u, n_centroids);
     return n_centroids;
+}
+
+// ── ColBERTSaR query-aware centroid training ──
+// Implements unsupervised anchor optimization from the paper:
+//   min_C  mean_i( ||Q_i · C[assign(Q_i)]^T  -  Q_i · D^T|| )
+// where Q are query embeddings (in-batch docs as pseudo-queries), D are doc embeddings
+//
+// Gradient: d(loss)/d(c_k) ∝ sum_{i∈queries} sum_{j: assign[j]=k} (q_i·c_k - q_i·d_j) * q_i
+//
+// Uses SGD with the following per-batch computation:
+//   1. sims = D @ C.T          → assignments
+//   2. qc   = Q @ C[assign].T  → centroid-based scores
+//   3. qd   = Q @ D.T          → exact scores
+//   4. diff = qc - qd
+//   5. grad = diff^T @ Q       → gradient for each batch element
+//   6. scatter-add to centroids
+void PlaidIndex::TrainQueryAwareCentroids(const u32 n_centroids,
+                                          const f32 *embedding_data,
+                                          const u64 embedding_num,
+                                          const u32 batch_size,
+                                          const u32 n_epochs,
+                                          const f32 learning_rate) {
+    const u32 dim = embedding_dimension_;
+    const u32 K = n_centroids;
+
+    // Sample K random embeddings as initial centroids
+    {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<u64> dist(0, embedding_num - 1);
+
+        std::unordered_set<u64> seen;
+        u64 centroid_idx = 0;
+        while (centroid_idx < K) {
+            const u64 idx = dist(gen);
+            if (seen.insert(idx).second) {
+                std::copy_n(embedding_data + idx * dim, dim, centroids_data_.data() + centroid_idx * dim);
+                ++centroid_idx;
+            }
+        }
+    }
+
+    // Compute initial centroid norms
+    for (u32 k = 0; k < K; ++k) {
+        centroid_norms_neg_half_[k] = -0.5f * L2NormSquare<f32, f32, u32>(centroids_data_.data() + k * dim, dim);
+    }
+
+    LOG_INFO(fmt::format("TrainQueryAwareCentroids: Starting SGD with {} centroids, {} embeddings, batch={}, epochs={}, lr={}",
+                         K,
+                         embedding_num,
+                         batch_size,
+                         n_epochs,
+                         learning_rate));
+
+    // Create shuffled index array for epoch-based training
+    std::vector<u64> indices(embedding_num);
+    for (u64 i = 0; i < embedding_num; ++i)
+        indices[i] = i;
+
+    // Gradient accumulation buffer for centroids (one per batch)
+    auto grad_accum = std::make_unique<f32[]>(K * dim);
+
+    for (u32 epoch = 0; epoch < n_epochs; ++epoch) {
+        // Shuffle indices for this epoch
+        std::random_device rd;
+        std::mt19937 gen_epoch(rd());
+        std::shuffle(indices.begin(), indices.end(), gen_epoch);
+
+        f32 epoch_loss = 0.0f;
+        u32 n_batches = 0;
+
+        // Process data in mini-batches
+        for (u64 offset = 0; offset < embedding_num; offset += batch_size) {
+            const u32 cur_batch = static_cast<u32>(std::min(static_cast<u64>(batch_size), embedding_num - offset));
+            std::memset(grad_accum.get(), 0, K * dim * sizeof(f32));
+
+            // Gather batch embeddings: D [cur_batch, dim]
+            auto batch = std::make_unique<f32[]>(cur_batch * dim);
+            for (u32 j = 0; j < cur_batch; ++j) {
+                std::copy_n(embedding_data + indices[offset + j] * dim, dim, batch.get() + j * dim);
+            }
+
+            // 1. Compute sims = D @ C.T  [cur_batch, K]
+            auto sims = std::make_unique<f32[]>(cur_batch * K);
+            matrixA_multiply_transpose_matrixB_output_to_C(batch.get(), centroids_data_.data(), cur_batch, K, dim, sims.get());
+
+            // 2. assignments = argmax over K for each batch element
+            auto assignments = std::make_unique<u32[]>(cur_batch);
+            for (u32 j = 0; j < cur_batch; ++j) {
+                u32 best_k = 0;
+                f32 best_val = sims[j * K];
+                for (u32 k = 1; k < K; ++k) {
+                    const f32 val = sims[j * K + k];
+                    if (val > best_val) {
+                        best_val = val;
+                        best_k = k;
+                    }
+                }
+                assignments[j] = best_k;
+            }
+
+            // 3. Gather A = C[assignments]  [cur_batch, dim]
+            auto approx = std::make_unique<f32[]>(cur_batch * dim);
+            for (u32 j = 0; j < cur_batch; ++j) {
+                std::copy_n(centroids_data_.data() + assignments[j] * dim, dim, approx.get() + j * dim);
+            }
+
+            // 4. Compute query-centroid and query-doc scores (in-batch: docs = queries)
+            //    qc = Q @ A.T   [cur_batch, cur_batch] — centroid-based
+            auto qc = std::make_unique<f32[]>(cur_batch * cur_batch);
+            matrixA_multiply_transpose_matrixB_output_to_C(batch.get(), approx.get(), cur_batch, cur_batch, dim, qc.get());
+
+            //    qd = Q @ D.T   [cur_batch, cur_batch] — exact
+            auto qd = std::make_unique<f32[]>(cur_batch * cur_batch);
+            matrixA_multiply_transpose_matrixB_output_to_C(batch.get(), batch.get(), cur_batch, cur_batch, dim, qd.get());
+
+            // 5. diff = qc - qd  [cur_batch, cur_batch]
+            //    Compute loss = mean_i(||diff[i,:]||) = mean_i(sqrt(sum_j diff[i][j]²))
+            f32 batch_loss = 0.0f;
+            auto diff_T = std::make_unique<f32[]>(cur_batch * cur_batch); // Stored as [cur_batch, cur_batch] but as diff^T layout
+            for (u32 i = 0; i < cur_batch; ++i) {
+                f32 norm_sq = 0.0f;
+                for (u32 j = 0; j < cur_batch; ++j) {
+                    const f32 d = qc[i * cur_batch + j] - qd[i * cur_batch + j];
+                    // Store in diff^T layout: diff_T[j][i] = diff[i][j]
+                    diff_T[j * cur_batch + i] = d;
+                    norm_sq += d * d;
+                }
+                batch_loss += std::sqrt(norm_sq);
+            }
+            epoch_loss += batch_loss;
+            ++n_batches;
+
+            // 6. Compute gradient: grad_contrib = diff_T @ Q  [cur_batch, dim]
+            //    diff_T is [cur_batch, cur_batch], Q = batch is [cur_batch, dim]
+            //    Use: A = diff_T [cur_batch, cur_batch] (M=cur_batch, K=cur_batch)
+            //         B = batch [dim, cur_batch]        (N=dim, K=cur_batch)
+            //    out[M,N] = A @ B^T = diff_T @ batch^T... wait, we need diff_T @ batch
+            //
+            //    Actually: grad_contrib[j][d] = sum_i diff_T[j][i] * batch[i][d]
+            //    = (diff_T @ batch)[j, d] where diff_T [B,B] and batch [B,dim]
+            //    We need: A = diff_T [B, B], B = batch^T [dim, B]
+            //    C = A @ B^T = diff_T @ batch → [B, dim] ✓
+            //    So we need batch stored transposed: B_mat [dim, B] where B_mat[d][i] = batch[i][d]
+
+            // Transpose batch to [dim, cur_batch] for the GEMM
+            auto batch_T = std::make_unique<f32[]>(dim * cur_batch);
+            for (u32 i = 0; i < cur_batch; ++i) {
+                for (u32 d = 0; d < dim; ++d) {
+                    batch_T[d * cur_batch + i] = batch[i * dim + d];
+                }
+            }
+
+            // grad_contrib [cur_batch, dim] = diff_T @ batch
+            auto grad_contrib = std::make_unique<f32[]>(cur_batch * dim);
+            matrixA_multiply_transpose_matrixB_output_to_C(diff_T.get(), batch_T.get(), cur_batch, dim, cur_batch, grad_contrib.get());
+
+            // Scale: 2/(Nq * B) where Nq = B = cur_batch (in-batch mode)
+            const f32 scale = 2.0f / (static_cast<f32>(cur_batch) * static_cast<f32>(cur_batch));
+
+            // 7. Scatter-add gradients to centroids
+            for (u32 j = 0; j < cur_batch; ++j) {
+                const u32 k = assignments[j];
+                for (u32 d = 0; d < dim; ++d) {
+                    grad_accum[k * dim + d] += scale * grad_contrib[j * dim + d];
+                }
+            }
+
+            // 8. Apply SGD update
+            for (u32 k = 0; k < K; ++k) {
+                for (u32 d = 0; d < dim; ++d) {
+                    centroids_data_[k * dim + d] -= learning_rate * grad_accum[k * dim + d];
+                }
+            }
+        }
+
+        // Recompute centroid norms after each epoch
+        for (u32 k = 0; k < K; ++k) {
+            centroid_norms_neg_half_[k] = -0.5f * L2NormSquare<f32, f32, u32>(centroids_data_.data() + k * dim, dim);
+        }
+
+        const f32 avg_loss = (n_batches > 0) ? epoch_loss / static_cast<f32>(n_batches) : 0.0f;
+        LOG_TRACE(fmt::format("TrainQueryAwareCentroids: Epoch {}/{} avg_loss={:.6f}", epoch + 1, n_epochs, avg_loss));
+    }
+
+    LOG_INFO(fmt::format("TrainQueryAwareCentroids: Training complete. {} centroids trained.", K));
 }
 
 void PlaidIndex::BatchedIVFProbe(const f32 *query_ptr,

--- a/src/storage/knn_index/plaid/plaid_index_in_mem.cppm
+++ b/src/storage/knn_index/plaid/plaid_index_in_mem.cppm
@@ -62,6 +62,9 @@ export class PlaidIndexInMem : public BaseMemIndex {
     // Updated after each dump to point to the next new row
     RowID current_begin_row_id_ = {};
 
+    // ColBERTSaR mode flag
+    bool colbertsar_mode_ = false;
+
     // Global centroids shared across all chunks in the segment
     // If null, will train new centroids on first build
     std::shared_ptr<PlaidGlobalCentroids> global_centroids_;
@@ -80,7 +83,12 @@ public:
                                                                             RowID begin_row_id,
                                                                             std::shared_ptr<PlaidGlobalCentroids> global_centroids);
 
-    PlaidIndexInMem(u32 nbits, u32 n_centroids, u32 embedding_dimension, RowID begin_row_id, std::shared_ptr<ColumnDef> column_def);
+    PlaidIndexInMem(u32 nbits,
+                    u32 n_centroids,
+                    u32 embedding_dimension,
+                    RowID begin_row_id,
+                    std::shared_ptr<ColumnDef> column_def,
+                    bool colbertsar_mode = false);
 
     // Constructor with global centroids
     PlaidIndexInMem(u32 nbits,
@@ -88,7 +96,8 @@ public:
                     u32 embedding_dimension,
                     RowID begin_row_id,
                     std::shared_ptr<ColumnDef> column_def,
-                    std::shared_ptr<PlaidGlobalCentroids> global_centroids);
+                    std::shared_ptr<PlaidGlobalCentroids> global_centroids,
+                    bool colbertsar_mode = false);
 
     ~PlaidIndexInMem() override;
 

--- a/src/storage/knn_index/plaid/plaid_index_in_mem_impl.cpp
+++ b/src/storage/knn_index/plaid/plaid_index_in_mem_impl.cpp
@@ -38,8 +38,14 @@ std::shared_ptr<PlaidIndexInMem> PlaidIndexInMem::NewPlaidIndexInMem(const std::
     const auto *index_plaid = static_cast<const IndexPLAID *>(index_base.get());
     const auto *embedding_info = static_cast<EmbeddingInfo *>(column_def->type()->type_info().get());
     const u32 embedding_dimension = embedding_info->Dimension();
-    LOG_INFO(fmt::format("PlaidIndexInMem::NewPlaidIndexInMem: embedding_dimension={}", embedding_dimension));
-    return std::make_shared<PlaidIndexInMem>(index_plaid->nbits_, index_plaid->n_centroids_, embedding_dimension, begin_row_id, column_def);
+    const bool colbertsar_mode = index_plaid->colbertsar_mode_;
+    LOG_INFO(fmt::format("PlaidIndexInMem::NewPlaidIndexInMem: embedding_dimension={}, colbertsar_mode={}", embedding_dimension, colbertsar_mode));
+    return std::make_shared<PlaidIndexInMem>(index_plaid->nbits_,
+                                             index_plaid->n_centroids_,
+                                             embedding_dimension,
+                                             begin_row_id,
+                                             column_def,
+                                             colbertsar_mode);
 }
 
 std::shared_ptr<PlaidIndexInMem> PlaidIndexInMem::NewPlaidIndexInMemWithCentroids(const std::shared_ptr<IndexBase> &index_base,
@@ -49,24 +55,28 @@ std::shared_ptr<PlaidIndexInMem> PlaidIndexInMem::NewPlaidIndexInMemWithCentroid
     const auto *index_plaid = static_cast<const IndexPLAID *>(index_base.get());
     const auto *embedding_info = static_cast<EmbeddingInfo *>(column_def->type()->type_info().get());
     const u32 embedding_dimension = embedding_info->Dimension();
-    LOG_INFO(fmt::format("PlaidIndexInMem::NewPlaidIndexInMemWithCentroids: embedding_dimension={}, has_centroids={}",
+    const bool colbertsar_mode = index_plaid->colbertsar_mode_;
+    LOG_INFO(fmt::format("PlaidIndexInMem::NewPlaidIndexInMemWithCentroids: embedding_dimension={}, has_centroids={}, colbertsar_mode={}",
                          embedding_dimension,
-                         global_centroids != nullptr));
+                         global_centroids != nullptr,
+                         colbertsar_mode));
     return std::make_shared<PlaidIndexInMem>(index_plaid->nbits_,
                                              index_plaid->n_centroids_,
                                              embedding_dimension,
                                              begin_row_id,
                                              column_def,
-                                             std::move(global_centroids));
+                                             std::move(global_centroids),
+                                             colbertsar_mode);
 }
 
 PlaidIndexInMem::PlaidIndexInMem(const u32 nbits,
                                  const u32 n_centroids,
                                  const u32 embedding_dimension,
                                  const RowID begin_row_id,
-                                 std::shared_ptr<ColumnDef> column_def)
+                                 std::shared_ptr<ColumnDef> column_def,
+                                 const bool colbertsar_mode)
     : nbits_(nbits), requested_n_centroids_(n_centroids), embedding_dimension_(embedding_dimension), begin_row_id_(begin_row_id),
-      column_def_(std::move(column_def)), current_begin_row_id_(begin_row_id) {
+      column_def_(std::move(column_def)), current_begin_row_id_(begin_row_id), colbertsar_mode_(colbertsar_mode) {
     // Threshold for building index: at least enough for k-means
     build_index_threshold_ = std::max(256u, n_centroids * 32);
     // Incremental threshold: smaller batch for frequent updates
@@ -78,9 +88,11 @@ PlaidIndexInMem::PlaidIndexInMem(const u32 nbits,
                                  const u32 embedding_dimension,
                                  const RowID begin_row_id,
                                  std::shared_ptr<ColumnDef> column_def,
-                                 std::shared_ptr<PlaidGlobalCentroids> global_centroids)
+                                 std::shared_ptr<PlaidGlobalCentroids> global_centroids,
+                                 const bool colbertsar_mode)
     : nbits_(nbits), requested_n_centroids_(n_centroids), embedding_dimension_(embedding_dimension), begin_row_id_(begin_row_id),
-      column_def_(std::move(column_def)), current_begin_row_id_(begin_row_id), global_centroids_(std::move(global_centroids)) {
+      column_def_(std::move(column_def)), current_begin_row_id_(begin_row_id), colbertsar_mode_(colbertsar_mode),
+      global_centroids_(std::move(global_centroids)) {
     // Threshold for building index: at least enough for k-means
     build_index_threshold_ = std::max(256u, n_centroids * 32);
     // Incremental threshold: smaller batch for frequent updates
@@ -221,7 +233,7 @@ bool PlaidIndexInMem::BuildIndexFromScratch() {
     const auto time_0 = std::chrono::high_resolution_clock::now();
 
     // Create and train global centroids first
-    global_centroids_ = std::make_shared<PlaidGlobalCentroids>(local_embedding_dim, local_nbits);
+    global_centroids_ = std::make_shared<PlaidGlobalCentroids>(local_embedding_dim, local_nbits, colbertsar_mode_);
     global_centroids_->Train(n_centroids, all_embeddings.get(), local_embedding_count, 4);
 
     const auto time_1 = std::chrono::high_resolution_clock::now();
@@ -229,7 +241,7 @@ bool PlaidIndexInMem::BuildIndexFromScratch() {
     LOG_INFO(fmt::format("PlaidIndexInMem::BuildIndexFromScratch: Training took {} ms", train_ms));
 
     // Create index with global centroids
-    auto temp_index = std::make_unique<PlaidIndex>(local_start_segment_offset, local_embedding_dim, local_nbits, n_centroids);
+    auto temp_index = std::make_unique<PlaidIndex>(local_start_segment_offset, local_embedding_dim, local_nbits, n_centroids, colbertsar_mode_);
 
     // Copy centroids and quantizer from global_centroids_ to the index
     temp_index->CopyCentroidsFrom(global_centroids_->centroids_data(),
@@ -316,18 +328,16 @@ bool PlaidIndexInMem::BuildIndexWithGlobalCentroids() {
     auto centroid_ids = std::make_unique<u32[]>(local_embedding_count);
     global_centroids_->FindNearestCentroids(all_embeddings.get(), local_embedding_count, centroid_ids.get());
 
-    // Compute residuals and quantize in-place to save memory
-    // Instead of allocating a separate residuals array, we reuse all_embeddings
-    global_centroids_->ComputeResiduals(all_embeddings.get(), local_embedding_count, centroid_ids.get(), all_embeddings.get());
-
-    // Quantize residuals (now stored in all_embeddings) using global quantizer
+    std::unique_ptr<u8[]> packed_residuals;
     u32 packed_dim = 0;
-    auto packed_residuals = global_centroids_->quantizer()->Quantize(all_embeddings.get(), local_embedding_count, packed_dim);
+
+    if (!colbertsar_mode_) {
+        // PLAID: Compute residuals and quantize in-place
+        global_centroids_->ComputeResiduals(all_embeddings.get(), local_embedding_count, centroid_ids.get(), all_embeddings.get());
+        packed_residuals = global_centroids_->quantizer()->Quantize(all_embeddings.get(), local_embedding_count, packed_dim);
+    }
 
     // Release all_embeddings early to free memory
-    // Note: all_embeddings is no longer needed after quantization.
-    // AddMultipleDocsEmbeddingsWithCentroids uses pre-computed centroid_ids and packed_residuals,
-    // not the raw embedding_data parameter (which is unused in that code path).
     all_embeddings.reset();
 
     const auto time_3 = std::chrono::high_resolution_clock::now();
@@ -335,12 +345,12 @@ bool PlaidIndexInMem::BuildIndexWithGlobalCentroids() {
     // Create or update PlaidIndex
     if (!is_built_.test() || plaid_index_ == nullptr) {
         // Create new index
-        auto temp_index = std::make_unique<PlaidIndex>(local_start_segment_offset, local_embedding_dim, local_nbits, n_centroids);
+        auto temp_index = std::make_unique<PlaidIndex>(local_start_segment_offset, local_embedding_dim, local_nbits, n_centroids, colbertsar_mode_);
 
         // Share global centroids (avoids copying, saves memory)
         temp_index->ShareGlobalCentroids(global_centroids_);
 
-        // Add documents with pre-computed centroid IDs and packed residuals
+        // Add documents with pre-computed centroid IDs and (optionally) packed residuals
         temp_index->AddMultipleDocsEmbeddingsWithCentroids(nullptr, local_doc_lens, centroid_ids.get(), packed_residuals.get(), packed_dim);
 
         // Re-acquire lock

--- a/src/unit_test/storage/knnindex/plaid_search/test_plaid_ut.cpp
+++ b/src/unit_test/storage/knnindex/plaid_search/test_plaid_ut.cpp
@@ -23,6 +23,7 @@ import :infinity_exception;
 import :plaid_index;
 import :plaid_quantizer;
 import :local_file_handle;
+import :roaring_bitmap;
 
 using namespace infinity;
 
@@ -307,4 +308,317 @@ TEST_F(PlaidIndexTest, test_mem_usage) {
 
     size_t calc_size = index.CalcSize();
     EXPECT_EQ(mem_usage, calc_size);
+}
+
+// ── ColBERTSaR mode tests ──
+
+class PlaidIndexColBERTSaRTest : public BaseTest {
+protected:
+    static constexpr u32 embedding_dim_ = 16; // smaller dim for faster test
+    static constexpr u32 n_centroids_ = 8;
+    static constexpr u32 n_train_embeddings_ = 512; // enough for query-aware training
+    static constexpr u32 n_docs_ = 10;
+    static constexpr u32 embeddings_per_doc_ = 6;
+
+    // Generate fixed-seed random data
+    static void GenerateData(std::vector<f32> &data, u32 count, u32 seed = 42) {
+        data.resize(count * embedding_dim_);
+        std::mt19937 gen(seed);
+        std::normal_distribution<f32> dis(0.0f, 0.5f);
+        for (auto &v : data) {
+            v = dis(gen);
+        }
+    }
+};
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_construction) {
+    PlaidIndex index(0, embedding_dim_, 4 /*nbits ignored in colbertsar mode*/, n_centroids_, true);
+
+    EXPECT_TRUE(index.IsColBERTSaRMode());
+    EXPECT_EQ(index.GetEmbeddingDimension(), embedding_dim_);
+    EXPECT_EQ(index.GetNCentroids(), 0u); // Not trained yet
+    EXPECT_EQ(index.GetDocNum(), 0u);
+    EXPECT_EQ(index.GetTotalEmbeddingNum(), 0u);
+    EXPECT_FALSE(index.IsMmap());
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_train_and_add) {
+    PlaidIndex index(0, embedding_dim_, 4, n_centroids_, true);
+    EXPECT_TRUE(index.IsColBERTSaRMode());
+
+    // Generate training data
+    std::vector<f32> train_data;
+    GenerateData(train_data, n_train_embeddings_, 42);
+
+    // Train
+    index.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+    EXPECT_EQ(index.GetNCentroids(), n_centroids_);
+
+    // Add documents
+    std::vector<u32> doc_lens;
+    std::vector<f32> all_embeddings;
+    for (u32 doc = 0; doc < n_docs_; ++doc) {
+        std::vector<f32> doc_emb;
+        GenerateData(doc_emb, embeddings_per_doc_, 100 + doc);
+        all_embeddings.insert(all_embeddings.end(), doc_emb.begin(), doc_emb.end());
+        doc_lens.push_back(embeddings_per_doc_);
+    }
+
+    index.AddMultipleDocsEmbeddings(all_embeddings.data(), doc_lens);
+
+    EXPECT_EQ(index.GetDocNum(), n_docs_);
+    EXPECT_EQ(index.GetTotalEmbeddingNum(), n_docs_ * embeddings_per_doc_);
+
+    // Verify document lengths
+    for (u32 doc = 0; doc < n_docs_; ++doc) {
+        EXPECT_EQ(index.GetDocLen(doc), embeddings_per_doc_);
+    }
+
+    // ColBERTSaR: no residuals stored → CalcSize should be smaller than PLAID equivalent
+    // PLAID with same data would have packed_residuals (n_total_embeddings * packed_dim bytes)
+    // ColBERTSaR has no packed_residuals, so CalcSize is noticeably smaller
+    size_t colbertsar_size = index.CalcSize();
+    EXPECT_GT(colbertsar_size, 0u);
+
+    // Verify: a non-colbertsar index with same data is strictly larger
+    PlaidIndex plaid_index(0, embedding_dim_, 4, n_centroids_, false);
+    plaid_index.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+    plaid_index.AddMultipleDocsEmbeddings(all_embeddings.data(), doc_lens);
+    size_t plaid_size = plaid_index.CalcSize();
+    EXPECT_GT(plaid_size, colbertsar_size);
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_basic_search) {
+    PlaidIndex index(0, embedding_dim_, 4, n_centroids_, true);
+
+    std::vector<f32> train_data;
+    GenerateData(train_data, n_train_embeddings_, 42);
+    index.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+
+    // Add documents
+    std::vector<u32> doc_lens;
+    std::vector<f32> all_embeddings;
+    for (u32 doc = 0; doc < n_docs_; ++doc) {
+        std::vector<f32> doc_emb;
+        GenerateData(doc_emb, embeddings_per_doc_, 100 + doc);
+        all_embeddings.insert(all_embeddings.end(), doc_emb.begin(), doc_emb.end());
+        doc_lens.push_back(embeddings_per_doc_);
+    }
+    index.AddMultipleDocsEmbeddings(all_embeddings.data(), doc_lens);
+    EXPECT_EQ(index.GetDocNum(), n_docs_);
+
+    // Build a simple query from the first doc's first embedding
+    // Use a random query vector
+    std::vector<f32> query(embedding_dim_, 0.0f);
+    query[0] = 1.0f;
+
+    // Create full bitmask (all docs visible)
+    Bitmask bitmask(index.GetDocNum() + 1);
+    bitmask.SetAllTrue();
+
+    // Search
+    constexpr u32 n_ivf_probe = 4;
+    constexpr u32 top_k = 3;
+    auto [result_count, scores, ids] = index.SearchWithBitmask(query.data(),
+                                                               1 /* single query token */,
+                                                               top_k,
+                                                               bitmask,
+                                                               nullptr,
+                                                               0 /* begin_ts */,
+                                                               n_ivf_probe,
+                                                               0.0f /* no threshold */,
+                                                               top_k /* n_doc_to_score */,
+                                                               0 /* no full rerank since colbertsar */);
+
+    // Should return some results (possibly 0 with random data, but at least doesn't crash)
+    EXPECT_LE(result_count, top_k);
+    if (result_count > 0) {
+        for (u32 i = 0; i < result_count; ++i) {
+            EXPECT_LT(ids[i], n_docs_ + index.GetNCentroids()); // ids are offset by start_segment_offset (0)
+            EXPECT_TRUE(std::isfinite(scores[i]));
+        }
+    }
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_save_load) {
+    PlaidIndex index1(0, embedding_dim_, 4, n_centroids_, true);
+
+    std::vector<f32> train_data;
+    GenerateData(train_data, n_train_embeddings_, 42);
+    index1.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+
+    std::vector<u32> doc_lens;
+    std::vector<f32> all_embeddings;
+    for (u32 doc = 0; doc < n_docs_; ++doc) {
+        std::vector<f32> doc_emb;
+        GenerateData(doc_emb, embeddings_per_doc_, 100 + doc);
+        all_embeddings.insert(all_embeddings.end(), doc_emb.begin(), doc_emb.end());
+        doc_lens.push_back(embeddings_per_doc_);
+    }
+    index1.AddMultipleDocsEmbeddings(all_embeddings.data(), doc_lens);
+
+    size_t calc_size = index1.CalcSize();
+    EXPECT_GT(calc_size, 0u);
+
+    // Save to memory
+    auto buffer = std::make_unique<char[]>(calc_size);
+    size_t offset = 0;
+    index1.SaveToPtr(buffer.get(), offset);
+
+    // Load into new index (colbertsar mode is read from file format, constructor mode matches)
+    PlaidIndex index2(0, embedding_dim_, 4, n_centroids_, true);
+    index2.LoadFromPtr(buffer.get(), calc_size, calc_size);
+
+    // Verify loaded index
+    EXPECT_TRUE(index2.IsColBERTSaRMode());
+    EXPECT_EQ(index2.GetNCentroids(), n_centroids_);
+    EXPECT_EQ(index2.GetDocNum(), n_docs_);
+    EXPECT_EQ(index2.GetTotalEmbeddingNum(), n_docs_ * embeddings_per_doc_);
+
+    // Verify document lengths
+    for (u32 doc = 0; doc < n_docs_; ++doc) {
+        EXPECT_EQ(index2.GetDocLen(doc), embeddings_per_doc_);
+    }
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_move_semantics) {
+    PlaidIndex index1(0, embedding_dim_, 4, n_centroids_, true);
+    EXPECT_TRUE(index1.IsColBERTSaRMode());
+
+    std::vector<f32> train_data;
+    GenerateData(train_data, n_train_embeddings_, 42);
+    index1.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+
+    std::vector<u32> doc_lens = {8};
+    index1.AddMultipleDocsEmbeddings(train_data.data(), doc_lens);
+
+    // Move construct
+    PlaidIndex index2(std::move(index1));
+    EXPECT_TRUE(index2.IsColBERTSaRMode());
+    EXPECT_EQ(index2.GetNCentroids(), n_centroids_);
+    EXPECT_EQ(index2.GetDocNum(), 1u);
+
+    // Move assign
+    PlaidIndex index3(0, embedding_dim_, 4, n_centroids_, true);
+    index3 = std::move(index2);
+    EXPECT_TRUE(index3.IsColBERTSaRMode());
+    EXPECT_EQ(index3.GetNCentroids(), n_centroids_);
+    EXPECT_EQ(index3.GetDocNum(), 1u);
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_mem_usage) {
+    PlaidIndex index(0, embedding_dim_, 4, n_centroids_, true);
+
+    std::vector<f32> train_data;
+    GenerateData(train_data, n_train_embeddings_, 42);
+    index.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+
+    std::vector<u32> doc_lens = {8};
+    index.AddMultipleDocsEmbeddings(train_data.data(), doc_lens);
+
+    size_t mem_usage = index.MemUsage();
+    EXPECT_GT(mem_usage, 0u);
+
+    size_t calc_size = index.CalcSize();
+    EXPECT_EQ(mem_usage, calc_size);
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_merge) {
+    // Test that MergeChunks works in colbertsar mode (no residuals)
+    // MergeChunks replaces all data with chunks — create two chunk indices,
+    // then merge both into a fresh target index
+    std::vector<f32> train_data;
+    GenerateData(train_data, n_train_embeddings_, 42);
+
+    // Train primary index (supplier of centroids)
+    PlaidIndex primary(0, embedding_dim_, 4, n_centroids_, true);
+    primary.Train(n_centroids_, train_data.data(), n_train_embeddings_);
+
+    // Create two chunks with shared centroids
+    auto make_chunk = [&](u32 seed_start) -> PlaidIndex * {
+        auto *chunk = new PlaidIndex(0, embedding_dim_, 4, n_centroids_, true);
+        chunk->CopyCentroidsFrom(primary.centroids_data(), primary.centroid_norms_neg_half(), n_centroids_, nullptr, false);
+
+        std::vector<u32> dl;
+        std::vector<f32> emb;
+        for (u32 doc = 0; doc < 5; ++doc) {
+            std::vector<f32> de;
+            GenerateData(de, embeddings_per_doc_, seed_start + doc);
+            emb.insert(emb.end(), de.begin(), de.end());
+            dl.push_back(embeddings_per_doc_);
+        }
+        chunk->AddMultipleDocsEmbeddings(emb.data(), dl);
+        EXPECT_EQ(chunk->GetDocNum(), 5u);
+        return chunk;
+    };
+
+    auto *chunk1 = make_chunk(200);
+    auto *chunk2 = make_chunk(300);
+
+    // Merge both chunks into a fresh index
+    // Note: MergeChunks ignores the doc_offset from the pair; doc IDs are assigned 0..total_docs-1
+    PlaidIndex merged(0, embedding_dim_, 4, n_centroids_, true);
+    merged.CopyCentroidsFrom(primary.centroids_data(), primary.centroid_norms_neg_half(), n_centroids_, nullptr, false);
+    merged.MergeChunks({{0, chunk1}, {0, chunk2}});
+
+    EXPECT_EQ(merged.GetDocNum(), 10u);
+    EXPECT_EQ(merged.GetTotalEmbeddingNum(), 10 * embeddings_per_doc_);
+
+    delete chunk1;
+    delete chunk2;
+}
+
+TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_size_smaller_than_plaid) {
+    // Verify that ColBERTSaR index is strictly smaller than PLAID with same data
+    constexpr u32 local_dim = 32; // need larger dim to see size difference clearly
+    constexpr u32 local_n_centroids = 8;
+    constexpr u32 local_n_train = 512;
+    constexpr u32 local_n_docs = 10;
+    constexpr u32 local_emb_per_doc = 8;
+
+    std::vector<f32> train_data(local_n_train * local_dim);
+    std::mt19937 gen(42);
+    std::normal_distribution<f32> dis(0.0f, 1.0f);
+    for (auto &v : train_data)
+        v = dis(gen);
+
+    std::vector<u32> doc_lens;
+    std::vector<f32> all_emb;
+    for (u32 doc = 0; doc < local_n_docs; ++doc) {
+        for (u32 i = 0; i < local_emb_per_doc * local_dim; ++i)
+            all_emb.push_back(dis(gen));
+        doc_lens.push_back(local_emb_per_doc);
+    }
+
+    // Build ColBERTSaR index
+    PlaidIndex colbertsar_index(0, local_dim, 4, local_n_centroids, true);
+    colbertsar_index.Train(local_n_centroids, train_data.data(), local_n_train);
+    colbertsar_index.AddMultipleDocsEmbeddings(all_emb.data(), doc_lens);
+    size_t colbertsar_size = colbertsar_index.CalcSize();
+
+    // Build standard PLAID index
+    PlaidIndex plaid_index(0, local_dim, 4, local_n_centroids, false);
+    plaid_index.Train(local_n_centroids, train_data.data(), local_n_train);
+    plaid_index.AddMultipleDocsEmbeddings(all_emb.data(), doc_lens);
+    size_t plaid_size = plaid_index.CalcSize();
+
+    // ColBERTSaR saves: centroids + centroid_ids + IVF lists
+    // PLAID adds: packed_residuals (n_total_emb * packed_dim bytes) + quantizer
+    //
+    // n_total_emb = 10 * 8 = 80
+    // packed_residuals = 80 * (32*4/8) = 80 * 16 = 1280 bytes
+    // quantizer ≈ (n_buckets-1 + n_buckets) * sizeof(f32) + LUTs ≈ ~2KB
+    // Difference should be at least ~1280 bytes
+    //
+    // Centroids: local_n_centroids * local_dim * 4 = 8*32*4 = 1024 bytes for both
+    // Centroid_ids: 80 * 4 = 320 bytes for both
+    // IVF: similar for both
+
+    EXPECT_GT(plaid_size, colbertsar_size) << "PLAID index should be larger due to packed residuals + quantizer";
+
+    // The difference should be at least the size of packed residuals
+    const u32 n_total_emb = local_n_docs * local_emb_per_doc;
+    const u32 packed_dim = (local_dim * 4 + 7) / 8;
+    const size_t min_residual_size = n_total_emb * packed_dim;
+    EXPECT_GE(plaid_size - colbertsar_size, min_residual_size) << "Difference should be at least packed residual size";
 }

--- a/src/unit_test/storage/knnindex/plaid_search/test_plaid_ut.cpp
+++ b/src/unit_test/storage/knnindex/plaid_search/test_plaid_ut.cpp
@@ -434,7 +434,7 @@ TEST_F(PlaidIndexColBERTSaRTest, test_colbertsar_basic_search) {
     EXPECT_LE(result_count, top_k);
     if (result_count > 0) {
         for (u32 i = 0; i < result_count; ++i) {
-            EXPECT_LT(ids[i], n_docs_ + index.GetNCentroids()); // ids are offset by start_segment_offset (0)
+            EXPECT_LT(ids[i], n_docs_);
             EXPECT_TRUE(std::isfinite(scores[i]));
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

https://arxiv.org/abs/2606.05568

1. Centroid training:
Query-aware anchor optimization：

```
loss = ||q·centroids[assignments] - q·original_embeddings||  # L2 norm of MaxSim error
```

2. Remove residuals storage

The biggest advantages of ColBERTSaR are: residual-free storage (index size reduced by 2x+), elimination of K-means and quantizer training (faster training), and no residual dequantization needed during search (faster retrieval). The trade-off is a minor loss in recall, which the paper's experiments show to be negligible.


```
-- PLAID Mode（default）
CREATE INDEX plaid_idx ON t (col) USING PLAID WITH (nbits = 4, centroids = 4096);

-- ColBERTSaR Mode
CREATE INDEX colbertsar_idx ON t (col) USING PLAID WITH (centroids = 500000, colbertsar_mode = true);
```
### Type of change

- [x] New Feature (non-breaking change which adds functionality)
