### PR TITLE
Use variable-length storage for JsonTermT

### DIFF
--- a/src/parser/type/complex/json_term.h
+++ b/src/parser/type/complex/json_term.h
@@ -16,83 +16,39 @@
 
 #include <compare>
 #include <cstdint>
-#include <cstring>
 #include <limits>
-#include <stdexcept>
 #include <string>
 
 // JsonTermT represents a flattened JSON term used for JSON index.
 // Term format: {path}:{type_tag}:{encoded_value}
 // The string is kept ordered (dictionary order = value order).
-// Uses fixed-size storage for trivially copyable serialization.
+// Uses std::string for variable-length storage.
 
 constexpr size_t JSON_TERM_MAX_LENGTH = 512;
 
 namespace infinity {
 
 struct JsonTermT {
-    uint32_t length_{0};
-    char data_[JSON_TERM_MAX_LENGTH]{};
+    std::string data_;
 
     JsonTermT() = default;
+    explicit JsonTermT(std::string_view term) : data_(term) {}
 
-    explicit JsonTermT(const std::string &term) { Assign(term.data(), term.size()); }
+    bool operator==(const JsonTermT &other) const = default;
+    auto operator<=>(const JsonTermT &other) const = default;
 
-    bool operator==(const JsonTermT &other) const {
-        const auto this_len = std::min<size_t>(length_, JSON_TERM_MAX_LENGTH);
-        const auto other_len = std::min<size_t>(other.length_, JSON_TERM_MAX_LENGTH);
-        if (this_len != other_len)
-            return false;
-        return std::memcmp(data_, other.data_, this_len) == 0;
-    }
-
-    auto operator<=>(const JsonTermT &other) const {
-        // Defensive: ensure valid lengths
-        auto this_len = std::min<size_t>(length_, JSON_TERM_MAX_LENGTH);
-        auto other_len = std::min<size_t>(other.length_, JSON_TERM_MAX_LENGTH);
-        auto cmp = std::memcmp(data_, other.data_, std::min(this_len, other_len));
-        if (cmp != 0)
-            return cmp < 0 ? std::strong_ordering::less : std::strong_ordering::greater;
-        return this_len <=> other_len;
-    }
-
-    std::string ToString() const { return std::string(data_, std::min<size_t>(length_, JSON_TERM_MAX_LENGTH)); }
-
-    void Reset() { length_ = 0; }
-
-    void Append(const char *src, size_t len) {
-        const auto current_len = std::min<size_t>(length_, JSON_TERM_MAX_LENGTH);
-        if (current_len + len > JSON_TERM_MAX_LENGTH) {
-            throw std::length_error("JsonTermT overflow: JSON index term exceeds JSON_TERM_MAX_LENGTH");
-        }
-        std::memcpy(data_ + current_len, src, len);
-        length_ = static_cast<uint32_t>(current_len + len);
-    }
+    const std::string &ToString() const { return data_; }
+    uint32_t size() const { return static_cast<uint32_t>(data_.size()); }
 
     // Return a "max" term that sorts after all valid terms
     static JsonTermT Max() {
         JsonTermT result;
-        result.length_ = JSON_TERM_MAX_LENGTH;
-        memset(result.data_, 0xFF, JSON_TERM_MAX_LENGTH);
+        result.data_.assign(JSON_TERM_MAX_LENGTH, '\xFF');
         return result;
     }
 
     // Return a "min" term that sorts before all valid terms
-    static JsonTermT Min() {
-        JsonTermT result;
-        result.length_ = 0;
-        memset(result.data_, 0, JSON_TERM_MAX_LENGTH);
-        return result;
-    }
-
-private:
-    void Assign(const char *src, size_t len) {
-        if (len > JSON_TERM_MAX_LENGTH) {
-            throw std::length_error("JsonTermT overflow: JSON index term exceeds JSON_TERM_MAX_LENGTH");
-        }
-        std::memcpy(data_, src, len);
-        length_ = static_cast<uint32_t>(len);
-    }
+    static JsonTermT Min() { return JsonTermT(); }
 };
 
 } // namespace infinity

