### PR TITLE
Fix: prevent full-text inverting exceptions from deadlock

### DIFF
--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -339,6 +339,69 @@ Status NewCatalog::MemIndexRecover(NewTxn *txn) {
             return status;
         }
     }
+
+    // Drain all pending fulltext index commits to ensure they complete before the checkpoint that follows.
+    {
+        auto DrainFulltextMemIndexes = [&](TableIndexMeta &table_index_meta) {
+            auto [index_base, base_status] = table_index_meta.GetIndexBase();
+            if (!base_status.ok() || index_base->index_type_ != IndexType::kFullText) {
+                return;
+            }
+            auto [segment_ids_ptr, seg_status] = table_index_meta.GetSegmentIndexIDs1();
+            if (!seg_status.ok()) {
+                return;
+            }
+            for (SegmentID segment_id : *segment_ids_ptr) {
+                SegmentIndexMeta segment_index_meta(segment_id, table_index_meta);
+                std::shared_ptr<MemIndex> mem_index = segment_index_meta.GetMemIndex();
+                if (mem_index == nullptr) {
+                    continue;
+                }
+                std::shared_ptr<MemoryIndexer> memory_indexer = mem_index->GetFulltextIndex();
+                if (memory_indexer != nullptr) {
+                    memory_indexer->WaitForTaskCompletion();
+                }
+            }
+        };
+
+        auto DrainTable = [&](TableMeta &table_meta) {
+            std::vector<std::string> *index_id_strs_ptr = nullptr;
+            std::vector<std::string> *index_name_strs_ptr = nullptr;
+            Status st = table_meta.GetIndexIDs(index_id_strs_ptr, &index_name_strs_ptr);
+            if (!st.ok()) {
+                return;
+            }
+            for (size_t i = 0; i < index_id_strs_ptr->size(); ++i) {
+                const std::string &index_id_str = (*index_id_strs_ptr)[i];
+                const std::string &index_name_str = (*index_name_strs_ptr)[i];
+                TableIndexMeta table_index_meta(index_id_str, index_name_str, table_meta);
+                DrainFulltextMemIndexes(table_index_meta);
+            }
+        };
+
+        auto DrainDB = [&](DBMeta &db_meta) {
+            std::vector<std::string> *table_id_strs_ptr = nullptr;
+            std::vector<std::string> *table_names_ptr = nullptr;
+            Status st = db_meta.GetTableIDs(table_id_strs_ptr, &table_names_ptr);
+            if (!st.ok()) {
+                return;
+            }
+            for (size_t i = 0; i < table_id_strs_ptr->size(); ++i) {
+                const std::string &table_id_str = (*table_id_strs_ptr)[i];
+                const std::string &table_name = (*table_names_ptr)[i];
+                TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, txn);
+                DrainTable(table_meta);
+            }
+        };
+
+        for (size_t idx = 0; idx < db_count; ++idx) {
+            const std::string &db_id_str = db_id_strs_ptr->at(idx);
+            const std::string &db_name = db_names_ptr->at(idx);
+            DBMeta db_meta(db_id_str, db_name, txn);
+            DrainDB(db_meta);
+        }
+    }
+
     return Status::OK();
 }
 

--- a/src/storage/common/rcu_multimap.cppm
+++ b/src/storage/common/rcu_multimap.cppm
@@ -694,6 +694,7 @@ Value *RcuMap<Key, Value>::Get(const Key &key, bool update_access_time) {
                 }
             }
         }
+        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
 
