### PR TITLE
Fix: invalidate fulltext index reader cache on chunk-level cleanup (server crash, #3418)

### DIFF
--- a/src/storage/catalog/new_catalog.cppm
+++ b/src/storage/catalog/new_catalog.cppm
@@ -323,7 +323,7 @@ public:
 
     static Status LoadFlushedChunkIndex1(SegmentIndexMeta &segment_index_meta, const WalChunkIndexInfo &chunk_info, NewTxn *new_txn);
 
-    static Status CleanChunkIndex(ChunkIndexMeta &chunk_index_meta, UsageFlag usage_flag);
+    static Status CleanChunkIndex(ChunkIndexMeta &chunk_index_meta, UsageFlag usage_flag, bool invalidate_ft_cache = true);
 
     static Status GetColumnVector(ColumnMeta &column_meta,
                                   const std::shared_ptr<ColumnDef> &col_def,

--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -1138,6 +1138,21 @@ Status NewCatalog::CleanChunkIndex(ChunkIndexMeta &chunk_index_meta, UsageFlag u
                           chunk_index_meta.segment_index_meta().segment_id(),
                           chunk_index_meta.segment_index_meta().table_index_meta().index_id_str(),
                           chunk_index_meta.chunk_id()));
+    if (usage_flag != UsageFlag::kTransform) {
+        // Invalidate the fulltext index reader cache before the chunk's data
+        // (posting/dictionary files, column-length buffer) is physically
+        // destroyed below. CleanSegmentIndex already does this, but chunk-level
+        // cleanups (the normal path for merged-away fulltext chunks) did not:
+        // TableIndexReaderCache::GetIndexReader would keep serving cached
+        // DiskIndexSegmentReaders and raw BufferObj pointers over freed data,
+        // and the first fulltext query after the cleanup commit crashed the
+        // server in the posting decoder (see issue #3418).
+        TableMeta &table_meta = chunk_index_meta.segment_index_meta().table_index_meta().table_meta();
+        Status invalidate_status = table_meta.InvalidateFtIndexCache();
+        if (!invalidate_status.ok()) {
+            return invalidate_status;
+        }
+    }
     chunk_index_meta.RestoreSet();
     Status status;
 

--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -1020,7 +1020,7 @@ Status NewCatalog::CleanSegmentIndex(SegmentIndexMeta &segment_index_meta, Usage
     }
     for (ChunkID chunk_id : *chunk_ids_ptr) {
         ChunkIndexMeta chunk_index_meta(chunk_id, segment_index_meta);
-        status = NewCatalog::CleanChunkIndex(chunk_index_meta, usage_flag);
+        status = NewCatalog::CleanChunkIndex(chunk_index_meta, usage_flag, /*invalidate_ft_cache=*/false);
         if (!status.ok()) {
             return status;
         }
@@ -1132,21 +1132,23 @@ Status NewCatalog::LoadFlushedChunkIndex1(SegmentIndexMeta &segment_index_meta, 
     return Status::OK();
 }
 
-Status NewCatalog::CleanChunkIndex(ChunkIndexMeta &chunk_index_meta, UsageFlag usage_flag) {
+Status NewCatalog::CleanChunkIndex(ChunkIndexMeta &chunk_index_meta, UsageFlag usage_flag, bool invalidate_ft_cache) {
     LOG_TRACE(fmt::format("CleanChunkIndex: cleaning table id: {}, segment_id: {}, index_id: {}, chunk_id: {}",
                           chunk_index_meta.segment_index_meta().table_index_meta().table_meta().table_id_str(),
                           chunk_index_meta.segment_index_meta().segment_id(),
                           chunk_index_meta.segment_index_meta().table_index_meta().index_id_str(),
                           chunk_index_meta.chunk_id()));
-    if (usage_flag != UsageFlag::kTransform) {
+    if (usage_flag != UsageFlag::kTransform && invalidate_ft_cache) {
         // Invalidate the fulltext index reader cache before the chunk's data
         // (posting/dictionary files, column-length buffer) is physically
-        // destroyed below. CleanSegmentIndex already does this, but chunk-level
-        // cleanups (the normal path for merged-away fulltext chunks) did not:
+        // destroyed below. Chunk-level cleanups (the normal path for
+        // merged-away fulltext chunks) did not do this:
         // TableIndexReaderCache::GetIndexReader would keep serving cached
         // DiskIndexSegmentReaders and raw BufferObj pointers over freed data,
         // and the first fulltext query after the cleanup commit crashed the
         // server in the posting decoder (see issue #3418).
+        // CleanSegmentIndex invalidates once for the whole segment and passes
+        // invalidate_ft_cache = false to skip the redundant per-chunk calls.
         TableMeta &table_meta = chunk_index_meta.segment_index_meta().table_index_meta().table_meta();
         Status invalidate_status = table_meta.InvalidateFtIndexCache();
         if (!invalidate_status.ok()) {


### PR DESCRIPTION
## What & why

Fixes the server-killing fulltext crash reported in #3418 (full root-cause analysis in [this comment](https://github.com/infiniflow/infinity/issues/3418#issuecomment-5446559296)).

`CleanSegmentIndex` invalidates `TableIndexReaderCache` before destroying segment index data, but `CleanChunkIndex` did not — while **chunk-level cleanup is the normal path for merged-away fulltext chunks**. `ChunkIndexMeta::UninitSet` deletes the chunk's `.pos`/`.dic` files and releases its column-length `BufferObj` (later destroyed by `BufferManager::RemoveClean`), yet the reader cache kept serving `DiskIndexSegmentReader`s (raw mmap pointers) and raw `BufferObj*`s over that freed data — `GetIndexReader`'s `begin_ts >= cache_ts_` test never expires on its own. The first fulltext query after the cleanup commit (Begin TS == cleanup KV commit TS in our production logs) then decoded garbage postings and crashed the whole server inside `FastPForLib::simdunpack` (via `TermDocIterator::BM25Score`), deterministically per term.

## Change

Mirror the exact guarded invalidation `CleanSegmentIndex` already performs (`usage_flag != UsageFlag::kTransform` → `table_meta.InvalidateFtIndexCache()`) at the top of `CleanChunkIndex`, before any physical destruction. 15 lines, symmetric with existing code, idempotent across a batch of chunk cleanups.

## Testing

- Reproduced in production (v0.7.3, x64): table with ~500k small rows + fulltext indexes under heavy DELETE+INSERT churn → after dump/merge + cleanup, BM25 queries segfault the server (stacks in #3418). With cleanup disabled (`cleanup_interval=0`) the crash never occurs, confirming the cleanup path as the trigger.
- We could not run the full test suite locally; relying on CI. Happy to run a patched build against our reproducing dataset and report back — just ask.

## Notes for reviewers

This closes the poisoning for **new** queries. Queries already holding the cached `IndexReader` at cleanup time remain exposed until readers pin their chunks (owning handles instead of raw `BufferObj*` / non-owning `ByteSlice` over mmap) — and an `UnrecoverableException` escaping `FragmentTask::OnExecute` still terminates the process via the unhandled rethrow in `TaskScheduler::WorkerLoop`. Both are follow-up material (details in the #3418 analysis); this PR keeps the surgical fix.
