### PR TITLE
Fix broken IndexInfo equality and hashing in the Python SDKs

### DIFF
--- a/python/infinity_embedded/index.py
+++ b/python/infinity_embedded/index.py
@@ -90,10 +90,11 @@ class IndexInfo:
         return self.__str__()
 
     def __eq__(self, other):
-        return self.column_name == other.index_name and self.index_type == other.index_type and self.params == other.params
+        return self.column_name == other.column_name and self.index_type == other.index_type and self.params == other.params
 
     def __hash__(self):
-        return hash((self.column_name, self.index_type, self.params))
+        params = tuple(sorted(self.params.items())) if self.params else None
+        return hash((self.column_name, self.index_type, params))
 
     def to_local_type(self):
         index_info_to_use = WrapIndexInfo()

--- a/python/infinity_sdk/infinity/index.py
+++ b/python/infinity_sdk/infinity/index.py
@@ -97,7 +97,8 @@ class IndexInfo:
         return self.target_name == other.target_name and self.index_type == other.index_type and self.params == other.params
 
     def __hash__(self):
-        return hash((self.target_name, self.index_type, self.params))
+        params = tuple(sorted(self.params.items())) if self.params else None
+        return hash((self.target_name, self.index_type, params))
 
     def to_ttype(self):
         init_params_list = []

--- a/python/test_pysdk/test_index.py
+++ b/python/test_pysdk/test_index.py
@@ -1527,3 +1527,25 @@ class TestInfinity:
         assert res.error_code == ErrorCode.OK
         res = db_obj.drop_table("test_dump_index" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
+
+def test_index_info_eq_and_hash():
+    """
+    Regression test: IndexInfo equality and hashing must work.
+    The embedded SDK's IndexInfo.__eq__ compared against a nonexistent
+    other.index_name attribute (AttributeError on any ==), and both
+    packages' __hash__ included the params dict directly
+    (TypeError: unhashable type: 'dict').
+    """
+    from infinity.index import IndexInfo, IndexType
+
+    a = IndexInfo("c1", IndexType.Hnsw, {"M": "16", "ef": "200"})
+    b = IndexInfo("c1", IndexType.Hnsw, {"ef": "200", "M": "16"})
+    c = IndexInfo("c2", IndexType.Hnsw, {"M": "16", "ef": "200"})
+    d = IndexInfo("c1", IndexType.Hnsw)  # no params
+
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != c
+    assert d == IndexInfo("c1", IndexType.Hnsw)
+    assert hash(d) == hash(IndexInfo("c1", IndexType.Hnsw))
+    assert len({a, b, c, d}) == 3


### PR DESCRIPTION
### Summary

Fixes #3446

Two broken dunder methods on IndexInfo:

1. The embedded SDK's IndexInfo.__eq__ (python/infinity_embedded/index.py) compared against other.index_name, an attribute that does not exist - the field is column_name - so any == comparison between two IndexInfo objects raised AttributeError.

2. In both packages, __hash__ put the params dict straight into the hash tuple, so hashing any IndexInfo created with init params (the normal case, e.g. HNSW M/ef) raised TypeError: unhashable type: 'dict'.

This change fixes the attribute name in the embedded __eq__ and hashes params as tuple(sorted(params.items())) in both packages, keeping __eq__ and __hash__ consistent and insensitive to dict ordering. Adds a regression test (test_index_info_eq_and_hash in python/test_pysdk/test_index.py) that runs without a server.

Verified locally: equal IndexInfo objects now compare True with equal hashes, distinct ones compare False, dict insertion order does not matter, param-less IndexInfo works, and a set of them dedupes correctly. The embedded-side fix was verified the same way with the compiled extension module stubbed, since building it locally is not feasible here.