### PR TITLE
fix(sdk): send search expression in HTTP explain()

### DIFF
--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -925,11 +925,6 @@ class table_http_result:
         self._output = output
         self._highlight = []
         self._filter = ""
-        self._fusion = []
-        self._knn = []
-        self._match = []
-        self._match_tensor = []
-        self._match_sparse = []
         self._search_exprs = []
         self._sort = []
         self._group_by = []
@@ -1011,16 +1006,8 @@ class table_http_result:
         tmp = {}
         if len(self._filter):
             tmp["filter"] = self._filter
-        if len(self._fusion):
-            tmp["fusion"] = self._fusion
-        if len(self._knn):
-            tmp["knn"] = self._knn
-        if len(self._match):
-            tmp["match"] = self._match
-        if len(self._match_tensor):
-            tmp["match_tensor"] = self._match_tensor
-        if len(self._match_sparse):
-            tmp["match_sparse"] = self._match_sparse
+        if len(self._search_exprs):
+            tmp["search"] = self._search_exprs
         if len(self._output):
             tmp["output"] = self._output
         if len(self._highlight):

--- a/python/test_pysdk/test_explain.py
+++ b/python/test_pysdk/test_explain.py
@@ -72,3 +72,24 @@ class TestInfinity:
             print(res)
 
         db_obj.drop_table("test_explain_default"+suffix, ConflictType.Error)
+    def test_explain_with_match_dense(self, suffix):
+        """
+        Regression test: explain() must send the search expression to the server.
+        The HTTP client used to build the explain request from stale fields
+        (_knn/_match/_match_tensor/_match_sparse/_fusion) that were never
+        populated, so every match_*/fusion clause was silently dropped and
+        the server explained a plain table scan instead of the search query.
+        """
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_explain_match_dense"+suffix, ConflictType.Ignore)
+        table = db_obj.create_table("test_explain_match_dense"+suffix, {
+            "c1": {"type": "varchar", "constraints": ["primary key"]},
+            "vec": {"type": "vector,4,float"}}, ConflictType.Error)
+        assert table
+
+        res = table.output(["c1"]).match_dense("vec", [0.1, 0.2, 0.3, 0.4], "float", "l2", 10) \
+            .explain(ExplainType.Physical)
+        # the physical plan of a match_dense query must contain a KNN SCAN operator
+        assert "KNN SCAN" in str(res)
+
+        db_obj.drop_table("test_explain_match_dense"+suffix, ConflictType.Error)


### PR DESCRIPTION
### Summary

`table_http_result.explain()` read search clauses from `self._fusion/_knn/_match/_match_tensor/_match_sparse` - five lists that are initialized empty and never written to. Every `match_*`/`fusion` method appends to `self._search_exprs` instead, so over HTTP the explain request never contained the search expression and the server (`HTTPSearch::Explain` only parses the `"search"` key) returned the plan for a plain table scan instead of the actual search query.

Fixes #3438

Changes:
- `python/infinity_sdk/infinity/infinity_http.py`: `explain()` now sends `self._search_exprs` under the `"search"` key, same as `select()`; removed the five dead fields.
- `python/test_pysdk/test_explain.py`: added `test_explain_with_match_dense`, which asserts that explaining a `match_dense` query produces a physical plan containing `KNN SCAN`.

Verified by capturing the HTTP request payload before/after: `explain()` previously sent no `"search"` key for a query with `match_dense` + `match_text` + `fusion`, and now sends the identical search payload as `select()`. The new regression test is integration-style and needs a running server, so it should be exercised by the http-mode `test_explain` suite in CI.