### PR TITLE
fix(sdk): accept plain lists of numpy scalars in INSERT vector columns

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -321,6 +321,8 @@ def get_local_constant_expr_from_python_value(value) -> WrapConstantExpr:
         else:
             raise InfinityException(ErrorCode.INVALID_EXPRESSION,
                                     f"Invalid list member type: {type(value[0])}, ndarray dimension > 2")
+    elif isinstance(value, list) and isinstance(value[0], (np.integer, np.floating)):
+        value = [x.item() for x in value]
     elif isinstance(value, np.ndarray):
         if value.ndim <= 2:
             value = value.tolist()

--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -321,8 +321,9 @@ def get_local_constant_expr_from_python_value(value) -> WrapConstantExpr:
         else:
             raise InfinityException(ErrorCode.INVALID_EXPRESSION,
                                     f"Invalid list member type: {type(value[0])}, ndarray dimension > 2")
-    elif isinstance(value, list) and isinstance(value[0], (np.integer, np.floating)):
-        value = [x.item() for x in value]
+    elif isinstance(value, list) and len(value) > 0:
+        # Normalize numpy scalars in list to native Python types (element-wise check)
+        value = [x.item() if isinstance(x, (np.integer, np.floating, np.longdouble)) else x for x in value]
     elif isinstance(value, np.ndarray):
         if value.ndim <= 2:
             value = value.tolist()

--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -794,7 +794,7 @@ class table_http:
                         for idx in range(len(value[key])):
                             if isinstance(value[key][idx], np.ndarray):
                                 value[key][idx] = value[key][idx].tolist()
-                            elif isinstance(value[key][idx], (np.integer, np.floating)):
+                            elif isinstance(value[key][idx], (np.integer, np.floating, np.longdouble)):
                                 value[key][idx] = value[key][idx].item()
                     elif isinstance(value[key], SparseVector):
                         value[key] = value[key].to_dict()

--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -794,6 +794,8 @@ class table_http:
                         for idx in range(len(value[key])):
                             if isinstance(value[key][idx], np.ndarray):
                                 value[key][idx] = value[key][idx].tolist()
+                            elif isinstance(value[key][idx], (np.integer, np.floating)):
+                                value[key][idx] = value[key][idx].item()
                     elif isinstance(value[key], SparseVector):
                         value[key] = value[key].to_dict()
 

--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -718,6 +718,8 @@ def get_remote_constant_expr_from_python_value(value) -> ttypes.ConstantExpr:
         else:
             raise InfinityException(ErrorCode.INVALID_EXPRESSION,
                                     f"Invalid list member type: {type(value[0])}, ndarray dimension > 2")
+    elif isinstance(value, list) and isinstance(value[0], (np.integer, np.floating)):
+        value = [x.item() for x in value]
     elif isinstance(value, np.ndarray):
         if value.ndim <= 2:
             value = value.tolist()

--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -718,8 +718,9 @@ def get_remote_constant_expr_from_python_value(value) -> ttypes.ConstantExpr:
         else:
             raise InfinityException(ErrorCode.INVALID_EXPRESSION,
                                     f"Invalid list member type: {type(value[0])}, ndarray dimension > 2")
-    elif isinstance(value, list) and isinstance(value[0], (np.integer, np.floating)):
-        value = [x.item() for x in value]
+    elif isinstance(value, list) and len(value) > 0:
+        # Normalize numpy scalars in list to native Python types (element-wise check)
+        value = [x.item() if isinstance(x, (np.integer, np.floating, np.longdouble)) else x for x in value]
     elif isinstance(value, np.ndarray):
         if value.ndim <= 2:
             value = value.tolist()

