### PR TITLE
fix(admin): handle missing catalog in database listing

### DIFF
--- a/src/admin/admin_executor_impl.cpp
+++ b/src/admin/admin_executor_impl.cpp
@@ -650,7 +650,13 @@ QueryResult AdminExecutor::ListDatabases(QueryContext *query_context, const Admi
 
     auto catalog_dir = InfinityContext::instance().config()->CatalogDir();
 
-    rocksdb::TransactionDB::OpenForReadOnly(options, catalog_dir, &db);
+    auto status = rocksdb::TransactionDB::OpenForReadOnly(options, catalog_dir, &db);
+    if (!status.ok()) {
+        query_result.result_table_ = nullptr;
+        query_result.status_ =
+            Status::RocksDBError(status, fmt::format("Failed to open catalog directory: {}", catalog_dir));
+        return query_result;
+    }
 
     struct db_output_obj {
         std::string name_;

--- a/src/unit_test/main/infinity_ut.cpp
+++ b/src/unit_test/main/infinity_ut.cpp
@@ -20,7 +20,9 @@ module infinity_core:ut.infinity;
 
 import :ut.base_test;
 import :infinity;
+import :infinity_context;
 import :query_result;
+import :status;
 import :data_block;
 import :value;
 import :query_options;
@@ -253,6 +255,24 @@ TEST_F(InfinityTest, test1) {
     }
     infinity->LocalDisconnect();
 
+    Infinity::LocalUnInit();
+}
+
+TEST_F(InfinityTest, admin_show_databases_reports_missing_catalog) {
+    Infinity::LocalUnInit();
+    RemoveDbDirs();
+
+    std::shared_ptr<std::string> config_path = nullptr;
+    InfinityContext::instance().InitPhase1(config_path);
+    InfinityContext::instance().InitPhase2(true);
+
+    std::shared_ptr<Infinity> infinity = Infinity::LocalConnect();
+    QueryResult result = infinity->Query("admin show databases;");
+
+    EXPECT_FALSE(result.IsOk());
+    EXPECT_EQ(result.ErrorCode(), ErrorCode::kRocksDBError);
+
+    infinity->LocalDisconnect();
     Infinity::LocalUnInit();
 }
 


### PR DESCRIPTION
### Summary

Fixes #3421.

`ADMIN SHOW DATABASES` could dereference a null RocksDB handle when the catalog directory was missing or could not be opened. The command now returns an error response instead of terminating the process.

### Implementation

Check the status returned by `OpenForReadOnly` in `AdminExecutor::ListDatabases` and return `Status::RocksDBError` when opening the catalog fails. Successful catalog reads are unchanged.

### Testing

- `git diff --check`
- Added `InfinityTest.admin_show_databases_reports_missing_catalog` to cover the missing-catalog failure path. The repository's Clang 20/x64-v2 Docker builder was unavailable locally, so the focused C++ test and full build remain pending.
- The repository's `ci` label could not be added because the current GitHub account lacks permission to modify PR labels.
