### PR TITLE
Fix embedded SDK crash selecting an array-of-embedding column

### DIFF
--- a/python/infinity_embedded/local_infinity/types.py
+++ b/python/infinity_embedded/local_infinity/types.py
@@ -166,8 +166,8 @@ def parse_single_array_bytes(column_data_type: WrapDataType, bytes_data, offset)
         case LogicalType.kBFloat16:
             single_pod_element_size = 2
         case LogicalType.kEmbedding:
-            embedding_dimension = column_data_type.embedding_type.dimension
-            match column_data_type.embedding_type.element_type:
+            embedding_dimension = element_data_type.embedding_type.dimension
+            match element_data_type.embedding_type.element_type:
                 case EmbeddingDataType.kElemBit:
                     single_pod_element_size = embedding_dimension // 8
                 case EmbeddingDataType.kElemUInt8:

--- a/python/test_pysdk/test_select.py
+++ b/python/test_pysdk/test_select.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from common.utils import copy_data
 from infinity import index
-from infinity.common import ConflictType, SortType
+from infinity.common import Array, ConflictType, SortType
 from infinity.errors import ErrorCode
 from infinity.infinity_http import infinity_http
 
@@ -195,6 +195,28 @@ class TestInfinity:
 
         res = db_obj.drop_table("test_select" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
+
+    def test_select_array_embedding_embedded(self, suffix, request):
+        # embedded-only regression test: selecting an array-of-embedding column
+        # crashed the embedded SDK result parser (parse_single_array_bytes read
+        # the embedding info from the array's WrapDataType instead of the
+        # element's, so the element size came out 0 and the parser asserted)
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_select_array_embedding_embedded" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table("test_select_array_embedding_embedded" + suffix,
+                                        {"c1": {"type": "array,vector,4,float"}},
+                                        ConflictType.Error)
+        assert table_obj
+        res = table_obj.insert([{"c1": Array([1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0])}])
+        assert res.error_code == ErrorCode.OK
+        res, extra_result = table_obj.output(["*"]).to_df()
+        pd.testing.assert_frame_equal(res, pd.DataFrame(
+            {'c1': ([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]],)}))
+        res = db_obj.drop_table("test_select_array_embedding_embedded" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
 
     def test_select_json(self, suffix):
         db_obj = self.infinity_obj.get_database("default_db")


### PR DESCRIPTION
### Summary

- `parse_single_array_bytes()` in the embedded SDK read the embedding dimension/element type from `column_data_type.embedding_type`; for an array column the `WrapDataType` union carries `array_type` and `embedding_type` stays zero-initialized, so the element size computed to 0 and any select over an `array,vector` column died on `assert single_pod_element_size > 0`.
- Read the embedding info from `element_data_type.embedding_type` (the array's element `WrapDataType`), matching the byte layout the engine writes. Same root cause as the thrift-side fix in #3445; this covers the embedded package.
- Regression test `test_select_array_embedding_embedded` in `test_select.py` round-trips an `array,vector,4,float` column; it is scoped to `--local-infinity` runs so it does not depend on the still-open thrift-side fix. Verified the parser fix against hand-built wire bytes with a stubbed `WrapDataType` (crash before, correct values after); like the rest of the pysdk suite the full test needs a running embedded instance.

Fixes #3454