### PR TITLE
Fix embedded SDK filters crashing with AttributeError on current sqlglot

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -58,7 +58,7 @@ def traverse_conditions(cons, fn=None):
             cons.key.lower())  # key is the function name cover to >, <, >=, <=, =, and, or, etc.
 
         arguments = []
-        for value in cons.hashable_args:
+        for value in (cons.this, cons.expression):
             if fn:
                 expr = fn(value)
             else:
@@ -91,7 +91,7 @@ def traverse_conditions(cons, fn=None):
         function_expr = WrapFunctionExpr()
         function_expr.func_name = "not"
         arguments = []
-        for value in cons.hashable_args:
+        for value in (cons.this,):
             if fn:
                 expr = fn(value)
             else:
@@ -146,13 +146,12 @@ def traverse_conditions(cons, fn=None):
         return parsed_expr
 
     elif isinstance(cons, exp.Paren):
-        for value in cons.hashable_args:
-            return traverse_conditions(value)
+        return traverse_conditions(cons.this)
 
     elif isinstance(cons, exp.Neg):
         func_expr = WrapFunctionExpr()
         func_expr.func_name = '-'
-        func_expr.arguments = [parse_expr(cons.hashable_args[0])]
+        func_expr.arguments = [parse_expr(cons.args['this'])]
         parsed_expr = WrapParsedExpr()
         parsed_expr.type = ParsedExprType.kFunction
         parsed_expr.function_expr = func_expr

--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -146,6 +146,8 @@ def traverse_conditions(cons, fn=None):
         return parsed_expr
 
     elif isinstance(cons, exp.Paren):
+        if fn:
+            return fn(cons.this)
         return traverse_conditions(cons.this)
 
     elif isinstance(cons, exp.Neg):

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -61,8 +61,16 @@ class TestInfinity:
             "-8 < c1 and c1 <= -7",
             "(-7 < c1 or 9 <= c1) and (c1 = 3)",
             "!(9 <= c1)",
+            "c1 IN (1,2,3)",
+            "c1 NOT IN (1,2,3)",
         ]:
             res = embedded_traverse(condition(cond_str))
             print(cond_str)
             print(res)
             assert res
+
+        # operand order must be stable: column first, literal second
+        res = embedded_traverse(condition("c1 > 1"))
+        args = res.function_expr.arguments
+        assert getattr(args[0], "column_expr", None) is not None
+        assert getattr(args[1], "constant_expr", None) is not None

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,23 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_condition_embedded(self, request):
+        # embedded SDK filter traversal must work with current sqlglot releases
+        # (hashable_args was removed from sqlglot; using it crashed every
+        # binary/NOT/paren/negated filter with AttributeError)
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.local_infinity.utils import traverse_conditions as embedded_traverse
+        for cond_str in [
+            "c1 = 1",
+            "c1 != 1",
+            "c1 > 1 and c2 < 2 or c3 = 3.3",
+            "-8 < c1 and c1 <= -7",
+            "(-7 < c1 or 9 <= c1) and (c1 = 3)",
+            "!(9 <= c1)",
+        ]:
+            res = embedded_traverse(condition(cond_str))
+            print(cond_str)
+            print(res)
+            assert res


### PR DESCRIPTION
### Summary

- `traverse_conditions()` in the embedded SDK read operands via `cons.hashable_args` in the Binary/Not/Paren/Neg arms; sqlglot removed that property (repo pins `sqlglot[rs]>=27.10.0`, current releases are 30.x), so every comparison / AND / OR / NOT / parenthesized / negated filter in embedded mode crashed with `AttributeError: ... has no attribute 'hashable_args'`.
- Take the operands explicitly instead: `(cons.this, cons.expression)` for Binary, `cons.this` for Not/Paren/Neg. This also fixes a latent operand-order bug: `hashable_args` yielded a frozenset of `(key, value)` pairs, so the argument order of comparison filters was hash-dependent and could flip between runs.
- Regression test `test_condition_embedded` in `test_condition.py` (scoped to `--local-infinity` runs) traverses the same condition list the thrift-side test covers. Verified serverless against sqlglot 30.18 with a stubbed extension module: all listed conditions traverse, and `c1 > 1` builds operands in stable `[column, constant]` order.

Fixes #3458