### PR TITLE
Fix embedded SDK crashing on TRIM variants (LTRIM/RTRIM/position/character)

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -171,6 +171,26 @@ def traverse_conditions(cons, fn=None):
         parsed_expr.type = ParsedExprType.kFunction
         parsed_expr.function_expr = func_expr
         return parsed_expr
+    elif isinstance(cons, exp.Trim):
+        # TRIM variants (incl. LTRIM/RTRIM, which sqlglot folds into Trim
+        # with a position flag) carry non-expression args ('position' is a
+        # plain string) that the generic Func arm feeds to parse_expr and
+        # crashes on. Map to the server's trim/ltrim/rtrim like the thrift
+        # SDK does.
+        position = cons.args.get('position')
+        if position == 'LEADING':
+            func_name = "ltrim"
+        elif position == 'TRAILING':
+            func_name = "rtrim"
+        else:
+            func_name = "trim"
+        func_expr = WrapFunctionExpr()
+        func_expr.func_name = func_name
+        func_expr.arguments = [parse_expr(cons.args['this'])]
+        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
+        parsed_expr.function_expr = func_expr
+        return parsed_expr
+
     elif isinstance(cons, exp.Func):
         arguments = []
         for arg in cons.args.values():

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,22 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_output_trim_embedded(self, request):
+        # embedded SDK output traversal crashed on TRIM variants carrying a
+        # position/character ("unknown expression type: TRIM(name, ' ')");
+        # sqlglot also folds LTRIM/RTRIM into Trim with a position flag.
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from sqlglot import parse_one
+        from infinity_embedded.local_infinity.utils import parse_expr as embedded_parse_expr
+        for output_str, expected_func in [
+            ("trim(name)", "trim"),
+            ("trim(both ' ' from name)", "trim"),
+            ("trim(leading 'x' from name)", "ltrim"),
+            ("trim(trailing from name)", "rtrim"),
+            ("ltrim(name)", "ltrim"),
+            ("rtrim(name)", "rtrim"),
+        ]:
+            res = embedded_parse_expr(parse_one(output_str))
+            assert res.function_expr.func_name == expected_func, f"{output_str}: got {res.function_expr.func_name}"


### PR DESCRIPTION
### Summary

`TRIM(BOTH ' ' FROM col)`, `TRIM(LEADING ...)`, `LTRIM`, and `RTRIM` all crashed the embedded SDK with `unknown expression type: TRIM(...)`: sqlglot folds every trim variant into `exp.Trim`, whose `position` arg is a plain string and whose character arg is a literal — the generic `Func` arm fed both to `parse_expr`, which matches no arm. The thrift SDK maps `Trim` by position, and the server registers `trim` / `ltrim` / `rtrim`.

Added a dedicated `exp.Trim` arm before the generic `Func` arm mirroring the thrift mapping (`LEADING` -> `ltrim`, `TRAILING` -> `rtrim`, else `trim`). Regression test covers all six spellings.

Note: pysdk tests require a running server; the traversal change was verified directly against `parse_expr` with sqlglot 30.18.0.

Fixes #3469