### PR TITLE
Fix Json Index bugs

### DIFF
--- a/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
@@ -594,6 +594,7 @@ private:
                 Value value = Value::MakeNull();
                 std::optional<Value> raw_value_for_double;
                 FilterCompareType compare_type;
+                FilterCompareType original_compare_type;
                 std::shared_ptr<TableIndexMeta> table_index_meta;
                 std::string json_path;
 
@@ -735,6 +736,8 @@ private:
                         auto *json_func_expr = static_cast<FunctionExpression *>(function_expression->arguments()[0].get());
                         raw_value_for_double = FilterExpressionPushDownHelper::CalcValueResult(function_expression->arguments()[1]);
                         compare_type = PossibleCompareTypes[std::distance(PossibleFunctionNames.begin(), it)];
+                        // Save original compare_type before HandleJsonComparison mutates it (kGreater→kGreaterEqual, etc.)
+                        original_compare_type = compare_type;
                         HandleJsonComparison(json_func_expr, *raw_value_for_double, compare_type);
                         break;
                     }
@@ -744,6 +747,8 @@ private:
                         auto *json_func_expr = static_cast<FunctionExpression *>(function_expression->arguments()[1].get());
                         raw_value_for_double = FilterExpressionPushDownHelper::CalcValueResult(function_expression->arguments()[0]);
                         compare_type = PossibleReverseCompareTypes[std::distance(PossibleFunctionNames.begin(), it)];
+                        // Save original compare_type before HandleJsonComparison mutates it (kGreater→kGreaterEqual, etc.)
+                        original_compare_type = compare_type;
                         HandleJsonComparison(json_func_expr, *raw_value_for_double, compare_type);
                         break;
                     }
@@ -778,14 +783,18 @@ private:
                                 FilterCompareType int_cmp_type = FilterCompareType::kEqual;
                                 int64_t int_val = int_val_for_eq;
 