--- a/src/parser/type/complex/json_term.h
+++ b/src/parser/type/complex/json_term.h
@@ -24,8 +24,6 @@
 // The string is kept ordered (dictionary order = value order).
 // Uses std::string for variable-length storage.
 
-constexpr size_t JSON_TERM_MAX_LENGTH = 512;
-
 namespace infinity {
 
 struct JsonTermT {
@@ -43,7 +41,7 @@ struct JsonTermT {
     // Return a "max" term that sorts after all valid terms
     static JsonTermT Max() {
         JsonTermT result;
-        result.data_.assign(JSON_TERM_MAX_LENGTH, '\xFF');
+        result.data_ = "\xFF";
         return result;
     }
 

--- a/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
@@ -624,7 +624,7 @@ private:
                     // Build JSON term
                     std::string func_name = json_func_expr->ScalarFunctionName();
                     JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, json_path, raw_value, cmp_type);
-                    std::string term_str(term.data_, term.length_);
+                    std::string term_str = term.ToString();
                     value = Value::MakeVarchar(term_str);
                 };
 
@@ -663,7 +663,7 @@ private:
                             compare_type = FilterCompareType::kEqual;
                             // Build JSON term with the token value
                             JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, path, raw_value, compare_type);
-                            std::string term_str(term.data_, term.length_);
+                            std::string term_str = term.ToString();
                             value = Value::MakeVarchar(term_str);
                         }
                         // Handle 2-arg json_contains: json_contains(col, 'token')
@@ -672,7 +672,7 @@ private:
                             compare_type = FilterCompareType::kEqual;
                             // Build term with "$" path for top-level array contains (root array uses "$" as parent path)
                             JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, "$", value, compare_type);
-                            std::string term_str(term.data_, term.length_);
+                            std::string term_str = term.ToString();
                             value = Value::MakeVarchar(term_str);
                         }
                         // Handle json_exists_path: json_exists_path(col, '$.path')
@@ -687,7 +687,7 @@ private:
                             }
                             compare_type = FilterCompareType::kEqual;
                             JsonTermT term = FilterExpressionPushDownHelper::BuildJsonTerm(func_name, path, Value::MakeBool(true), compare_type);
-                            std::string term_str(term.data_, term.length_);
+                            std::string term_str = term.ToString();
                             value = Value::MakeVarchar(term_str);
                         }
                         // Fallback for other JSON functions
@@ -792,7 +792,7 @@ private:
                                 Value int_value = Value::MakeBigInt(int_val);
                                 JsonTermT int_term =
                                     FilterExpressionPushDownHelper::BuildJsonTerm("json_extract_int", json_path, int_value, int_cmp_type);
