### PR TITLE
Add Slovak and Czech language support to the RAG analyzer

### DIFF
--- a/docs/guides/search_guide.md
+++ b/docs/guides/search_guide.md
@@ -67,6 +67,8 @@ This analyzer offers better recall for Chinese than the [Jieba](https://github.c
 
 Use `"rag"` to select the RAG analyzer or `"rag-fine"` for fine-grained mode, which outputs tokenization results with the second highest score.
 
+Append a language name to select language-specific processing of Latin text, e.g. `"rag-dutch"` (Snowball stemmer) or `"rag-slovak"` / `"rag-czech"`, which fold diacritics to ASCII and skip stemming so that queries typed with or without accents match the same tokens. Suffixes combine in any order: `"rag-czech-fine"`.
+
 :::note
 Both RAG tokenization and fine-grained RAG tokenization are used in RAGFlow to ensure high recall.
 :::

--- a/python/infinity_sdk/infinity/rag_tokenizer.py
+++ b/python/infinity_sdk/infinity/rag_tokenizer.py
@@ -37,6 +37,7 @@ import math
 import os
 import re
 import string
+import unicodedata
 
 import datrie
 from hanziconv import HanziConv
@@ -64,6 +65,33 @@ _SNOWBALL_LANGUAGE_MAP = {
     "swedish": "swedish",
     "turkish": "turkish",
 }
+
+# Languages tokenized with diacritics folded to ASCII and no stemming.
+# SPLIT_CHAR only keeps ASCII letter runs whole, so accented words would
+# otherwise be fragmented before indexing ('škola' -> 'š kola'), and
+# neither language has a Snowball stemmer.
+_DIACRITIC_FOLDING_LANGUAGES = {"slovak", "czech"}
+
+
+def _fold_char(char: str) -> str:
+    # Latin-1 Supplement and Latin Extended-A letters whose NFD decomposition
+    # is one ASCII letter plus combining marks fold to that letter (Š -> S,
+    # ď -> d); everything else (æ, ø, ł, ß, non-Latin scripts) is kept. Same
+    # rule as RAGAnalyzer::FoldDiacritics in the C++ analyzer.
+    if not (0xC0 <= ord(char) < 0x180):
+        return char
+    decomposed = unicodedata.normalize("NFD", char)
+    base = decomposed[0]
+    if base.isascii() and base.isalpha() and all(unicodedata.combining(c) for c in decomposed[1:]):
+        return base
+    return char
+
+
+def fold_diacritics(text: str) -> str:
+    """Fold Latin diacritics to ASCII: 'škola' -> 'skola'."""
+    if text.isascii():
+        return text
+    return "".join(_fold_char(c) for c in text)
 
 
 class RagTokenizer:
@@ -122,6 +150,7 @@ class RagTokenizer:
         self.stemmer = SnowballStemmer("english")
         self.lemmatizer = WordNetLemmatizer()
         self._use_lemmatizer = True  # WordNet only supports English
+        self._fold_diacritics = False
 
         self.SPLIT_CHAR = r"([ ,\.<>/?;:'\[\]\\`!@#$%^&*\(\)\{\}\|_+=《》，。？、；‘’：“”【】~！￥%……（）——-]+|[a-zA-Z0-9,\.-]+)"
 
@@ -163,6 +192,14 @@ class RagTokenizer:
                       Case-insensitive.
         """
         lang_key = language.strip().lower()
+
+        self._fold_diacritics = lang_key in _DIACRITIC_FOLDING_LANGUAGES
+        if self._fold_diacritics:
+            # Folded to ASCII in tokenize() and left unstemmed: there is no
+            # Snowball stemmer for these languages (see _normalize_token).
+            logging.debug("Tokenizer language set to '%s' (diacritics folding, no stemming)", language)
+            return
+
         snowball_lang = _SNOWBALL_LANGUAGE_MAP.get(lang_key)
 
         if snowball_lang is not None:
@@ -389,8 +426,11 @@ class RagTokenizer:
 
         When the lemmatizer is enabled (English), applies lemmatization
         before stemming.  For other Snowball-supported languages, only
-        stemming is applied.  Non-alphabetic tokens are returned as-is.
+        stemming is applied.  Non-alphabetic tokens are returned as-is,
+        and so is every token of a diacritic-folding language.
         """
+        if self._fold_diacritics:
+            return t
         if re.match(r"[a-zA-Z_-]+$", t):
             if self._use_lemmatizer:
                 return self.stemmer.stem(self.lemmatizer.lemmatize(t))
@@ -421,6 +461,8 @@ class RagTokenizer:
         return txt_lang_pairs
 
     def tokenize(self, line: str) -> str:
+        if self._fold_diacritics:
+            line = fold_diacritics(line)
         line = re.sub(r"\W+", " ", line)
         line = self._strQ2B(line).lower()
         line = self._tradi2simp(line)

--- a/src/common/analyzer/analyzer_pool_impl.cpp
+++ b/src/common/analyzer/analyzer_pool_impl.cpp
@@ -136,7 +136,14 @@ std::tuple<std::unique_ptr<Analyzer>, Status> AnalyzerPool::GetAnalyzer(const st
             return {std::move(analyzer), Status::OK()};
         }
         case Str2Int(RAG.data()): {
-            // rag-{coarse|fine}
+            // rag[-<suffix>]* — each '-'-separated suffix segment is either
+            // "fine" (fine-grained tokenization) or a language name passed to
+            // RAGAnalyzer::SetLanguage(), in any order: e.g. "rag", "rag-fine",
+            // "rag-slovak", "rag-czech-fine", "rag-fine-czech". "slovak" and
+            // "czech" fold diacritics to ASCII and disable stemming; Snowball
+            // language names ("english", "dutch", …) select a stemmer.
+            // Unrecognized segments are silently ignored (SetLanguage keeps
+            // defaults for unknown languages) to stay backward compatible.
             Analyzer *prototype = cache_[RAG].get();
             if (prototype == nullptr) {
                 std::string path;
@@ -155,15 +162,25 @@ std::tuple<std::unique_ptr<Analyzer>, Status> AnalyzerPool::GetAnalyzer(const st
                 prototype = analyzer.get();
                 cache_[RAG] = std::move(analyzer);
             }
+            std::unique_ptr<RAGAnalyzer> analyzer = std::make_unique<RAGAnalyzer>(*reinterpret_cast<RAGAnalyzer *>(prototype));
             bool fine_grained = false;
             const char *str = name.data();
             while (*str != '\0' && *str != '-') {
                 str++;
             }
-            if (strcmp(str, "-fine") == 0) {
-                fine_grained = true;
+            while (*str == '-') {
+                str++;
+                const char *segment_start = str;
+                while (*str != '\0' && *str != '-') {
+                    str++;
+                }
+                std::string_view segment(segment_start, str - segment_start);
+                if (segment == "fine") {
+                    fine_grained = true;
+                } else if (!segment.empty()) {
+                    analyzer->SetLanguage(std::string(segment));
+                }
             }
-            std::unique_ptr<RAGAnalyzer> analyzer = std::make_unique<RAGAnalyzer>(*reinterpret_cast<RAGAnalyzer *>(prototype));
             analyzer->SetFineGrained(fine_grained);
             return {std::move(analyzer), Status::OK()};
         }

--- a/src/common/analyzer/rag_analyzer.cppm
+++ b/src/common/analyzer/rag_analyzer.cppm
@@ -57,6 +57,14 @@ public:
     // these terms from the emitted token stream.
     static bool IsStopword(const std::string &term);
 
+    // Fold Latin-1 Supplement / Latin Extended-A letters whose NFD
+    // decomposition is one ASCII letter plus combining marks to that base
+    // letter, preserving case (Š→S, ď→d). Letters without such a
+    // decomposition (æ, œ, ß, ø, ł, …) pass through unchanged. Applied to
+    // the whole input before tokenization when SetLanguage selected a
+    // diacritics-folding language (Slovak, Czech).
+    static std::string FoldDiacritics(const std::string &input);
+
     std::pair<std::vector<std::string>, std::vector<std::pair<unsigned, unsigned>>> TokenizeWithPosition(const std::string &line);
     std::string Tokenize(const std::string &line);
 
@@ -141,6 +149,10 @@ public:
     WordNetLemmatizer *wordnet_lemma_{nullptr};
 
     bool use_lemmatizer_{true}; // WordNet only supports English
+
+    bool use_stemmer_{true}; // Disabled for languages without a Snowball stemmer (Slovak, Czech)
+
+    bool fold_diacritics_{false}; // Fold Latin diacritics to ASCII before tokenization (Slovak, Czech)
 
     std::unique_ptr<Stemmer> stemmer_;
 

--- a/src/common/analyzer/rag_analyzer_impl.cpp
+++ b/src/common/analyzer/rag_analyzer_impl.cpp
@@ -687,6 +687,8 @@ RAGAnalyzer::~RAGAnalyzer() {
 void RAGAnalyzer::InitStemmer(Language language) {
     stemmer_->Init(language);
     use_lemmatizer_ = (language == STEM_LANG_ENGLISH);
+    use_stemmer_ = true;
+    fold_diacritics_ = false;
 }
 
 void RAGAnalyzer::SetLanguage(const std::string &language) {
@@ -696,6 +698,17 @@ void RAGAnalyzer::SetLanguage(const std::string &language) {
     // Trim whitespace
     lang_key.erase(lang_key.find_last_not_of(" \t") + 1);
     lang_key.erase(0, lang_key.find_first_not_of(" \t"));
+
+    // Slovak and Czech have no Snowball stemmer. Instead their diacritics
+    // are folded to ASCII before tokenization, and stemming/lemmatization
+    // are disabled, matching rag_tokenizer.py.
+    if (lang_key == "slovak" || lang_key == "czech") {
+        fold_diacritics_ = true;
+        use_stemmer_ = false;
+        use_lemmatizer_ = false;
+        LOG_DEBUG(fmt::format("Tokenizer language set to '{}' (diacritics folding, no stemming)", language));
+        return;
+    }
 
     Language stem_lang = STEM_LANG_UNKNOWN;
     std::string snowball_lang;
@@ -708,8 +721,7 @@ void RAGAnalyzer::SetLanguage(const std::string &language) {
     }
 
     if (stem_lang != STEM_LANG_UNKNOWN) {
-        stemmer_->Init(stem_lang);
-        use_lemmatizer_ = (stem_lang == STEM_LANG_ENGLISH);
+        InitStemmer(stem_lang);
         LOG_DEBUG(fmt::format("Tokenizer language set to '{}' (Snowball: {}, lemmatizer: {})", language, snowball_lang, use_lemmatizer_));
     } else {
         // Unsupported language (Chinese, Japanese, Korean, etc.) –
@@ -864,6 +876,71 @@ std::string RAGAnalyzer::StrQ2B(const std::string &input) {
                 output += static_cast<char>(0x80 | (codepoint & 0x3F));
             }
         }
+    }
+
+    return output;
+}
+
+// ASCII base letter for each codepoint in Latin-1 Supplement (U+00C0–U+00FF)
+// and Latin Extended-A (U+0100–U+017F), indexed by codepoint - 0xC0. Only
+// letters whose NFD decomposition is exactly one ASCII letter plus combining
+// marks are folded; '\0' marks a pass-through codepoint (Æ, Ð, ×, Ø, Þ, ß,
+// Đ, Ħ, ı, Ĳ, ĸ, Ŀ, Ł, ŉ, Ŋ, Œ, Ŧ, ſ and their case pairs). Derived from
+// Unicode NFD, the same rule rag_tokenizer.py applies at runtime through
+// unicodedata, so both sides fold identically.
+static constexpr char DIACRITICS_FOLD_TABLE[0x180 - 0xC0] = {
+    // clang-format off
+    // U+00C0 À Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï
+    'A', 'A', 'A', 'A', 'A', 'A', 0, 'C', 'E', 'E', 'E', 'E', 'I', 'I', 'I', 'I',
+    // U+00D0 Ð Ñ Ò Ó Ô Õ Ö × Ø Ù Ú Û Ü Ý Þ ß
+    0, 'N', 'O', 'O', 'O', 'O', 'O', 0, 0, 'U', 'U', 'U', 'U', 'Y', 0, 0,
+    // U+00E0 à á â ã ä å æ ç è é ê ë ì í î ï
+    'a', 'a', 'a', 'a', 'a', 'a', 0, 'c', 'e', 'e', 'e', 'e', 'i', 'i', 'i', 'i',
+    // U+00F0 ð ñ ò ó ô õ ö ÷ ø ù ú û ü ý þ ÿ
+    0, 'n', 'o', 'o', 'o', 'o', 'o', 0, 0, 'u', 'u', 'u', 'u', 'y', 0, 'y',
+    // U+0100 Ā ā Ă ă Ą ą Ć ć Ĉ ĉ Ċ ċ Č č Ď ď
+    'A', 'a', 'A', 'a', 'A', 'a', 'C', 'c', 'C', 'c', 'C', 'c', 'C', 'c', 'D', 'd',
+    // U+0110 Đ đ Ē ē Ĕ ĕ Ė ė Ę ę Ě ě Ĝ ĝ Ğ ğ
+    0, 0, 'E', 'e', 'E', 'e', 'E', 'e', 'E', 'e', 'E', 'e', 'G', 'g', 'G', 'g',
+    // U+0120 Ġ ġ Ģ ģ Ĥ ĥ Ħ ħ Ĩ ĩ Ī ī Ĭ ĭ Į į
+    'G', 'g', 'G', 'g', 'H', 'h', 0, 0, 'I', 'i', 'I', 'i', 'I', 'i', 'I', 'i',
+    // U+0130 İ ı Ĳ ĳ Ĵ ĵ Ķ ķ ĸ Ĺ ĺ Ļ ļ Ľ ľ Ŀ
+    'I', 0, 0, 0, 'J', 'j', 'K', 'k', 0, 'L', 'l', 'L', 'l', 'L', 'l', 0,
+    // U+0140 ŀ Ł ł Ń ń Ņ ņ Ň ň ŉ Ŋ ŋ Ō ō Ŏ ŏ
+    0, 0, 0, 'N', 'n', 'N', 'n', 'N', 'n', 0, 0, 0, 'O', 'o', 'O', 'o',
+    // U+0150 Ő ő Œ œ Ŕ ŕ Ŗ ŗ Ř ř Ś ś Ŝ ŝ Ş ş
+    'O', 'o', 0, 0, 'R', 'r', 'R', 'r', 'R', 'r', 'S', 's', 'S', 's', 'S', 's',
+    // U+0160 Š š Ţ ţ Ť ť Ŧ ŧ Ũ ũ Ū ū Ŭ ŭ Ů ů
+    'S', 's', 'T', 't', 'T', 't', 0, 0, 'U', 'u', 'U', 'u', 'U', 'u', 'U', 'u',
+    // U+0170 Ű ű Ų ų Ŵ ŵ Ŷ ŷ Ÿ Ź ź Ż ż Ž ž ſ
+    'U', 'u', 'U', 'u', 'W', 'w', 'Y', 'y', 'Y', 'Z', 'z', 'Z', 'z', 'Z', 'z', 0,
+    // clang-format on
+};
+
+std::string RAGAnalyzer::FoldDiacritics(const std::string &input) {
+    std::string output;
+    output.reserve(input.size());
+
+    size_t i = 0;
+    while (i < input.size()) {
+        unsigned char c = input[i];
+        // Only 2-byte UTF-8 sequences can encode U+00C0–U+017F.
+        if ((c & 0xE0) == 0xC0 && i + 1 < input.size()) {
+            uint32_t codepoint = ((c & 0x1F) << 6) | (static_cast<unsigned char>(input[i + 1]) & 0x3F);
+            if (codepoint >= 0xC0 && codepoint < 0x180) {
+                if (char folded = DIACRITICS_FOLD_TABLE[codepoint - 0xC0]; folded != '\0') {
+                    output += folded;
+                    i += 2;
+                    continue;
+                }
+            }
+            output += input[i];
+            output += input[i + 1];
+            i += 2;
+            continue;
+        }
+        output += input[i];
+        i += 1;
     }
 
     return output;
@@ -1395,7 +1472,11 @@ void RAGAnalyzer::EnglishNormalize(const std::vector<std::string> &tokens, std::
                 term_to_stem = lowercase_term;
             }
             std::string stem_term;
-            stemmer_->Stem(term_to_stem, stem_term);
+            if (use_stemmer_) {
+                stemmer_->Stem(term_to_stem, stem_term);
+            } else {
+                stem_term = term_to_stem;
+            }
             res.push_back(stem_term);
         } else {
             res.push_back(t);
@@ -1730,8 +1811,17 @@ std::string PCRE2GlobalReplace(const std::string &text, const std::string &patte
 }
 
 std::string RAGAnalyzer::Tokenize(const std::string &line) {
+    // Fold diacritics to ASCII before any other processing when the
+    // language asks for it (Slovak, Czech).
+    std::string folded_line;
+    const std::string *input = &line;
+    if (fold_diacritics_) {
+        folded_line = FoldDiacritics(line);
+        input = &folded_line;
+    }
+
     // Python-style simple tokenization: re.sub(r"\\W+", " ", line)
-    std::string processed_line = PCRE2GlobalReplace(line, R"#(\W+)#", " ");
+    std::string processed_line = PCRE2GlobalReplace(*input, R"#(\W+)#", " ");
     std::string str1 = StrQ2B(processed_line);
     std::string strline;
     opencc_->convert(str1, strline);
@@ -1762,7 +1852,11 @@ std::string RAGAnalyzer::Tokenize(const std::string &line) {
                     term_to_stem = lowercase_term;
                 }
                 std::string stem_term;
-                stemmer_->Stem(term_to_stem, stem_term);
+                if (use_stemmer_) {
+                    stemmer_->Stem(term_to_stem, stem_term);
+                } else {
+                    stem_term = term_to_stem;
+                }
                 res.push_back(stem_term);
             }
             continue;
@@ -1794,9 +1888,23 @@ std::string RAGAnalyzer::Tokenize(const std::string &line) {
 }
 
 std::pair<std::vector<std::string>, std::vector<std::pair<unsigned, unsigned>>> RAGAnalyzer::TokenizeWithPosition(const std::string &line) {
+    // Fold diacritics to ASCII before any other processing when the
+    // language asks for it (Slovak, Czech). Folding shrinks 2-byte UTF-8
+    // letters to 1-byte ASCII, so byte offsets shift; like the StrQ2B and
+    // OpenCC stages below, a position mapping recovers offsets on the
+    // original input.
+    std::string folded_line;
+    std::vector<unsigned> fold_pos_mapping;
+    const std::string *input = &line;
+    if (fold_diacritics_) {
+        folded_line = FoldDiacritics(line);
+        BuildPositionMapping(line, folded_line, fold_pos_mapping);
+        input = &folded_line;
+    }
+
     // Python-style simple tokenization: re.sub(r"\W+", " ", line)
     // Get processed line and position mapping from PCRE2GlobalReplace
-    auto [processed_line, pcre2_pos_mapping] = PCRE2GlobalReplaceWithPosition(line, R"#(\W+)#", " ");
+    auto [processed_line, pcre2_pos_mapping] = PCRE2GlobalReplaceWithPosition(*input, R"#(\W+)#", " ");
 
     std::string str1 = StrQ2B(processed_line);
     std::string strline;
@@ -1812,7 +1920,7 @@ std::pair<std::vector<std::string>, std::vector<std::pair<unsigned, unsigned>>> 
     std::vector<unsigned> opencc_pos_mapping;
     BuildPositionMapping(str1, strline, opencc_pos_mapping);
 
-    // Combine all position mappings: strline -> str1 -> processed_line -> line
+    // Combine all position mappings: strline -> str1 -> processed_line -> (folded_)line
     std::vector<unsigned> final_pos_mapping;
     final_pos_mapping.resize(strline.size() + 1);
 
@@ -1824,19 +1932,26 @@ std::pair<std::vector<std::string>, std::vector<std::pair<unsigned, unsigned>>> 
                 if (processed_pos < pcre2_pos_mapping.size()) {
                     final_pos_mapping[i] = pcre2_pos_mapping[processed_pos].first;
                 } else {
-                    final_pos_mapping[i] = static_cast<unsigned>(line.size());
+                    final_pos_mapping[i] = static_cast<unsigned>(input->size());
                 }
             } else {
-                final_pos_mapping[i] = static_cast<unsigned>(line.size());
+                final_pos_mapping[i] = static_cast<unsigned>(input->size());
             }
         } else {
-            final_pos_mapping[i] = static_cast<unsigned>(line.size());
+            final_pos_mapping[i] = static_cast<unsigned>(input->size());
         }
     }
 
     // Fill the last position
     if (strline.size() < final_pos_mapping.size()) {
-        final_pos_mapping[strline.size()] = static_cast<unsigned>(line.size());
+        final_pos_mapping[strline.size()] = static_cast<unsigned>(input->size());
+    }
+
+    // Remap folded-line offsets back to the original input.
+    if (fold_diacritics_) {
+        for (auto &pos : final_pos_mapping) {
+            pos = pos < fold_pos_mapping.size() ? fold_pos_mapping[pos] : static_cast<unsigned>(line.size());
+        }
     }
 
     // Use SplitByLang to separate by language
@@ -1884,7 +1999,11 @@ std::pair<std::vector<std::string>, std::vector<std::pair<unsigned, unsigned>>> 
                             term_to_stem = lowercase_term;
                         }
                         std::string stem_term;
-                        stemmer_->Stem(term_to_stem, stem_term);
+                        if (use_stemmer_) {
+                            stemmer_->Stem(term_to_stem, stem_term);
+                        } else {
+                            stem_term = term_to_stem;
+                        }
 
                         tokens.push_back(stem_term);
 
@@ -2214,7 +2333,11 @@ void RAGAnalyzer::EnglishNormalizeWithPosition(const std::vector<std::string> &t
                 term_to_stem = lowercase_term;
             }
             std::string stem_term;
-            stemmer_->Stem(term_to_stem, stem_term);
+            if (use_stemmer_) {
+                stemmer_->Stem(term_to_stem, stem_term);
+            } else {
+                stem_term = term_to_stem;
+            }
 
             normalize_tokens.push_back(stem_term);
             normalize_positions.emplace_back(start_pos, end_pos);

--- a/src/unit_test/common/analyzer/analyzer_pool_ut.cpp
+++ b/src/unit_test/common/analyzer/analyzer_pool_ut.cpp
@@ -1,0 +1,192 @@
+// Copyright(C) 2023 InfiniFlow, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include "unit_test/gtest_expand.h"
+
+module infinity_core:ut.analyzer_pool;
+
+import :ut.base_test;
+import :term;
+import :analyzer;
+import :analyzer_pool;
+import :rag_analyzer;
+import :status;
+
+using namespace infinity;
+
+namespace fs = std::filesystem;
+
+// Covers AnalyzerPool::GetAnalyzer() name parsing for the RAG analyzer:
+// "rag" optionally followed by '-'-separated segments that are either "fine"
+// or a language name, in any order. The RAGAnalyzer behaviour itself is
+// covered by RAGAnalyzerTest; here we only assert that the name string is
+// translated into the right SetLanguage() / SetFineGrained() calls.
+class AnalyzerPoolTest : public BaseTest {
+public:
+    void SetUp() override {
+        BaseTest::SetUp();
+        fs::path resource_dir = "/usr/share/infinity/resource";
+        resource_available_ = fs::exists(resource_dir);
+        if (!resource_available_) {
+            std::cerr << "Resource directory doesn't exist: " << resource_dir << std::endl;
+        }
+    }
+
+    // Fetches a RAG analyzer from the pool, or nullptr when the resource
+    // directory is missing (the analyzer dictionaries cannot be loaded).
+    std::unique_ptr<RAGAnalyzer> GetRAGAnalyzer(const std::string &name) {
+        auto [analyzer, status] = AnalyzerPool::instance().GetAnalyzer(name);
+        EXPECT_TRUE(status.ok()) << "GetAnalyzer(\"" << name << "\") failed: " << status.message();
+        if (!status.ok() || analyzer == nullptr) {
+            return nullptr;
+        }
+        auto *rag = dynamic_cast<RAGAnalyzer *>(analyzer.get());
+        EXPECT_NE(rag, nullptr) << "GetAnalyzer(\"" << name << "\") did not return a RAGAnalyzer";
+        if (rag == nullptr) {
+            return nullptr;
+        }
+        analyzer.release();
+        return std::unique_ptr<RAGAnalyzer>(rag);
+    }
+
+    // Analyze() is the only place fine-grained tokenization is observable:
+    // Tokenize() is always coarse.
+    static std::vector<std::string> AnalyzeToTokens(RAGAnalyzer &analyzer, const std::string &text) {
+        TermList term_list;
+        analyzer.Analyze(text, term_list);
+        std::vector<std::string> tokens;
+        tokens.reserve(term_list.size());
+        for (const auto &term : term_list) {
+            tokens.push_back(term.text_);
+        }
+        return tokens;
+    }
+
+    bool resource_available_{false};
+
+    // Coarse tokenization keeps this as one token, fine-grained tokenization
+    // splits it into "中华" + "人民共和国".
+    static constexpr const char *GRAIN_PROBE = "中华人民共和国";
+};
+
+TEST_F(AnalyzerPoolTest, test_rag_default_is_english_and_coarse) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    auto analyzer = GetRAGAnalyzer("rag");
+    ASSERT_NE(analyzer, nullptr);
+
+    // English stemming is on by default.
+    EXPECT_EQ(analyzer->Tokenize("running"), "run");
+    // Diacritics are not folded for the default language.
+    EXPECT_NE(analyzer->Tokenize("škola").find("kola"), std::string::npos);
+    EXPECT_EQ(analyzer->Tokenize("škola").find("skola"), std::string::npos);
+    // Coarse grain.
+    EXPECT_EQ(AnalyzeToTokens(*analyzer, GRAIN_PROBE), (std::vector<std::string>{"中华人民共和国"}));
+}
+
+TEST_F(AnalyzerPoolTest, test_rag_fine_keeps_english_stemming) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    auto analyzer = GetRAGAnalyzer("rag-fine");
+    ASSERT_NE(analyzer, nullptr);
+
+    EXPECT_EQ(analyzer->Tokenize("running"), "run");
+    EXPECT_EQ(AnalyzeToTokens(*analyzer, GRAIN_PROBE), (std::vector<std::string>{"中华", "人民共和国"}));
+}
+
+TEST_F(AnalyzerPoolTest, test_rag_slovak_folds_and_disables_stemming) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    auto analyzer = GetRAGAnalyzer("rag-slovak");
+    ASSERT_NE(analyzer, nullptr);
+
+    EXPECT_EQ(analyzer->Tokenize("škola"), "skola");
+    EXPECT_EQ(analyzer->Tokenize("daňové priznanie"), "danove priznanie");
+    // No stemming for Slovak.
+    EXPECT_EQ(analyzer->Tokenize("running"), "running");
+    // Still coarse without a "fine" segment.
+    EXPECT_EQ(AnalyzeToTokens(*analyzer, GRAIN_PROBE), (std::vector<std::string>{"中华人民共和国"}));
+}
+
+TEST_F(AnalyzerPoolTest, test_rag_czech_folds_and_disables_stemming) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    auto analyzer = GetRAGAnalyzer("rag-czech");
+    ASSERT_NE(analyzer, nullptr);
+
+    EXPECT_EQ(analyzer->Tokenize("škola"), "skola");
+    EXPECT_EQ(analyzer->Tokenize("příliš žluťoučký kůň"), "prilis zlutoucky kun");
+    EXPECT_EQ(analyzer->Tokenize("running"), "running");
+    EXPECT_EQ(AnalyzeToTokens(*analyzer, GRAIN_PROBE), (std::vector<std::string>{"中华人民共和国"}));
+}
+
+TEST_F(AnalyzerPoolTest, test_rag_language_and_fine_in_both_orders) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    const std::vector<std::string> expected{"skola", "中华", "人民共和国"};
+    for (const std::string &name : {"rag-czech-fine", "rag-fine-czech", "rag-slovak-fine", "rag-fine-slovak"}) {
+        auto analyzer = GetRAGAnalyzer(name);
+        ASSERT_NE(analyzer, nullptr) << name;
+        EXPECT_EQ(analyzer->Tokenize("škola"), "skola") << name;
+        EXPECT_EQ(analyzer->Tokenize("running"), "running") << name;
+        EXPECT_EQ(AnalyzeToTokens(*analyzer, std::string("škola ") + GRAIN_PROBE), expected) << name;
+    }
+}
+
+TEST_F(AnalyzerPoolTest, test_rag_unknown_segment_falls_back_to_legacy) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    // Unknown languages, an empty segment and a stray trailing '-' must not
+    // crash and must leave the legacy English/coarse behaviour in place.
+    for (const std::string &name : {"rag-", "rag--", "rag-slovakk", "rag-klingon", "rag-nosuchlang"}) {
+        auto analyzer = GetRAGAnalyzer(name);
+        ASSERT_NE(analyzer, nullptr) << name;
+        EXPECT_EQ(analyzer->Tokenize("running"), "run") << name;
+        EXPECT_EQ(analyzer->Tokenize("škola").find("skola"), std::string::npos) << name;
+        EXPECT_EQ(AnalyzeToTokens(*analyzer, GRAIN_PROBE), (std::vector<std::string>{"中华人民共和国"})) << name;
+    }
+
+    // An unknown segment next to "fine" still selects fine-grained.
+    auto analyzer = GetRAGAnalyzer("rag-klingon-fine");
+    ASSERT_NE(analyzer, nullptr);
+    EXPECT_EQ(analyzer->Tokenize("running"), "run");
+    EXPECT_EQ(AnalyzeToTokens(*analyzer, GRAIN_PROBE), (std::vector<std::string>{"中华", "人民共和国"}));
+}
+
+TEST_F(AnalyzerPoolTest, test_rag_analyzers_are_independent) {
+    if (!resource_available_) {
+        FAIL() << "Resource directory not available, skipping test";
+    }
+    // Every GetAnalyzer() call copies the cached prototype; a language-specific
+    // instance must not leak its settings into the next one handed out.
+    auto slovak = GetRAGAnalyzer("rag-slovak");
+    ASSERT_NE(slovak, nullptr);
+    EXPECT_EQ(slovak->Tokenize("škola"), "skola");
+
+    auto english = GetRAGAnalyzer("rag");
+    ASSERT_NE(english, nullptr);
+    EXPECT_EQ(english->Tokenize("running"), "run");
+    EXPECT_EQ(english->Tokenize("škola").find("skola"), std::string::npos);
+
+    // The Slovak instance is unaffected by the later English one.
+    EXPECT_EQ(slovak->Tokenize("daňové"), "danove");
+}