-                                if (compare_type == FilterCompareType::kGreater || compare_type == FilterCompareType::kGreaterEqual) {
+                                const bool is_integral_boundary = std::floor(double_val) == double_val;
+                                if (original_compare_type == FilterCompareType::kGreater) {
                                     int_val = static_cast<int64_t>(std::ceil(double_val));
-                                    // For int >= ceil(X), we use kGreaterEqual with int_val - 1
-                                    // because BuildJsonTerm does int_val + 1 for kGreater
+                                    int_cmp_type = is_integral_boundary ? FilterCompareType::kGreater : FilterCompareType::kGreaterEqual;
+                                } else if (original_compare_type == FilterCompareType::kGreaterEqual) {
+                                    int_val = static_cast<int64_t>(std::ceil(double_val));
                                     int_cmp_type = FilterCompareType::kGreaterEqual;
-                                } else if (compare_type == FilterCompareType::kLess || compare_type == FilterCompareType::kLessEqual) {
+                                } else if (original_compare_type == FilterCompareType::kLess) {
                                     int_val = static_cast<int64_t>(std::floor(double_val));
-                                    // For int <= floor(X), we use kLessEqual with the floor value directly
+                                    int_cmp_type = is_integral_boundary ? FilterCompareType::kLess : FilterCompareType::kLessEqual;
+                                } else if (original_compare_type == FilterCompareType::kLessEqual) {
+                                    int_val = static_cast<int64_t>(std::floor(double_val));
                                     int_cmp_type = FilterCompareType::kLessEqual;
                                 }
 
@@ -795,10 +804,11 @@ private:
                                 std::string int_term_str = int_term.ToString();
                                 JsonTermT int_term_key(int_term_str);
 
-                                if (compare_type == FilterCompareType::kEqual) {
+                                if (original_compare_type == FilterCompareType::kEqual) {
                                     // For equality, just add the int term as an additional exact match
                                     evaluator->AddRange(std::make_pair(int_term_key, int_term_key));
-                                } else if (compare_type == FilterCompareType::kGreater || compare_type == FilterCompareType::kGreaterEqual) {
+                                } else if (original_compare_type == FilterCompareType::kGreater ||
+                                           original_compare_type == FilterCompareType::kGreaterEqual) {
                                     // For > and >=, int range is [int_lower_bound, +inf)
                                     std::string path_prefix = json_path + ":i:";
                                     evaluator->AddRange(std::make_pair(int_term_key, JsonTermT(path_prefix + "~")));

--- a/src/storage/catalog/meta/chunk_index_meta.cppm
+++ b/src/storage/catalog/meta/chunk_index_meta.cppm
@@ -33,7 +33,7 @@ export struct ChunkIndexMetaInfo {
         : base_name_(base_name), base_row_id_(base_row_id), row_cnt_(row_cnt), term_cnt_(term_cnt), index_size_(index_size) {}
     std::string base_name_{};
     RowID base_row_id_{};
-    size_t row_cnt_{};
+    size_t row_cnt_{};  // number of data rows covered by this chunk
     size_t term_cnt_{}; // used only in fulltext index
     size_t index_size_{};
 

--- a/src/storage/json_index/json_flattener_impl.cpp
+++ b/src/storage/json_index/json_flattener_impl.cpp
@@ -83,6 +83,9 @@ void JsonFlattener::FlattenRecursive(const JsonTypeDef &json_value, const std::s
             std::string child_path = current_path.empty() ? std::string("$") + "." + item.key() : current_path + "." + item.key();
             FlattenRecursive(item.value(), child_path, terms);
         }
+        // Emit path exists term for json_exists_path support
+        std::string object_path = current_path.empty() ? "$" : current_path;
+        terms.push_back({object_path + ":p:"});
     } else if (json_value.is_array()) {
         size_t idx = 0;
         for (const auto &val : json_value) {
@@ -97,6 +100,8 @@ void JsonFlattener::FlattenRecursive(const JsonTypeDef &json_value, const std::s
         for (const auto &val : json_value) {
             AddScalarTerm(val, parent_path);
         }
+        // Emit path exists term for json_exists_path support
+        terms.push_back({parent_path + ":p:"});
     } else {
         AddScalarTerm(json_value, current_path);
         // Emit path exists term for json_exists_path support (for non-null scalar values)

--- a/src/storage/new_txn/new_txn.cppm
+++ b/src/storage/new_txn/new_txn.cppm
@@ -599,7 +599,8 @@ private:
                            RowID &base_rowid,
                            u32 &row_cnt,
                            u32 &term_cnt,
-                           std::string &base_name);
+                           std::string &base_name,
+                           std::vector<ChunkID> &deprecate_ids);
 
     Status OptimizeVecIndex(std::shared_ptr<IndexBase> index_base,
                             std::shared_ptr<ColumnDef> column_def,

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -350,6 +350,7 @@ Status NewTxn::OptimizeIndexInner(SegmentIndexMeta &segment_index_meta,
     u32 row_cnt = 0;
     u32 term_cnt = 0;
     std::vector<size_t> row_cnts;
+    std::vector<ChunkID> deprecate_ids;
 
     std::string base_name;
 
@@ -358,7 +359,7 @@ Status NewTxn::OptimizeIndexInner(SegmentIndexMeta &segment_index_meta,
         return index_status;
     }
     if (index_base->index_type_ == IndexType::kFullText) {
-        status = OptimizeFtIndex(index_base, segment_index_meta, base_rowid, row_cnt, term_cnt, base_name);
+        status = OptimizeFtIndex(index_base, segment_index_meta, base_rowid, row_cnt, term_cnt, base_name, deprecate_ids);
         if (!status.ok()) {
             return status;
         }
@@ -368,11 +369,9 @@ Status NewTxn::OptimizeIndexInner(SegmentIndexMeta &segment_index_meta,
         ChunkIndexMetaInfo *chunk_info_ptr = nullptr;
         for (ChunkID old_chunk_id : *old_chunk_ids_ptr) {
             ChunkIndexMeta old_chunk_meta(old_chunk_id, segment_index_meta);
-            {
-                status = old_chunk_meta.GetChunkInfo(chunk_info_ptr);
-                if (!status.ok()) {
-                    return status;
-                }
+            status = old_chunk_meta.GetChunkInfo(chunk_info_ptr);
+            if (!status.ok()) {
+                return status;
             }
             if (last_rowid != chunk_info_ptr->base_row_id_) {
                 UnrecoverableError("OptimizeIndex: base_row_id is not continuous");
@@ -381,8 +380,8 @@ Status NewTxn::OptimizeIndexInner(SegmentIndexMeta &segment_index_meta,
             row_cnt += chunk_info_ptr->row_cnt_;
             row_cnts.push_back(chunk_info_ptr->row_cnt_);
         }
+        deprecate_ids = *old_chunk_ids_ptr;
     }
-    std::vector<ChunkID> deprecate_ids = *old_chunk_ids_ptr;
     ChunkID chunk_id = 0;
     std::tie(chunk_id, status) = segment_index_meta.GetAndSetNextChunkID();
     if (!status.ok()) {
@@ -2144,7 +2143,8 @@ Status NewTxn::OptimizeFtIndex(std::shared_ptr<IndexBase> index_base,
                                RowID &base_rowid_out,
                                u32 &row_cnt_out,
                                u32 &term_cnt_out,
-                               std::string &base_name_out) {
+                               std::string &base_name_out,
+                               std::vector<ChunkID> &deprecate_ids) {
     const auto *index_fulltext = static_cast<const IndexFullText *>(index_base.get());
 
     std::vector<ChunkID> chunk_ids;
@@ -2220,6 +2220,7 @@ Status NewTxn::OptimizeFtIndex(std::shared_ptr<IndexBase> index_base,
         row_cnt_out = total_row_count;
         term_cnt_out = total_term_count;
         base_name_out = dst_base_name;
+        deprecate_ids = std::move(chunk_ids);
     }
 
     LOG_INFO(fmt::format("finish merging {} {}", *index_fulltext->index_name_, dst_base_name));
@@ -2812,8 +2813,6 @@ Status NewTxn::RecoverMemIndex(TableIndexMeta &table_index_meta) {
     for (SegmentID segment_id : *segment_ids_ptr) {
         SegmentMeta segment_meta(segment_id, table_meta);
         if (!index_segment_ids_set.contains(segment_id)) {
-            //            std::shared_ptr<std::string> error_msg = std::make_shared<std::string>(fmt::format("Segment {} not in index {}",
-            //            segment_id, table_index_meta.index_id_str())); LOG_WARN(*error_msg); UnrecoverableError(*error_msg);//
             std::optional<SegmentIndexMeta> segment_index_meta;
             status = NewCatalog::AddNewSegmentIndex1(table_index_meta, this, segment_id, segment_index_meta);
             if (!status.ok()) {

--- a/src/storage/secondary_index/secondary_index_data_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_data_impl.cpp
@@ -132,19 +132,14 @@ template <typename RawValueType>
 struct SecondaryIndexChunkMerger<RawValueType, HighCardinalityTag> {
     using OrderedKeyType = ConvertToOrderedType<RawValueType>;
     std::vector<SecondaryIndexChunkDataReader<RawValueType, HighCardinalityTag>> readers_;
-    std::vector<u32> reader_offsets_;
     std::priority_queue<std::tuple<OrderedKeyType, u32, u32>,
                         std::vector<std::tuple<OrderedKeyType, u32, u32>>,
                         std::greater<std::tuple<OrderedKeyType, u32, u32>>>
         pq_;
     explicit SecondaryIndexChunkMerger(const std::vector<std::pair<u32, BufferObj *>> &buffer_objs) {
         readers_.reserve(buffer_objs.size());
-        reader_offsets_.reserve(buffer_objs.size());
-        u32 offset_shift = 0;
         for (const auto &[row_count, buffer_obj] : buffer_objs) {
             readers_.emplace_back(buffer_obj, row_count);
-            reader_offsets_.push_back(offset_shift);
-            offset_shift += row_count;
         }
         OrderedKeyType key = {};
         u32 offset = 0;
@@ -160,7 +155,7 @@ struct SecondaryIndexChunkMerger<RawValueType, HighCardinalityTag> {
         }
         const auto [key, offset, reader_id] = pq_.top();
         out_key = key;
-        out_offset = offset + reader_offsets_[reader_id];
+        out_offset = offset;
         pq_.pop();
         OrderedKeyType next_key = {};
         u32 next_offset = 0;
@@ -176,19 +171,14 @@ template <typename RawValueType>
 struct SecondaryIndexChunkMerger<RawValueType, LowCardinalityTag> {
     using OrderedKeyType = ConvertToOrderedType<RawValueType>;
     std::vector<SecondaryIndexChunkDataReader<RawValueType, LowCardinalityTag>> readers_;
-    std::vector<u32> reader_offsets_;
     std::priority_queue<std::tuple<OrderedKeyType, u32, u32>,
                         std::vector<std::tuple<OrderedKeyType, u32, u32>>,
                         std::greater<std::tuple<OrderedKeyType, u32, u32>>>
         pq_;
     explicit SecondaryIndexChunkMerger(const std::vector<std::pair<u32, BufferObj *>> &file_workers) {
         readers_.reserve(file_workers.size());
-        reader_offsets_.reserve(file_workers.size());
-        u32 offset_shift = 0;
         for (const auto &[row_count, file_worker] : file_workers) {
             readers_.emplace_back(file_worker, row_count);
-            reader_offsets_.push_back(offset_shift);
-            offset_shift += row_count;
         }
         OrderedKeyType key = {};
         u32 offset = 0;
@@ -204,7 +194,7 @@ struct SecondaryIndexChunkMerger<RawValueType, LowCardinalityTag> {
         }
         const auto [key, offset, reader_id] = pq_.top();
         out_key = key;
-        out_offset = offset + reader_offsets_[reader_id];
+        out_offset = offset;
         pq_.pop();
         OrderedKeyType next_key = {};
         u32 next_offset = 0;
@@ -424,8 +414,10 @@ public:
         if (!map_ptr) {
             UnrecoverableError("InsertData(): error: map_ptr type error.");
         }
-        if (map_ptr->size() != chunk_row_count_) {
-            UnrecoverableError(fmt::format("InsertData(): error: map size: {} != chunk_row_count_: {}", map_ptr->size(), chunk_row_count_));
+        if constexpr (!std::is_same_v<RawValueType, JsonTermT>) {
+            if (map_ptr->size() != chunk_row_count_) {
+                UnrecoverableError(fmt::format("InsertData(): error: map size: {} != chunk_row_count_: {}", map_ptr->size(), chunk_row_count_));
+            }
         }
 
         // Build unique keys and corresponding bitmaps
@@ -476,16 +468,18 @@ public:
             max_offset = std::max(max_offset, offset);
         }
 
-        if (total_count != chunk_row_count_) {
+        if constexpr (!std::is_same_v<RawValueType, JsonTermT>) {
             // Debug: print more information about the mismatch
-            LOG_ERROR(fmt::format("InsertMergeData(): total_count: {} != chunk_row_count_: {}", total_count, chunk_row_count_));
-            LOG_ERROR(fmt::format("InsertMergeData(): old_chunks.size(): {}", old_chunks.size()));
-            for (size_t i = 0; i < old_chunks.size(); ++i) {
-                LOG_ERROR(fmt::format("InsertMergeData(): old_chunks[{}].first (row_count): {}", i, old_chunks[i].first));
+            if (total_count != chunk_row_count_) {
+                LOG_ERROR(fmt::format("InsertMergeData(): total_count: {} != chunk_row_count_: {}", total_count, chunk_row_count_));
+                LOG_ERROR(fmt::format("InsertMergeData(): old_chunks.size(): {}", old_chunks.size()));
+                for (size_t i = 0; i < old_chunks.size(); ++i) {
+                    LOG_ERROR(fmt::format("InsertMergeData(): old_chunks[{}].first (row_count): {}", i, old_chunks[i].first));
+                }
+                LOG_ERROR(fmt::format("InsertMergeData(): unique_key_count_: {}", unique_key_count_));
+                LOG_ERROR(fmt::format("InsertMergeData(): key_to_offsets.size(): {}", key_to_offsets.size()));
+                UnrecoverableError(fmt::format("InsertMergeData(): error: total_count: {} != chunk_row_count_: {}", total_count, chunk_row_count_));
             }
-            LOG_ERROR(fmt::format("InsertMergeData(): unique_key_count_: {}", unique_key_count_));
-            LOG_ERROR(fmt::format("InsertMergeData(): key_to_offsets.size(): {}", key_to_offsets.size()));
-            UnrecoverableError(fmt::format("InsertMergeData(): error: total_count: {} != chunk_row_count_: {}", total_count, chunk_row_count_));
         }
 
         // Bitmap size should be max_offset + 1, not chunk_row_count_

--- a/src/storage/secondary_index/secondary_index_in_mem.cppm
+++ b/src/storage/secondary_index/secondary_index_in_mem.cppm
@@ -33,8 +33,6 @@ export class SecondaryIndexInMem : public BaseMemIndex {
 protected:
     explicit SecondaryIndexInMem(SecondaryIndexCardinality cardinality) : cardinality_(cardinality) {}
 
-    virtual u32 GetRowCountNoLock() const = 0;
-
     virtual u32 MemoryCostOfEachRow() const = 0;
 
     virtual u32 MemoryCostOfThis() const = 0;
@@ -46,9 +44,13 @@ public:
 
     const ChunkIndexMetaInfo GetChunkIndexMetaInfo() const override;
 
+    virtual size_t GetMemUsed() const = 0;
+
     virtual RowID GetBeginRowID() const override = 0;
 
     virtual u32 GetRowCount() const = 0;
+
+    virtual u32 GetEntryCount() const = 0;
 
     virtual void InsertBlockData(SegmentOffset block_offset, const ColumnVector &col, BlockOffset offset, BlockOffset row_cnt) = 0;
 

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -235,9 +235,9 @@ private:
 };
 
 MemIndexTracerInfo SecondaryIndexInMem::GetInfo() const {
-    const auto entry_cnt = GetEntryCount();
+    const auto row_cnt = GetRowCount();
     const auto mem = MemoryCostOfThis() + GetMemUsed();
-    return MemIndexTracerInfo(nullptr, nullptr, nullptr, mem, entry_cnt);
+    return MemIndexTracerInfo(nullptr, nullptr, nullptr, mem, row_cnt);
 }
 
 const ChunkIndexMetaInfo SecondaryIndexInMem::GetChunkIndexMetaInfo() const { return ChunkIndexMetaInfo{"", GetBeginRowID(), GetRowCount(), 0, 0}; }

--- a/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
+++ b/src/storage/secondary_index/secondary_index_in_mem_impl.cpp
@@ -54,36 +54,51 @@ class SecondaryIndexInMemT final : public SecondaryIndexInMem {
     const RowID begin_row_id_;
     // Replaced std::multimap + mutex with RcuMultiMap for better concurrent performance
     RcuMultiMap<KeyType, u32> in_mem_secondary_index_;
-    std::atomic_size_t json_key_bytes_{0};
+    std::atomic<size_t> json_key_bytes_{0};
+
+    // Track the number of data rows for JSON index only (one row → many entries).
+    // Non-JSON uses in_mem_secondary_index_.size() instead (one entry per row).
+    std::atomic<u32> row_count_{0};
 
 protected:
-    u32 GetRowCountNoLock() const override { return in_mem_secondary_index_.size(); }
-    u32 MemoryCostOfEachRow() const override {
+    // Memory cost per row for non-JSON indexes (1 row = 1 entry).
+    // JSON indexes track exact memory via json_key_bytes_, not this.
+    u32 MemoryCostOfEachRow() const override { return map_memory_bloat_factor * (sizeof(KeyType) + sizeof(u32)); }
+
+    u32 MemoryCostOfThis() const override { return sizeof(*this); }
+
+    size_t GetMemUsed() const override {
         if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
-            return map_memory_bloat_factor * (sizeof(KeyType) + 64 + sizeof(u32));
+            return json_key_bytes_.load(std::memory_order_relaxed) + GetEntryCount() * sizeof(u32);
         } else {
-            return map_memory_bloat_factor * (sizeof(KeyType) + sizeof(u32));
+            return GetRowCount() * MemoryCostOfEachRow();
         }
     }
-    u32 MemoryCostOfThis() const override { return sizeof(*this); }
 
 public:
     explicit SecondaryIndexInMemT(const RowID begin_row_id, SecondaryIndexCardinality cardinality)
         : SecondaryIndexInMem(cardinality), begin_row_id_(begin_row_id) {
         IncreaseMemoryUsageBase(MemoryCostOfThis());
     }
-    ~SecondaryIndexInMemT() override {
+    ~SecondaryIndexInMemT() override { DecreaseMemoryUsageBase(MemoryCostOfThis() + GetMemUsed()); }
+    virtual RowID GetBeginRowID() const override { return begin_row_id_; }
+
+    u32 GetRowCount() const override {
+        // Returns the number of data rows inserted into this index.
         if constexpr (std::is_same_v<RawValueType, JsonTermT>) {
-            DecreaseMemoryUsageBase(MemoryCostOfThis() + json_key_bytes_.load(std::memory_order_relaxed) +
-                                    static_cast<size_t>(GetRowCount()) * sizeof(u32));
+            // For JSON: one data row → many entries, need to track separately.
+            return row_count_;
         } else {
-            DecreaseMemoryUsageBase(MemoryCostOfThis() + GetRowCount() * MemoryCostOfEachRow());
+            // For non-JSON: one entry per row, no separate counter needed.
+            return static_cast<u32>(in_mem_secondary_index_.size());
         }
     }
-    virtual RowID GetBeginRowID() const override { return begin_row_id_; }
-    u32 GetRowCount() const override {
+
+    u32 GetEntryCount() const override {
+        // Returns the number of index entries in the multimap.
         // RcuMultiMap is thread-safe, no lock needed
-        return in_mem_secondary_index_.size();
+        // For JSON: one data row → many entries (entry count ≥ row count).
+        return static_cast<u32>(in_mem_secondary_index_.size());
     }
 
     void InsertBlockData(SegmentOffset block_offset, const ColumnVector &col, BlockOffset offset, BlockOffset row_count) override {
@@ -118,6 +133,7 @@ public:
         }
         json_key_bytes_.fetch_add(key_bytes, std::memory_order_relaxed);
         IncreaseMemoryUsageBase(key_bytes + static_cast<size_t>(inserted_count) * sizeof(u32));
+        row_count_.fetch_add(row_count, std::memory_order_relaxed);
     }
 
     void Dump(BufferObj *buffer_obj) const override {
@@ -219,9 +235,9 @@ private:
 };
 
 MemIndexTracerInfo SecondaryIndexInMem::GetInfo() const {
-    const auto row_cnt = GetRowCount();
-    const auto mem = MemoryCostOfThis() + row_cnt * MemoryCostOfEachRow();
-    return MemIndexTracerInfo(nullptr, nullptr, nullptr, mem, row_cnt);
+    const auto entry_cnt = GetEntryCount();
+    const auto mem = MemoryCostOfThis() + GetMemUsed();
+    return MemIndexTracerInfo(nullptr, nullptr, nullptr, mem, entry_cnt);
 }
 
 const ChunkIndexMetaInfo SecondaryIndexInMem::GetChunkIndexMetaInfo() const { return ChunkIndexMetaInfo{"", GetBeginRowID(), GetRowCount(), 0, 0}; }

--- a/test/sql/dml/optimize/test_optimize_json_index.slt
+++ b/test/sql/dml/optimize/test_optimize_json_index.slt
@@ -1,0 +1,135 @@
+# Test OPTIMIZE on a table with JSON secondary index
+
+statement ok
+DROP TABLE IF EXISTS test_optimize_json_index;
+
+statement ok
+CREATE TABLE test_optimize_json_index (
+    id integer,
+    meta json
+);
+
+statement ok
+CREATE INDEX idx_meta ON test_optimize_json_index (meta) USING SECONDARY;
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (1, '{"year": 2020, "character": ["value1", "value2"], "score": 1, "author": "Alice"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (2, '{"year": 2021, "character": ["value3"], "score": 2, "author": "Bob"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (3, '{"year": 2019, "character": ["value1", "value4"], "score": 2.5, "author": "Alice"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (4, '{"year": 2022, "name": "test", "score": 3.0, "author": "Charlie"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (5, '{"year": 2020, "author": "Alice"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (6, '{"data": {"inner": 50, "outer": 100}}');
+
+statement ok
+DUMP INDEX idx_meta ON test_optimize_json_index;
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (7, '{"year": 2018, "score": 0.5, "author": "Eve"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (8, '{"year": 2023, "character": ["value6"], "score": 3.5, "author": "Frank"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (9, '{"year": 2021, "score": 1.5}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (10, '{"year": 2020, "character": ["value7", "value8"], "author": "Grace"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (11, '{"year": 2024, "score": 6.0, "author": "Hank"}');
+
+statement ok
+INSERT INTO test_optimize_json_index (id, meta) VALUES (12, '{"year": 2017, "character": ["value9"], "score": -1.0, "author": "Ivy"}');
+
+statement ok
+DUMP INDEX idx_meta ON test_optimize_json_index;
+
+# Query before OPTIMIZE — data from both chunks
+query I
+SELECT id FROM test_optimize_json_index WHERE json_extract_int(meta, '$.year') = 2020;
+----
+1
+5
+10
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_extract_double(meta, '$.score') > 2;
+----
+3
+4
+8
+11
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_contains(meta, '$.character', 'value1');
+----
+1
+3
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_exists_path(meta, '$.character');
+----
+1
+2
+3
+8
+10
+12
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_contains(meta, '$.data.inner', 50);
+----
+6
+
+# OPTIMIZE: merge 2 chunks
+statement ok
+OPTIMIZE test_optimize_json_index;
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_extract_int(meta, '$.year') = 2020;
+----
+1
+5
+10
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_extract_double(meta, '$.score') > 2;
+----
+3
+4
+8
+11
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_contains(meta, '$.character', 'value1');
+----
+1
+3
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_exists_path(meta, '$.character');
+----
+1
+2
+3
+8
+10
+12
+
+query I
+SELECT id FROM test_optimize_json_index WHERE json_contains(meta, '$.data.inner', 50);
+----
+6
+
+statement ok
+DROP TABLE test_optimize_json_index;

--- a/test/sql/dml/optimize/test_optimize_secondary_index.slt
+++ b/test/sql/dml/optimize/test_optimize_secondary_index.slt
@@ -1,0 +1,89 @@
+# Test OPTIMIZE on a table with secondary index
+
+statement ok
+DROP TABLE IF EXISTS test_optimize_secondary_index;
+
+statement ok
+CREATE TABLE test_optimize_secondary_index (
+    id integer,
+    c1 integer,
+    c2 varchar
+);
+
+statement ok
+CREATE INDEX idx_c1 ON test_optimize_secondary_index (c1) USING SECONDARY;
+
+statement ok
+INSERT INTO test_optimize_secondary_index (id, c1, c2) VALUES (1, 10, 'apple'), (2, 20, 'banana'), (3, 30, 'cherry'), (4, 10, 'date'), (5, 20, 'elderberry'), (6, 40, 'fig');
+
+statement ok
+DUMP INDEX idx_c1 ON test_optimize_secondary_index;
+
+statement ok
+INSERT INTO test_optimize_secondary_index (id, c1, c2) VALUES (7, 10, 'grape'), (8, 50, 'honeydew'), (9, 20, 'kiwi'), (10, 30, 'lemon'), (11, 10, 'mango'), (12, 60, 'nectarine');
+
+statement ok
+DUMP INDEX idx_c1 ON test_optimize_secondary_index;
+
+query I
+SELECT id FROM test_optimize_secondary_index WHERE c1 = 10;
+----
+1
+4
+7
+11
+
+query I
+SELECT id FROM test_optimize_secondary_index WHERE c1 <= 20;
+----
+1
+2
+4
+5
+7
+9
+11
+
+query I
+SELECT id FROM test_optimize_secondary_index WHERE c1 > 25;
+----
+3
+6
+8
+10
+12
+
+# OPTIMIZE: merge 2 chunks
+statement ok
+OPTIMIZE test_optimize_secondary_index;
+
+query I
+SELECT id FROM test_optimize_secondary_index WHERE c1 = 10;
+----
+1
+4
+7
+11
+
+query I
+SELECT id FROM test_optimize_secondary_index WHERE c1 <= 20;
+----
+1
+2
+4
+5
+7
+9
+11
+
+query I
+SELECT id FROM test_optimize_secondary_index WHERE c1 > 25;
+----
+3
+6
+8
+10
+12
+
+statement ok
+DROP TABLE test_optimize_secondary_index;


### PR DESCRIPTION
### What problem does this PR solve?

- JSON Index row_cnt_ 
  One JSON row produces multiple index entries.  row_cnt_ is not the same as index entry count. Correct it.
- Planner cross-type matching
  json_extract_double > N was treating > as >= for integer-typed values; now preserves original compare type
- JSON flattener
  :p: path-exists term emitted for objects and arrays (was only scalars), fixing json_exists_path for non-scalar paths
- OPTIMIZE merge
   removed broken reader_offsets_ adjustment that corrupted segment offsets during chunk merge

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
