### PR TITLE
fix(sdk): validate empty thrift array constants

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -712,7 +712,7 @@ def get_remote_constant_expr_from_python_value(value) -> ttypes.ConstantExpr:
         value = int(value)
     elif isinstance(value, np.floating):
         value = float(value)
-    elif isinstance(value, list) and isinstance(value[0], np.ndarray):
+    elif isinstance(value, list) and value and isinstance(value[0], np.ndarray):
         if value[0].ndim <= 2:
             value = [x.tolist() for x in value]
         else:

--- a/python/test_pysdk/test_thrift_constant_expr.py
+++ b/python/test_pysdk/test_thrift_constant_expr.py
@@ -28,14 +28,22 @@ def test_empty_list_constant_is_invalid_expression():
 
 
 @pytest.mark.parametrize(
-    ("value", "literal_type"),
+    ("value", "literal_type", "payload_field", "payload_value"),
     [
-        ([1], ttypes.LiteralType.IntegerArray),
-        (np.array([1]), ttypes.LiteralType.IntegerArray),
-        ([np.array([1, 2])], ttypes.LiteralType.IntegerTensor),
+        ([1], ttypes.LiteralType.IntegerArray, "i64_array_value", [1]),
+        (np.array([1]), ttypes.LiteralType.IntegerArray, "i64_array_value", [1]),
+        (
+            [np.array([1, 2])],
+            ttypes.LiteralType.IntegerTensor,
+            "i64_tensor_value",
+            [[1, 2]],
+        ),
     ],
 )
-def test_non_empty_array_constants_remain_supported(value, literal_type):
+def test_non_empty_array_constants_remain_supported(
+    value, literal_type, payload_field, payload_value
+):
     constant_expression = get_remote_constant_expr_from_python_value(value)
 
     assert constant_expression.literal_type == literal_type
+    assert getattr(constant_expression, payload_field) == payload_value

--- a/python/test_pysdk/test_thrift_constant_expr.py
+++ b/python/test_pysdk/test_thrift_constant_expr.py
@@ -1,0 +1,41 @@
+# Copyright(C) 2026 InfiniFlow, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+from infinity.common import InfinityException
+from infinity.errors import ErrorCode
+from infinity.remote_thrift.infinity_thrift_rpc import ttypes
+from infinity.remote_thrift.utils import get_remote_constant_expr_from_python_value
+
+
+def test_empty_list_constant_is_invalid_expression():
+    with pytest.raises(InfinityException) as exc_info:
+        get_remote_constant_expr_from_python_value([])
+
+    assert exc_info.value.error_code == ErrorCode.INVALID_EXPRESSION
+
+
+@pytest.mark.parametrize(
+    ("value", "literal_type"),
+    [
+        ([1], ttypes.LiteralType.IntegerArray),
+        (np.array([1]), ttypes.LiteralType.IntegerArray),
+        ([np.array([1, 2])], ttypes.LiteralType.IntegerTensor),
+    ],
+)
+def test_non_empty_array_constants_remain_supported(value, literal_type):
+    constant_expression = get_remote_constant_expr_from_python_value(value)
+
+    assert constant_expression.literal_type == literal_type


### PR DESCRIPTION
### Summary

Validate empty list constants before inspecting their first member. Empty lists now raise the SDK's InfinityException with INVALID_EXPRESSION, while non-empty Python and NumPy arrays retain their existing conversion paths.

Tests: uv run pytest python/test_pysdk/test_thrift_constant_expr.py; uvx ruff check python/infinity_sdk/infinity/remote_thrift/utils.py python/test_pysdk/test_thrift_constant_expr.py; uv build.