### PR TITLE
Fix embedded SDK rejecting all LIKE / NOT LIKE / ESCAPE filters

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -45,13 +45,52 @@ from infinity_embedded.local_infinity.types import build_result, logic_type_to_d
 from infinity_embedded.utils import binary_exp_to_paser_exp
 
 
+def _make_escape_expr(escape_char=None):
+    """Create escape expression, using explicit escape char if provided."""
+    escape_constant = WrapConstantExpr()
+    escape_constant.literal_type = LiteralType.kString
+    # escape_char may be a sqlglot Literal or a plain string
+    if escape_char is not None:
+        if hasattr(escape_char, 'output_name'):
+            escape_value = escape_char.output_name
+        else:
+            escape_value = str(escape_char)
+    else:
+        escape_value = "\\"
+    escape_constant.str_value = escape_value
+    escape_expr = WrapParsedExpr(ParsedExprType.kConstant)
+    escape_expr.constant_expr = escape_constant
+    return escape_expr
+
+
+def _parse_like(like_node, escape_char=None, force_not=False):
+    """Parse a Like node into a ParsedExpr.
+
+    sqlglot >= 30.x parses NOT LIKE as a Like node with negate=True instead
+    of wrapping it in a Not node, so the negation must be read off the node.
+    """
+    negate = force_not or bool(like_node.args.get('negate'))
+    func_expr = WrapFunctionExpr()
+    func_expr.func_name = binary_exp_to_paser_exp('notlike' if negate else 'like')
+
+    left_expr = parse_expr(like_node.args['this'])
+    pattern_expr = parse_expr(like_node.args['expression'])
+
+    func_expr.arguments = [left_expr, pattern_expr, _make_escape_expr(escape_char)]
+    parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
+    parsed_expr.function_expr = func_expr
+    return parsed_expr
+
+
 def traverse_conditions(cons, fn=None):
     if isinstance(cons, exp.Alias):
         expr = traverse_conditions(cons.args['this'])
         expr.alias_name = cons.alias
         return expr
 
-    if isinstance(cons, exp.Binary):
+    # Like/Escape are Binary subclasses but need their dedicated arms below
+    # (they carry a third escape argument and a negate flag).
+    if isinstance(cons, exp.Binary) and not isinstance(cons, (exp.Like, exp.Escape)):
         parsed_expr = WrapParsedExpr()
         function_expr = WrapFunctionExpr()
         function_expr.func_name = binary_exp_to_paser_exp(
@@ -237,6 +276,20 @@ def traverse_conditions(cons, fn=None):
         parsed_expr.in_expr = in_expr
 
         return parsed_expr
+    elif isinstance(cons, exp.Escape):
+        # LIKE 'pattern' ESCAPE '!' (NOT included via Like's negate flag)
+        like_node = cons.args['this']
+        escape_char = cons.args.get('expression')
+        return _parse_like(like_node, escape_char)
+    elif isinstance(cons, exp.Not) and isinstance(cons.args['this'], exp.Escape):
+        # NOT LIKE 'pattern' ESCAPE '!' on older sqlglot (Not wrapper)
+        raw_escape = cons.args['this']
+        return _parse_like(raw_escape.args['this'], raw_escape.args.get('expression'), force_not=True)
+    elif isinstance(cons, exp.Like):
+        return _parse_like(cons, None)
+    elif isinstance(cons, exp.Not) and isinstance(cons.args['this'], exp.Like):
+        # NOT LIKE on older sqlglot (Not wrapper)
+        return _parse_like(cons.args['this'], None, force_not=True)
     else:
         raise Exception(f"unknown condition type: {cons}")
 

--- a/python/infinity_embedded/utils.py
+++ b/python/infinity_embedded/utils.py
@@ -47,6 +47,10 @@ def binary_exp_to_paser_exp(binary_expr_key) -> str:
         return "%"
     elif binary_expr_key == "trunc":
         return binary_expr_key
+    elif binary_expr_key == "like":
+        return "like"
+    elif binary_expr_key == "notlike":
+        return "not_like"
     else:
         raise InfinityException(ErrorCode.INVALID_EXPRESSION, f"unknown binary expression: {binary_expr_key}")
 

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,20 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_condition_embedded_like(self, request):
+        # embedded SDK must support LIKE / NOT LIKE / ESCAPE filters; it
+        # previously raised "unknown binary expression: like/escape".
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.local_infinity.utils import traverse_conditions as embedded_traverse
+        for cond_str, expected_func in [
+            ("c1 LIKE '%test%'", "like"),
+            ("c1 NOT LIKE '%test%'", "not_like"),
+            ("c1 LIKE '%test!%' ESCAPE '!'", "like"),
+            ("c1 NOT LIKE '%test!%' ESCAPE '!'", "not_like"),
+        ]:
+            res = embedded_traverse(condition(cond_str))
+            func_expr = res.function_expr
+            assert func_expr.func_name == expected_func, f"{cond_str}: got {func_expr.func_name}"
+            assert len(func_expr.arguments) == 3  # left, pattern, escape


### PR DESCRIPTION
### Summary

The embedded SDK raised `unknown binary expression: like` (or `escape`) on every LIKE filter: `exp.Like` / `exp.Escape` are sqlglot `Binary` subclasses and fell into the generic `Binary` arm, whose operator map has no LIKE entries. The thrift SDK and the server (`like` / `not_like` in `src/function/scalar/like_impl.cpp`) both support LIKE.

- Added `like` / `notlike` entries to the embedded operator map.
- Added dedicated `exp.Like` / `exp.Escape` traversal arms mirroring the thrift SDK, emitting `(left, pattern, escape)` like the thrift path and honoring the sqlglot >= 30.x `Like(negate=True)` form of `NOT LIKE`.
- Narrowed the generic `Binary` arm so `Like` / `Escape` reach the dedicated arms.

Regression test asserts the generated function name and argument count for LIKE / NOT LIKE with and without ESCAPE.

Note: pysdk tests require a running server; the traversal changes were verified directly against `traverse_conditions` with sqlglot 30.18.0.

Fixes #3465