### PR TITLE
Fix embedded SDK rejecting IS NULL filters

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -51,6 +51,40 @@ def traverse_conditions(cons, fn=None):
         expr.alias_name = cons.alias
         return expr
 
+    if isinstance(cons, exp.Is):
+        # Handle IS NULL / IS TRUE / IS FALSE / IS UNKNOWN.
+        # exp.Is is a sqlglot Binary subclass, so this arm must come before the
+        # generic Binary arm below, otherwise it is unreachable.
+        # Only IS NULL is supported; others must be rejected.
+        if not isinstance(cons.args.get('expression'), exp.Null):
+            raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                    f"Unsupported IS expression: {cons}. Only IS NULL / IS NOT NULL are supported.")
+        func_expr = WrapFunctionExpr()
+        func_expr.func_name = "is_null"
+        if fn:
+            func_expr.arguments = [fn(cons.this)]
+        else:
+            func_expr.arguments = [traverse_conditions(cons.this)]
+        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
+        parsed_expr.function_expr = func_expr
+        return parsed_expr
+    elif isinstance(cons, exp.Not) and isinstance(cons.args['this'], exp.Is):
+        # Handle IS NOT NULL / IS NOT TRUE / IS NOT FALSE / IS NOT UNKNOWN.
+        # Only IS NOT NULL is supported; others must be rejected.
+        inner_is = cons.args['this']
+        if not isinstance(inner_is.args.get('expression'), exp.Null):
+            raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                    f"Unsupported IS expression: {cons}. Only IS NULL / IS NOT NULL are supported.")
+        func_expr = WrapFunctionExpr()
+        func_expr.func_name = "is_not_null"
+        if fn:
+            func_expr.arguments = [fn(inner_is.this)]
+        else:
+            func_expr.arguments = [traverse_conditions(inner_is.this)]
+        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
+        parsed_expr.function_expr = func_expr
+        return parsed_expr
+
     if isinstance(cons, exp.Binary):
         parsed_expr = WrapParsedExpr()
         function_expr = WrapFunctionExpr()
@@ -69,22 +103,6 @@ def traverse_conditions(cons, fn=None):
         parsed_expr.type = ParsedExprType.kFunction
         parsed_expr.function_expr = function_expr
 
-        return parsed_expr
-    elif isinstance(cons, exp.Not) and isinstance(cons.args['this'], exp.Is):
-        # Handle IS NOT NULL / IS NOT TRUE / IS NOT FALSE / IS NOT UNKNOWN.
-        # Only IS NOT NULL is supported; others must be rejected.
-        inner_is = cons.args['this']
-        if not isinstance(inner_is.args.get('expression'), exp.Null):
-            raise InfinityException(ErrorCode.INVALID_EXPRESSION,
-                                    f"Unsupported IS expression: {cons}. Only IS NULL / IS NOT NULL are supported.")
-        func_expr = WrapFunctionExpr()
-        func_expr.func_name = "is_not_null"
-        if fn:
-            func_expr.arguments = [fn(inner_is.this)]
-        else:
-            func_expr.arguments = [traverse_conditions(inner_is.this)]
-        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
-        parsed_expr.function_expr = func_expr
         return parsed_expr
     elif isinstance(cons, exp.Not) and not isinstance(cons.args['this'], exp.In):
         parsed_expr = WrapParsedExpr()
@@ -183,21 +201,6 @@ def traverse_conditions(cons, fn=None):
 
         parsed_expr = WrapParsedExpr()
         parsed_expr.type = ParsedExprType.kFunction
-        parsed_expr.function_expr = func_expr
-        return parsed_expr
-    elif isinstance(cons, exp.Is):
-        # Handle IS NULL / IS TRUE / IS FALSE / IS UNKNOWN.
-        # Only IS NULL is supported; others must be rejected.
-        if not isinstance(cons.args.get('expression'), exp.Null):
-            raise InfinityException(ErrorCode.INVALID_EXPRESSION,
-                                    f"Unsupported IS expression: {cons}. Only IS NULL / IS NOT NULL are supported.")
-        func_expr = WrapFunctionExpr()
-        func_expr.func_name = "is_null"
-        if fn:
-            func_expr.arguments = [fn(cons.this)]
-        else:
-            func_expr.arguments = [traverse_conditions(cons.this)]
-        parsed_expr = WrapParsedExpr(ParsedExprType.kFunction)
         parsed_expr.function_expr = func_expr
         return parsed_expr
     # in

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,16 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_condition_embedded_is_null(self, request):
+        # embedded SDK must support IS NULL filters: exp.Is is a sqlglot Binary
+        # subclass, so it hit the generic binary arm and raised
+        # "unknown binary expression: is" before the dedicated arm was reached.
+        # IS NOT NULL already worked because exp.Not is not a Binary.
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.local_infinity.utils import traverse_conditions as embedded_traverse
+        res = embedded_traverse(condition("c1 IS NULL"))
+        assert res.function_expr.func_name == "is_null"
+        res = embedded_traverse(condition("c1 IS NOT NULL"))
+        assert res.function_expr.func_name == "is_not_null"


### PR DESCRIPTION
### Summary

The embedded SDK crashed on `c1 IS NULL` with `unknown binary expression: is`. sqlglot parses `IS NULL` as `exp.Is`, which is a `Binary` subclass, so the generic binary arm swallowed the node before the dedicated `IS NULL` arm (placed below it) could run. `IS NOT NULL` worked because `exp.Not` is not a `Binary`.

The fix moves the `exp.Is` / `exp.Not + exp.Is` arms above the generic `exp.Binary` arm in `traverse_conditions()`. No other arm is touched.

Fixes #3471

### Testing

- Reproduced the crash on current main (eca7266, sqlglot 30.18.0); after the change `IS NULL` builds the `is_null` function expression and `IS NOT NULL` still builds `is_not_null`. `IS TRUE` / `IS FALSE` still raise the intended "Unsupported IS expression" error.
- Added `test_condition_embedded_is_null` (embedded-only) to `python/test_pysdk/test_condition.py`.
- The full pysdk suite was not run locally (needs a built embedded engine); the change is a pure reordering of two existing arms.