### PR TITLE
Add RAGFlow-compatible Chinese stopword filter to RAGAnalyzer

### DIFF
--- a/src/common/analyzer/rag_analyzer.cppm
+++ b/src/common/analyzer/rag_analyzer.cppm
@@ -52,6 +52,11 @@ public:
 
     void SetEnablePosition(bool enable_position) { enable_position_ = enable_position; }
 
+    // True if the term is in the canonical RAGFlow Chinese stopword set
+    // (see rag/nlp/term_weight.py Dealer.stop_words). AnalyzeImpl drops
+    // these terms from the emitted token stream.
+    static bool IsStopword(const std::string &term);
+
     std::pair<std::vector<std::string>, std::vector<std::pair<unsigned, unsigned>>> TokenizeWithPosition(const std::string &line);
     std::string Tokenize(const std::string &line);
 

--- a/src/common/analyzer/rag_analyzer_impl.cpp
+++ b/src/common/analyzer/rag_analyzer_impl.cpp
@@ -2445,6 +2445,8 @@ int RAGAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
         for (size_t i = 0; i < tokens.size(); ++i) {
             if (tokens[i].empty())
                 continue;
+            if (IsStopword(tokens[i]))
+                continue;
             const auto &[start_pos, end_pos] = positions[i];
             func(data, tokens[i].c_str(), tokens[i].size(), start_pos, end_pos, false, 0);
         }
@@ -2460,10 +2462,22 @@ int RAGAnalyzer::AnalyzeImpl(const Term &input, void *data, HookType func) {
         for (auto &t : tokens) {
             if (t.empty())
                 continue;
+            if (IsStopword(t))
+                continue;
             func(data, t.c_str(), t.size(), offset++, 0, false, 0);
         }
     }
     return 0;
+}
+
+bool RAGAnalyzer::IsStopword(const std::string &term) {
+    // Mirrors rag/nlp/term_weight.py Dealer.stop_words in RAGFlow.
+    // Kept hard-coded (not loaded from a resource file) for parity with RAGFlow.
+    static const std::unordered_set<std::string> kStopwords = {
+        "请问", "您", "你", "我", "他", "是", "的", "就", "有", "于",   "及",   "即",   "在",   "为", "最",
+        "从",   "以", "了", "将", "与", "吗", "吧", "中", "#",  "什么", "怎么", "哪个", "哪些", "啥", "相关",
+    };
+    return kStopwords.find(term) != kStopwords.end();
 }
 
 } // namespace infinity

--- a/src/unit_test/common/analyzer/rag_analyzer_ut.cpp
+++ b/src/unit_test/common/analyzer/rag_analyzer_ut.cpp
@@ -271,12 +271,13 @@ TEST_F(RAGAnalyzerTest, test_fine_grained_tokenize_consistency_with_python) {
         if (line.empty())
             continue;
 
-        TermList term_list;
-        analyzer_->Analyze(line, term_list);
+        std::string coarse = analyzer_->Tokenize(line);
+        std::vector<std::string> term_list;
+        analyzer_->FineGrainedTokenize(coarse, term_list);
 
         std::string fine_grained_tokens =
-            std::accumulate(term_list.begin(), term_list.end(), std::string(""), [](const std::string &a, const Term &b) {
-                return a + (a.empty() ? "" : " ") + b.text_;
+            std::accumulate(term_list.begin(), term_list.end(), std::string(""), [](const std::string &a, const std::string &b) {
+                return a + (a.empty() ? "" : " ") + b;
             });
 
         std::cout << "Input text: " << std::endl << line << std::endl;
@@ -291,9 +292,8 @@ TEST_F(RAGAnalyzerTest, test_fine_grained_tokenize_consistency_with_python) {
         bool is_match = true;
         if (is_size_match) {
             for (size_t i = 0; i < term_list.size(); ++i) {
-                if (term_list[i].text_ != python_tokenize_result[i]) {
-                    std::cout << "MISMATCH at " << i << ": C++='" << term_list[i].text_ << "' Python='" << python_tokenize_result[i] << "'"
-                              << std::endl;
+                if (term_list[i] != python_tokenize_result[i]) {
+                    std::cout << "MISMATCH at " << i << ": C++='" << term_list[i] << "' Python='" << python_tokenize_result[i] << "'" << std::endl;
                     is_match = false;
                     break;
                 }
@@ -337,4 +337,59 @@ TEST_F(RAGAnalyzerTest, test_set_language_dutch) {
 
     EXPECT_TRUE(cxx_result.find("huiz") != std::string::npos);
     EXPECT_EQ(cxx_result, python_result);
+}
+
+TEST_F(RAGAnalyzerTest, test_chinese_stopword_filter) {
+    if (!analyzer_) {
+        FAIL() << "RAGAnalyzer not loaded, skipping test";
+    }
+
+    // IsStopword is a static predicate over the canonical set.
+    EXPECT_TRUE(RAGAnalyzer::IsStopword("的"));
+    EXPECT_TRUE(RAGAnalyzer::IsStopword("是"));
+    EXPECT_TRUE(RAGAnalyzer::IsStopword("了"));
+    EXPECT_TRUE(RAGAnalyzer::IsStopword("什么"));
+    EXPECT_TRUE(RAGAnalyzer::IsStopword("怎么"));
+    EXPECT_FALSE(RAGAnalyzer::IsStopword("贡献"));
+    EXPECT_FALSE(RAGAnalyzer::IsStopword("最大"));
+    EXPECT_FALSE(RAGAnalyzer::IsStopword("谁"));
+
+    const std::string query = "谁的贡献最大";
+
+    // Path A: position disabled.
+    analyzer_->SetEnablePosition(false);
+    analyzer_->SetFineGrained(false);
+    {
+        TermList terms;
+        analyzer_->Analyze(query, terms);
+        std::cout << "[no-pos] ";
+        for (const auto &t : terms)
+            std::cout << "[" << t.text_ << "] ";
+        std::cout << std::endl;
+        for (const auto &t : terms) {
+            EXPECT_NE(t.text_, "的") << "Analyzer must drop 的 from token stream";
+        }
+    }
+
+    // Path B: position enabled (highlighter path).
+    analyzer_->SetEnablePosition(true);
+    {
+        TermList terms;
+        analyzer_->Analyze(query, terms);
+        std::cout << "[with-pos] ";
+        for (const auto &t : terms)
+            std::cout << "[" << t.text_ << "@" << t.word_offset_ << "," << t.end_offset_ << "] ";
+        std::cout << std::endl;
+        for (const auto &t : terms) {
+            EXPECT_NE(t.text_, "的") << "Position-enabled path must also drop 的";
+        }
+    }
+
+    // Path C: the raw Tokenize() string-level API is unaffected by the filter —
+    // stopword filtering lives at the AnalyzeImpl boundary so direct tokenizer
+    // callers (and unit tests of the tokenizer itself) see the unfiltered stream.
+    analyzer_->SetEnablePosition(false);
+    std::string raw = analyzer_->Tokenize(query);
+    std::cout << "[raw Tokenize] " << raw << std::endl;
+    EXPECT_NE(raw.find("的"), std::string::npos) << "Raw Tokenize() must still emit 的 (filter is only at AnalyzeImpl boundary)";
 }


### PR DESCRIPTION
### What problem does this PR solve?

Add RAGFlow-compatible Chinese stopword filter to RAGAnalyzer, for example, filter 的 from the tokens

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
