### PR TITLE
Fix: contain per-query failures to the failing query instead of killing the whole server

### DIFF
--- a/src/main/query_context_impl.cpp
+++ b/src/main/query_context_impl.cpp
@@ -317,6 +317,9 @@ QueryResult QueryContext::QueryStatementInternal(const BaseStatement *base_state
                     this->RollbackTxn();
                 } catch (std::exception &rollback_e) {
                     LOG_CRITICAL(rollback_e.what());
+                    // The rollback did not reach its own ResetNewTxn: drop the session's
+                    // reference so the next statement cannot reuse the broken transaction.
+                    session_ptr_->ResetNewTxn();
                 }
             }
             StopProfile(QueryPhase::kRollback);

--- a/src/main/query_context_impl.cpp
+++ b/src/main/query_context_impl.cpp
@@ -305,10 +305,24 @@ QueryResult QueryContext::QueryStatementInternal(const BaseStatement *base_state
         query_result.status_.Init(ErrorCode::kParserError, e.what());
 
     } catch (UnrecoverableException &e) {
-        printf("UnrecoverableException %s\n", e.what());
         LOG_CRITICAL(e.what());
-        raise(SIGUSR1);
-        //        throw e;
+
+        NewTxn *new_txn = this->GetNewTxn();
+        if (new_txn != nullptr) {
+            StopProfile();
+            StartProfile(QueryPhase::kRollback);
+            TxnState txn_state = new_txn->GetTxnState();
+            if (txn_state == TxnState::kRollbacking or txn_state == TxnState::kStarted) {
+                try {
+                    this->RollbackTxn();
+                } catch (std::exception &rollback_e) {
+                    LOG_CRITICAL(rollback_e.what());
+                }
+            }
+            StopProfile(QueryPhase::kRollback);
+        }
+        query_result.result_table_ = nullptr;
+        query_result.status_.Init(ErrorCode::kUnexpectedError, e.what());
     }
 
     //    ProfilerStop();

--- a/src/scheduler/fragment_task.cppm
+++ b/src/scheduler/fragment_task.cppm
@@ -95,6 +95,11 @@ public:
     // for test.
     [[nodiscard]] inline FragmentTaskStatus status() const { return status_; }
 
+    inline void SetErrorStatus() {
+        std::unique_lock lock(mutex_);
+        status_ = FragmentTaskStatus::kError;
+    }
+
     FragmentContext *fragment_context() const;
 
 public:

--- a/src/scheduler/fragment_task_impl.cpp
+++ b/src/scheduler/fragment_task_impl.cpp
@@ -66,9 +66,20 @@ void FragmentTask::OnExecute() {
     }
 
     bool execute_success{false};
-    source_op->Execute(query_context, source_state_.get());
     Status operator_status{};