-                                std::string int_term_str(int_term.data_, int_term.length_);
+                                std::string int_term_str = int_term.ToString();
                                 JsonTermT int_term_key(int_term_str);
 
                                 if (compare_type == FilterCompareType::kEqual) {

--- a/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
@@ -1071,11 +1071,17 @@ Bitmask IndexFilterEvaluatorSecondaryT<ColumnValueT>::Evaluate(const SegmentID s
     result.SetAllFalse();
     for (const auto rng : secondary_index_start_end_pairs_) {
         Bitmask part_result(segment_row_count);
-        if (cardinality == SecondaryIndexCardinality::kHighCardinality) {
-            part_result = ExecuteSingleRangeHighCardinalityT<ColumnValueT>(rng, &*index_meta, segment_row_count);
-        } else {
-            part_result = ExecuteSingleRangeLowCardinalityT<ColumnValueT>(rng, &*index_meta, segment_row_count);
+        // JsonTermT uses std::string and is not trivially copyable,
+        // so the HighCardinality memcpy path cannot be instantiated for it.
+        // JsonTermT always takes LowCardinality.
+        if constexpr (std::is_trivially_copyable_v<SecondaryIndexOrderedT>) {
+            if (cardinality == SecondaryIndexCardinality::kHighCardinality) {
+                part_result = ExecuteSingleRangeHighCardinalityT<ColumnValueT>(rng, &*index_meta, segment_row_count);
+                result.MergeOr(part_result);
+                continue;
+            }
         }
+        part_result = ExecuteSingleRangeLowCardinalityT<ColumnValueT>(rng, &*index_meta, segment_row_count);
         result.MergeOr(part_result);
     }
     result.RunOptimize();

--- a/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
+++ b/src/planner/optimizer/index_scan/index_filter_evaluators_impl.cpp
@@ -1080,6 +1080,8 @@ Bitmask IndexFilterEvaluatorSecondaryT<ColumnValueT>::Evaluate(const SegmentID s
                 result.MergeOr(part_result);
                 continue;
             }
+        } else if (cardinality == SecondaryIndexCardinality::kHighCardinality) {
+            UnrecoverableError("High-cardinality secondary indexes require trivially copyable ordered keys.");
         }
         part_result = ExecuteSingleRangeLowCardinalityT<ColumnValueT>(rng, &*index_meta, segment_row_count);
         result.MergeOr(part_result);

--- a/src/storage/secondary_index/secondary_index_data_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_data_impl.cpp
@@ -311,7 +311,17 @@ public:
 
         // Save unique keys
         if (unique_key_count_ > 0) {
-            file_handle.Append(unique_keys_.data(), unique_key_count_ * sizeof(OrderedKeyType));
+            if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+                for (const auto &key : unique_keys_) {
+                    u32 len = key.size();
+                    file_handle.Append(&len, sizeof(len));
+                    if (len > 0) {
+                        file_handle.Append(key.ToString().data(), len);
+                    }
+                }
+            } else {
+                file_handle.Append(unique_keys_.data(), unique_key_count_ * sizeof(OrderedKeyType));
+            }
 
             // Save RoaringBitmaps
             for (const auto &bitmap : offset_bitmaps_) {
@@ -333,8 +343,22 @@ public:
 
         if (unique_key_count_ > 0) {
             // Read unique keys
-            unique_keys_.resize(unique_key_count_);
-            file_handle.Read(unique_keys_.data(), unique_key_count_ * sizeof(OrderedKeyType));
+            if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+                unique_keys_.clear();
+                unique_keys_.reserve(unique_key_count_);
+                for (u32 i = 0; i < unique_key_count_; ++i) {
+                    u32 len = 0;
+                    file_handle.Read(&len, sizeof(len));
+                    std::string key_data(len, '\0');
+                    if (len > 0) {
+                        file_handle.Read(key_data.data(), len);
+                    }
+                    unique_keys_.emplace_back(std::move(key_data));
+                }
+            } else {
+                unique_keys_.resize(unique_key_count_);
+                file_handle.Read(unique_keys_.data(), unique_key_count_ * sizeof(OrderedKeyType));
+            }
 
             // Read RoaringBitmaps
             offset_bitmaps_.clear();
@@ -364,9 +388,20 @@ public:
 
         if (unique_key_count_ > 0) {
             // Read unique keys
-            unique_keys_.resize(unique_key_count_);
-            std::memcpy(unique_keys_.data(), ptr, unique_key_count_ * sizeof(OrderedKeyType));
-            ptr += unique_key_count_ * sizeof(OrderedKeyType);
+            if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+                unique_keys_.clear();
+                unique_keys_.reserve(unique_key_count_);
+                for (u32 i = 0; i < unique_key_count_; ++i) {
+                    u32 len = *reinterpret_cast<const u32 *>(ptr);
+                    ptr += sizeof(u32);
+                    unique_keys_.emplace_back(std::string_view(ptr, len));
+                    ptr += len;
+                }
+            } else {
+                unique_keys_.resize(unique_key_count_);
+                std::memcpy(unique_keys_.data(), ptr, unique_key_count_ * sizeof(OrderedKeyType));
+                ptr += unique_key_count_ * sizeof(OrderedKeyType);
+            }
 
             // Read RoaringBitmaps
             offset_bitmaps_.clear();

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -14,6 +14,7 @@
 
 module;
 
+#include <atomic>
 #include <cassert>
 
 module infinity_core:secondary_index_in_mem.impl;
@@ -53,7 +54,7 @@ class SecondaryIndexInMemT final : public SecondaryIndexInMem {
     const RowID begin_row_id_;
     // Replaced std::multimap + mutex with RcuMultiMap for better concurrent performance
     RcuMultiMap<KeyType, u32> in_mem_secondary_index_;
-    size_t json_key_bytes_ = 0;
+    std::atomic_size_t json_key_bytes_{0};
 
 protected:
     u32 GetRowCountNoLock() const override { return in_mem_secondary_index_.size(); }
@@ -73,7 +74,8 @@ public:
     }
     ~SecondaryIndexInMemT() override {
         if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
-            DecreaseMemoryUsageBase(MemoryCostOfThis() + json_key_bytes_ + static_cast<size_t>(GetRowCount()) * sizeof(u32));
+            DecreaseMemoryUsageBase(MemoryCostOfThis() + json_key_bytes_.load(std::memory_order_relaxed) +
+                                    static_cast<size_t>(GetRowCount()) * sizeof(u32));
         } else {
             DecreaseMemoryUsageBase(MemoryCostOfThis() + GetRowCount() * MemoryCostOfEachRow());
         }
@@ -114,7 +116,7 @@ public:
                 }
             }
         }
