### PR TITLE
Fix JSON -> and ->> operators crashing both Python SDKs

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -51,6 +51,28 @@ def traverse_conditions(cons, fn=None):
         expr.alias_name = cons.alias
         return expr
 
+    elif isinstance(cons, (exp.JSONExtract, exp.JSONExtractScalar)):
+        # JSON operators -> and ->>. sqlglot parses the right side as a
+        # JSONPath node; the server functions take the path as a string.
+        func_expr = WrapFunctionExpr()
+        func_expr.func_name = (
+            'json_extract_string' if isinstance(cons, exp.JSONExtractScalar) else 'json_extract')
+
+        json_expr = parse_expr(cons.args['this'])
+        path_sql = cons.args['expression'].sql()
+        if len(path_sql) >= 2 and path_sql.startswith("'") and path_sql.endswith("'"):
+            path_sql = path_sql[1:-1]
+        path_constant = WrapConstantExpr()
+        path_constant.literal_type = LiteralType.kString
+        path_constant.str_value = path_sql
+        path_expr = WrapParsedExpr(ParsedExprType.kConstant)
+        path_expr.constant_expr = path_constant
+
+        func_expr.arguments = [json_expr, path_expr]
+        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
+        parsed_expr.function_expr = func_expr
+        return parsed_expr
+
     if isinstance(cons, exp.Binary):
         parsed_expr = WrapParsedExpr()
         function_expr = WrapFunctionExpr()

--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -349,6 +349,31 @@ def traverse_conditions(cons: exp.Condition, fn=None) -> ttypes.ParsedExpr:
         parser_expr_type.function_expr = function_expr
         parsed_expr.type = parser_expr_type
         return parsed_expr
+    elif isinstance(cons, (exp.JSONExtract, exp.JSONExtractScalar)):
+        # JSON operators -> and ->>. sqlglot parses the right side as a
+        # JSONPath node; the server functions take the path as a string.
+        function_expr = ttypes.FunctionExpr()
+        function_expr.function_name = (
+            'json_extract_string' if isinstance(cons, exp.JSONExtractScalar) else 'json_extract')
+
+        json_expr = parse_expr(cons.args['this'])
+        path_sql = cons.args['expression'].sql()
+        if len(path_sql) >= 2 and path_sql.startswith("'") and path_sql.endswith("'"):
+            path_sql = path_sql[1:-1]
+        path_expr = ttypes.ParsedExpr()
+        path_constant = ttypes.ConstantExpr()
+        path_constant.literal_type = ttypes.LiteralType.String
+        path_constant.str_value = path_sql
+        path_expr_type = ttypes.ParsedExprType()
+        path_expr_type.constant_expr = path_constant
+        path_expr.type = path_expr_type
+
+        function_expr.arguments = [json_expr, path_expr]
+        parser_expr_type = ttypes.ParsedExprType()
+        parser_expr_type.function_expr = function_expr
+        parsed_expr = ttypes.ParsedExpr()
+        parsed_expr.type = parser_expr_type
+        return parsed_expr
     elif isinstance(cons, exp.Binary):
         parsed_expr = ttypes.ParsedExpr()
         function_expr = ttypes.FunctionExpr()

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -39,6 +39,8 @@ class TestInfinity:
             "c1 NOT LIKE '%test%'",
             "c1 LIKE '%test%' ESCAPE '!'",
             "c1 NOT LIKE '%test%' ESCAPE '!'",
+            "c3->'a' = 'x'",
+            "c3->>'a' = 'x'",
         ]:
             print(cond_str)
             cond = condition(cond_str)
@@ -46,3 +48,34 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_condition_json_operators(self):
+        # -> and ->> must map to the json_extract / json_extract_string
+        # server functions with the JSON path passed as a string constant;
+        # previously -> recursed until RecursionError and ->> raised
+        # "unknown binary expression: jsonextractscalar".
+        for cond_str, expected_func in [
+            ("c3->'a' = 'x'", "json_extract"),
+            ("c3->>'a' = 'x'", "json_extract_string"),
+        ]:
+            res = traverse_conditions(condition(cond_str))
+            args = res.type.function_expr.arguments
+            inner = args[0].type.function_expr
+            assert inner.function_name == expected_func, f"{cond_str}: got {inner.function_name}"
+            path_const = inner.arguments[1].type.constant_expr
+            assert path_const.str_value == "$.a", f"{cond_str}: got path {path_const.str_value}"
+
+    def test_json_operators_embedded(self, request):
+        # embedded SDK output traversal must support the JSON operators too
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from sqlglot import parse_one
+        from infinity_embedded.local_infinity.utils import parse_expr as embedded_parse_expr
+        for output_str, expected_func in [
+            ("c3->'a'", "json_extract"),
+            ("c3->>'a'", "json_extract_string"),
+            ("c3->'a'->>'b'", "json_extract_string"),
+        ]:
+            res = embedded_parse_expr(parse_one(output_str))
+            assert res.function_expr.func_name == expected_func, f"{output_str}: got {res.function_expr.func_name}"
+            assert res.function_expr.arguments[1].constant_expr.str_value.endswith("b" if output_str.endswith("b'") else "a")


### PR DESCRIPTION
### Summary

The JSON operators `->` / `->>` crashed in both Python SDKs while the server supports them (`json_extract` / `json_extract_string` are registered, and the explicit `json_extract(c3,'$.2')` call form already works):

- **thrift**: `->` infinite-recursed in the traversal's `else` fallback (`cons[1]` builds a new `Bracket` node on current sqlglot, so the fallback calls itself forever); `->>` raised `unknown binary expression: jsonextractscalar` (the operator map's `jsonextractstring` key never matches sqlglot's key).
- **embedded**: both operators raised `unknown binary expression` since the embedded operator map has no JSON entries.

Each SDK gets a dedicated `JSONExtract` / `JSONExtractScalar` traversal arm mapping `->` to `json_extract` and `->>` to `json_extract_string`, with the `JSONPath` node converted to the string constant the server functions take (`data->'a'` -> `json_extract(data, '$.a')`). Regression tests assert the generated function name and path constant for both SDKs.

Note: pysdk tests require a running server; the traversal changes were verified directly against `traverse_conditions` / `parse_expr` with sqlglot 30.18.0.

Fixes #3463