### PR TITLE
Fix HTTP SDK corrupting list-like and sparse-like varchar values in to_df

### DIFF
--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -1202,14 +1202,24 @@ class table_http_result:
                 if len(tup) == line_i + 1:
                     continue
 
+                declared_type = col_types.get(col_name)
                 if v is None or isinstance(v, (int, float)):
                     new_tup = tup + (v,)
-                elif is_list(v) and not is_json_function(col_name):
+                elif (is_list(v) and not is_json_function(col_name)
+                      and (declared_type is None
+                           or declared_type.lower().startswith(
+                               ("embedding", "tensor", "multivector", "array", "emptyarray")))):
+                    # Only parse stringified lists for vector/array columns (or
+                    # expression columns with no declared type); a varchar cell
+                    # that happens to contain "[1, 2]" must stay a string.
                     # Don't parse lists for JSON extraction functions - keep them as strings
                     new_tup = tup + (ast.literal_eval(v),)
                 elif is_date(v) or is_time(v) or is_datetime(v):
                     new_tup = tup + (v,)
-                elif is_sparse(v):  # sparse vector
+                elif (is_sparse(v)
+                      and (declared_type is None or declared_type.lower().startswith("sparse"))):
+                    # sparse vector - only parse when the column is declared
+                    # sparse (or untyped); a varchar like "12:30" is not sparse
                     sparse_vec = str2sparse(v)
                     new_tup = tup + (sparse_vec,)
                 else:

--- a/python/test_pysdk/test_select.py
+++ b/python/test_pysdk/test_select.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from common.utils import copy_data
 from infinity import index
-from infinity.common import ConflictType, SortType
+from infinity.common import ConflictType, SortType, SparseVector
 from infinity.errors import ErrorCode
 from infinity.infinity_http import infinity_http
 
@@ -2491,3 +2491,29 @@ class TestInfinity:
 
         res = db_obj.drop_table("test_unnest_json_nested" + suffix)
         assert res.error_code == ErrorCode.OK
+
+    def test_select_varchar_list_and_sparse_like_strings(self, suffix):
+        """
+        Regression test (HTTP SDK): varchar cells containing strings that look
+        like lists ("[1, 2]") or sparse vectors ("12:30") must come back
+        verbatim. The HTTP client used to ast.literal_eval any list-looking
+        string and str2sparse any "idx:value" string regardless of the column's
+        declared type, corrupting varchar data. Those conversions are meant for
+        vector/array and sparse columns, which the HTTP server serializes as
+        strings.
+        """
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_varchar_list_sparse"+suffix, ConflictType.Ignore)
+        table = db_obj.create_table("test_varchar_list_sparse"+suffix, {
+            "c1": {"type": "varchar"},
+            "c2": {"type": "sparse,100,float,int"}}, ConflictType.Error)
+        assert table
+
+        table.insert([{"c1": "[1, 2]", "c2": SparseVector([3, 7], [1.5, 2.5])},
+                      {"c1": "12:30", "c2": SparseVector([1], [0.5])}])
+
+        res, extra_result = table.output(["c1", "c2"]).sort([["c1", SortType.Asc]]).to_df()
+        assert res["c1"].tolist() == ["12:30", "[1, 2]"]
+        assert res["c2"].tolist() == [{"1": 0.5}, {"3": 1.5, "7": 2.5}]
+
+        db_obj.drop_table("test_varchar_list_sparse"+suffix, ConflictType.Error)


### PR DESCRIPTION
### Summary

Fixes #3450

The HTTP server serializes vector/array and sparse columns as strings ("[0.1, 0.2]", "[3:1.5,7:2.5]" via ColumnVector::ToString), so the HTTP client's to_result parses list-looking strings with ast.literal_eval and sparse-looking strings with str2sparse. It did so for ANY string value without checking the column's declared type, so a varchar cell containing "[1, 2]" came back as the list [1, 2] and "12:30" as the dict {"12": 30} - stored data corrupted on read. Same class of issue as the bool-like varchar corruption fixed in #3443.

This change gates both conversions on the declared column type from show_columns_type(): list parsing only for embedding/tensor/multivector/array columns, sparse parsing only for sparse columns, keeping the heuristics for expression columns with no declared type. Adds a regression test (test_select_varchar_list_and_sparse_like_strings in python/test_pysdk/test_select.py) round-tripping "[1, 2]" and "12:30" through a varchar column alongside a real sparse column.

Verified serverless by stubbing show_columns_type and feeding the exact JSON shape the server produces: varchar values now pass through verbatim, embedding lists and sparse vectors still parse, and bool coercion (declared bool columns and untyped expressions) is intact. The new integration test needs a running server and should be exercised in CI, as I could not run the full pysdk suite locally.