### PR TITLE
Fix thrift SDK crash rendering explain output with constants

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -95,25 +95,25 @@ def parsed_expression_to_string(expr: ttypes.ParsedExpr) -> str:
             case ttypes.LiteralType.Boolean:
                 return str(expr_type.constant_expr.bool_value)
             case ttypes.LiteralType.Int64:
-                return str(expr_type.i64_value)
+                return str(expr_type.constant_expr.i64_value)
             case ttypes.LiteralType.Double:
-                return str(expr_type.f64_value)
+                return str(expr_type.constant_expr.f64_value)
             case ttypes.LiteralType.String:
-                return expr_type.str_value
+                return expr_type.constant_expr.str_value
             case ttypes.LiteralType.IntegerArray:
-                return str(expr_type.i64_array_value)
+                return str(expr_type.constant_expr.i64_array_value)
             case ttypes.LiteralType.DoubleArray:
-                return str(expr_type.f64_array_value)
+                return str(expr_type.constant_expr.f64_array_value)
             case ttypes.LiteralType.IntegerTensor:
-                return str(expr_type.i64_tensor_value)
+                return str(expr_type.constant_expr.i64_tensor_value)
             case ttypes.LiteralType.DoubleTensor:
-                return str(expr_type.f64_tensor_value)
+                return str(expr_type.constant_expr.f64_tensor_value)
             case ttypes.LiteralType.IntegerTensorArray:
-                return str(expr_type.i64_tensor_array)
+                return str(expr_type.constant_expr.i64_tensor_array_value)
             case ttypes.LiteralType.DoubleTensorArray:
-                return str(expr_type.f64_tensor_array)
+                return str(expr_type.constant_expr.f64_tensor_array_value)
             case ttypes.LiteralType.SparseIntegerArray:
-                return str(expr_type.i64_array_idx)
+                return str(expr_type.constant_expr.i64_array_idx)
 
     if expr_type.column_expr:
         if expr_type.column_expr.column_name:

--- a/python/test_pysdk/test_explain.py
+++ b/python/test_pysdk/test_explain.py
@@ -103,3 +103,12 @@ def test_parsed_expression_to_string_constants():
     assert parsed_expression_to_string(
         mk(ttypes.LiteralType.IntegerTensorArray,
            i64_tensor_array_value=[[[1, 2], [3, 4]]])) == "[[[1, 2], [3, 4]]]"
+    assert parsed_expression_to_string(
+        mk(ttypes.LiteralType.DoubleArray, f64_array_value=[1.5, 2.5])) == "[1.5, 2.5]"
+    assert parsed_expression_to_string(
+        mk(ttypes.LiteralType.IntegerTensor, i64_tensor_value=[[1, 2]])) == "[[1, 2]]"
+    assert parsed_expression_to_string(
+        mk(ttypes.LiteralType.DoubleTensorArray,
+           f64_tensor_array_value=[[[1.5]]])) == "[[[1.5]]]"
+    assert parsed_expression_to_string(
+        mk(ttypes.LiteralType.SparseIntegerArray, i64_array_idx=[0, 3])) == "[0, 3]"

--- a/python/test_pysdk/test_explain.py
+++ b/python/test_pysdk/test_explain.py
@@ -72,3 +72,34 @@ class TestInfinity:
             print(res)
 
         db_obj.drop_table("test_explain_default"+suffix, ConflictType.Error)
+
+def test_parsed_expression_to_string_constants():
+    """
+    Regression test: parsed_expression_to_string() read constant values from
+    expr_type (ParsedExprType) instead of expr_type.constant_expr, so every
+    constant literal except Boolean crashed with AttributeError when an
+    explain result with a limit/offset/filter was rendered (thrift SDK).
+    Two tensor-array branches also used stale field names without the _value
+    suffix.
+    """
+    from infinity.remote_thrift.utils import parsed_expression_to_string
+    from infinity.remote_thrift.infinity_thrift_rpc import ttypes
+
+    def mk(literal_type, **kw):
+        constant_expr = ttypes.ConstantExpr(literal_type=literal_type, **kw)
+        expr_type = ttypes.ParsedExprType()
+        expr_type.constant_expr = constant_expr
+        expr = ttypes.ParsedExpr()
+        expr.type = expr_type
+        return expr
+
+    assert parsed_expression_to_string(mk(ttypes.LiteralType.Int64, i64_value=10)) == "10"
+    assert parsed_expression_to_string(mk(ttypes.LiteralType.Double, f64_value=1.5)) == "1.5"
+    assert parsed_expression_to_string(mk(ttypes.LiteralType.String, str_value="abc")) == "abc"
+    assert parsed_expression_to_string(mk(ttypes.LiteralType.Boolean, bool_value=True)) == "True"
+    assert parsed_expression_to_string(mk(ttypes.LiteralType.IntegerArray, i64_array_value=[1, 2])) == "[1, 2]"
+    assert parsed_expression_to_string(
+        mk(ttypes.LiteralType.DoubleTensor, f64_tensor_value=[[1.0, 2.0]])) == "[[1.0, 2.0]]"
+    assert parsed_expression_to_string(
+        mk(ttypes.LiteralType.IntegerTensorArray,
+           i64_tensor_array_value=[[[1, 2], [3, 4]]])) == "[[[1, 2], [3, 4]]]"


### PR DESCRIPTION
### Summary

Fixes #3448

parsed_expression_to_string() (python/infinity_sdk/infinity/remote_thrift/utils.py), used by table._to_string to render explain results over thrift, read constant literal values from expr_type (ParsedExprType) instead of expr_type.constant_expr. ParsedExprType has no such fields, so any explain output containing a constant - a limit, an offset, a literal in a filter - crashed with AttributeError: 'ParsedExprType' object has no attribute 'i64_value'. Only the Boolean branch read from the right place; Int64, Double, String, and all array/tensor branches were broken. The two tensor-array branches additionally used stale field names missing the _value suffix (i64_tensor_array / f64_tensor_array instead of i64_tensor_array_value / f64_tensor_array_value).

This change reads every constant value from constant_expr, corrects the tensor-array field names, and adds a regression test (test_parsed_expression_to_string_constants in python/test_pysdk/test_explain.py) that covers every literal branch and runs without a server. Test passes locally.