-    if (source_state_->status_.ok()) {
+    try {
+        source_op->Execute(query_context, source_state_.get());
+    } catch (RecoverableException &e) {
+        LOG_ERROR(e.what());
+        operator_status = Status(e.ErrorCode(), e.what());
+    } catch (std::exception &e) {
+        LOG_CRITICAL(e.what());
+        operator_status = Status::UnexpectedError(e.what());
+    } catch (...) {
+        LOG_CRITICAL("Unknown exception in source operator");
+        operator_status = Status::UnexpectedError("Unknown exception in source operator");
+    }
+    if (operator_status.ok() && source_state_->status_.ok()) {
         // No source error
         std::vector<PhysicalOperator *> &operator_refs = fragment_context->GetOperators();
 
@@ -100,7 +111,13 @@ void FragmentTask::OnExecute() {
             operator_status = Status::ParserError(e.what());
         } catch (UnrecoverableException &e) {
             LOG_CRITICAL(e.what());
-            throw e;
+            operator_status = Status::UnexpectedError(e.what());
+        } catch (std::exception &e) {
+            LOG_CRITICAL(e.what());
+            operator_status = Status::UnexpectedError(e.what());
+        } catch (...) {
+            LOG_CRITICAL("Unknown exception during operator execution");
+            operator_status = Status::UnexpectedError("Unknown exception during operator execution");
         }
 
         profiler.End();
@@ -112,7 +129,21 @@ void FragmentTask::OnExecute() {
         status_ = FragmentTaskStatus::kError;
     } else if (execute_success) {
         PhysicalSink *sink_op = fragment_context->GetSinkOperator();
-        sink_op->Execute(query_context, fragment_context, sink_state_.get());
+        try {
+            sink_op->Execute(query_context, fragment_context, sink_state_.get());
+        } catch (RecoverableException &e) {
+            LOG_ERROR(e.what());
+            sink_state_->status_ = Status(e.ErrorCode(), e.what());
+            status_ = FragmentTaskStatus::kError;
+        } catch (std::exception &e) {
+            LOG_CRITICAL(e.what());
+            sink_state_->status_ = Status::UnexpectedError(e.what());
+            status_ = FragmentTaskStatus::kError;
+        } catch (...) {
+            LOG_CRITICAL("Unknown exception in sink operator");
+            sink_state_->status_ = Status::UnexpectedError("Unknown exception in sink operator");
+            status_ = FragmentTaskStatus::kError;
+        }
     }
 }
 

--- a/src/scheduler/task_scheduler_impl.cpp
+++ b/src/scheduler/task_scheduler_impl.cpp
@@ -251,7 +251,17 @@ void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id
         if (!fragment_ctx->notifier()->StartTask()) {
             error = true;
         } else {
-            fragment_task->OnExecute();
+            try {
+                fragment_task->OnExecute();
+            } catch (std::exception &e) {
+                // WorkerLoop is a thread entry point: an exception unwinding past this
+                // frame calls std::terminate and kills the whole server. Fail the fragment.
+                LOG_CRITICAL(fmt::format("Worker {}: exception escaped fragment task execution: {}", worker_id, e.what()));
+                error = true;
+            } catch (...) {
+                LOG_CRITICAL(fmt::format("Worker {}: unknown exception escaped fragment task execution", worker_id));
+                error = true;
+            }
             fragment_task->SetLastWorkID(worker_id);
             if (fragment_task->status() == FragmentTaskStatus::kError) {
                 error = true;

--- a/src/scheduler/task_scheduler_impl.cpp
+++ b/src/scheduler/task_scheduler_impl.cpp
@@ -257,9 +257,11 @@ void TaskScheduler::WorkerLoop(FragmentTaskBlockQueue *task_queue, i64 worker_id
                 // WorkerLoop is a thread entry point: an exception unwinding past this
                 // frame calls std::terminate and kills the whole server. Fail the fragment.
                 LOG_CRITICAL(fmt::format("Worker {}: exception escaped fragment task execution: {}", worker_id, e.what()));
+                fragment_task->SetErrorStatus();
                 error = true;
             } catch (...) {
                 LOG_CRITICAL(fmt::format("Worker {}: unknown exception escaped fragment task execution", worker_id));
+                fragment_task->SetErrorStatus();
                 error = true;
             }
             fragment_task->SetLastWorkID(worker_id);

--- a/src/storage/buffer/buffer_handle_impl.cpp
+++ b/src/storage/buffer/buffer_handle_impl.cpp
@@ -18,11 +18,18 @@ import :buffer_handle;
 import :buffer_handle;
 import :buffer_obj;
 import :file_worker_type;
+import :logger;
+
+import std;
 
 namespace infinity {
 BufferHandle::BufferHandle(BufferObj *buffer_obj, void *data) : buffer_obj_(buffer_obj), data_(data) {}
 
-BufferHandle::BufferHandle(const BufferHandle &other) : buffer_obj_(other.buffer_obj_), data_(other.data_) { buffer_obj_->LoadInner(); }
+BufferHandle::BufferHandle(const BufferHandle &other) : buffer_obj_(other.buffer_obj_), data_(other.data_) {
+    if (buffer_obj_) {
+        buffer_obj_->LoadInner();
+    }
+}
 
 BufferHandle &BufferHandle::operator=(const BufferHandle &other) {
     if (buffer_obj_) {
@@ -30,7 +37,9 @@ BufferHandle &BufferHandle::operator=(const BufferHandle &other) {
     }
     buffer_obj_ = other.buffer_obj_;
     data_ = other.data_;
-    buffer_obj_->LoadInner();
+    if (buffer_obj_) {
+        buffer_obj_->LoadInner();
+    }
     return *this;
 }
 
@@ -52,7 +61,13 @@ BufferHandle &BufferHandle::operator=(BufferHandle &&other) {
 
 BufferHandle::~BufferHandle() {
     if (buffer_obj_) {
-        buffer_obj_->UnloadInner();
+        try {
+            buffer_obj_->UnloadInner();
+        } catch (const std::exception &e) {
+            // A destructor is implicitly noexcept: an exception escaping here would call
+            // std::terminate and bypass every handler above, taking down the whole server.
+            LOG_CRITICAL(e.what());
+        }
     }
     buffer_obj_ = nullptr;
     data_ = nullptr;


### PR DESCRIPTION
## What problem does this PR solve?

Related to #3418, where a poisoned fulltext index read aborted the entire server. Whatever the root cause of any given failure, a single bad query can currently kill the whole process through two independent mechanisms:

1. **An explicit kill switch**: `QueryContext::QueryStatementInternal` catches `UnrecoverableException` and calls `raise(SIGUSR1)`, which the main signal handler treats as a full server shutdown. Any `UnrecoverableError` thrown on the client thread (binding, planning, optimizing, commit) therefore stops the server for every session. The handler also falls through with a default-constructed (`kOk`) status and a null result table, so callers that check `IsOk()` then dereference null.

2. **Unprotected worker threads**: `TaskScheduler::WorkerLoop` is a bare `std::thread` entry with no try/catch, and `FragmentTask::OnExecute` re-throws `UnrecoverableException` (`throw e;`) while its try block covers neither the source nor the sink operator and catches no std exception type. Any escaping exception — `UnrecoverableException`, `std::bad_alloc`, `std::filesystem::filesystem_error` (e.g. `VirtualStore::MmapFile`'s throwing `std::filesystem::file_size` racing a cleanup unlink) — unwinds off the worker thread and calls `std::terminate` (exit 134).

## What is changed and how it works?

Every path now converts the failure into an error status on the query that caused it:

- `QueryContext`: rollback the transaction (guarded, like the `RecoverableException` path) and return `ErrorCode::kUnexpectedError` to the client instead of raising SIGUSR1.
- `FragmentTask::OnExecute`: source, operator loop and sink are each covered; all exceptions are routed into the operator/sink status, which the scheduler and sink already propagate (`sink_state_->status_` / `FragmentTaskStatus::kError`).
- `TaskScheduler::WorkerLoop`: defensive catch-all so no future exception can escape a worker thread and terminate the process.
- `BufferHandle`: the destructor no longer lets `UnloadInner` exceptions escape (destructors are implicitly `noexcept`, so a throw there terminates the process bypassing every handler); copy construction/assignment now tolerate a default-constructed source instead of dereferencing a null `buffer_obj_`.

No behavior change for successful queries. Failures that used to abort the process now surface to the client as a failed statement with the original message, and `LOG_CRITICAL` still records them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)