### PR TITLE
Fix embedded SDK crashing on UNNEST(...) in output columns

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -157,6 +157,20 @@ def traverse_conditions(cons, fn=None):
         parsed_expr.type = ParsedExprType.kFunction
         parsed_expr.function_expr = func_expr
         return parsed_expr
+    elif isinstance(cons, exp.Unnest):
+        # UNNEST carries its columns under 'expressions' (a list); the
+        # generic Func arm would feed the raw list to parse_expr and crash.
+        arguments = []
+        for arg in cons.args['expressions']:
+            if arg is not None:
+                arguments.append(parse_expr(arg))
+        func_expr = WrapFunctionExpr()
+        func_expr.func_name = cons.key
+        func_expr.arguments = arguments
+        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
+        parsed_expr.function_expr = func_expr
+        return parsed_expr
+
     elif isinstance(cons, exp.Anonymous):
         arguments = []
         for arg in cons.args['expressions']:

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,16 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_output_unnest_embedded(self, request):
+        # embedded SDK output traversal must support UNNEST; the generic Func
+        # arm fed the raw 'expressions' list to parse_expr and crashed with
+        # "unknown expression type: UNNEST(arr)".
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from sqlglot import parse_one
+        from infinity_embedded.local_infinity.utils import parse_expr as embedded_parse_expr
+        res = embedded_parse_expr(parse_one("unnest(arr)"))
+        assert res.function_expr.func_name == "unnest"
+        assert len(res.function_expr.arguments) == 1
+        assert res.function_expr.arguments[0].column_expr is not None


### PR DESCRIPTION
### Summary

`unnest(arr)` in the output list crashed the embedded SDK with `unknown expression type: UNNEST(arr)`: `exp.Unnest` stores its columns as a list under `expressions`, and the generic `Func` arm fed that raw list to `parse_expr`. The thrift SDK handles `Unnest` explicitly and the server binder recognizes `unnest`.

Added a dedicated `exp.Unnest` traversal arm (before `Anonymous` / `Func`) that iterates `cons.args['expressions']` like the thrift SDK. Regression test asserts the function name and column argument.

Note: pysdk tests require a running server; the traversal change was verified directly against `parse_expr` with sqlglot 30.18.0.

Fixes #3467