--- a/src/unit_test/common/analyzer/analyzer_pool_ut.cpp
+++ b/src/unit_test/common/analyzer/analyzer_pool_ut.cpp
@@ -36,6 +36,9 @@ namespace fs = std::filesystem;
 // translated into the right SetLanguage() / SetFineGrained() calls.
 class AnalyzerPoolTest : public BaseTest {
 public:
+    // A missing resource directory is a hard failure rather than a GTEST_SKIP,
+    // matching RAGAnalyzerTest and HighlighterTest: CI always mounts it, so
+    // skipping would turn a broken resource setup into a green run.
     void SetUp() override {
         BaseTest::SetUp();
         fs::path resource_dir = "/usr/share/infinity/resource";
@@ -84,7 +87,7 @@ public:
 
 TEST_F(AnalyzerPoolTest, test_rag_default_is_english_and_coarse) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     auto analyzer = GetRAGAnalyzer("rag");
     ASSERT_NE(analyzer, nullptr);
@@ -100,7 +103,7 @@ TEST_F(AnalyzerPoolTest, test_rag_default_is_english_and_coarse) {
 
 TEST_F(AnalyzerPoolTest, test_rag_fine_keeps_english_stemming) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     auto analyzer = GetRAGAnalyzer("rag-fine");
     ASSERT_NE(analyzer, nullptr);
@@ -111,7 +114,7 @@ TEST_F(AnalyzerPoolTest, test_rag_fine_keeps_english_stemming) {
 
 TEST_F(AnalyzerPoolTest, test_rag_slovak_folds_and_disables_stemming) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     auto analyzer = GetRAGAnalyzer("rag-slovak");
     ASSERT_NE(analyzer, nullptr);
@@ -126,7 +129,7 @@ TEST_F(AnalyzerPoolTest, test_rag_slovak_folds_and_disables_stemming) {
 
 TEST_F(AnalyzerPoolTest, test_rag_czech_folds_and_disables_stemming) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     auto analyzer = GetRAGAnalyzer("rag-czech");
     ASSERT_NE(analyzer, nullptr);
@@ -139,7 +142,7 @@ TEST_F(AnalyzerPoolTest, test_rag_czech_folds_and_disables_stemming) {
 
 TEST_F(AnalyzerPoolTest, test_rag_language_and_fine_in_both_orders) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     const std::vector<std::string> expected{"skola", "中华", "人民共和国"};
     for (const std::string &name : {"rag-czech-fine", "rag-fine-czech", "rag-slovak-fine", "rag-fine-slovak"}) {
@@ -153,7 +156,7 @@ TEST_F(AnalyzerPoolTest, test_rag_language_and_fine_in_both_orders) {
 
 TEST_F(AnalyzerPoolTest, test_rag_unknown_segment_falls_back_to_legacy) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     // Unknown languages, an empty segment and a stray trailing '-' must not
     // crash and must leave the legacy English/coarse behaviour in place.
@@ -174,7 +177,7 @@ TEST_F(AnalyzerPoolTest, test_rag_unknown_segment_falls_back_to_legacy) {
 
 TEST_F(AnalyzerPoolTest, test_rag_analyzers_are_independent) {
     if (!resource_available_) {
-        FAIL() << "Resource directory not available, skipping test";
+        FAIL() << "Resource directory /usr/share/infinity/resource not available; the analyzer cannot be loaded";
     }
     // Every GetAnalyzer() call copies the cached prototype; a language-specific
     // instance must not leak its settings into the next one handed out.

--- a/src/unit_test/common/analyzer/rag_analyzer_ut.cpp
+++ b/src/unit_test/common/analyzer/rag_analyzer_ut.cpp
@@ -339,6 +339,115 @@ TEST_F(RAGAnalyzerTest, test_set_language_dutch) {
     EXPECT_EQ(cxx_result, python_result);
 }
 
+TEST_F(RAGAnalyzerTest, test_set_language_slovak) {
+    if (!analyzer_) {
+        FAIL() << "RAGAnalyzer not loaded, skipping test";
+    }
+    // Slovak has no Snowball stemmer; diacritics are folded to ASCII instead.
+    // Compare C++ result with Python result.
+    std::string python_cmd = "uv run " + rag_tokenizer_path_ + "/rag_tokenizer.py " + "-l slovak \"škola daňové priznanie\"";
+    std::cout << "Call Python tokenizer: " << python_cmd << std::endl;
+
+    FILE *pipe = popen(python_cmd.c_str(), "r");
+    std::string python_result;
+    char buffer[128];
+    if (pipe) {
+        while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+            python_result += buffer;
+        }
+        pclose(pipe);
+    }
+    // Remove trailing newline
+    python_result.erase(python_result.find_last_not_of(" \n\r\t") + 1);
+    std::cout << "Python 'škola daňové priznanie' tokenized (Slovak): " << python_result << std::endl;
+
+    analyzer_->SetLanguage("slovak");
+    std::string cxx_result = analyzer_->Tokenize("škola daňové priznanie");
+    std::cout << "C++ 'škola daňové priznanie' tokenized (Slovak): " << cxx_result << std::endl;
+
+    EXPECT_TRUE(cxx_result.find("skola") != std::string::npos);
+    EXPECT_TRUE(cxx_result.find("danove") != std::string::npos);
+    EXPECT_EQ(cxx_result, python_result);
+}
+
+TEST_F(RAGAnalyzerTest, test_set_language_czech) {
+    if (!analyzer_) {
+        FAIL() << "RAGAnalyzer not loaded, skipping test";
+    }
+    std::string python_cmd = "uv run " + rag_tokenizer_path_ + "/rag_tokenizer.py " + "-l czech \"příliš žluťoučký kůň\"";
+    std::cout << "Call Python tokenizer: " << python_cmd << std::endl;
+
+    FILE *pipe = popen(python_cmd.c_str(), "r");
+    std::string python_result;
+    char buffer[128];
+    if (pipe) {
+        while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+            python_result += buffer;
+        }
+        pclose(pipe);
+    }
+    // Remove trailing newline
+    python_result.erase(python_result.find_last_not_of(" \n\r\t") + 1);
+    std::cout << "Python 'příliš žluťoučký kůň' tokenized (Czech): " << python_result << std::endl;
+
+    analyzer_->SetLanguage("czech");
+    std::string cxx_result = analyzer_->Tokenize("příliš žluťoučký kůň");
+    std::cout << "C++ 'příliš žluťoučký kůň' tokenized (Czech): " << cxx_result << std::endl;
+
+    EXPECT_TRUE(cxx_result.find("prilis") != std::string::npos);
+    EXPECT_TRUE(cxx_result.find("zlutoucky") != std::string::npos);
+    EXPECT_TRUE(cxx_result.find("kun") != std::string::npos);
+    EXPECT_EQ(cxx_result, python_result);
+}
+
+TEST_F(RAGAnalyzerTest, test_slovak_no_stemming) {
+    if (!analyzer_) {
+        FAIL() << "RAGAnalyzer not loaded, skipping test";
+    }
+    // Slovak disables stemming and lemmatization: "running" must pass
+    // through unstemmed and "skoly" must keep its inflected form.
+    analyzer_->SetLanguage("slovak");
+    EXPECT_EQ(analyzer_->Tokenize("skoly running"), "skoly running");
+
+    // Switching back to a Snowball language re-enables stemming.
+    analyzer_->SetLanguage("english");
+    EXPECT_EQ(analyzer_->Tokenize("running"), "run");
+}
+
+TEST_F(RAGAnalyzerTest, test_diacritics_folding_table) {
+    // All Slovak letters fold to their ASCII bases, case preserved.
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("áäčďéíĺľňóôŕšťúýž"), "aacdeillnoorstuyz");
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("ÁÄČĎÉÍĹĽŇÓÔŔŠŤÚÝŽ"), "AACDEILLNOORSTUYZ");
+    // Czech letters not in the Slovak alphabet.
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("ěřůý ĚŘŮÝ"), "eruy ERUY");
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("Škola Daňové"), "Skola Danove");
+    // Letters without a single-ASCII-letter NFD decomposition pass through.
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("æœßøłđÆŒØŁĐ"), "æœßøłđÆŒØŁĐ");
+    // ASCII and non-Latin text is untouched.
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("hello world 123"), "hello world 123");
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("中文测试"), "中文测试");
+}
+
+TEST_F(RAGAnalyzerTest, test_slovak_tokenize_with_position) {
+    if (!analyzer_) {
+        FAIL() << "RAGAnalyzer not loaded, skipping test";
+    }
+    // Folding shrinks 2-byte letters to 1 byte; positions must still refer
+    // to byte offsets in the original input ("š" and "ň"/"é" are 2 bytes).
+    analyzer_->SetLanguage("slovak");
+    auto [tokens, positions] = analyzer_->TokenizeWithPosition("škola daňové");
+    ASSERT_EQ(tokens.size(), 2u);
+    EXPECT_EQ(tokens[0], "skola");
+    EXPECT_EQ(tokens[1], "danove");
+    ASSERT_EQ(positions.size(), 2u);
+    EXPECT_EQ(positions[0].first, 0u);
+    // "škola" spans bytes [0, 6) of the original input.
+    EXPECT_EQ(positions[0].second, 6u);
+    // "daňové" spans bytes [7, 15) of the original input.
+    EXPECT_EQ(positions[1].first, 7u);
+    EXPECT_EQ(positions[1].second, 15u);
+}
+
 TEST_F(RAGAnalyzerTest, test_chinese_stopword_filter) {
     if (!analyzer_) {
         FAIL() << "RAGAnalyzer not loaded, skipping test";

--- a/src/unit_test/common/analyzer/rag_analyzer_ut.cpp
+++ b/src/unit_test/common/analyzer/rag_analyzer_ut.cpp
@@ -423,9 +423,54 @@ TEST_F(RAGAnalyzerTest, test_diacritics_folding_table) {
     EXPECT_EQ(RAGAnalyzer::FoldDiacritics("Škola Daňové"), "Skola Danove");
     // Letters without a single-ASCII-letter NFD decomposition pass through.
     EXPECT_EQ(RAGAnalyzer::FoldDiacritics("æœßøłđÆŒØŁĐ"), "æœßøłđÆŒØŁĐ");
+    // Folding is deliberately limited to U+00C0-U+017F. Decomposable letters
+    // outside that range (Latin Extended Additional, precomposed Hangul, …)
+    // are left alone so the table stays in step with rag_tokenizer.py, which
+    // applies the same range guard before consulting unicodedata.
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("ḍṣṭḥ ḌỊ"), "ḍṣṭḥ ḌỊ");
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("한국어"), "한국어");
+    // Combining marks are not stripped either: an already-decomposed "š"
+    // (s + U+030C) keeps both code points on both sides.
+    EXPECT_EQ(RAGAnalyzer::FoldDiacritics("s\u030Ckola"), "s\u030Ckola");
     // ASCII and non-Latin text is untouched.
     EXPECT_EQ(RAGAnalyzer::FoldDiacritics("hello world 123"), "hello world 123");
     EXPECT_EQ(RAGAnalyzer::FoldDiacritics("中文测试"), "中文测试");
+}
+
+TEST_F(RAGAnalyzerTest, test_out_of_range_diacritics_parity_with_python) {
+    if (!analyzer_) {
+        FAIL() << "RAGAnalyzer not loaded, skipping test";
+    }
+    // The C++ fold table covers U+00C0-U+017F only; rag_tokenizer.py applies
+    // the same range guard before NFD. Characters that decompose but sit
+    // outside the range (ḍ, ṣṭḥ) and precomposed Hangul must therefore survive
+    // identically on both sides - this is what keeps the hard-coded table and
+    // the runtime unicodedata lookup from drifting apart.
+    const std::string input = "škola ḍamage 한국어 ṣṭḥ";
+    std::string python_cmd = "uv run " + rag_tokenizer_path_ + "/rag_tokenizer.py " + "-l slovak \"" + input + "\"";
+    std::cout << "Call Python tokenizer: " << python_cmd << std::endl;
+
+    FILE *pipe = popen(python_cmd.c_str(), "r");
+    std::string python_result;
+    char buffer[128];
+    if (pipe) {
+        while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+            python_result += buffer;
+        }
+        pclose(pipe);
+    }
+    python_result.erase(python_result.find_last_not_of(" \n\r\t") + 1);
+    std::cout << "Python tokenized (Slovak): " << python_result << std::endl;
+
+    analyzer_->SetLanguage("slovak");
+    std::string cxx_result = analyzer_->Tokenize(input);
+    std::cout << "C++ tokenized (Slovak): " << cxx_result << std::endl;
+
+    // In-range diacritics fold, out-of-range ones are carried through as-is.
+    EXPECT_TRUE(cxx_result.find("skola") != std::string::npos);
+    EXPECT_TRUE(cxx_result.find("한국어") != std::string::npos);
+    EXPECT_TRUE(cxx_result.find("ṣṭḥ") != std::string::npos);
+    EXPECT_EQ(cxx_result, python_result);
 }
 
 TEST_F(RAGAnalyzerTest, test_slovak_tokenize_with_position) {


### PR DESCRIPTION
### What

Add Slovak and Czech to the RAG analyzer (C++) and to `rag_tokenizer.py` (Python SDK), requested in infiniflow/ragflow#19013.

Both tokenizers only keep ASCII letter runs whole when splitting Latin text, so every accented Slovak or Czech word is fragmented before indexing (`škola` -> `š kola`) and full-text search never matches. Neither language has a Snowball stemmer, so `set_language()` also left whatever stemmer the previous language configured.

### Approach

For `slovak` and `czech`, fold Latin diacritics to ASCII before tokenization and skip stemming/lemmatization. Folding uses the Unicode NFD base letter (`Š` -> `S`, `ď` -> `d`); letters without a single-letter decomposition (`æ`, `ø`, `ł`, `ß`, …) pass through. Applied symmetrically at index and query time, queries typed with or without diacritics match the same tokens. Same split as the Dutch support (#3356): Python and C++ produce byte-identical output.

- **Python SDK**: `fold_diacritics()` via `unicodedata`; `set_language("slovak"|"czech")` flags the instance, `tokenize()` folds, `_normalize_token()` skips the stemmer.
- **C++ `RAGAnalyzer`**: `FoldDiacritics()` with a 192-entry table for U+00C0–U+017F derived from the same NFD rule; `SetLanguage()` disables the stemmer; `TokenizeWithPosition()` maps offsets back onto the unfolded input (2-byte letters shrink to 1 byte).
- **`AnalyzerPool`**: `rag-<language>` and `rag-<language>-fine` analyzer names (`rag-slovak`, `rag-czech-fine`, `rag-fine-czech`) so a table column can select the language server-side. Unknown segments are ignored, existing names behave as before.
- `docs/guides/search_guide.md` documents the suffix.

### Tests

`RAGAnalyzerTest`: C++/Python parity for Slovak and Czech samples (same pattern as the Dutch test), fold table coverage (Slovak/Czech alphabets, pass-through letters, ASCII/CJK untouched), no stemming for Slovak and stemming restored for English, positions on the original input. 12/12 pass locally in `infinity_builder`.
