### PR TITLE
Improve error printout

### DIFF
--- a/src/common/status.cppm
+++ b/src/common/status.cppm
@@ -241,7 +241,7 @@ public:
     // 2. Auth error
     static Status WrongPasswd(const std::string &user_name);
     static Status InsufficientPrivilege(const std::string &user_name, const std::string &detailed_error);
-    static Status UnsupportedVersionIndex(i64 given_index);
+    static Status UnsupportedVersionIndex(i64 given_index, i64 max_index);
     static Status ClientVersionMismatch(const char *expected_version, const char *given_version);
     static Status AdminOnlySupportInMaintenanceMode();
     static Status NotSupportInMaintenanceMode();

--- a/src/common/status_impl.cpp
+++ b/src/common/status_impl.cpp
@@ -121,12 +121,12 @@ Status Status::InsufficientPrivilege(const std::string &user_name, const std::st
                   std::make_unique<std::string>(fmt::format("{} do not have permission to {}", user_name, detailed_error)));
 }
 
-Status Status::UnsupportedVersionIndex(i64 given_index) {
-    return Status(
-        ErrorCode::kUnsupportedVersionIndex,
-        std::make_unique<std::string>(fmt::format(
-            "Index: {} isn't supported, you are using a deprecated version of Python SDK. Please install the corresponding version Python SDK.",
-            given_index)));
+Status Status::UnsupportedVersionIndex(i64 given_index, i64 max_index) {
+    return Status(ErrorCode::kUnsupportedVersionIndex,
+                  std::make_unique<std::string>(fmt::format(
+                      "Client version inndex: {} isn't supported, current max SDK version index is {}. Please install the corresponding version SDK.",
+                      given_index,
+                      max_index)));
 }
 
 Status Status::ClientVersionMismatch(const char *expected_version, const char *given_version) {

--- a/src/network/infinity_thrift_service_impl.cpp
+++ b/src/network/infinity_thrift_service_impl.cpp
@@ -113,7 +113,7 @@ ClientVersions::ClientVersions() {
 std::pair<const char *, Status> ClientVersions::GetVersionByIndex(i64 version_index) {
     auto iter = client_version_map_.find(version_index);
     if (iter == client_version_map_.end()) {
-        return {nullptr, Status::UnsupportedVersionIndex(version_index)};
+        return {nullptr, Status::UnsupportedVersionIndex(version_index, 37)}; // Index for 0.7.3
     }
     return {iter->second.c_str(), Status::OK()};
 }


### PR DESCRIPTION
```
Index: 37 isn't supported, you are using a deprecated version of Python SDK. Please install the corresponding version Python SDK.
```
Above message is only for Python SDK.