### PR TITLE
Fix HTTP fusion(match_tensor) mutating the caller's params dict

### DIFF
--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -1153,11 +1153,9 @@ class table_http_result:
         if method == "match_tensor":
             tmp_new_params = {"field": fusion_params["field"], "query_tensor": fusion_params["query_tensor"],
                               "element_type": fusion_params["element_type"]}
-            # handle left params
-            fusion_params.pop("field")
-            fusion_params.pop("query_tensor")
-            fusion_params.pop("element_type")
-            tmp_new_params.update(fusion_params)
+            # handle left params without mutating the caller's dict
+            tmp_new_params.update({k: v for k, v in fusion_params.items()
+                                   if k not in ("field", "query_tensor", "element_type")})
             tmp_fusion_expr["params"] = tmp_new_params
         else:
             if fusion_params is not None:

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -1104,6 +1104,39 @@ class TestInfinity:
         res = db_obj.drop_table("test_with_multiple_fusion" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
+    def test_fusion_match_tensor_reused_params(self, check_data, suffix):
+        # HTTP fusion(match_tensor) must not consume the caller's fusion_params
+        # dict: it used to pop "field"/"query_tensor"/"element_type" out of it,
+        # so reusing the same dict for a second query raised KeyError.
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_fusion_match_tensor_reused_params" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table("test_fusion_match_tensor_reused_params" + suffix,
+                                        {"num": {"type": "int"},
+                                         "t": {"type": "tensor, 4, float"},
+                                         "body": {"type": "varchar"}})
+        table_obj.create_index("ft_index",
+                               index.IndexInfo("body",
+                                               index.IndexType.FullText,
+                                               {"ANALYZER": "standard"}),
+                               ConflictType.Error)
+        table_obj.insert([{"num": 1, "t": [[1.0, 0.0, 0.0, 0.0]], "body": "off"}])
+
+        fusion_params = {"field": "t", "element_type": "float",
+                         "query_tensor": [[0.0, -10.0, 0.0, 0.7]]}
+        for _ in range(2):
+            res, extra_result = (table_obj
+                                 .output(["num"])
+                                 .match_text("body", "off", 4)
+                                 .match_tensor("t", [[1.0, 0.0, 0.0, 0.0]], "float", 2)
+                                 .fusion(method="rrf", topn=10)
+                                 .fusion(method="match_tensor", topn=2, fusion_params=fusion_params)
+                                 .to_pl())
+            assert fusion_params == {"field": "t", "element_type": "float",
+                                     "query_tensor": [[0.0, -10.0, 0.0, 0.7]]}
+
+        res = db_obj.drop_table("test_fusion_match_tensor_reused_params" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
     @pytest.mark.parametrize("check_data", [{"file_name": "pysdk_test_knn.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     @pytest.mark.parametrize("index_column_name", ["gender_vector"])

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -1104,7 +1104,7 @@ class TestInfinity:
         res = db_obj.drop_table("test_with_multiple_fusion" + suffix, ConflictType.Error)
         assert res.error_code == ErrorCode.OK
 
-    def test_fusion_match_tensor_reused_params(self, check_data, suffix):
+    def test_fusion_match_tensor_reused_params(self, suffix):
         # HTTP fusion(match_tensor) must not consume the caller's fusion_params
         # dict: it used to pop "field"/"query_tensor"/"element_type" out of it,
         # so reusing the same dict for a second query raised KeyError.


### PR DESCRIPTION
### Summary

`fusion(method="match_tensor", fusion_params=...)` popped `field` / `query_tensor` / `element_type` out of the caller's dict while building the request, so a params dict could only be used once - the second call raised `KeyError: 'field'`. Loops, shared configs, and retries all hit this.

The merge now uses a dict comprehension over the remaining keys and never touches the caller's dict. The request payload is byte-identical to before.

Fixes #3475

### Testing

- Reproduced on current main (eca7266): one `fusion("match_tensor", ...)` call gutted the caller's dict, second call raised `KeyError`. After the fix, two calls with the same dict build the same params and the dict is unchanged.
- Added `test_fusion_match_tensor_reused_params` to `python/test_pysdk/test_knn.py` (reuses one params dict across two match_tensor fusion queries).
- The full pysdk suite was not run locally (needs a running server); the change is confined to the HTTP client's fusion payload builder.