### PR TITLE
Fix HTTP SDK corrupting bool-like varchar values in to_df

### DIFF
--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -1213,12 +1213,18 @@ class table_http_result:
                     sparse_vec = str2sparse(v)
                     new_tup = tup + (sparse_vec,)
                 else:
-                    if v.lower() == 'true':
-                        v = True
-                    elif v.lower() == 'false':
-                        v = False
-                    elif v.lower() == 'none':  # Convert string "None" to Python None
-                        v = None
+                    # The HTTP server serializes boolean columns as the strings
+                    # "true"/"false". Only coerce when the column is actually boolean
+                    # (or has no declared type, e.g. an expression), so varchar cells
+                    # that happen to contain "true"/"false"/"None" are not corrupted.
+                    col_type = col_types.get(col_name)
+                    if col_type is None or col_type.lower() in ("bool", "boolean"):
+                        if v.lower() == 'true':
+                            v = True
+                        elif v.lower() == 'false':
+                            v = False
+                        elif v.lower() == 'none':  # Convert string "None" to Python None
+                            v = None
                     new_tup = tup + (v,)
                 df_dict[col_name] = new_tup
             line_i += 1

--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -61,7 +61,7 @@ def _parse_cast_target_type(cast_expr: str) -> str | None:
     if not cast_expr.lower().startswith("cast("):
         return None
 
-    match = re.search(r'\)\s*AS\s+(\w+)\s*\)$', cast_expr, re.IGNORECASE)
+    match = re.search(r'\bAS\s+(\w+)\s*\)$', cast_expr, re.IGNORECASE)
     if not match:
         return None
 
@@ -1218,7 +1218,16 @@ class table_http_result:
                     # (or has no declared type, e.g. an expression), so varchar cells
                     # that happen to contain "true"/"false"/"None" are not corrupted.
                     col_type = col_types.get(col_name)
-                    if col_type is None or col_type.lower() in ("bool", "boolean"):
+                    if col_type is None:
+                        # No declared type: an expression column. An explicit
+                        # CAST pins the result type (e.g. CAST(c1 AS VARCHAR)
+                        # must stay a string), so only coerce when the cast
+                        # target is boolean or there is no cast at all.
+                        cast_dtype = _parse_cast_target_type(col_name)
+                        coerce_bool = cast_dtype is None or cast_dtype == "boolean"
+                    else:
+                        coerce_bool = col_type.lower() in ("bool", "boolean")
+                    if coerce_bool:
                         if v.lower() == 'true':
                             v = True
                         elif v.lower() == 'false':

--- a/python/test_pysdk/test_select.py
+++ b/python/test_pysdk/test_select.py
@@ -2516,4 +2516,9 @@ class TestInfinity:
         assert res["c1"].tolist() == ["None", "false", "true"]
         assert res["c2"].tolist() == [False, True, True]
 
+        # an explicit CAST pins the result type: CAST(c2 AS VARCHAR) must stay
+        # a string and must not be bool-coerced
+        res, extra_result = table.output(["cast(c2 as varchar)"]).sort([["cast(c2 as varchar)", SortType.Asc]]).to_df()
+        assert res["cast(c2 as varchar)"].tolist() == ["false", "true", "true"]
+
         db_obj.drop_table("test_varchar_bool_like"+suffix, ConflictType.Error)

--- a/python/test_pysdk/test_select.py
+++ b/python/test_pysdk/test_select.py
@@ -2491,3 +2491,29 @@ class TestInfinity:
 
         res = db_obj.drop_table("test_unnest_json_nested" + suffix)
         assert res.error_code == ErrorCode.OK
+
+    def test_select_varchar_bool_like_strings(self, suffix):
+        """
+        Regression test (HTTP SDK): varchar cells containing "true"/"false"/"None"
+        must come back verbatim. The HTTP client used to coerce any string value
+        that looked like a boolean into True/False/None regardless of the column's
+        declared type, corrupting varchar data ("true" -> True -> "True" in the
+        output DataFrame, "None" -> null). The coercion is meant for actual boolean
+        columns, which the HTTP server serializes as the strings "true"/"false".
+        """
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_varchar_bool_like"+suffix, ConflictType.Ignore)
+        table = db_obj.create_table("test_varchar_bool_like"+suffix, {
+            "c1": {"type": "varchar"},
+            "c2": {"type": "bool"}}, ConflictType.Error)
+        assert table
+
+        table.insert([{"c1": "true", "c2": True},
+                      {"c1": "None", "c2": False},
+                      {"c1": "false", "c2": True}])
+
+        res, extra_result = table.output(["c1", "c2"]).sort([["c1", SortType.Asc]]).to_df()
+        assert res["c1"].tolist() == ["None", "false", "true"]
+        assert res["c2"].tolist() == [False, True, True]
+
+        db_obj.drop_table("test_varchar_bool_like"+suffix, ConflictType.Error)


### PR DESCRIPTION
### Summary

Fixes #3442

The HTTP server serializes boolean columns as the strings "true"/"false" (default branch of the value switch in HTTPSearch::Search -> ColumnVector::ToString(row)), so the HTTP Python client coerces matching strings back to booleans in table_http_result.to_result. It did so for ANY string value without checking the column's declared type, so a varchar cell containing "true" came back as True (rendered "True" in the string DataFrame column) and "None" became a null - stored data was corrupted on read. Nulls are already carried by the *_bitmap fields, so the coercion is only ever needed for actual boolean columns.

This change gates the coercion on the declared column type from show_columns_type() (boolean/bool), keeping it for expression columns with no declared type (e.g. "c1 > c2"), and adds a regression test round-tripping "true"/"None"/"false" through a varchar column.

Verified the fix serverless by stubbing the HTTP net layer with the exact JSON shape the server produces: varchar values now pass through verbatim, actual boolean columns still coerce, NULL handling via the bitmap fields is intact, and the "c1 > c2" expression coercion is preserved. The new integration test (test_select_varchar_bool_like_strings in python/test_pysdk/test_select.py) needs a running server and should be exercised in CI, as I could not run the full pysdk suite locally.