--- a/python/test_pysdk/test_insert.py
+++ b/python/test_pysdk/test_insert.py
@@ -297,6 +297,43 @@ class TestInfinity:
         res = db_obj.drop_table("test_insert_embedding_4" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
+    def _test_insert_embedding_numpy(self, suffix):
+        """
+        target: test insert embedding column with numpy array values (#1253)
+        method: insert a raw np.ndarray, and a plain list of numpy scalars
+                (e.g. list(embedding_array), which isn't itself an ndarray)
+        expected: ok
+        """
+        db_obj = self.infinity_obj.get_database("default_db")
+
+        db_obj.drop_table("test_insert_embedding_numpy_int" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table(
+            "test_insert_embedding_numpy_int" + suffix, {"c1": {"type": "vector,3,int"}}, ConflictType.Error)
+        assert table_obj
+        res = table_obj.insert([{"c1": np.array([1, 2, 3], dtype=np.int64)}])
+        assert res.error_code == ErrorCode.OK
+        res = table_obj.insert([{"c1": list(np.array([4, 5, 6], dtype=np.int64))}])
+        assert res.error_code == ErrorCode.OK
+        res, extra_result = table_obj.output(["*"]).to_df()
+        pd.testing.assert_frame_equal(res, pd.DataFrame({'c1': ([1, 2, 3], [4, 5, 6])}))
+        res = db_obj.drop_table("test_insert_embedding_numpy_int" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
+        db_obj.drop_table("test_insert_embedding_numpy_float" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table(
+            "test_insert_embedding_numpy_float" + suffix, {"c1": {"type": "vector,3,float"}}, ConflictType.Error)
+        assert table_obj
+        res = table_obj.insert([{"c1": np.array([1.1, 2.2, 3.3], dtype=np.float32)}])
+        assert res.error_code == ErrorCode.OK
+        res = table_obj.insert([{"c1": list(np.array([4.4, 5.5, 6.6], dtype=np.float32))}])
+        assert res.error_code == ErrorCode.OK
+        res, extra_result = table_obj.output(["*"]).to_df()
+        pd.testing.assert_frame_equal(res, pd.DataFrame(
+            {'c1': (np.array([1.1, 2.2, 3.3], dtype=np.float32).tolist(),
+                    np.array([4.4, 5.5, 6.6], dtype=np.float32).tolist())}))
+        res = db_obj.drop_table("test_insert_embedding_numpy_float" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
     def _test_insert_big_embedding(self, suffix):
         """
         target: test insert embedding with big dimension
@@ -816,6 +853,7 @@ class TestInfinity:
         self._test_insert_varchar(suffix)
         self._test_insert_big_varchar(suffix)
         self._test_insert_embedding(suffix)
+        self._test_insert_embedding_numpy(suffix)
         self._test_insert_big_embedding(suffix)
         self._test_insert_big_embedding_float(suffix)
         self._test_insert_exceed_block_size(suffix)


### PR DESCRIPTION
Closes remaining gaps in numpy array support for INSERT, related to #1253.

Note up front: numpy array insert already works today in infinity-sdk. All
three client backends (thrift/remote, embedded/local, HTTP) already normalize
a raw `np.ndarray` value via `.tolist()` before building the insert
expression. This PR does not introduce that support from scratch; it closes
two remaining gaps in it.

### Key Changes Include:

**Bug fix**:
- A plain Python `list` built from numpy scalar elements (for example
  `list(embedding_array)` instead of `embedding_array.tolist()`) was not
  handled. `np.float32`/`np.integer` do not subtype Python `float`/`int`, so
  it fell through to `InfinityException(INVALID_EXPRESSION, "Invalid
  constant type: <class 'list'>")` on the thrift and embedded backends, and to
  an unhandled `TypeError` from `json.dumps` on the HTTP backend (numpy
  scalars are not JSON serializable). This is a realistic case since embedding
  models commonly output `float32`.
- Fixed in `remote_thrift/utils.py`, `local_infinity/utils.py`, and
  `infinity_http.py` by adding one small branch to each existing
  numpy-normalization choke point, following the same convention already used
  for `np.ndarray` and `list[np.ndarray]` (unwrap each element via
  `.item()`, which returns the correctly typed native `int`/`float`).

**Test coverage**:
- The existing insert tests only exercised numpy arrays for
  tensor/multivector columns, never for the plain single-vector
  (`vector,N,int`/`vector,N,float`) column type that "embedding model
  output" actually refers to. Added `_test_insert_embedding_numpy` in
  `test_insert.py`, covering both the direct `np.array(...)` insert (already
  working, now guarded by a test) and the previously broken
  `list(np.array(...))` case.

### Impact:
- **Correctness**: users assembling insert values from numpy output by hand
  (slicing, list comprehension, `list(arr)`) instead of calling `.tolist()`
  will no longer hit a confusing error, on any of the three client backends.
- **Regression coverage**: the primary vector column type now has explicit
  numpy insert test coverage, where before it only had list based coverage.

### Extra:
- Verified with a real server: pulled `infiniflow/infinity:nightly` in
  Docker and ran `pytest test_insert.py --http` plus an isolated end to end
  script against it. The fix was also reproduced and verified in isolation by
  calling `get_remote_constant_expr_from_python_value` directly, confirming
  it raises before the fix and returns a valid `ConstantExpr` after.
- `local_infinity/utils.py` imports a compiled C++ extension
  (`embedded_infinity_ext`) that could not be built in this environment, so
  that specific file's change was not independently executed; it is the same
  one line mechanical fix already proven correct on the thrift path.
- Two pre-existing, unrelated test failures were observed against the
  `nightly` image (`InfinityException(3013, "No default value found for
  column ...")` on a few NULL/default-value insert tests, and one missing
  local test data file for a fulltext index test). Confirmed unrelated by
  reverting this fix and reproducing the identical failures.
