### PR TITLE
Fix embedded SDK crashing on count(*) / count(col)

### DIFF
--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -174,9 +174,21 @@ def traverse_conditions(cons, fn=None):
     elif isinstance(cons, exp.Func):
         arguments = []
         for arg in cons.args.values():
-            if arg:
-                parsed_expr = parse_expr(arg)
-                arguments.append(parsed_expr)
+            if arg is None:
+                continue
+            if isinstance(arg, list):
+                if not arg:
+                    continue
+                # list-valued args need a dedicated arm (see exp.Unnest);
+                # keep raising instead of silently dropping them
+                parse_expr(arg)
+            if not isinstance(arg, exp.Expression):
+                # sqlglot nodes carry non-expression flags alongside their
+                # arguments (e.g. Count.big_int=True). Those are node metadata,
+                # not function arguments; skip them instead of feeding them to
+                # parse_expr, which crashes on values like True.
+                continue
+            arguments.append(parse_expr(arg))
         func_expr = WrapFunctionExpr()
         func_expr.func_name = cons.key
         func_expr.arguments = arguments

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -55,6 +55,11 @@ class TestInfinity:
             pytest.skip("embedded-only regression test")
         from sqlglot import parse_one
         from infinity_embedded.local_infinity.utils import parse_expr as embedded_parse
-        for expr in ("count(*)", "count(c1)"):
-            res = embedded_parse(parse_one(expr))
-            assert res.function_expr.func_name == "count"
+        res = embedded_parse(parse_one("count(*)"))
+        assert res.function_expr.func_name == "count"
+        assert len(res.function_expr.arguments) == 1
+        assert res.function_expr.arguments[0].column_expr.star
+        res = embedded_parse(parse_one("count(c1)"))
+        assert res.function_expr.func_name == "count"
+        assert len(res.function_expr.arguments) == 1
+        assert res.function_expr.arguments[0].column_expr.names == ["c1"]

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,15 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_output_embedded_count(self, request):
+        # embedded SDK must parse count(*) / count(c1) in output columns: the
+        # generic Func arm fed sqlglot's Count.big_int flag (a plain bool) into
+        # parse_expr and crashed with "unknown expression type: True".
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from sqlglot import parse_one
+        from infinity_embedded.local_infinity.utils import parse_expr as embedded_parse
+        for expr in ("count(*)", "count(c1)"):
+            res = embedded_parse(parse_one(expr))
+            assert res.function_expr.func_name == "count"


### PR DESCRIPTION
### Summary

`output(["count(*)"])` and `output(["count(c1)"])`) crashed in the embedded SDK with `unknown expression type: True`. sqlglot's `Count` node carries a `big_int` boolean flag (and an empty `expressions` list) next to its real argument, and the generic `exp.Func` arm fed every entry of `cons.args.values()` into `parse_expr`, crashing on the plain bool.

The arm now skips `None` entries, empty lists, and non-expression node flags. Non-empty list args still raise, so cases that need a dedicated arm (e.g. `UNNEST`) keep failing loudly. The result matches the thrift SDK: `count(*)` produces a `count` function expression with a single star column argument.

Fixes #3473

### Testing

- Reproduced the crash on current main (eca7266, sqlglot 30.18.0); `count(*)` / `count(c1)` parse correctly after the change, and `sum` / `abs` / `round` / `substring` / `length` / `upper` / `unnest` / `coalesce` behavior is unchanged.
- Added `test_output_embedded_count` (embedded-only) to `python/test_pysdk/test_condition.py`.
- The full pysdk suite was not run locally (needs a built embedded engine); the change is confined to argument filtering in one traversal arm.