### PR TITLE
fix: set db_name in TableMeta constructor to fix mem index dump failure(#3420)

### DIFF
--- a/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
+++ b/src/planner/optimizer/index_scan/filter_expression_push_down_indexscanfilter_impl.cpp
@@ -112,7 +112,7 @@ struct ExpressionIndexScanInfo {
         Status status;
         if (!base_table_ref->block_index_->table_meta_) {
             base_table_ref->block_index_->table_meta_ =
-                std::make_unique<TableMeta>(table_info->db_id_, table_info->table_id_, *table_info->table_name_, new_txn);
+                std::make_unique<TableMeta>(table_info->db_id_, *table_info->db_name_, table_info->table_id_, *table_info->table_name_, new_txn);
         }
         table_meta_ = base_table_ref->block_index_->table_meta_.get();
         auto &table_index_meta_map = base_table_ref->block_index_->table_index_meta_map_;

--- a/src/storage/catalog/meta/table_meta.cppm
+++ b/src/storage/catalog/meta/table_meta.cppm
@@ -37,6 +37,7 @@ export class TableMeta {
 public:
     // TableMeta(const std::string &db_id_str, const std::string &table_id_str, KVInstance &kv_instance, TxnTimeStamp begin_ts, UsageEnum usage);
     TableMeta(const std::string &db_id_str,
+              const std::string &db_name,
               const std::string &table_id_str,
               const std::string &table_name,
               KVInstance *kv_instance,
@@ -44,7 +45,7 @@ public:
               TxnTimeStamp commit_ts,
               MetaCache *meta_cache);
 
-    TableMeta(const std::string &db_id_str, const std::string &table_id_str, const std::string &table_name, NewTxn *txn);
+    TableMeta(const std::string &db_id_str, const std::string &db_name, const std::string &table_id_str, const std::string &table_name, NewTxn *txn);
 
     TxnTimeStamp begin_ts() const { return begin_ts_; }
     TxnTimeStamp commit_ts() const { return commit_ts_; }
@@ -100,10 +101,6 @@ public:
     Status GetTableDetail(TableDetail &table_detail);
 
     std::pair<std::string, std::string> GetDBTableName() const { return std::make_pair(db_name_, table_name_); }
-    void SetDBTableName(const std::string &db_name, const std::string &table_name) {
-        db_name_ = db_name;
-        table_name_ = table_name;
-    }
 
     Status AddColumn(const ColumnDef &column_def);
 
@@ -135,6 +132,7 @@ public:
 
     MetaCache *meta_cache() const;
 
+    const std::string &db_name() const;
     const std::string &table_name() const;
 
     u64 db_id() const;
@@ -165,9 +163,9 @@ private:
 
     std::string db_id_str_;
     u64 db_id_{};
+    std::string db_name_{};
     std::string table_id_str_;
     u64 table_id_{};
-    std::string db_name_{};
     std::string table_name_{};
 
     std::optional<std::string> comment_;

--- a/src/storage/catalog/meta/table_meta_impl.cpp
+++ b/src/storage/catalog/meta/table_meta_impl.cpp
@@ -46,20 +46,25 @@ import create_index_info;
 namespace infinity {
 
 TableMeta::TableMeta(const std::string &db_id_str,
+                     const std::string &db_name,
                      const std::string &table_id_str,
                      const std::string &table_name,
                      KVInstance *kv_instance,
                      TxnTimeStamp begin_ts,
                      TxnTimeStamp commit_ts,
                      MetaCache *meta_cache)
-    : begin_ts_(begin_ts), commit_ts_(commit_ts), kv_instance_(kv_instance), meta_cache_(meta_cache), db_id_str_(db_id_str),
+    : begin_ts_(begin_ts), commit_ts_(commit_ts), kv_instance_(kv_instance), meta_cache_(meta_cache), db_id_str_(db_id_str), db_name_(db_name),
       table_id_str_(table_id_str), table_name_(table_name) {
     db_id_ = std::stoull(db_id_str);
     table_id_ = std::stoull(table_id_str);
 }
 
-TableMeta::TableMeta(const std::string &db_id_str, const std::string &table_id_str, const std::string &table_name, NewTxn *txn)
-    : txn_(txn), db_id_str_(db_id_str), table_id_str_(table_id_str), table_name_(table_name) {
+TableMeta::TableMeta(const std::string &db_id_str,
+                     const std::string &db_name,
+                     const std::string &table_id_str,
+                     const std::string &table_name,
+                     NewTxn *txn)
+    : txn_(txn), db_id_str_(db_id_str), db_name_(db_name), table_id_str_(table_id_str), table_name_(table_name) {
     if (txn == nullptr) {
         UnrecoverableError("Null txn pointer");
     }
@@ -1108,6 +1113,8 @@ std::tuple<size_t, Status> TableMeta::GetTableRowCount() {
 }
 
 MetaCache *TableMeta::meta_cache() const { return meta_cache_; }
+
+const std::string &TableMeta::db_name() const { return db_name_; }
 
 const std::string &TableMeta::table_name() const { return table_name_; }
 

--- a/src/storage/catalog/new_catalog_static_impl.cpp
+++ b/src/storage/catalog/new_catalog_static_impl.cpp
@@ -208,7 +208,7 @@ Status NewCatalog::InitCatalog(MetaCache *meta_cache, KVInstance *kv_instance, T
         return Status::OK();
     };
     auto InitTable = [&](const std::string &table_id_str, const std::string &table_name, DBMeta &db_meta) {
-        TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, kv_instance, checkpoint_ts, MAX_TIMESTAMP, meta_cache);
+        TableMeta table_meta(db_meta.db_id_str(), db_meta.db_name(), table_id_str, table_name, kv_instance, checkpoint_ts, MAX_TIMESTAMP, meta_cache);
 
         std::vector<SegmentID> *segment_ids_ptr = nullptr;
         std::tie(segment_ids_ptr, status) = table_meta.GetSegmentIDs1();
@@ -321,7 +321,10 @@ Status NewCatalog::MemIndexRecover(NewTxn *txn) {
         for (size_t idx = 0; idx < table_count; ++idx) {
             const std::string &table_id_str = table_id_strs_ptr->at(idx);
             const std::string &table_name = table_names_ptr->at(idx);
-            TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, txn);
+            // The database name must reach the table meta: TableIndexMeta holds it by reference, so AppendMemIndex
+            // reads the name off it when it builds the dump task. Leaving it empty made the dump fail with
+            // "Database:  doesn't exist."
+            TableMeta table_meta(db_meta.db_id_str(), db_meta.db_name(), table_id_str, table_name, txn);
             status = IndexRecoverTable(table_meta);
             if (!status.ok()) {
                 return status;
@@ -391,7 +394,7 @@ Status NewCatalog::MemIndexRecover(NewTxn *txn) {
             for (size_t i = 0; i < table_id_strs_ptr->size(); ++i) {
                 const std::string &table_id_str = (*table_id_strs_ptr)[i];
                 const std::string &table_name = (*table_names_ptr)[i];
-                TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, txn);
+                TableMeta table_meta(db_meta.db_id_str(), db_meta.db_name(), table_id_str, table_name, txn);
                 DrainTable(table_meta);
             }
         };
@@ -455,7 +458,7 @@ Status NewCatalog::GetAllMemIndexes(NewTxn *txn, std::vector<std::shared_ptr<Mem
         for (size_t i = 0; i < table_id_strs_ptr->size(); ++i) {
             const std::string &table_id_str = (*table_id_strs_ptr)[i];
             const std::string &table_name = (*table_names_ptr)[i];
-            TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, txn);
+            TableMeta table_meta(db_meta.db_id_str(), db_name, table_id_str, table_name, txn);
             status = TraverseTable(table_meta, db_name, table_name);
             if (!status.ok()) {
                 return status;
@@ -520,7 +523,14 @@ Status NewCatalog::CleanDB(DBMeta &db_meta, TxnTimeStamp begin_ts, UsageFlag usa
     for (size_t i = 0; i < table_id_strs_ptr->size(); ++i) {
         const std::string &table_id_str = (*table_id_strs_ptr)[i];
         const std::string &table_name = (*table_names_ptr)[i];
-        TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, db_meta.kv_instance(), begin_ts, MAX_TIMESTAMP, db_meta.meta_cache());
+        TableMeta table_meta(db_meta.db_id_str(),
+                             db_meta.db_name(),
+                             table_id_str,
+                             table_name,
+                             db_meta.kv_instance(),
+                             begin_ts,
+                             MAX_TIMESTAMP,
+                             db_meta.meta_cache());
         status = NewCatalog::CleanTable(table_meta, begin_ts, usage_flag);
         if (!status.ok()) {
             return status;
@@ -550,7 +560,14 @@ Status NewCatalog::AddNewTable(DBMeta &db_meta,
         return status;
     }
 
-    table_meta = std::make_shared<TableMeta>(db_meta.db_id_str(), table_id_str, table_name, kv_instance, begin_ts, commit_ts, db_meta.meta_cache());
+    table_meta = std::make_shared<TableMeta>(db_meta.db_id_str(),
+                                             db_meta.db_name(),
+                                             table_id_str,
+                                             table_name,
+                                             kv_instance,
+                                             begin_ts,
+                                             commit_ts,
+                                             db_meta.meta_cache());
     status = table_meta->InitSet(table_def);
     if (!status.ok()) {
         return status;
@@ -1243,7 +1260,14 @@ Status NewCatalog::GetDBFilePaths(TxnTimeStamp begin_ts, TxnTimeStamp commit_ts,
     for (size_t idx = 0; idx < table_count; ++idx) {
         const std::string &table_id_str = table_id_strs_ptr->at(idx);
         const std::string &table_name = table_names_ptr->at(idx);
-        TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, db_meta.kv_instance(), begin_ts, commit_ts, db_meta.meta_cache());
+        TableMeta table_meta(db_meta.db_id_str(),
+                             db_meta.db_name(),
+                             table_id_str,
+                             table_name,
+                             db_meta.kv_instance(),
+                             begin_ts,
+                             commit_ts,
+                             db_meta.meta_cache());
         status = GetTableFilePaths(begin_ts, table_meta, file_paths);
         if (!status.ok()) {
             return status;

--- a/src/storage/invertedindex/column_index_reader_impl.cpp
+++ b/src/storage/invertedindex/column_index_reader_impl.cpp
@@ -207,7 +207,9 @@ std::shared_ptr<IndexReader> TableIndexReaderCache::GetIndexReader(NewTxn *txn) 
         return index_reader;
     }
 
-    TableMeta table_meta(db_id_str_, table_id_str_, table_name_, txn);
+    // Only the ids are needed here: this path reads index metadata,
+    // so the database name is left empty.
+    TableMeta table_meta(db_id_str_, "", table_id_str_, table_name_, txn);
     std::vector<std::string> *index_id_strs = nullptr;
     std::vector<std::string> *index_name_strs = nullptr;
     {

--- a/src/storage/knn_index/emvb/emvb_index_in_mem_impl.cpp
+++ b/src/storage/knn_index/emvb/emvb_index_in_mem_impl.cpp
@@ -98,7 +98,9 @@ void EMVBIndexInMem::Insert(const ColumnVector &column_vector,
                                                       residual_pq_subspace_num_,
                                                       residual_pq_subspace_bits_);
 
-            TableMeta table_meta(db_id_str_, table_id_str_, table_name_, &kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
+            // Only the ids are needed here: building the EMVB index reads the segment,
+            // so the database name is left empty.
+            TableMeta table_meta(db_id_str_, "", table_id_str_, table_name_, &kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
             SegmentMeta segment_meta(segment_id_, table_meta);
             emvb_index_->BuildEMVBIndex(begin_row_id_, row_count_, segment_meta, column_def_);
             if (emvb_index_->GetDocNum() != row_count_ || emvb_index_->GetTotalEmbeddingNum() != embedding_count_) {

--- a/src/storage/new_txn/new_txn_data_impl.cpp
+++ b/src/storage/new_txn/new_txn_data_impl.cpp
@@ -1711,11 +1711,12 @@ Status NewTxn::CreateTableSnapshotFile(std::shared_ptr<TableSnapshotInfo> table_
 Status NewTxn::PrepareCommitImport(WalCmdImportV2 *import_cmd) {
     TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     const std::string &db_id_str = import_cmd->db_id_;
+    const std::string &db_name = import_cmd->db_name_;
     const std::string &table_id_str = import_cmd->table_id_;
     const std::string &table_name = import_cmd->table_name_;
 
     WalSegmentInfo &segment_info = import_cmd->segment_info_;
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
     SegmentMeta segment_meta(segment_info.segment_id_, table_meta);
 
     Status status = table_meta.CommitSegment(segment_info.segment_id_, commit_ts);
@@ -1751,11 +1752,12 @@ Status NewTxn::PrepareCommitImport(WalCmdImportV2 *import_cmd) {
 Status NewTxn::PrepareCommitReplayImport(WalCmdImportV2 *import_cmd) {
     TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     const std::string &db_id_str = import_cmd->db_id_;
+    const std::string &db_name = import_cmd->db_name_;
     const std::string &table_id_str = import_cmd->table_id_;
     const std::string &table_name = import_cmd->table_name_;
 
     WalSegmentInfo &segment_info = import_cmd->segment_info_;
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
     SegmentMeta segment_meta(segment_info.segment_id_, table_meta);
 
     Status status = table_meta.CommitSegment(segment_info.segment_id_, commit_ts);
@@ -1790,8 +1792,7 @@ Status NewTxn::CommitBottomAppend(WalCmdAppendV2 *append_cmd) {
     const std::string &db_id_str = append_cmd->db_id_;
     const std::string &table_id_str = append_cmd->table_id_;
     TxnTimeStamp commit_ts = CommitTS();
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
-    table_meta.SetDBTableName(db_name, table_name);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
     std::optional<SegmentMeta> segment_meta;
     std::optional<BlockMeta> block_meta;
     size_t copied_row_cnt = 0;
@@ -1909,10 +1910,11 @@ Status NewTxn::CommitBottomAppend(WalCmdAppendV2 *append_cmd) {
 
 Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
     const std::string &db_id_str = delete_cmd->db_id_;
+    const std::string &db_name = delete_cmd->db_name_;
     const std::string &table_id_str = delete_cmd->table_id_;
     const std::string &table_name = delete_cmd->table_name_;
 
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
 
     std::optional<SegmentMeta> segment_meta;
     std::optional<BlockMeta> block_meta;
@@ -1947,9 +1949,10 @@ Status NewTxn::PrepareCommitDelete(const WalCmdDeleteV2 *delete_cmd) {
 Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
     TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     const std::string &db_id_str = delete_cmd->db_id_;
+    const std::string &db_name = delete_cmd->db_name_;
     const std::string &table_id_str = delete_cmd->table_id_;
     const std::string &table_name = delete_cmd->table_name_;
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
 
     NewTxnTableStore1 *txn_table_store = txn_store_.GetNewTxnTableStore1(db_id_str, table_id_str);
     DeleteState &delete_state = txn_table_store->delete_state();
@@ -1975,10 +1978,11 @@ Status NewTxn::CommitBottomDelete(const WalCmdDeleteV2 *delete_cmd) {
 
 Status NewTxn::RollbackDelete(const DeleteTxnStore *delete_txn_store) {
     const std::string &db_id_str = delete_txn_store->db_id_str_;
+    const std::string &db_name = delete_txn_store->db_name_;
     const std::string &table_id_str = delete_txn_store->table_id_str_;
     const std::string &table_name = delete_txn_store->table_name_;
 
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
 
     std::optional<SegmentMeta> segment_meta;
     std::optional<BlockMeta> block_meta;
@@ -2009,6 +2013,7 @@ Status NewTxn::RollbackDelete(const DeleteTxnStore *delete_txn_store) {
 Status NewTxn::PrepareCommitCompact(WalCmdCompactV2 *compact_cmd) {
     Status status;
     const std::string &db_id_str = compact_cmd->db_id_;
+    const std::string &db_name = compact_cmd->db_name_;
     const std::string &table_id_str = compact_cmd->table_id_;
     const std::string &table_name = compact_cmd->table_name_;
     TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
@@ -2023,7 +2028,7 @@ Status NewTxn::PrepareCommitCompact(WalCmdCompactV2 *compact_cmd) {
     WalSegmentInfo &segment_info = segment_infos[0];
     std::vector<SegmentID> new_segment_ids{segment_info.segment_id_};
 
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
     SegmentMeta segment_meta(segment_info.segment_id_, table_meta);
 
     status = table_meta.CommitSegment(segment_info.segment_id_, commit_ts);

--- a/src/storage/new_txn/new_txn_impl.cpp
+++ b/src/storage/new_txn/new_txn_impl.cpp
@@ -374,7 +374,6 @@ Status NewTxn::GetTables(const std::string &db_name, std::vector<std::shared_ptr
             return status;
         }
         std::shared_ptr<TableDetail> table_detail = std::make_shared<TableDetail>();
-        table_meta->SetDBTableName(db_name, table_name);
         status = table_meta->GetTableDetail(*table_detail);
         table_detail->create_ts_ = create_timestamp;
         output_table_array.push_back(table_detail);
@@ -1885,7 +1884,7 @@ Status NewTxn::CheckpointDB(DBMeta &db_meta, const CheckpointOption &option, Che
     for (size_t idx = 0; idx < table_count; ++idx) {
         const std::string &table_id_str = table_id_strs_ptr->at(idx);
         const std::string &table_name = table_names_ptr->at(idx);
-        TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, this);
+        TableMeta table_meta(db_meta.db_id_str(), db_meta.db_name(), table_id_str, table_name, this);
         status = this->CheckpointTable(table_meta, option, ckp_txn_store);
         if (!status.ok()) {
             return status;
@@ -2465,7 +2464,6 @@ Status NewTxn::GetTableMeta(const std::string &db_name,
     if (!status.ok()) {
         return status;
     }
-    table_meta->SetDBTableName(db_name, table_name);
     return Status::OK();
 }
 
@@ -2481,8 +2479,7 @@ Status NewTxn::GetTableMeta(const std::string &table_name,
         return status;
     }
     LOG_DEBUG(fmt::format("GetTableMeta: txn_id: {} table_id: {}", TxnID(), table_id_str));
-    table_meta = std::make_shared<TableMeta>(db_meta->db_id_str(), table_id_str, table_name, this);
-    table_meta->SetDBTableName(db_meta->db_name(), table_name);
+    table_meta = std::make_shared<TableMeta>(db_meta->db_id_str(), db_meta->db_name(), table_id_str, table_name, this);
     if (table_key_ptr) {
         *table_key_ptr = table_key;
     }
@@ -2507,7 +2504,6 @@ Status NewTxn::GetTableIndexMeta(const std::string &db_name,
     if (!status.ok()) {
         return status;
     }
-    table_meta->SetDBTableName(db_name, table_name);
     status = GetTableIndexMeta(index_name, *table_meta, table_index_meta, index_key_ptr);
     if (!status.ok()) {
         return status;
@@ -2782,7 +2778,7 @@ Status NewTxn::CommitCheckpointDB(DBMeta &db_meta, const WalCmdCheckpointV2 *che
     for (size_t idx = 0; idx < table_count; ++idx) {
         const std::string &table_id_str = table_id_strs_ptr->at(idx);
         const std::string &table_name = table_names_ptr->at(idx);
-        TableMeta table_meta(db_meta.db_id_str(), table_id_str, table_name, this);
+        TableMeta table_meta(db_meta.db_id_str(), db_meta.db_name(), table_id_str, table_name, this);
         status = CommitCheckpointTable(table_meta, checkpoint_cmd);
         if (!status.ok()) {
             return status;
@@ -2829,8 +2825,11 @@ Status NewTxn::RestoreTableFromSnapshot(const WalCmdRestoreTableSnapshot *restor
             return status;
         }
     } else {
-        table_meta =
-            std::make_shared<TableMeta>(db_meta.db_id_str(), restore_table_snapshot_cmd->table_id_, restore_table_snapshot_cmd->table_name_, this);
+        table_meta = std::make_shared<TableMeta>(db_meta.db_id_str(),
+                                                 db_meta.db_name(),
+                                                 restore_table_snapshot_cmd->table_id_,
+                                                 restore_table_snapshot_cmd->table_name_,
+                                                 this);
     }
 
     // restore metadata of the table
@@ -4769,6 +4768,7 @@ Status NewTxn::PostRollback(TxnTimeStamp abort_ts) {
             MetaCache *meta_cache = txn_mgr_->storage()->meta_cache();
             CreateIndexTxnStore *create_index_txn_store = static_cast<CreateIndexTxnStore *>(base_txn_store_.get());
             TableMeta table_meta(create_index_txn_store->db_id_str_,
+                                 create_index_txn_store->db_name_,
                                  create_index_txn_store->table_id_str_,
                                  create_index_txn_store->table_name_,
                                  kv_instance_.get(),
@@ -5259,7 +5259,10 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
                 if (!status.ok()) {
                     return status;
                 }
+                // Cleanup only needs the ids, so the database name is
+                // left empty.
                 TableMeta table_meta(table_meta_key->db_id_str_,
+                                     "",
                                      table_meta_key->table_id_str_,
                                      table_meta_key->table_name_,
                                      kv_instance,
@@ -5285,8 +5288,14 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
             }
             case MetaType::kSegment: {
                 auto *segment_meta_key = static_cast<SegmentMetaKey *>(meta.get());
-                TableMeta
-                    table_meta(segment_meta_key->db_id_str_, segment_meta_key->table_id_str_, "", kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
+                TableMeta table_meta(segment_meta_key->db_id_str_,
+                                     "",
+                                     segment_meta_key->table_id_str_,
+                                     "",
+                                     kv_instance,
+                                     begin_ts,
+                                     MAX_TIMESTAMP,
+                                     meta_cache);
                 Status status = table_meta.RemoveSegmentIDs1({segment_meta_key->segment_id_});
                 if (!status.ok()) {
                     return status;
@@ -5301,7 +5310,8 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
             }
             case MetaType::kBlock: {
                 auto *block_meta_key = static_cast<BlockMetaKey *>(meta.get());
-                TableMeta table_meta(block_meta_key->db_id_str_, block_meta_key->table_id_str_, "", kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
+                TableMeta
+                    table_meta(block_meta_key->db_id_str_, "", block_meta_key->table_id_str_, "", kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
                 SegmentMeta segment_meta(block_meta_key->segment_id_, table_meta);
                 BlockMeta block_meta(block_meta_key->block_id_, segment_meta);
                 Status status = NewCatalog::CleanBlock(block_meta, UsageFlag::kOther);
@@ -5325,7 +5335,7 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
             case MetaType::kBlockColumn: {
                 auto *column_meta_key = static_cast<ColumnMetaKey *>(meta.get());
                 TableMeta
-                    table_meta(column_meta_key->db_id_str_, column_meta_key->table_id_str_, "", kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
+                    table_meta(column_meta_key->db_id_str_, "", column_meta_key->table_id_str_, "", kv_instance, begin_ts, MAX_TIMESTAMP, meta_cache);
                 SegmentMeta segment_meta(column_meta_key->segment_id_, table_meta);
                 BlockMeta block_meta(column_meta_key->block_id_, segment_meta);
                 ColumnMeta column_meta(column_meta_key->column_def_->id(), block_meta);
@@ -5347,6 +5357,7 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
                 }
 
                 TableMeta table_meta(table_index_meta_key->db_id_str_,
+                                     "",
                                      table_index_meta_key->table_id_str_,
                                      "",
                                      kv_instance,
@@ -5366,6 +5377,7 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
             case MetaType::kSegmentIndex: {
                 auto *segment_index_meta_key = static_cast<SegmentIndexMetaKey *>(meta.get());
                 TableMeta table_meta(segment_index_meta_key->db_id_str_,
+                                     "",
                                      segment_index_meta_key->table_id_str_,
                                      "",
                                      kv_instance,
@@ -5383,6 +5395,7 @@ Status NewTxn::CleanupInner(const std::vector<std::shared_ptr<MetaKey>> &metas) 
             case MetaType::kChunkIndex: {
                 auto *chunk_index_meta_key = static_cast<ChunkIndexMetaKey *>(meta.get());
                 TableMeta table_meta(chunk_index_meta_key->db_id_str_,
+                                     "",
                                      chunk_index_meta_key->table_id_str_,
                                      "",
                                      kv_instance,

--- a/src/storage/new_txn/new_txn_index_impl.cpp
+++ b/src/storage/new_txn/new_txn_index_impl.cpp
@@ -2921,7 +2921,7 @@ Status NewTxn::PrepareCommitCreateIndex(WalCmdCreateIndexV2 *create_index_cmd) {
     const auto &index_id_str = create_index_cmd->index_id_;
     std::shared_ptr<IndexBase> &index_base = create_index_cmd->index_base_;
 
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
     std::shared_ptr<TableIndexMeta> table_index_meta_ptr;
     Status status = new_catalog_->AddNewTableIndex(table_meta, index_id_str, commit_ts, index_base, table_index_meta_ptr);
     if (!status.ok()) {
@@ -2983,6 +2983,7 @@ Status NewTxn::PrepareCommitCreateIndex(WalCmdCreateIndexV2 *create_index_cmd) {
 
 Status NewTxn::PrepareCommitDropIndex(const WalCmdDropIndexV2 *drop_index_cmd) {
     const std::string &db_id_str = drop_index_cmd->db_id_;
+    const std::string &db_name = drop_index_cmd->db_name_;
     const std::string &table_id_str = drop_index_cmd->table_id_;
     const std::string &table_name = drop_index_cmd->table_name_;
     const std::string &index_id_str = drop_index_cmd->index_id_;
@@ -2995,7 +2996,7 @@ Status NewTxn::PrepareCommitDropIndex(const WalCmdDropIndexV2 *drop_index_cmd) {
     auto ts_str = std::to_string(commit_ts);
     kv_instance_->Put(KeyEncode::DropTableIndexKey(db_id_str, table_id_str, drop_index_cmd->index_name_, create_ts, index_id_str), ts_str);
 
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
     TableIndexMeta table_index_meta(index_id_str, index_name, table_meta);
     auto [index_base, status] = table_index_meta.GetIndexBase();
     if (!status.ok()) {
@@ -3017,13 +3018,14 @@ Status NewTxn::PrepareCommitDropIndex(const WalCmdDropIndexV2 *drop_index_cmd) {
 Status NewTxn::PrepareCommitDumpIndex(const WalCmdDumpIndexV2 *dump_index_cmd, KVInstance *kv_instance) {
     const TxnTimeStamp commit_ts = txn_context_ptr_->commit_ts_;
     const std::string &db_id_str = dump_index_cmd->db_id_;
+    const std::string &db_name = dump_index_cmd->db_name_;
     const std::string &table_id_str = dump_index_cmd->table_id_;
     const std::string &table_name = dump_index_cmd->table_name_;
     const std::string &index_id_str = dump_index_cmd->index_id_;
     const std::string &index_name = dump_index_cmd->index_name_;
     SegmentID segment_id = dump_index_cmd->segment_id_;
 
-    TableMeta table_meta(db_id_str, table_id_str, table_name, this);
+    TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, this);
 
     TableIndexMeta table_index_meta(index_id_str, index_name, table_meta);
 

--- a/src/storage/storage_impl.cpp
+++ b/src/storage/storage_impl.cpp
@@ -1035,7 +1035,7 @@ bool Storage::ConvertJsonIndexFormat() const {
             const std::string &table_id_str = (*table_id_strs)[j];
             const std::string &table_name = (*table_names)[j];
 
-            TableMeta table_meta(db_id_str, table_id_str, table_name, txn);
+            TableMeta table_meta(db_id_str, db_name, table_id_str, table_name, txn);
 
             std::vector<std::string> *index_id_strs = nullptr;
             std::vector<std::string> *index_names = nullptr;

--- a/src/unit_test/storage/new_catalog/table_meta_ut.cpp
+++ b/src/unit_test/storage/new_catalog/table_meta_ut.cpp
@@ -97,6 +97,7 @@ TEST_P(TestTxnTableMeta, table_meta) {
 
     std::unique_ptr<KVInstance> kv_instance = infinity::InfinityContext::instance().storage()->KVInstance();
     TableMeta table_meta(table_info->db_id_,
+                         *table_info->db_name_,
                          table_info->table_id_,
                          *table_info->table_name_,
                          kv_instance.get(),


### PR DESCRIPTION
- Fixes #3420: TableMeta now receives db_name at construction, so mem index dump tasks correctly resolve the database instead of failing with "Database: doesn't exist."
- Removes the SetDBTableName mutator so the table's database name is fixed once at construction and cannot drift into an inconsistent state.