### PR TITLE
go sdk: add connection limits to connection pool and configurable connection constructor

### DIFF
--- a/go/connection_pool.go
+++ b/go/connection_pool.go
@@ -24,22 +24,22 @@ import (
 // ConnectionPoolConfig contains configuration for the connection pool
 type ConnectionPoolConfig struct {
 	URI                 URI
-	InitialSize         int           // Initial number of connections to create
-	MaxIdleTime         time.Duration // Maximum time a connection can be idle
-	HealthCheckInterval time.Duration // Interval for health checks (ignored)
-	WaitTimeout         time.Duration // Maximum time to wait for a connection from the pool (ignored)
-	BlockWhenExhausted  bool          // Whether to block when pool is exhausted (ignored)
+	InitialSize         int           // Initial number of idle connections to create.
+	MaxOpen             int           // Maximum total open connections.
+	MaxIdle             int           // Maximum number of idle connections kept in the pool.
+	MaxIdleTime         time.Duration // Maximum time a connection can be idle.
+	HealthCheckInterval time.Duration // Interval for health checks (ignored).
 }
 
 // DefaultConnectionPoolConfig returns a default configuration
 func DefaultConnectionPoolConfig(uri URI) ConnectionPoolConfig {
 	return ConnectionPoolConfig{
 		URI:                 uri,
-		InitialSize:         10,
+		InitialSize:         0,
+		MaxOpen:             10,
+		MaxIdle:             2,
 		MaxIdleTime:         30 * time.Minute,
 		HealthCheckInterval: 5 * time.Minute,
-		WaitTimeout:         30 * time.Second,
-		BlockWhenExhausted:  true,
 	}
 }
 
@@ -48,6 +48,7 @@ type PooledConnection struct {
 	conn       *InfinityConnection
 	createdAt  time.Time
 	lastUsedAt time.Time
+	inUse      bool
 }
 
 // ConnectionPool manages a pool of Infinity connections
@@ -56,9 +57,11 @@ type ConnectionPool struct {
 	config       ConnectionPoolConfig
 	factory      func(URI) (*InfinityConnection, error)
 	mu           sync.Mutex
+	cond         *sync.Cond
 	closed       bool
 	available    []*PooledConnection
 	createdCount int
+	openingCount int
 	connToPooled map[*InfinityConnection]*PooledConnection
 }
 
@@ -70,6 +73,22 @@ func NewConnectionPool(config ConnectionPoolConfig, factory func(URI) (*Infinity
 	if config.MaxIdleTime <= 0 {
 		config.MaxIdleTime = 30 * time.Minute
 	}
+	if config.MaxOpen <= 0 {
+		if config.InitialSize > 0 {
+			config.MaxOpen = config.InitialSize
+		} else {
+			config.MaxOpen = 10
+		}
+	}
+	if config.MaxIdle < 0 {
+		config.MaxIdle = 0
+	}
+	if config.MaxIdle > config.MaxOpen {
+		config.MaxIdle = config.MaxOpen
+	}
+	if config.InitialSize > config.MaxIdle {
+		config.InitialSize = config.MaxIdle
+	}
 	if factory == nil {
 		factory = Connect
 	}
@@ -78,27 +97,34 @@ func NewConnectionPool(config ConnectionPoolConfig, factory func(URI) (*Infinity
 		uri:          config.URI,
 		config:       config,
 		factory:      factory,
-		available:    make([]*PooledConnection, 0, config.InitialSize),
+		available:    make([]*PooledConnection, 0, config.MaxIdle),
 		connToPooled: make(map[*InfinityConnection]*PooledConnection),
 	}
+	pool.cond = sync.NewCond(&pool.mu)
 
 	// Create initial connections
 	pool.mu.Lock()
-	defer pool.mu.Unlock()
 	for i := 0; i < config.InitialSize; i++ {
 		pooledConn, err := pool.createConnection()
 		if err != nil {
-			pool.Close()
+			for conn := range pool.connToPooled {
+				conn.Disconnect()
+			}
+			pool.connToPooled = make(map[*InfinityConnection]*PooledConnection)
+			pool.available = nil
+			pool.createdCount = 0
+			pool.mu.Unlock()
 			return nil, fmt.Errorf("failed to create initial connection %d: %w", i, err)
 		}
+		pool.registerConnection(pooledConn)
 		pool.available = append(pool.available, pooledConn)
 	}
+	pool.mu.Unlock()
 
 	return pool, nil
 }
 
-// createConnection creates a new pooled connection
-// Caller must hold p.mu lock
+// createConnection creates a new pooled connection without registering it
 func (p *ConnectionPool) createConnection() (*PooledConnection, error) {
 	conn, err := p.factory(p.uri)
 	if err != nil {
@@ -106,19 +132,32 @@ func (p *ConnectionPool) createConnection() (*PooledConnection, error) {
 	}
 
 	now := time.Now()
-	pooledConn := &PooledConnection{
+	return &PooledConnection{
 		conn:       conn,
 		createdAt:  now,
 		lastUsedAt: now,
-	}
-
-	p.connToPooled[conn] = pooledConn
-	p.createdCount++
-
-	return pooledConn, nil
+	}, nil
 }
 
-// Get gets a connection from the pool
+// registerConnection adds a newly created connection to pool accounting.
+// Caller must hold p.mu lock.
+func (p *ConnectionPool) registerConnection(pooledConn *PooledConnection) {
+	p.connToPooled[pooledConn.conn] = pooledConn
+	p.createdCount++
+}
+
+// reserveOpenSlot claims capacity for a connection that will be opened outside the lock.
+// Caller must hold p.mu lock.
+func (p *ConnectionPool) reserveOpenSlot() bool {
+	if p.createdCount+p.openingCount >= p.config.MaxOpen {
+		return false
+	}
+	p.openingCount++
+	return true
+}
+
+// Get gets a connection from the pool.
+// It blocks until a connection is available or the pool is closed.
 func (p *ConnectionPool) Get() (*InfinityConnection, error) {
 	return p.GetContext(context.Background())
 }
@@ -133,42 +172,77 @@ func (p *ConnectionPool) GetContext(ctx context.Context) (*InfinityConnection, e
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.closed {
-		return nil, NewInfinityException(int(ErrorCodeClientClose), "Connection pool is closed")
-	}
-
-	// Clean up idle or invalid connections from available slice
-	valid := p.available[:0]
-	for _, pooledConn := range p.available {
-		// Check if connection is still alive
-		if !pooledConn.conn.IsConnected() {
-			p.removeConnection(pooledConn)
-			continue
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			p.mu.Lock()
+			p.cond.Broadcast()
+			p.mu.Unlock()
+		case <-done:
 		}
-		// Check if connection has been idle too long
-		if time.Since(pooledConn.lastUsedAt) > p.config.MaxIdleTime {
-			p.removeConnection(pooledConn)
-			continue
+	}()
+
+	for {
+		if p.closed {
+			return nil, NewInfinityException(int(ErrorCodeClientClose), "Connection pool is closed")
 		}
-		valid = append(valid, pooledConn)
-	}
-	p.available = valid
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 
-	// If there are available connections, take the last one
-	if len(p.available) > 0 {
-		pooledConn := p.available[len(p.available)-1]
-		p.available = p.available[:len(p.available)-1]
-		pooledConn.lastUsedAt = time.Now()
-		conn := pooledConn.conn
-		return conn, nil
-	}
+		valid := p.available[:0]
+		for _, pooledConn := range p.available {
+			if !pooledConn.conn.IsConnected() {
+				p.removeConnection(pooledConn)
+				continue
+			}
+			if time.Since(pooledConn.lastUsedAt) > p.config.MaxIdleTime {
+				p.removeConnection(pooledConn)
+				continue
+			}
+			valid = append(valid, pooledConn)
+		}
+		p.available = valid
 
-	// No available connections, create a new one
-	pooledConn, err := p.createConnection()
-	if err != nil {
-		return nil, err
+		if len(p.available) > 0 {
+			pooledConn := p.available[len(p.available)-1]
+			p.available = p.available[:len(p.available)-1]
+			pooledConn.lastUsedAt = time.Now()
+			pooledConn.inUse = true
+			return pooledConn.conn, nil
+		}
+
+		if p.reserveOpenSlot() {
+			p.mu.Unlock()
+			pooledConn, err := p.createConnection()
+			p.mu.Lock()
+			p.openingCount--
+			if err != nil {
+				p.cond.Signal()
+				return nil, err
+			}
+			if p.closed {
+				pooledConn.conn.Disconnect()
+				p.cond.Signal()
+				return nil, NewInfinityException(int(ErrorCodeClientClose), "Connection pool is closed")
+			}
+			if err := ctx.Err(); err != nil {
+				pooledConn.conn.Disconnect()
+				p.cond.Signal()
+				return nil, err
+			}
+			p.registerConnection(pooledConn)
+			pooledConn.inUse = true
+			return pooledConn.conn, nil
+		}
+
+		p.cond.Wait()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 	}
-	return pooledConn.conn, nil
 }
 
 // Put returns a connection to the pool
@@ -198,26 +272,36 @@ func (p *ConnectionPool) Put(conn *InfinityConnection) error {
 		return NewInfinityException(int(ErrorCodeClientClose), "Connection is dead, removed from pool")
 	}
 
-	// Check if connection is already in available list (double release)
-	for _, available := range p.available {
-		if available.conn == conn {
-			return NewInfinityException(int(ErrorCodeInvalidParameterValue), "Connection is already in pool (double release)")
-		}
+	if !pooledConn.inUse {
+		return NewInfinityException(int(ErrorCodeInvalidParameterValue), "Connection is already in pool (double release)")
 	}
 
 	// Always return connection to pool (no max size limit)
 	pooledConn.lastUsedAt = time.Now()
-	p.available = append(p.available, pooledConn)
+	pooledConn.inUse = false
+	if len(p.available) < p.config.MaxIdle {
+		p.available = append(p.available, pooledConn)
+		p.cond.Signal()
+		return nil
+	}
+
+	p.removeConnection(pooledConn)
 	return nil
 }
 
 // removeConnection closes a pooled connection and removes it from tracking
 func (p *ConnectionPool) removeConnection(pooledConn *PooledConnection) {
-	if pooledConn.conn != nil {
-		delete(p.connToPooled, pooledConn.conn)
-		pooledConn.conn.Disconnect()
-		p.createdCount--
+	if pooledConn.conn == nil {
+		return
 	}
+
+	conn := pooledConn.conn
+	pooledConn.conn = nil
+	pooledConn.inUse = false
+	delete(p.connToPooled, conn)
+	conn.Disconnect()
+	p.createdCount--
+	p.cond.Signal()
 }
 
 // isClosed checks if the pool is closed
@@ -245,6 +329,7 @@ func (p *ConnectionPool) Close() error {
 	p.available = nil
 	p.createdCount = 0
 
+	p.cond.Broadcast()
 	p.mu.Unlock()
 	return nil
 }

--- a/go/connection_pool.go
+++ b/go/connection_pool.go
@@ -276,7 +276,8 @@ func (p *ConnectionPool) Put(conn *InfinityConnection) error {
 		return NewInfinityException(int(ErrorCodeInvalidParameterValue), "Connection is already in pool (double release)")
 	}
 
-	// Always return connection to pool (no max size limit)
+	// Release the connection back to the pool; if the idle list is at
+	// MaxIdle capacity, close the excess connection instead of keeping it.
 	pooledConn.lastUsedAt = time.Now()
 	pooledConn.inUse = false
 	if len(p.available) < p.config.MaxIdle {

--- a/go/example/connection_pool_example.go
+++ b/go/example/connection_pool_example.go
@@ -98,10 +98,10 @@ func exampleCustomConfig() {
 	config := infinity.ConnectionPoolConfig{
 		URI:                 infinity.LocalHost,
 		InitialSize:         2,
+		MaxOpen:             4,
+		MaxIdle:             2,
 		MaxIdleTime:         10 * time.Minute,
 		HealthCheckInterval: 1 * time.Minute,
-		WaitTimeout:         10 * time.Second,
-		BlockWhenExhausted:  true,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, func(uri infinity.URI) (*infinity.InfinityConnection, error) {
@@ -117,8 +117,9 @@ func exampleCustomConfig() {
 
 	fmt.Printf("Pool created with custom config:\n")
 	fmt.Printf("  Initial Size: %d\n", config.InitialSize)
+	fmt.Printf("  Max Open: %d\n", config.MaxOpen)
+	fmt.Printf("  Max Idle: %d\n", config.MaxIdle)
 	fmt.Printf("  Max Idle Time: %v\n", config.MaxIdleTime)
-	fmt.Printf("  Wait Timeout: %v\n", config.WaitTimeout)
 
 	// Get multiple connections to see initial connections being used
 	for i := 0; i < 3; i++ {
@@ -139,10 +140,10 @@ func exampleConcurrentAccess() {
 	fmt.Println("--- Example 3: Concurrent Pool Access ---")
 
 	config := infinity.ConnectionPoolConfig{
-		URI:                 infinity.LocalHost,
-		InitialSize:         1,
-		BlockWhenExhausted:  true,
-		WaitTimeout:         5 * time.Second,
+		URI:         infinity.LocalHost,
+		InitialSize: 1,
+		MaxOpen:     2,
+		MaxIdle:     1,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)
@@ -152,7 +153,7 @@ func exampleConcurrentAccess() {
 	}
 	defer pool.Close()
 
-	fmt.Printf("Pool initial size: %d, simulating %d concurrent workers\n", config.InitialSize, 5)
+	fmt.Printf("Pool initial size: %d, max open: %d, simulating %d concurrent workers\n", config.InitialSize, config.MaxOpen, 5)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
@@ -160,8 +161,10 @@ func exampleConcurrentAccess() {
 		go func(workerID int) {
 			defer wg.Done()
 
-			// Get connection from pool
-			conn, err := pool.Get()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			conn, err := pool.GetContext(ctx)
 			if err != nil {
 				fmt.Printf("  Worker %d: Failed to get connection: %v\n", workerID, err)
 				return
@@ -244,12 +247,11 @@ func printStats(stats infinity.PoolStats) {
 func exampleContextTimeout() {
 	fmt.Println("--- Example 5: Context Timeout ---")
 
-	// Create a pool with only 1 connection
 	config := infinity.ConnectionPoolConfig{
-		URI:                 infinity.LocalHost,
-		InitialSize:         1,
-		BlockWhenExhausted:  true,
-		WaitTimeout:         2 * time.Second,
+		URI:         infinity.LocalHost,
+		InitialSize: 1,
+		MaxOpen:     1,
+		MaxIdle:     1,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)

--- a/go/example/example.go
+++ b/go/example/example.go
@@ -289,6 +289,8 @@ func main() {
 		infinity.ConnectionPoolConfig{
 			URI:         infinity.LocalHost,
 			InitialSize: 10,
+			MaxOpen:     10,
+			MaxIdle:     10,
 		},
 		func(uri infinity.URI) (*infinity.InfinityConnection, error) {
 			return infinity.Connect(uri)

--- a/go/infinity.go
+++ b/go/infinity.go
@@ -40,7 +40,7 @@ const ClientVersion = 36 // version: 0.7.2
 func Connect(uri URI) (*InfinityConnection, error) {
 	switch u := uri.(type) {
 	case NetworkAddress:
-		return NewInfinityConnection(u)
+		return NewInfinityConnectionWithConfig(u, &thrift.TConfiguration{})
 	default:
 		return nil, NewInfinityException(
 			int(ErrorCodeInvalidServerAddress),
@@ -61,9 +61,18 @@ type InfinityConnection struct {
 
 // NewInfinityConnection creates a new connection to Infinity server
 func NewInfinityConnection(address NetworkAddress) (*InfinityConnection, error) {
+	return NewInfinityConnectionWithConfig(address, &thrift.TConfiguration{})
+}
+
+// NewInfinityConnectionWithConfig creates a new connection to Infinity server with a custom thrift configuration.
+func NewInfinityConnectionWithConfig(address NetworkAddress, conf *thrift.TConfiguration) (*InfinityConnection, error) {
+	if conf == nil {
+		conf = &thrift.TConfiguration{}
+	}
+
 	// Create thrift transport
 	// Use TBufferedTransport for sync communication (matching Python's TBufferedTransport)
-	transport := thrift.NewTSocketConf(fmt.Sprintf("%s:%d", address.IP, address.Port), &thrift.TConfiguration{})
+	transport := thrift.NewTSocketConf(fmt.Sprintf("%s:%d", address.IP, address.Port), conf)
 
 	// Use buffered transport
 	bufferedTransport := thrift.NewTBufferedTransport(transport, 8192)

--- a/go/infinity.go
+++ b/go/infinity.go
@@ -78,7 +78,7 @@ func NewInfinityConnectionWithConfig(address NetworkAddress, conf *thrift.TConfi
 	bufferedTransport := thrift.NewTBufferedTransport(transport, 8192)
 
 	// Create binary protocol (matching Python's TBinaryProtocol)
-	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
+	protocolFactory := thrift.NewTBinaryProtocolFactoryConf(conf)
 	protocol := protocolFactory.GetProtocol(bufferedTransport)
 
 	// Create client

--- a/go/tests/connection_pool_test.go
+++ b/go/tests/connection_pool_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/infiniflow/infinity-go-sdk"
 )
 
-// TestConnectionPool tests connection pool functionality
-// Based on Python SDK test_pysdk/test_connection_pool.py
+// TestConnectionPool tests connection pool functionality.
 func TestConnectionPool(t *testing.T) {
-	// Create connection pool with initial size 8 (max_size in Python)
+	// Create a bounded connection pool with 8 warm connections.
 	config := infinity.ConnectionPoolConfig{
 		URI:         testLocalHost,
 		InitialSize: 8,
+		MaxOpen:     8,
+		MaxIdle:     8,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)
@@ -170,11 +171,52 @@ func TestConnectionPool(t *testing.T) {
 	t.Logf("Test completed successfully")
 }
 
+func TestConnectionPoolZeroMaxIdle(t *testing.T) {
+	config := infinity.ConnectionPoolConfig{
+		URI:         testLocalHost,
+		InitialSize: 1,
+		MaxOpen:     1,
+		MaxIdle:     0,
+	}
+
+	pool, err := infinity.NewConnectionPool(config, nil)
+	if err != nil {
+		t.Fatalf("Failed to create connection pool: %v", err)
+	}
+	defer pool.Close()
+
+	stats := pool.Stats()
+	if stats.TotalConnections != 0 || stats.AvailableConnections != 0 {
+		t.Fatalf("Expected no prewarmed idle connections when MaxIdle is 0, got total=%d available=%d", stats.TotalConnections, stats.AvailableConnections)
+	}
+
+	conn, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Failed to get connection: %v", err)
+	}
+
+	stats = pool.Stats()
+	if stats.TotalConnections != 1 || stats.AvailableConnections != 0 || stats.InUseConnections != 1 {
+		t.Fatalf("Unexpected stats while connection is checked out: %+v", stats)
+	}
+
+	if err := pool.Put(conn); err != nil {
+		t.Fatalf("Failed to put connection back: %v", err)
+	}
+
+	stats = pool.Stats()
+	if stats.TotalConnections != 0 || stats.AvailableConnections != 0 || stats.InUseConnections != 0 {
+		t.Fatalf("Expected returned connection to be closed when MaxIdle is 0, got %+v", stats)
+	}
+}
+
 // TestConnectionPoolStats tests pool statistics
 func TestConnectionPoolStats(t *testing.T) {
 	config := infinity.ConnectionPoolConfig{
 		URI:         testLocalHost,
 		InitialSize: 5,
+		MaxOpen:     5,
+		MaxIdle:     5,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)
@@ -246,6 +288,8 @@ func TestConnectionPoolWithDatabaseOperations(t *testing.T) {
 	config := infinity.ConnectionPoolConfig{
 		URI:         testLocalHost,
 		InitialSize: 3,
+		MaxOpen:     4,
+		MaxIdle:     4,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)
@@ -319,6 +363,8 @@ func TestConnectionPoolMultipleConnections(t *testing.T) {
 	config := infinity.ConnectionPoolConfig{
 		URI:         testLocalHost,
 		InitialSize: 3,
+		MaxOpen:     4,
+		MaxIdle:     4,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)
@@ -346,7 +392,7 @@ func TestConnectionPoolMultipleConnections(t *testing.T) {
 		t.Errorf("Expected 0 available connections, got %d", stats.AvailableConnections)
 	}
 
-	// Getting another connection should create a new one (no max size limit in Go implementation)
+	// Getting another connection should create a new one because MaxOpen allows 4 total connections.
 	conn4, err := pool.Get()
 	if err != nil {
 		t.Fatalf("Failed to get 4th connection: %v", err)
@@ -386,6 +432,8 @@ func TestConnectionPoolClosed(t *testing.T) {
 	config := infinity.ConnectionPoolConfig{
 		URI:         testLocalHost,
 		InitialSize: 2,
+		MaxOpen:     2,
+		MaxIdle:     2,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)
@@ -433,6 +481,8 @@ func TestConnectionPoolZeroInitialSize(t *testing.T) {
 	config := infinity.ConnectionPoolConfig{
 		URI:         testLocalHost,
 		InitialSize: 0,
+		MaxOpen:     1,
+		MaxIdle:     1,
 	}
 
 	pool, err := infinity.NewConnectionPool(config, nil)

--- a/go/tests/connection_pool_test.go
+++ b/go/tests/connection_pool_test.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/infiniflow/infinity-go-sdk"
 )
@@ -207,6 +208,51 @@ func TestConnectionPoolZeroMaxIdle(t *testing.T) {
 	stats = pool.Stats()
 	if stats.TotalConnections != 0 || stats.AvailableConnections != 0 || stats.InUseConnections != 0 {
 		t.Fatalf("Expected returned connection to be closed when MaxIdle is 0, got %+v", stats)
+	}
+
+	// Regression: a Get() blocked at MaxOpen must be woken when a Put frees
+	// capacity, even though MaxIdle is 0. The returned connection is closed,
+	// so the waiter must be allowed to create a fresh one.
+	blockedConn, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Failed to get connection for contended case: %v", err)
+	}
+
+	gotCh := make(chan *infinity.InfinityConnection, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		c, e := pool.Get()
+		if e != nil {
+			errCh <- e
+			return
+		}
+		gotCh <- c
+	}()
+
+	// Confirm the waiter is actually blocked before capacity is freed.
+	select {
+	case <-gotCh:
+		t.Fatal("waiter acquired a connection before capacity was freed")
+	case <-errCh:
+		t.Fatal("waiter errored before capacity was freed")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: still blocked at MaxOpen.
+	}
+
+	if err := pool.Put(blockedConn); err != nil {
+		t.Fatalf("Failed to put connection back in contended case: %v", err)
+	}
+
+	select {
+	case c := <-gotCh:
+		if c == nil {
+			t.Fatal("waiter got nil connection after capacity freed")
+		}
+		_ = pool.Put(c)
+	case e := <-errCh:
+		t.Fatalf("waiter failed after capacity freed: %v", e)
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiter blocked indefinitely after Put freed capacity (MaxIdle=0 regression)")
 	}
 }
 


### PR DESCRIPTION

### Summary

  This PR makes the Go SDK connection pool bounded (add MaxOpen and MaxIdle to ConnectionPoolConfig), and adds a configurable connection constructor for custom thrift transport settings.