### PR TITLE
Fix thrift SDK crash selecting an array-of-embedding column

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/types.py
+++ b/python/infinity_sdk/infinity/remote_thrift/types.py
@@ -320,8 +320,8 @@ def parse_single_array_bytes(column_data_type: ttypes.DataType, bytes_data, offs
             single_pod_element_size = 2
         case ttypes.LogicType.Embedding:
             tmp_column_type = ttypes.ColumnType.ColumnEmbedding
-            embedding_dimension = column_data_type.physical_type.embedding_type.dimension
-            match column_data_type.physical_type.embedding_type.element_type:
+            embedding_dimension = element_data_type.physical_type.embedding_type.dimension
+            match element_data_type.physical_type.embedding_type.element_type:
                 case ttypes.ElementType.ElementBit:
                     single_pod_element_size = embedding_dimension // 8
                 case ttypes.ElementType.ElementUInt8:

--- a/python/test_pysdk/test_insert.py
+++ b/python/test_pysdk/test_insert.py
@@ -845,6 +845,30 @@ class TestInfinity:
         res = db_obj.drop_table("test_insert_array_varchar" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
+    def _test_insert_array_embedding(self, suffix):
+        """
+        target: regression test - select on an array-of-embedding column must not crash
+        the thrift SDK result parser
+        method: create table with array,vector column, insert, read back
+        expected: values round-trip unchanged
+        """
+        if suffix == '_http':
+            pytest.skip("HTTP not support array type")
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_insert_array_embedding" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table("test_insert_array_embedding" + suffix,
+                                        {"c1": {"type": "array,vector,4,float"}},
+                                        ConflictType.Error)
+        assert table_obj
+        res = table_obj.insert([{"c1": Array([1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0])}])
+        assert res.error_code == ErrorCode.OK
+        res, extra_result = table_obj.output(["*"]).to_df()
+        print(res)
+        pd.testing.assert_frame_equal(res, pd.DataFrame(
+            {'c1': ([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]],)}))
+        res = db_obj.drop_table("test_insert_array_embedding" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
     def test_insert(self, suffix):
         # self.test_infinity_obj._test_version()
         self._test_insert_basic(suffix)
@@ -871,6 +895,7 @@ class TestInfinity:
         self._test_insert_tensor_array(suffix)
         self._test_insert_array(suffix)
         self._test_insert_array_varchar(suffix)
+        self._test_insert_array_embedding(suffix)
 
     def test_insert_rows_mismatch(self, suffix):
         db_obj = self.infinity_obj.get_database("default_db")


### PR DESCRIPTION
### Summary

Fixes #3444

parse_single_array_bytes() in the thrift SDK read the embedding dimension and element type from column_data_type.physical_type.embedding_type, but for an array column the DataType union carries array_type, so embedding_type is None and any select over an array-of-embedding column ("array,vector,N,float") crashed with AttributeError: 'NoneType' object has no attribute 'dimension'.

The embedding info lives on element_data_type (the array's element DataType, already extracted at the top of the function). This matches the wire layout the server writes (InfinityThriftService::HandleArrayTypeRecursively: i32 element count, then count * dimension * element-size raw bytes), and the downstream column_vector_to_list call already receives element_data_type, so only the size computation was wrong.

Two-line fix plus a regression test (_test_insert_array_embedding in python/test_pysdk/test_insert.py) that creates an array,vector,4,float column, inserts, and reads the values back.

Verified serverless by feeding parse_single_array_bytes the exact wire bytes the server produces: crashed with AttributeError before the fix, returns [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]] after. The new integration test needs a running server and should be exercised in CI, as I could not run the full pysdk suite locally.