### PR TITLE
Fix: downgrade leftover debug log to trace in query cache hot path

### DIFF
--- a/src/storage/invertedindex/column_index_reader_impl.cpp
+++ b/src/storage/invertedindex/column_index_reader_impl.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<IndexReader> TableIndexReaderCache::GetIndexReader(NewTxn *txn) 
     std::scoped_lock lock(mutex_);
     if (begin_ts >= cache_ts_) [[likely]] {
         // no need to build, use cache
-        LOG_INFO(fmt::format("DEBUG: Using cached index readers for table_id: '{}'", table_id_str_));
+        LOG_TRACE(fmt::format("Using cached index readers for table_id: '{}'", table_id_str_));
         index_reader->column_index_readers_ = cache_column_readers_;
         return index_reader;
     }


### PR DESCRIPTION
## Summary
- `TableIndexReaderCache::GetIndexReader` had a leftover `LOG_INFO("DEBUG: Using cached index readers...")` on its `[[likely]]` cache-hit branch, which runs on nearly every full-text/inverted-index query that hits the cache.
- At `LOG_INFO` level this spams `infinity.log` in production on a very hot path.
- Downgraded to `LOG_TRACE` (matching the convention used elsewhere in `src/storage/invertedindex/`, e.g. `disk_segment_reader_impl.cpp`) and dropped the stray `DEBUG:` prefix.

## Test plan
- [x] Reviewed surrounding logging conventions in the same directory for consistency
- [ ] CI build/tests