### PR TITLE
Fix: invalidate fulltext index reader cache on compact and import commit

### DIFF
--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -36,6 +36,7 @@ import :block_meta;
 import :segment_meta;
 import :table_meta;
 import :table_index_meta;
+import :index_base;
 import :segment_index_meta;
 import :new_catalog;
 import :meta_key;
@@ -67,6 +68,7 @@ import third_party;
 import column_def;
 import row_id;
 import constant_expr;
+import create_index_info;
 import data_type;
 
 namespace infinity {
@@ -1737,6 +1739,31 @@ Status NewTxn::PrepareCommitImport(WalCmdImportV2 *import_cmd) {
 
     BuildFastRoughFilterTask::ExecuteOnNewSealedSegment(&segment_meta);
 
+    {
+        // The imported segment's fulltext index chunks are carried by the import txn store,
+        // not by a WalCmdDumpIndexV2, so the invalidation in PrepareCommitDumpIndex never
+        // fires here: without this, cached readers keep serving a chunk list that misses
+        // the imported segment.
+        std::vector<std::string> *index_id_strs_ptr = nullptr;
+        std::vector<std::string> *index_name_strs_ptr = nullptr;
+        status = table_meta.GetIndexIDs(index_id_strs_ptr, &index_name_strs_ptr);
+        if (!status.ok()) {
+            return status;
+        }
+        size_t index_count = index_id_strs_ptr->size();
+        for (size_t idx = 0; idx < index_count; ++idx) {
+            TableIndexMeta table_index_meta(index_id_strs_ptr->at(idx), index_name_strs_ptr->at(idx), table_meta);
+            auto [index_base, index_status] = table_index_meta.GetIndexBase();
+            if (!index_status.ok()) {
+                return index_status;
+            }
+            if (index_base->index_type_ == IndexType::kFullText) {
+                table_meta.InvalidateFtIndexCache();
+                break;
+            }
+        }
+    }
+
     PersistenceManager *pm = InfinityContext::instance().persistence_manager();
     if (pm != nullptr) {
         // When all data and index is write to disk, try to finalize the
@@ -2058,12 +2085,27 @@ Status NewTxn::PrepareCommitCompact(WalCmdCompactV2 *compact_cmd) {
         if (!status.ok()) {
             return status;
         }
+        bool ft_index_cache_invalidated = false;
         size_t index_count = index_id_strs_ptr->size();
         for (size_t idx = 0; idx < index_count; ++idx) {
             const std::string &index_id_str = index_id_strs_ptr->at(idx);
             const std::string &index_name_str = index_name_strs_ptr->at(idx);
 
             TableIndexMeta table_index_meta(index_id_str, index_name_str, table_meta);
+
+            auto [index_base, index_status] = table_index_meta.GetIndexBase();
+            if (!index_status.ok()) {
+                return index_status;
+            }
+            if (index_base->index_type_ == IndexType::kFullText && !ft_index_cache_invalidated) {
+                // The compacted segment's fulltext index chunks are carried by the compact txn
+                // store, not by a WalCmdDumpIndexV2, so the invalidation in
+                // PrepareCommitDumpIndex never fires here: without this, cached readers keep
+                // serving the deprecated segments and never see the compacted one.
+                table_meta.InvalidateFtIndexCache();
+                ft_index_cache_invalidated = true;
+            }
+
             std::vector<SegmentID> *segment_ids_ptr = nullptr;
             std::tie(segment_ids_ptr, status) = table_index_meta.GetSegmentIndexIDs1();
             if (!status.ok()) {

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1758,7 +1758,10 @@ Status NewTxn::PrepareCommitImport(WalCmdImportV2 *import_cmd) {
                 return index_status;
             }
             if (index_base->index_type_ == IndexType::kFullText) {
-                table_meta.InvalidateFtIndexCache();
+                status = table_meta.InvalidateFtIndexCache();
+                if (!status.ok()) {
+                    return status;
+                }
                 break;
             }
         }
@@ -2102,7 +2105,10 @@ Status NewTxn::PrepareCommitCompact(WalCmdCompactV2 *compact_cmd) {
                 // store, not by a WalCmdDumpIndexV2, so the invalidation in
                 // PrepareCommitDumpIndex never fires here: without this, cached readers keep
                 // serving the deprecated segments and never see the compacted one.
-                table_meta.InvalidateFtIndexCache();
+                status = table_meta.InvalidateFtIndexCache();
+                if (!status.ok()) {
+                    return status;
+                }
                 ft_index_cache_invalidated = true;
             }
 


### PR DESCRIPTION
## What problem does this PR solve?

Follow-up to #3418, complementary to #3423 (different hole, no overlapping files).

The per-table `TableIndexReaderCache` is invalidated on fulltext index create/drop/dump/optimize (`PrepareCommitDumpIndex`) and on cleanup. **Compaction and import never invalidate it**: their fulltext chunk infos travel through the compact/import txn stores without emitting a `WalCmdDumpIndexV2`, so none of the existing invalidation call sites fire.

Because the cache freshness test (`begin_ts >= cache_ts_`) is satisfied by every transaction once the cache has been built, the consequences are:

- **After COMPACT commits**: fulltext queries keep being answered by cached `ColumnIndexReader`s over the *deprecated* segments, and never see the compacted segment — silently wrong results. When the cleanup task later physically frees the deprecated chunks, the cached readers dangle, which is the same failure mode as the server crash in #3418.
- **After IMPORT commits**: the imported rows are invisible to fulltext search until an unrelated append/dump/cleanup happens to invalidate the cache — silently missing results.

Both are reproducible with an existing populated reader cache (i.e. at least one fulltext query before the compact/import commits).

## What is changed and how it works?

`PrepareCommitCompact` and `PrepareCommitImport` now check whether the table has a fulltext index and call `table_meta.InvalidateFtIndexCache()`, exactly as `PrepareCommitDumpIndex` already does. 42 added lines, no behavior change for tables without a fulltext index.

Relationship to #3423: that PR closes the missing invalidation on the *cleanup* path (`CleanChunkIndex`); this one closes it on the *commit* paths (compact/import). They touch different files and are independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)