-        json_key_bytes_ += key_bytes;
+        json_key_bytes_.fetch_add(key_bytes, std::memory_order_relaxed);
         IncreaseMemoryUsageBase(key_bytes + static_cast<size_t>(inserted_count) * sizeof(u32));
     }
 

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -56,7 +56,13 @@ class SecondaryIndexInMemT final : public SecondaryIndexInMem {
 
 protected:
     u32 GetRowCountNoLock() const override { return in_mem_secondary_index_.size(); }
-    u32 MemoryCostOfEachRow() const override { return map_memory_bloat_factor * (sizeof(KeyType) + sizeof(u32)); }
+    u32 MemoryCostOfEachRow() const override {
+        if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+            return map_memory_bloat_factor * (sizeof(KeyType) + 64 + sizeof(u32));
+        } else {
+            return map_memory_bloat_factor * (sizeof(KeyType) + sizeof(u32));
+        }
+    }
     u32 MemoryCostOfThis() const override { return sizeof(*this); }
 
 public:
@@ -84,9 +90,8 @@ public:
 
     // Special insertion for JSON: flatten each JSON document and insert multiple terms per row
     void InsertBlockDataJson(SegmentOffset block_offset, const ColumnVector &col, BlockOffset offset, BlockOffset row_count) {
-        // This method inserts multiple terms per JSON document
-        // For each row, we flatten the JSON and insert each term
         u32 inserted_count = 0;
+        size_t key_bytes = 0;
         for (BlockOffset i = 0; i < row_count; ++i) {
             // Get the JSON value at position offset + i
             Value value = col.GetValueByIndex(offset + i);
@@ -96,12 +101,13 @@ public:
                 auto terms = JsonFlattener::FlattenDocument(json_info->bson_elements_.data(), json_info->bson_elements_.size());
                 for (const auto &term : terms) {
                     JsonTermT key(term.term_);
+                    key_bytes += sizeof(JsonTermT) + key.ToString().capacity();
                     in_mem_secondary_index_.Insert(key, block_offset + offset + i);
                     ++inserted_count;
                 }
             }
         }