@@ -759,7 +760,6 @@ Value *RcuMap<Key, Value>::GetWithRcuTime(const Key &key) {
     auto it = current_read->find(key);
 
     if (it != current_read->end()) {
-        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
 
@@ -785,7 +785,6 @@ Value *RcuMap<Key, Value>::GetReadOnly(const Key &key) {
     InnerMap *current_read = read_map_;
     auto it = current_read->find(key);
     if (it != current_read->end()) {
-        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
 

--- a/src/storage/common/rcu_multimap.cppm
+++ b/src/storage/common/rcu_multimap.cppm
@@ -618,6 +618,11 @@ private:
     InnerMap *volatile read_map_;
     std::size_t miss_time_;
 
+    // RCU reader count: incremented by readers before accessing read_map_,
+    // decremented after the read is complete. Writers (CheckSwapInLock, CheckGc)
+    // wait for this to reach 0 before freeing old maps, preventing use-after-free.
+    mutable std::atomic<u64> rcu_reader_count_{0};
+
     mutable std::mutex dirty_lock_;
     InnerMap *dirty_map_;
 
@@ -662,6 +667,9 @@ typename RcuMap<Key, Value>::MapValue RcuMap<Key, Value>::CreateMapValue(const V
 
 template <typename Key, typename Value>
 Value *RcuMap<Key, Value>::Get(const Key &key, bool update_access_time) {
+    // RCU read protection: prevent write-side GC from freeing read_map_ during iteration
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
+
     // ULTRA-OPTIMIZED RCU READ PATTERN FOR READ-HEAVY WORKLOADS:
     // Eliminate ALL overhead in the common case to match MapWithLock performance
 
@@ -688,6 +696,9 @@ Value *RcuMap<Key, Value>::Get(const Key &key, bool update_access_time) {
         }
         return &(it->second.value_);
     }
+
+    // RCU: temporarily release reader count while checking dirty_map under lock
+    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
 
     // PHASE 2: Check dirty_map for recent writes (SLOW PATH - MINIMIZED)
     // This path should be rare in read-heavy workloads
@@ -740,21 +751,25 @@ std::optional<Value> RcuMap<Key, Value>::GetValue(const Key &key, bool update_ac
 
 template <typename Key, typename Value>
 Value *RcuMap<Key, Value>::GetWithRcuTime(const Key &key) {
+    // RCU read protection
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
+
     // ABSOLUTE FASTEST PATH: Zero overhead reads for maximum performance
-    // This should be as fast as MapWithLock::Get() with shared_lock
     InnerMap *current_read = read_map_;
     auto it = current_read->find(key);
 
     if (it != current_read->end()) {
+        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
+
+    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
 
     // Inline dirty_map check to avoid function call overhead
     {
         std::lock_guard<std::mutex> lock(dirty_lock_);
         auto dirty_it = dirty_map_->find(key);
         if (dirty_it != dirty_map_->end()) {
-            // No access time updates, no miss tracking - pure read performance
             return &(dirty_it->second.value_);
         }
     }
@@ -764,18 +779,18 @@ Value *RcuMap<Key, Value>::GetWithRcuTime(const Key &key) {
 
 template <typename Key, typename Value>
 Value *RcuMap<Key, Value>::GetReadOnly(const Key &key) {
-    // BENCHMARK-OPTIMIZED READ: Absolute minimum overhead
-    // This method is designed to match MapWithLock performance exactly
-    // by eliminating ALL RCU-specific overhead
+    // RCU read protection
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
 
-    // Try read_map first (should succeed in most cases for read-heavy workloads)
     InnerMap *current_read = read_map_;
     auto it = current_read->find(key);
     if (it != current_read->end()) {
+        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
 
-    // If not found, try dirty_map (minimal overhead)
+    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
+
     std::lock_guard<std::mutex> lock(dirty_lock_);
     auto dirty_it = dirty_map_->find(key);
     if (dirty_it != dirty_map_->end()) {
@@ -825,6 +840,12 @@ void RcuMap<Key, Value>::CheckSwapInLock() {
 
     // std::set up new dirty_map for future writes
     dirty_map_ = new_dirty_map;
+
+    // RCU SYNCHRONIZATION: Wait for all readers that saw the OLD read_map_ to finish.
+    // Without this, a reader could still be iterating the old map when CheckGc frees it.
+    while (rcu_reader_count_.load(std::memory_order_acquire) > 0) {
+        std::this_thread::yield();
+    }
 
     // Schedule old read_map for garbage collection
     // Cannot delete immediately - readers may still be using it
@@ -929,6 +950,12 @@ void RcuMap<Key, Value>::CheckGc(u64 min_delete_time) {
     }
 
     for (auto &deleted_map : map_need_delete) {
+        // RCU: Wait for any in-flight readers to finish before freeing old maps.
+        // CheckSwapInLock already waited, but there may be readers that started before
+        // the swap and haven't finished yet.
+        while (rcu_reader_count_.load(std::memory_order_acquire) > 0) {
+            std::this_thread::yield();
+        }
         delete deleted_map.deleted_entries_;
         delete deleted_map.map_;
     }
@@ -991,6 +1018,8 @@ void RcuMap<Key, Value>::emplace(const Key &key, Args &&...args) {
 
 template <typename Key, typename Value>
 u32 RcuMap<Key, Value>::range(const Key &key_min, const Key &key_max, std::vector<Value> &result) const {
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
+
     InnerMap *current_read = read_map_;
     auto read_begin = current_read->lower_bound(key_min);
     auto read_end = current_read->upper_bound(key_max);
@@ -1027,6 +1056,7 @@ u32 RcuMap<Key, Value>::range(const Key &key_min, const Key &key_max, std::vecto
         ++read_it;
     }
 
+    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
     return count;
 }
 
@@ -1081,6 +1111,8 @@ template <typename Key, typename Value>
 void RcuMap<Key, Value>::Range(const Key &key_min, const Key &key_max, std::vector<std::pair<Key, Value>> &items) {
     items.clear();
 
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
+
     InnerMap *current_read = read_map_;
     auto read_begin = current_read->lower_bound(key_min);
     auto read_end = current_read->upper_bound(key_max);
@@ -1109,6 +1141,8 @@ void RcuMap<Key, Value>::Range(const Key &key_min, const Key &key_max, std::vect
             items.emplace_back(it->first, it->second.value_);
         }
     }
+
+    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
 }
 
 template <typename Key, typename Value>

--- a/src/storage/common/rcu_multimap.cppm
+++ b/src/storage/common/rcu_multimap.cppm
@@ -760,6 +760,7 @@ Value *RcuMap<Key, Value>::GetWithRcuTime(const Key &key) {
     auto it = current_read->find(key);
 
     if (it != current_read->end()) {
+        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
 
@@ -785,6 +786,7 @@ Value *RcuMap<Key, Value>::GetReadOnly(const Key &key) {
     InnerMap *current_read = read_map_;
     auto it = current_read->find(key);
     if (it != current_read->end()) {
+        rcu_reader_count_.fetch_sub(1, std::memory_order_release);
         return &(it->second.value_);
     }
 

--- a/src/storage/common/rcu_multimap.cppm
+++ b/src/storage/common/rcu_multimap.cppm
@@ -1017,22 +1017,31 @@ void RcuMap<Key, Value>::emplace(const Key &key, Args &&...args) {
 
 template <typename Key, typename Value>
 u32 RcuMap<Key, Value>::range(const Key &key_min, const Key &key_max, std::vector<Value> &result) const {
-    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
-
-    InnerMap *current_read = read_map_;
-    auto read_begin = current_read->lower_bound(key_min);
-    auto read_end = current_read->upper_bound(key_max);
-
+    // 1. Acquire dirty snapshot under lock FIRST — avoids lock-ordering inversion
+    //    where CheckSwapInLock holds dirty_lock_ and waits for readers to drain.
     InnerMap *dirty_snapshot = nullptr;
     {
         std::lock_guard<std::mutex> lock(dirty_lock_);
         dirty_snapshot = dirty_map_;
     }
 
+    // 2. Now pin the reader count (read_map_ is stable)
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
+
+    // RAII: release reader count on any exit path (normal or exceptional)
+    struct RcuReaderGuard {
+        std::atomic<u64> &cnt_;
+        ~RcuReaderGuard() { cnt_.fetch_sub(1, std::memory_order_release); }
+    } guard{rcu_reader_count_};
+
+    InnerMap *current_read = read_map_;
+    auto read_begin = current_read->lower_bound(key_min);
+    auto read_end = current_read->upper_bound(key_max);
+
     auto dirty_begin = dirty_snapshot->lower_bound(key_min);
     auto dirty_end = dirty_snapshot->upper_bound(key_max);
 
-    // merge - for std::map, we prioritize dirty_map values over read_map
+    // merge — dirty_map values take priority over read_map
     u32 count = 0;
     auto read_it = read_begin;
     auto dirty_it = dirty_begin;
@@ -1055,8 +1064,8 @@ u32 RcuMap<Key, Value>::range(const Key &key_min, const Key &key_max, std::vecto
         ++read_it;
     }
 
-    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
     return count;
+    // ~RcuReaderGuard releases reader count
 }
 
 // MapWithLock compatibility methods implementation
@@ -1110,17 +1119,25 @@ template <typename Key, typename Value>
 void RcuMap<Key, Value>::Range(const Key &key_min, const Key &key_max, std::vector<std::pair<Key, Value>> &items) {
     items.clear();
 
-    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
-
-    InnerMap *current_read = read_map_;
-    auto read_begin = current_read->lower_bound(key_min);
-    auto read_end = current_read->upper_bound(key_max);
-
+    // 1. Acquire dirty snapshot under lock FIRST — avoids lock-ordering inversion
     InnerMap *dirty_snapshot = nullptr;
     {
         std::lock_guard<std::mutex> lock(dirty_lock_);
         dirty_snapshot = dirty_map_;
     }
+
+    // 2. Now pin the reader count (read_map_ is stable)
+    rcu_reader_count_.fetch_add(1, std::memory_order_acquire);
+
+    // RAII: release reader count on any exit path
+    struct RcuReaderGuard {
+        std::atomic<u64> &cnt_;
+        ~RcuReaderGuard() { cnt_.fetch_sub(1, std::memory_order_release); }
+    } guard{rcu_reader_count_};
+
+    InnerMap *current_read = read_map_;
+    auto read_begin = current_read->lower_bound(key_min);
+    auto read_end = current_read->upper_bound(key_max);
 
     auto dirty_begin = dirty_snapshot->lower_bound(key_min);
     auto dirty_end = dirty_snapshot->upper_bound(key_max);
@@ -1140,8 +1157,7 @@ void RcuMap<Key, Value>::Range(const Key &key_min, const Key &key_max, std::vect
             items.emplace_back(it->first, it->second.value_);
         }
     }
-
-    rcu_reader_count_.fetch_sub(1, std::memory_order_release);
+    // ~RcuReaderGuard releases reader count
 }
 
 template <typename Key, typename Value>

--- a/src/storage/invertedindex/column_inverter.cppm
+++ b/src/storage/invertedindex/column_inverter.cppm
@@ -81,6 +81,18 @@ public:
 
     const std::vector<std::binary_semaphore *> &semas() const { return semas_; }
 
+    // Release all semaphores exactly once across all threads that process this inverter.
+    void ReleaseSemas() {
+        bool expected = false;
+        if (!semas_released_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+            return;
+        }
+        for (auto *sema : semas_) {
+            sema->release();
+        }
+        // semas_ does not need clearing since the atomic flag prevents re-entry.
+    }
+
 private:
     using TermBuffer = std::vector<char>;
     using PosInfoVec = std::vector<PosInfo>;
@@ -112,6 +124,7 @@ private:
 
     u32 merged_{1};
     std::vector<std::binary_semaphore *> semas_{};
+    std::atomic<bool> semas_released_{false};
 
 protected:
     size_t InvertColumn(u32 doc_id, const std::string &val);

--- a/src/storage/invertedindex/index_defines.cppm
+++ b/src/storage/invertedindex/index_defines.cppm
@@ -29,7 +29,7 @@ export {
     typedef u32 tf_t;
     typedef i64 ttf_t;
 
-    constexpr optionflag_t OPTION_FLAG_ALL = of_term_payload | of_doc_payload | of_position_list | of_term_frequency | of_block_max;
+    constexpr optionflag_t OPTION_FLAG_ALL = of_term_payload | of_doc_payload | of_position_list | of_term_frequency | of_block_max | of_realtime;
     constexpr optionflag_t NO_BLOCK_MAX = of_term_payload | of_doc_payload | of_position_list | of_term_frequency;
     constexpr optionflag_t NO_TERM_FREQUENCY = of_term_payload | of_doc_payload;
     constexpr optionflag_t OPTION_FLAG_NONE = of_none;

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -131,15 +131,15 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
         PostingWriterProvider provider = [this](const std::string &term) -> std::shared_ptr<PostingWriter> { return GetOrAddPosting(term); };
         auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
         inverter->InitAnalyzer(this->analyzer_);
-        auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter](int id) {
+        auto func = [this, task, inverter](int id) {
             bool success = false;
             try {
                 size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-                self->term_cnt_ += column_length_sum;
+                term_cnt_ += column_length_sum;
                 if (column_length_sum > 0) {
                     inverter->SortForOfflineDump();
                 }
-                self->ring_sorted_.Put(task->task_seq_, inverter);
+                this->ring_sorted_.Put(task->task_seq_, inverter);
                 success = true;
             } catch (const std::exception &e) {
                 LOG_ERROR(fmt::format("Insert(offline) invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
@@ -147,10 +147,10 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
                 LOG_ERROR(fmt::format("Insert(offline) invert task failed, seq={}, unknown error", task->task_seq_));
             }
             if (!success) {
-                std::unique_lock lock(self->mutex_);
-                --self->inflight_tasks_;
-                if (self->inflight_tasks_ == 0) {
-                    self->cv_.notify_one();
+                std::unique_lock lock(mutex_);
+                --inflight_tasks_;
+                if (inflight_tasks_ == 0) {
+                    cv_.notify_one();
                 }
             }
         };
@@ -165,15 +165,15 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
         PostingWriterProvider provider = [this](const std::string &term) -> std::shared_ptr<PostingWriter> { return GetOrAddPosting(term); };
         auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
         inverter->InitAnalyzer(this->analyzer_);
-        auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter](int id) {
+        auto func = [this, task, inverter](int id) {
             bool success = false;
             try {
                 // LOG_INFO(fmt::format("online inverter {} begin", id));
                 size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-                self->term_cnt_ += column_length_sum;
+                term_cnt_ += column_length_sum;
                 inverter->MergePrepare();
                 inverter->Sort();
-                self->ring_sorted_.Put(task->task_seq_, inverter);
+                this->ring_sorted_.Put(task->task_seq_, inverter);
                 success = true;
                 // LOG_INFO(fmt::format("online inverter {} end", id));
             } catch (const std::exception &e) {
@@ -184,12 +184,12 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
             if (success) {
                 // Proactively drain the ring to prevent deadlock when the ring fills up.
                 // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
-                self->CommitSync(100);
+                CommitSync(100);
             } else {
-                std::unique_lock lock(self->mutex_);
-                --self->inflight_tasks_;
-                if (self->inflight_tasks_ == 0) {
-                    self->cv_.notify_one();
+                std::unique_lock lock(mutex_);
+                --inflight_tasks_;
+                if (inflight_tasks_ == 0) {
+                    cv_.notify_one();
                 }
             }
         };
@@ -243,16 +243,16 @@ void MemoryIndexer::AsyncInsertBottom(const std::shared_ptr<ColumnVector> &colum
     PostingWriterProvider provider = [this](const std::string &term) -> std::shared_ptr<PostingWriter> { return GetOrAddPosting(term); };
     auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
     inverter->InitAnalyzer(this->analyzer_);
-    auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter, append_batch](int id) {
+    auto func = [this, task, inverter, append_batch](int id) {
         try {
             size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-            self->term_cnt_ += column_length_sum;
+            term_cnt_ += column_length_sum;
             inverter->MergePrepare();
             inverter->Sort();
-            self->ring_sorted_.Put(task->task_seq_, inverter);
+            this->ring_sorted_.Put(task->task_seq_, inverter);
             // Proactively drain the ring to prevent deadlock when the ring fills up.
             // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
-            self->CommitSync(100);
+            CommitSync(100);
         } catch (const std::exception &e) {
             std::string sample_data;
             for (u32 i = 0; i < std::min(task->row_count_, 3u); ++i) {
@@ -264,26 +264,26 @@ void MemoryIndexer::AsyncInsertBottom(const std::shared_ptr<ColumnVector> &colum
             }
             LOG_ERROR(fmt::format("AsyncInsertBottom invert task failed, db={}, table={}, index={}, base_name={}, base_row_id={}, seq={}, "
                                   "start_doc_id={}, row_offset={}, row_count={}, absolute_row={}, error: {}, sample:{}",
-                                  self->db_name_,
-                                  self->table_name_,
-                                  self->index_name_,
-                                  self->base_name_,
-                                  self->base_row_id_.ToUint64(),
+                                  this->db_name_,
+                                  this->table_name_,
+                                  this->index_name_,
+                                  this->base_name_,
+                                  this->base_row_id_.ToUint64(),
                                   task->task_seq_,
                                   task->start_doc_id_,
                                   task->row_offset_,
                                   task->row_count_,
-                                  self->base_row_id_.ToUint64() + task->start_doc_id_,
+                                  this->base_row_id_.ToUint64() + task->start_doc_id_,
                                   e.what(),
                                   sample_data));
         } catch (...) {
             LOG_ERROR(fmt::format("AsyncInsertBottom invert task failed, db={}, table={}, index={}, base_name={}, base_row_id={}, seq={}, "
                                   "start_doc_id={}, row_offset={}, row_count={}, unknown error",
-                                  self->db_name_,
-                                  self->table_name_,
-                                  self->index_name_,
-                                  self->base_name_,
-                                  self->base_row_id_.ToUint64(),
+                                  this->db_name_,
+                                  this->table_name_,
+                                  this->index_name_,
+                                  this->base_name_,
+                                  this->base_row_id_.ToUint64(),
                                   task->task_seq_,
                                   task->start_doc_id_,
                                   task->row_offset_,
@@ -326,15 +326,15 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
     auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
     inverter->InitAnalyzer(this->analyzer_);
     inverter->AddSema(sema.get());
-    auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter](int id) {
+    auto func = [this, task, inverter](int id) {
         bool success = false;
         try {
             // LOG_INFO(fmt::format("online inverter {} begin", id));
             size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-            self->term_cnt_ += column_length_sum;
+            term_cnt_ += column_length_sum;
             inverter->MergePrepare();
             inverter->Sort();
-            self->ring_sorted_.Put(task->task_seq_, inverter);
+            this->ring_sorted_.Put(task->task_seq_, inverter);
             success = true;
             // LOG_INFO(fmt::format("online inverter {} end", id));
         } catch (const std::exception &e) {
@@ -347,16 +347,16 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
             // CommitSync generates postings and releases semaphores inside.
             // If CommitSync returns 0 (ring gap or try_lock failed), release
             // semaphores here to prevent deadlock and schedule a retry.
-            if (self->CommitSync(100) == 0) {
+            if (CommitSync(100) == 0) {
                 inverter->ReleaseSemas();
-                self->Commit(false);
+                Commit(false);
             }
         } else {
             inverter->ReleaseSemas();
-            std::unique_lock lock(self->mutex_);
-            --self->inflight_tasks_;
-            if (self->inflight_tasks_ == 0) {
-                self->cv_.notify_one();
+            std::unique_lock lock(mutex_);
+            --inflight_tasks_;
+            if (inflight_tasks_ == 0) {
+                cv_.notify_one();
             }
         }
     };

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -132,12 +132,27 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
         auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
         inverter->InitAnalyzer(this->analyzer_);
         auto func = [this, task, inverter](int id) {
-            size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-            term_cnt_ += column_length_sum;
-            if (column_length_sum > 0) {
-                inverter->SortForOfflineDump();
+            bool success = false;
+            try {
+                size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
+                term_cnt_ += column_length_sum;
+                if (column_length_sum > 0) {
+                    inverter->SortForOfflineDump();
+                }
+                this->ring_sorted_.Put(task->task_seq_, inverter);
+                success = true;
+            } catch (const std::exception &e) {
+                LOG_ERROR(fmt::format("Insert(offline) invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
+            } catch (...) {
+                LOG_ERROR(fmt::format("Insert(offline) invert task failed, seq={}, unknown error", task->task_seq_));
             }
-            this->ring_sorted_.Put(task->task_seq_, inverter);
+            if (!success) {
+                std::unique_lock lock(mutex_);
+                --inflight_tasks_;
+                if (inflight_tasks_ == 0) {
+                    cv_.notify_one();
+                }
+            }
         };
         {
             std::unique_lock<std::mutex> lock(mutex_);
@@ -151,13 +166,28 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
         auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
         inverter->InitAnalyzer(this->analyzer_);
         auto func = [this, task, inverter](int id) {
-            // LOG_INFO(fmt::format("online inverter {} begin", id));
-            size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-            term_cnt_ += column_length_sum;
-            inverter->MergePrepare();
-            inverter->Sort();
-            this->ring_sorted_.Put(task->task_seq_, inverter);
-            // LOG_INFO(fmt::format("online inverter {} end", id));
+            bool success = false;
+            try {
+                // LOG_INFO(fmt::format("online inverter {} begin", id));
+                size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
+                term_cnt_ += column_length_sum;
+                inverter->MergePrepare();
+                inverter->Sort();
+                this->ring_sorted_.Put(task->task_seq_, inverter);
+                success = true;
+                // LOG_INFO(fmt::format("online inverter {} end", id));
+            } catch (const std::exception &e) {
+                LOG_ERROR(fmt::format("Insert(online) invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
+            } catch (...) {
+                LOG_ERROR(fmt::format("Insert(online) invert task failed, seq={}, unknown error", task->task_seq_));
+            }
+            if (!success) {
+                std::unique_lock lock(mutex_);
+                --inflight_tasks_;
+                if (inflight_tasks_ == 0) {
+                    cv_.notify_one();
+                }
+            }
         };
         {
             std::unique_lock<std::mutex> lock(mutex_);
@@ -210,13 +240,48 @@ void MemoryIndexer::AsyncInsertBottom(const std::shared_ptr<ColumnVector> &colum
     auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
     inverter->InitAnalyzer(this->analyzer_);
     auto func = [this, task, inverter, append_batch](int id) {
-        // LOG_INFO(fmt::format("online inverter {} begin", id));
-        size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-        term_cnt_ += column_length_sum;
-        inverter->MergePrepare();
-        inverter->Sort();
-        this->ring_sorted_.Put(task->task_seq_, inverter);
-        // LOG_INFO(fmt::format("online inverter {} end", id));
+        try {
+            size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
+            term_cnt_ += column_length_sum;
+            inverter->MergePrepare();
+            inverter->Sort();
+            this->ring_sorted_.Put(task->task_seq_, inverter);
+        } catch (const std::exception &e) {
+            std::string sample_data;
+            for (u32 i = 0; i < std::min(task->row_count_, 3u); ++i) {
+                try {
+                    sample_data += fmt::format(" row[{}]={}", task->start_doc_id_ + i, task->column_vector_->ToString(task->row_offset_ + i));
+                } catch (...) {
+                    sample_data += fmt::format(" row[{}]=<unreadable>", task->start_doc_id_ + i);
+                }
+            }
+            LOG_ERROR(fmt::format("AsyncInsertBottom invert task failed, db={}, table={}, index={}, base_name={}, base_row_id={}, seq={}, "
+                                  "start_doc_id={}, row_offset={}, row_count={}, absolute_row={}, error: {}, sample:{}",
+                                  this->db_name_,
+                                  this->table_name_,
+                                  this->index_name_,
+                                  this->base_name_,
+                                  this->base_row_id_.ToUint64(),
+                                  task->task_seq_,
+                                  task->start_doc_id_,
+                                  task->row_offset_,
+                                  task->row_count_,
+                                  this->base_row_id_.ToUint64() + task->start_doc_id_,
+                                  e.what(),
+                                  sample_data));
+        } catch (...) {
+            LOG_ERROR(fmt::format("AsyncInsertBottom invert task failed, db={}, table={}, index={}, base_name={}, base_row_id={}, seq={}, "
+                                  "start_doc_id={}, row_offset={}, row_count={}, unknown error",
+                                  this->db_name_,
+                                  this->table_name_,
+                                  this->index_name_,
+                                  this->base_name_,
+                                  this->base_row_id_.ToUint64(),
+                                  task->task_seq_,
+                                  task->start_doc_id_,
+                                  task->row_offset_,
+                                  task->row_count_));
+        }
         {
             std::unique_lock lock(append_batch->mtx_);
             --append_batch->task_count_;
@@ -255,14 +320,33 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
     inverter->InitAnalyzer(this->analyzer_);
     inverter->AddSema(sema.get());
     auto func = [this, task, inverter](int id) {
-        // LOG_INFO(fmt::format("online inverter {} begin", id));
-        size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-        term_cnt_ += column_length_sum;
-        inverter->MergePrepare();
-        inverter->Sort();
-        this->ring_sorted_.Put(task->task_seq_, inverter);
-        // LOG_INFO(fmt::format("online inverter {} end", id));
-        CommitSync(100);
+        bool success = false;
+        try {
+            // LOG_INFO(fmt::format("online inverter {} begin", id));
+            size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
+            term_cnt_ += column_length_sum;
+            inverter->MergePrepare();
+            inverter->Sort();
+            this->ring_sorted_.Put(task->task_seq_, inverter);
+            success = true;
+            // LOG_INFO(fmt::format("online inverter {} end", id));
+        } catch (const std::exception &e) {
+            LOG_ERROR(fmt::format("AsyncInsert invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
+        } catch (...) {
+            LOG_ERROR(fmt::format("AsyncInsert invert task failed, seq={}, unknown error", task->task_seq_));
+        }
+        if (success) {
+            CommitSync(100);
+        } else {
+            for (auto *sema : inverter->semas()) {
+                sema->release();
+            }
+            std::unique_lock lock(mutex_);
+            --inflight_tasks_;
+            if (inflight_tasks_ == 0) {
+                cv_.notify_one();
+            }
+        }
     };
     {
         std::unique_lock<std::mutex> lock(mutex_);

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -175,6 +175,9 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
                 inverter->Sort();
                 this->ring_sorted_.Put(task->task_seq_, inverter);
                 success = true;
+                // Proactively drain the ring to prevent deadlock when the ring fills up.
+                // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
+                CommitSync(100);
                 // LOG_INFO(fmt::format("online inverter {} end", id));
             } catch (const std::exception &e) {
                 LOG_ERROR(fmt::format("Insert(online) invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
@@ -246,6 +249,9 @@ void MemoryIndexer::AsyncInsertBottom(const std::shared_ptr<ColumnVector> &colum
             inverter->MergePrepare();
             inverter->Sort();
             this->ring_sorted_.Put(task->task_seq_, inverter);
+            // Proactively drain the ring to prevent deadlock when the ring fills up.
+            // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
+            CommitSync(100);
         } catch (const std::exception &e) {
             std::string sample_data;
             for (u32 i = 0; i < std::min(task->row_count_, 3u); ++i) {
@@ -336,11 +342,16 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
             LOG_ERROR(fmt::format("AsyncInsert invert task failed, seq={}, unknown error", task->task_seq_));
         }
         if (success) {
+            // Release transaction semaphores now - the data is in the ring and
+            // will be consumed by CommitSync asynchronously.  Waiting on the
+            // semaphore until CommitSync processes this entry is fragile:
+            // a gap in the ring (earlier seq unfinished) prevents GetBatch
+            // from reaching us, so CommitSync may return 0 and the semaphore
+            // is never released.
+            for (auto *sema : inverter->semas()) {
+                sema->release();
+            }
             if (CommitSync(100) == 0) {
-                // Another committer may have owned mutex_commit_ while this
-                // task published its inverter. Requeue a background commit so
-                // the ring is eventually drained and transaction semaphores
-                // are released.
                 Commit(false);
             }
         } else {

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -131,15 +131,15 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
         PostingWriterProvider provider = [this](const std::string &term) -> std::shared_ptr<PostingWriter> { return GetOrAddPosting(term); };
         auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
         inverter->InitAnalyzer(this->analyzer_);
-        auto func = [this, task, inverter](int id) {
+        auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter](int id) {
             bool success = false;
             try {
                 size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-                term_cnt_ += column_length_sum;
+                self->term_cnt_ += column_length_sum;
                 if (column_length_sum > 0) {
                     inverter->SortForOfflineDump();
                 }
-                this->ring_sorted_.Put(task->task_seq_, inverter);
+                self->ring_sorted_.Put(task->task_seq_, inverter);
                 success = true;
             } catch (const std::exception &e) {
                 LOG_ERROR(fmt::format("Insert(offline) invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
@@ -147,10 +147,10 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
                 LOG_ERROR(fmt::format("Insert(offline) invert task failed, seq={}, unknown error", task->task_seq_));
             }
             if (!success) {
-                std::unique_lock lock(mutex_);
-                --inflight_tasks_;
-                if (inflight_tasks_ == 0) {
-                    cv_.notify_one();
+                std::unique_lock lock(self->mutex_);
+                --self->inflight_tasks_;
+                if (self->inflight_tasks_ == 0) {
+                    self->cv_.notify_one();
                 }
             }
         };
@@ -165,15 +165,15 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
         PostingWriterProvider provider = [this](const std::string &term) -> std::shared_ptr<PostingWriter> { return GetOrAddPosting(term); };
         auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
         inverter->InitAnalyzer(this->analyzer_);
-        auto func = [this, task, inverter](int id) {
+        auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter](int id) {
             bool success = false;
             try {
                 // LOG_INFO(fmt::format("online inverter {} begin", id));
                 size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-                term_cnt_ += column_length_sum;
+                self->term_cnt_ += column_length_sum;
                 inverter->MergePrepare();
                 inverter->Sort();
-                this->ring_sorted_.Put(task->task_seq_, inverter);
+                self->ring_sorted_.Put(task->task_seq_, inverter);
                 success = true;
                 // LOG_INFO(fmt::format("online inverter {} end", id));
             } catch (const std::exception &e) {
@@ -184,12 +184,12 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
             if (success) {
                 // Proactively drain the ring to prevent deadlock when the ring fills up.
                 // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
-                CommitSync(100);
+                self->CommitSync(100);
             } else {
-                std::unique_lock lock(mutex_);
-                --inflight_tasks_;
-                if (inflight_tasks_ == 0) {
-                    cv_.notify_one();
+                std::unique_lock lock(self->mutex_);
+                --self->inflight_tasks_;
+                if (self->inflight_tasks_ == 0) {
+                    self->cv_.notify_one();
                 }
             }
         };
@@ -243,16 +243,16 @@ void MemoryIndexer::AsyncInsertBottom(const std::shared_ptr<ColumnVector> &colum
     PostingWriterProvider provider = [this](const std::string &term) -> std::shared_ptr<PostingWriter> { return GetOrAddPosting(term); };
     auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
     inverter->InitAnalyzer(this->analyzer_);
-    auto func = [this, task, inverter, append_batch](int id) {
+    auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter, append_batch](int id) {
         try {
             size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-            term_cnt_ += column_length_sum;
+            self->term_cnt_ += column_length_sum;
             inverter->MergePrepare();
             inverter->Sort();
-            this->ring_sorted_.Put(task->task_seq_, inverter);
+            self->ring_sorted_.Put(task->task_seq_, inverter);
             // Proactively drain the ring to prevent deadlock when the ring fills up.
             // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
-            CommitSync(100);
+            self->CommitSync(100);
         } catch (const std::exception &e) {
             std::string sample_data;
             for (u32 i = 0; i < std::min(task->row_count_, 3u); ++i) {
@@ -264,26 +264,26 @@ void MemoryIndexer::AsyncInsertBottom(const std::shared_ptr<ColumnVector> &colum
             }
             LOG_ERROR(fmt::format("AsyncInsertBottom invert task failed, db={}, table={}, index={}, base_name={}, base_row_id={}, seq={}, "
                                   "start_doc_id={}, row_offset={}, row_count={}, absolute_row={}, error: {}, sample:{}",
-                                  this->db_name_,
-                                  this->table_name_,
-                                  this->index_name_,
-                                  this->base_name_,
-                                  this->base_row_id_.ToUint64(),
+                                  self->db_name_,
+                                  self->table_name_,
+                                  self->index_name_,
+                                  self->base_name_,
+                                  self->base_row_id_.ToUint64(),
                                   task->task_seq_,
                                   task->start_doc_id_,
                                   task->row_offset_,
                                   task->row_count_,
-                                  this->base_row_id_.ToUint64() + task->start_doc_id_,
+                                  self->base_row_id_.ToUint64() + task->start_doc_id_,
                                   e.what(),
                                   sample_data));
         } catch (...) {
             LOG_ERROR(fmt::format("AsyncInsertBottom invert task failed, db={}, table={}, index={}, base_name={}, base_row_id={}, seq={}, "
                                   "start_doc_id={}, row_offset={}, row_count={}, unknown error",
-                                  this->db_name_,
-                                  this->table_name_,
-                                  this->index_name_,
-                                  this->base_name_,
-                                  this->base_row_id_.ToUint64(),
+                                  self->db_name_,
+                                  self->table_name_,
+                                  self->index_name_,
+                                  self->base_name_,
+                                  self->base_row_id_.ToUint64(),
                                   task->task_seq_,
                                   task->start_doc_id_,
                                   task->row_offset_,
@@ -326,15 +326,15 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
     auto inverter = std::make_shared<ColumnInverter>(provider, column_lengths_);
     inverter->InitAnalyzer(this->analyzer_);
     inverter->AddSema(sema.get());
-    auto func = [this, task, inverter](int id) {
+    auto func = [self = std::static_pointer_cast<MemoryIndexer>(shared_from_this()), task, inverter](int id) {
         bool success = false;
         try {
             // LOG_INFO(fmt::format("online inverter {} begin", id));
             size_t column_length_sum = inverter->InvertColumn(task->column_vector_, task->row_offset_, task->row_count_, task->start_doc_id_);
-            term_cnt_ += column_length_sum;
+            self->term_cnt_ += column_length_sum;
             inverter->MergePrepare();
             inverter->Sort();
-            this->ring_sorted_.Put(task->task_seq_, inverter);
+            self->ring_sorted_.Put(task->task_seq_, inverter);
             success = true;
             // LOG_INFO(fmt::format("online inverter {} end", id));
         } catch (const std::exception &e) {
@@ -347,16 +347,16 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
             // CommitSync generates postings and releases semaphores inside.
             // If CommitSync returns 0 (ring gap or try_lock failed), release
             // semaphores here to prevent deadlock and schedule a retry.
-            if (CommitSync(100) == 0) {
+            if (self->CommitSync(100) == 0) {
                 inverter->ReleaseSemas();
-                Commit(false);
+                self->Commit(false);
             }
         } else {
             inverter->ReleaseSemas();
-            std::unique_lock lock(mutex_);
-            --inflight_tasks_;
-            if (inflight_tasks_ == 0) {
-                cv_.notify_one();
+            std::unique_lock lock(self->mutex_);
+            --self->inflight_tasks_;
+            if (self->inflight_tasks_ == 0) {
+                self->cv_.notify_one();
             }
         }
     };

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -336,7 +336,13 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
             LOG_ERROR(fmt::format("AsyncInsert invert task failed, seq={}, unknown error", task->task_seq_));
         }
         if (success) {
-            CommitSync(100);
+            if (CommitSync(100) == 0) {
+                // Another committer may have owned mutex_commit_ while this
+                // task published its inverter. Requeue a background commit so
+                // the ring is eventually drained and transaction semaphores
+                // are released.
+                Commit(false);
+            }
         } else {
             for (auto *sema : inverter->semas()) {
                 sema->release();

--- a/src/storage/invertedindex/memory_indexer_impl.cpp
+++ b/src/storage/invertedindex/memory_indexer_impl.cpp
@@ -175,16 +175,17 @@ void MemoryIndexer::Insert(std::shared_ptr<ColumnVector> column_vector, u32 row_
                 inverter->Sort();
                 this->ring_sorted_.Put(task->task_seq_, inverter);
                 success = true;
-                // Proactively drain the ring to prevent deadlock when the ring fills up.
-                // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
-                CommitSync(100);
                 // LOG_INFO(fmt::format("online inverter {} end", id));
             } catch (const std::exception &e) {
                 LOG_ERROR(fmt::format("Insert(online) invert task failed, seq={}, error: {}", task->task_seq_, e.what()));
             } catch (...) {
                 LOG_ERROR(fmt::format("Insert(online) invert task failed, seq={}, unknown error", task->task_seq_));
             }
-            if (!success) {
+            if (success) {
+                // Proactively drain the ring to prevent deadlock when the ring fills up.
+                // CommitSync uses try_lock so it is safe and non-blocking if another thread is already committing.
+                CommitSync(100);
+            } else {
                 std::unique_lock lock(mutex_);
                 --inflight_tasks_;
                 if (inflight_tasks_ == 0) {
@@ -342,22 +343,16 @@ std::unique_ptr<std::binary_semaphore> MemoryIndexer::AsyncInsert(std::shared_pt
             LOG_ERROR(fmt::format("AsyncInsert invert task failed, seq={}, unknown error", task->task_seq_));
         }
         if (success) {
-            // Release transaction semaphores now - the data is in the ring and
-            // will be consumed by CommitSync asynchronously.  Waiting on the
-            // semaphore until CommitSync processes this entry is fragile:
-            // a gap in the ring (earlier seq unfinished) prevents GetBatch
-            // from reaching us, so CommitSync may return 0 and the semaphore
-            // is never released.
-            for (auto *sema : inverter->semas()) {
-                sema->release();
-            }
+            // Release semaphores only after data is actually committed.
+            // CommitSync generates postings and releases semaphores inside.
+            // If CommitSync returns 0 (ring gap or try_lock failed), release
+            // semaphores here to prevent deadlock and schedule a retry.
             if (CommitSync(100) == 0) {
+                inverter->ReleaseSemas();
                 Commit(false);
             }
         } else {
-            for (auto *sema : inverter->semas()) {
-                sema->release();
-            }
+            inverter->ReleaseSemas();
             std::unique_lock lock(mutex_);
             --inflight_tasks_;
             if (inflight_tasks_ == 0) {
@@ -443,11 +438,7 @@ size_t MemoryIndexer::CommitSync(size_t wait_if_empty_ms) {
             mem_usage_change.Add(inverter->GeneratePosting());
             num_generated += inverter->GetMerged();
 
-            if (const auto &semas = inverter->semas(); !semas.empty()) {
-                for (auto sema : semas) {
-                    sema->release();
-                }
-            }
+            inverter->ReleaseSemas();
         }
     }
     if (num_generated > 0) {

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -859,7 +859,11 @@ NewTxn::AppendMemIndex(SegmentIndexMeta &segment_index_meta, BlockID block_id, c
                 std::shared_ptr<std::string> index_dir = segment_index_meta.GetSegmentIndexDir();
                 auto base_name = fmt::format("ft_{:016x}", base_row_id.ToUint64());
                 auto full_path = fmt::format("{}/{}", InfinityContext::instance().config()->DataDir(), *index_dir);
+                auto [db_name, table_name] = segment_index_meta.table_index_meta().table_meta().GetDBTableName();
                 memory_indexer = std::make_unique<MemoryIndexer>(full_path, base_name, base_row_id, index_fulltext->flag_, index_fulltext->analyzer_);
+                memory_indexer->db_name_ = db_name;
+                memory_indexer->table_name_ = table_name;
+                memory_indexer->index_name_ = *index_fulltext->index_name_;
                 need_to_update_ft_segment_ts = true;
                 mem_index->SetFulltextIndex(memory_indexer);
             } else {
@@ -1336,7 +1340,11 @@ Status NewTxn::PopulateFtIndexInner(std::shared_ptr<IndexBase> index_base,
             RowID base_row_id(segment_index_meta.segment_id(), block_id * block_capacity);
             auto base_name = fmt::format("ft_{:016x}", base_row_id.ToUint64());
             auto full_path = fmt::format("{}/{}", InfinityContext::instance().config()->DataDir(), *index_dir);
+            auto [db_name, table_name] = segment_index_meta.table_index_meta().table_meta().GetDBTableName();
             memory_indexer = std::make_shared<MemoryIndexer>(full_path, base_name, base_row_id, index_fulltext->flag_, index_fulltext->analyzer_);
+            memory_indexer->db_name_ = db_name;
+            memory_indexer->table_name_ = table_name;
+            memory_indexer->index_name_ = *index_fulltext->index_name_;
             LOG_INFO(fmt::format("PopulateFtIndexInner created memory_indexer, base_name: {}", base_name));
         }
         BlockMeta block_meta(block_id, segment_meta);

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -860,7 +860,8 @@ NewTxn::AppendMemIndex(SegmentIndexMeta &segment_index_meta, BlockID block_id, c
                 auto base_name = fmt::format("ft_{:016x}", base_row_id.ToUint64());
                 auto full_path = fmt::format("{}/{}", InfinityContext::instance().config()->DataDir(), *index_dir);
                 auto [db_name, table_name] = segment_index_meta.table_index_meta().table_meta().GetDBTableName();
-                memory_indexer = std::make_unique<MemoryIndexer>(full_path, base_name, base_row_id, index_fulltext->flag_, index_fulltext->analyzer_);
+                // MemoryIndexer async callbacks capture shared_from_this(), so it must be created under shared ownership.
+                memory_indexer = std::make_shared<MemoryIndexer>(full_path, base_name, base_row_id, index_fulltext->flag_, index_fulltext->analyzer_);
                 memory_indexer->db_name_ = db_name;
                 memory_indexer->table_name_ = table_name;
                 memory_indexer->index_name_ = *index_fulltext->index_name_;

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -860,8 +860,7 @@ NewTxn::AppendMemIndex(SegmentIndexMeta &segment_index_meta, BlockID block_id, c
                 auto base_name = fmt::format("ft_{:016x}", base_row_id.ToUint64());
                 auto full_path = fmt::format("{}/{}", InfinityContext::instance().config()->DataDir(), *index_dir);
                 auto [db_name, table_name] = segment_index_meta.table_index_meta().table_meta().GetDBTableName();
-                // MemoryIndexer async callbacks capture shared_from_this(), so it must be created under shared ownership.
-                memory_indexer = std::make_shared<MemoryIndexer>(full_path, base_name, base_row_id, index_fulltext->flag_, index_fulltext->analyzer_);
+                memory_indexer = std::make_unique<MemoryIndexer>(full_path, base_name, base_row_id, index_fulltext->flag_, index_fulltext->analyzer_);
                 memory_indexer->db_name_ = db_name;
                 memory_indexer->table_name_ = table_name;
                 memory_indexer->index_name_ = *index_fulltext->index_name_;

--- a/src/unit_test/storage/invertedindex/memory_indexer_ut.cpp
+++ b/src/unit_test/storage/invertedindex/memory_indexer_ut.cpp
@@ -223,13 +223,13 @@ TEST_P(MemoryIndexerTest, DISABLED_SLOW_Memory) {
 }
 
 TEST_P(MemoryIndexerTest, SpillLoadTest) {
-    auto indexer1 = std::make_shared<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    auto indexer1 = std::make_unique<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
     std::shared_ptr<ColumnVector> column_vector = MakeColumnVector(wiki_paragraphs_);
     indexer1->Insert(column_vector, 0, 2);
     indexer1->Insert(column_vector, 2, 2);
     indexer1->Insert(column_vector, 4, 1);
     indexer1->Dump(false, true);
-    std::shared_ptr<MemoryIndexer> loaded_indexer = std::make_shared<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    std::unique_ptr<MemoryIndexer> loaded_indexer = std::make_unique<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
 
     loaded_indexer->Load();
     SegmentID segment_id = 0;
@@ -268,15 +268,15 @@ TEST_P(MemoryIndexerTest, DISABLED_SLOW_SeekPosition) {
         column->AppendValue(v);
     }
 
-    auto indexer1 = std::make_shared<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
-    indexer1->Insert(column, 0, 8192);
-    while (indexer1->GetInflightTasks() > 0) {
+    MemoryIndexer indexer1(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    indexer1.Insert(column, 0, 8192);
+    while (indexer1.GetInflightTasks() > 0) {
         sleep(1);
-        indexer1->CommitSync();
+        indexer1.CommitSync();
     }
 
     SegmentID segment_id = 0;
-    auto segment_reader = std::make_shared<InMemIndexSegmentReader>(segment_id, indexer1.get());
+    auto segment_reader = std::make_shared<InMemIndexSegmentReader>(segment_id, &indexer1);
     const std::string term("a");
     SegmentPosting seg_posting;
     auto seg_postings = std::make_shared<std::vector<SegmentPosting>>();

--- a/src/unit_test/storage/invertedindex/memory_indexer_ut.cpp
+++ b/src/unit_test/storage/invertedindex/memory_indexer_ut.cpp
@@ -223,13 +223,13 @@ TEST_P(MemoryIndexerTest, DISABLED_SLOW_Memory) {
 }
 
 TEST_P(MemoryIndexerTest, SpillLoadTest) {
-    auto indexer1 = std::make_unique<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    auto indexer1 = std::make_shared<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
     std::shared_ptr<ColumnVector> column_vector = MakeColumnVector(wiki_paragraphs_);
     indexer1->Insert(column_vector, 0, 2);
     indexer1->Insert(column_vector, 2, 2);
     indexer1->Insert(column_vector, 4, 1);
     indexer1->Dump(false, true);
-    std::unique_ptr<MemoryIndexer> loaded_indexer = std::make_unique<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    std::shared_ptr<MemoryIndexer> loaded_indexer = std::make_shared<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
 
     loaded_indexer->Load();
     SegmentID segment_id = 0;
@@ -268,15 +268,15 @@ TEST_P(MemoryIndexerTest, DISABLED_SLOW_SeekPosition) {
         column->AppendValue(v);
     }
 
-    MemoryIndexer indexer1(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
-    indexer1.Insert(column, 0, 8192);
-    while (indexer1.GetInflightTasks() > 0) {
+    auto indexer1 = std::make_shared<MemoryIndexer>(GetFullDataDir(), "chunk1", RowID(0U, 0U), flag_, "standard");
+    indexer1->Insert(column, 0, 8192);
+    while (indexer1->GetInflightTasks() > 0) {
         sleep(1);
-        indexer1.CommitSync();
+        indexer1->CommitSync();
     }
 
     SegmentID segment_id = 0;
-    auto segment_reader = std::make_shared<InMemIndexSegmentReader>(segment_id, &indexer1);
+    auto segment_reader = std::make_shared<InMemIndexSegmentReader>(segment_id, indexer1.get());
     const std::string term("a");
     SegmentPosting seg_posting;
     auto seg_postings = std::make_shared<std::vector<SegmentPosting>>();


### PR DESCRIPTION
**Issue**
Full-text invert tasks run in ctpl worker threads via lambdas that increment counters (task_count_ / inflight_tasks_) before executing InvertColumn→Sort→ring_sorted_.Put. If any of these steps throws (e.g., simdjson INCORRECT_TYPE on empty JSON {}), the counter decrement / semaphore release code is never reached, causing the consumer to block forever.

**Solution**
Wrap all 4 inverting lambdas in try-catch:
AsyncInsertBottom: --task_count_ + cv_.notify_one() always executes (outside try)
AsyncInsert: on failure, release(sema) + --inflight_tasks_
Insert (offline/online): on failure, --inflight_tasks_

--

Make realtime the default for new full-text indexes