### PR TITLE
fix(sdk): fix to_string() crash on queries with literal expressions

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -95,25 +95,25 @@ def parsed_expression_to_string(expr: ttypes.ParsedExpr) -> str:
             case ttypes.LiteralType.Boolean:
                 return str(expr_type.constant_expr.bool_value)
             case ttypes.LiteralType.Int64:
-                return str(expr_type.i64_value)
+                return str(expr_type.constant_expr.i64_value)
             case ttypes.LiteralType.Double:
-                return str(expr_type.f64_value)
+                return str(expr_type.constant_expr.f64_value)
             case ttypes.LiteralType.String:
-                return expr_type.str_value
+                return expr_type.constant_expr.str_value
             case ttypes.LiteralType.IntegerArray:
-                return str(expr_type.i64_array_value)
+                return str(expr_type.constant_expr.i64_array_value)
             case ttypes.LiteralType.DoubleArray:
-                return str(expr_type.f64_array_value)
+                return str(expr_type.constant_expr.f64_array_value)
             case ttypes.LiteralType.IntegerTensor:
-                return str(expr_type.i64_tensor_value)
+                return str(expr_type.constant_expr.i64_tensor_value)
             case ttypes.LiteralType.DoubleTensor:
-                return str(expr_type.f64_tensor_value)
+                return str(expr_type.constant_expr.f64_tensor_value)
             case ttypes.LiteralType.IntegerTensorArray:
-                return str(expr_type.i64_tensor_array)
+                return str(expr_type.constant_expr.i64_tensor_array)
             case ttypes.LiteralType.DoubleTensorArray:
-                return str(expr_type.f64_tensor_array)
+                return str(expr_type.constant_expr.f64_tensor_array)
             case ttypes.LiteralType.SparseIntegerArray:
-                return str(expr_type.i64_array_idx)
+                return str(expr_type.constant_expr.i64_array_idx)
 
     if expr_type.column_expr:
         if expr_type.column_expr.column_name:

--- a/python/test_pysdk/test_select.py
+++ b/python/test_pysdk/test_select.py
@@ -2491,3 +2491,26 @@ class TestInfinity:
 
         res = db_obj.drop_table("test_unnest_json_nested" + suffix)
         assert res.error_code == ErrorCode.OK
+
+    @pytest.mark.usefixtures("skip_if_http")
+    def test_to_string(self, suffix):
+        """
+        Regression test: RemoteTable.to_string() must not crash on queries
+        carrying literal expressions. parsed_expression_to_string() used to
+        read literal values from the wrong object (expr_type.i64_value
+        instead of expr_type.constant_expr.i64_value), so any query with a
+        limit, an offset, or a literal in the filter raised AttributeError.
+        """
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_to_string"+suffix, ConflictType.Ignore)
+        table = db_obj.create_table("test_to_string"+suffix, {
+            "c1": {"type": "int", "constraints": ["primary key"]},
+            "c2": {"type": "int"}}, ConflictType.Error)
+        assert table
+
+        res = table.output(["c1"]).filter("c2 > 3").limit(10).offset(5).to_string()
+        assert '"limit": "10"' in res
+        assert '"offset": "5"' in res
+        assert '"filter": ">(c2, 3)"' in res
+
+        db_obj.drop_table("test_to_string"+suffix, ConflictType.Error)


### PR DESCRIPTION
### Summary

`parsed_expression_to_string()` in the remote thrift SDK read literal values from the wrong object - `expr_type.i64_value`/`f64_value`/`str_value`/`i64_array_value`/... instead of `expr_type.constant_expr.*` (only the Boolean case was correct). `ParsedExprType` has no such attributes, so `RemoteTable.to_string()` raised `AttributeError` on any query carrying a `limit`, an `offset`, or a literal in its filter (e.g. `output(["c1"]).filter("c2 > 3").limit(10)`).

Fixes #3440

Changes:
- `python/infinity_sdk/infinity/remote_thrift/utils.py`: read every literal value from `expr_type.constant_expr`.
- `python/test_pysdk/test_select.py`: added `test_to_string` (thrift-only, skipped in http mode since `to_string` is a thrift-SDK API) covering filter + limit + offset.

Verified serverless before/after: `to_string()` raised `AttributeError: 'ParsedExprType' object has no attribute 'i64_value'` before, and now returns `{"db": "default_db", "table": "t", "columns": ["c1"], "filter": ">(c2, 3)", "limit": "10", "offset": "5"}`. The new test is integration-style and needs a running server, so it should be exercised by the thrift-mode test_select suite in CI.