### PR TITLE
Fix thrift SDK evaluating NOT LIKE filters as LIKE on current sqlglot

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -251,7 +251,10 @@ def _parse_like(like_node, escape_char=None):
     """Parse a Like node into a ParsedExpr."""
     parsed_expr = ttypes.ParsedExpr()
     function_expr = ttypes.FunctionExpr()
-    function_expr.function_name = binary_exp_to_paser_exp('like')
+    # sqlglot >= 30.x parses NOT LIKE as a Like node with negate=True instead
+    # of wrapping it in a Not node, so the negation must be read off the node.
+    function_expr.function_name = binary_exp_to_paser_exp(
+        'notlike' if like_node.args.get('negate') else 'like')
 
     left_expr = parse_expr(like_node.args['this'])
     pattern_expr = parse_expr(like_node.args['expression'])

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,17 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_condition_like_function_names(self):
+        # sqlglot >= 30.x parses NOT LIKE as a Like node with negate=True
+        # rather than a Not(Like) wrapper; the traversal must honor the flag.
+        cases = {
+            "c1 LIKE '%test%'": "like",
+            "c1 NOT LIKE '%test%'": "not_like",
+            "c1 LIKE '%test%' ESCAPE '!'": "like",
+            "c1 NOT LIKE '%test%' ESCAPE '!'": "not_like",
+        }
+        for cond_str, expected_func in cases.items():
+            res = traverse_conditions(condition(cond_str))
+            func_name = res.type.function_expr.function_name
+            assert func_name == expected_func, f"{cond_str}: got {func_name}, want {expected_func}"


### PR DESCRIPTION
### Summary

sqlglot >= 30.x parses `NOT LIKE` as a `Like` node with `negate=True` instead of a `Not(Like)` wrapper. `_parse_like()` hardcoded the `like` function name, so `NOT LIKE` (with or without `ESCAPE`) was silently evaluated as `LIKE`, returning inverted filter results.

- Read the `negate` flag when choosing between the `like` and `not_like` server functions (both registered in `src/function/scalar/like_impl.cpp`).
- Regression test asserts the generated function name for all four forms; the previous test only asserted a truthy result, which is how this slipped through.

Note: pysdk tests require a running server; the traversal fix itself was verified directly against `traverse_conditions` with sqlglot 30.18.0.

Fixes #3461