-        IncreaseMemoryUsageBase(inserted_count * MemoryCostOfEachRow());
+        IncreaseMemoryUsageBase(key_bytes + inserted_count * sizeof(u32));
     }
 
     void Dump(BufferObj *buffer_obj) const override {

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -53,6 +53,7 @@ class SecondaryIndexInMemT final : public SecondaryIndexInMem {
     const RowID begin_row_id_;
     // Replaced std::multimap + mutex with RcuMultiMap for better concurrent performance
     RcuMultiMap<KeyType, u32> in_mem_secondary_index_;
+    size_t json_key_bytes_ = 0;
 
 protected:
     u32 GetRowCountNoLock() const override { return in_mem_secondary_index_.size(); }
@@ -70,7 +71,13 @@ public:
         : SecondaryIndexInMem(cardinality), begin_row_id_(begin_row_id) {
         IncreaseMemoryUsageBase(MemoryCostOfThis());
     }
-    ~SecondaryIndexInMemT() override { DecreaseMemoryUsageBase(MemoryCostOfThis() + GetRowCount() * MemoryCostOfEachRow()); }
+    ~SecondaryIndexInMemT() override {
+        if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
+            DecreaseMemoryUsageBase(MemoryCostOfThis() + json_key_bytes_ + static_cast<size_t>(GetRowCount()) * sizeof(u32));
+        } else {
+            DecreaseMemoryUsageBase(MemoryCostOfThis() + GetRowCount() * MemoryCostOfEachRow());
+        }
+    }
     virtual RowID GetBeginRowID() const override { return begin_row_id_; }
     u32 GetRowCount() const override {
         // RcuMultiMap is thread-safe, no lock needed
@@ -101,13 +108,14 @@ public:
                 auto terms = JsonFlattener::FlattenDocument(json_info->bson_elements_.data(), json_info->bson_elements_.size());
                 for (const auto &term : terms) {
                     JsonTermT key(term.term_);
-                    key_bytes += sizeof(JsonTermT) + key.ToString().capacity();
+                    key_bytes += sizeof(JsonTermT) + key.ToString().size();
                     in_mem_secondary_index_.Insert(key, block_offset + offset + i);
                     ++inserted_count;
                 }
             }
         }
-        IncreaseMemoryUsageBase(key_bytes + inserted_count * sizeof(u32));
+        json_key_bytes_ += key_bytes;
+        IncreaseMemoryUsageBase(key_bytes + static_cast<size_t>(inserted_count) * sizeof(u32));
     }
 
     void Dump(BufferObj *buffer_obj) const override {

--- a/test/sql/ddl/index/test_json_index.slt
+++ b/test/sql/ddl/index/test_json_index.slt
@@ -234,3 +234,30 @@ DROP INDEX idx_data ON test_json_root_array;
 
 statement ok
 DROP TABLE test_json_root_array;
+
+
+# Test JSON index with long terms
+# Term format: $.key.key...key:i:0000000000000000
+
+statement ok
+DROP TABLE IF EXISTS test_json_long_term;
+
+statement ok
+CREATE TABLE test_json_long_term (
+    id integer,
+    meta json
+);
+
+statement ok
+INSERT INTO test_json_long_term (id, meta) VALUES (1, '{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":{"key":1}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}');
+
+statement ok
+CREATE INDEX idx_meta ON test_json_long_term (meta) USING SECONDARY;
+
+query I
+SELECT id FROM test_json_long_term WHERE json_extract_int(meta, '$.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key.key') = 1;
+----
+1
+
+statement ok
+DROP TABLE test_json_long_term;


### PR DESCRIPTION
### What problem does this PR solve?

`JsonTermT` used a fixed-size `char data_[512]` for every term, regardless of actual content length.  Replaced the fixed array with `std::string` for variable-length storage.


### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
