### PR TITLE
Fix HTTP match_sparse crashing on dict input

### DIFF
--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -1124,8 +1124,17 @@ class table_http_result:
 
     def match_sparse(self, vector_column_name: str, sparse_data: SparseVector | dict, distance_type: str, topn: int,
                      opt_params: dict | None = None):
+        if isinstance(sparse_data, SparseVector):
+            sparse_dict = sparse_data.to_dict()
+        elif isinstance(sparse_data, dict):
+            if len(sparse_data) == 0:
+                raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
+            sparse_dict = sparse_data
+        else:
+            raise InfinityException(ErrorCode.INVALID_CONSTANT_TYPE,
+                                    f"Invalid sparse data type {type(sparse_data)}")
         tmp_match_sparse = {"match_method": "sparse", "fields": vector_column_name,
-                            "query_vector": sparse_data.to_dict(), "metric_type": distance_type, "topn": topn}
+                            "query_vector": sparse_dict, "metric_type": distance_type, "topn": topn}
         if opt_params is not None:
             tmp_match_sparse["params"] = opt_params
         self._search_exprs.append(tmp_match_sparse)

--- a/python/test_pysdk/test_knn.py
+++ b/python/test_pysdk/test_knn.py
@@ -1022,6 +1022,31 @@ class TestInfinity:
 
     @pytest.mark.parametrize("check_data", [{"file_name": "sparse_knn.csv",
                                              "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
+    def test_sparse_knn_with_dict(self, check_data, suffix):
+        # match_sparse accepts SparseVector | dict; the HTTP client used to call
+        # sparse_data.to_dict() unconditionally, so a plain dict crashed with
+        # AttributeError before the request was even sent.
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_sparse_scan_dict" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table("test_sparse_scan_dict" + suffix,
+                                        {"c1": {"type": "int"}, "c2": {"type": "sparse,100,float,int8"}},
+                                        ConflictType.Error)
+        if not check_data:
+            copy_data("sparse_knn.csv")
+        test_csv_dir = common_values.TEST_TMP_DIR + "sparse_knn.csv"
+        table_obj.import_data(test_csv_dir, import_options={"delimiter": ","})
+
+        res, extra_result = (table_obj.output(["c1", "_similarity"])
+                             .match_sparse("c2", {0: 1.0, 20: 2.0, 80: 3.0}, "ip", 3)
+                             .to_df())
+        pd.testing.assert_frame_equal(res, pd.DataFrame({'c1': [4, 2, 1], 'SIMILARITY': [16.0, 12.0, 6.0]}).astype(
+            {'c1': 'Int32', 'SIMILARITY': 'Float32'}))
+
+        res = db_obj.drop_table("test_sparse_scan_dict" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK
+
+    @pytest.mark.parametrize("check_data", [{"file_name": "sparse_knn.csv",
+                                             "data_dir": common_values.TEST_TMP_DIR}], indirect=True)
     def test_sparse_knn_with_index(self, check_data, suffix):
         db_obj = self.infinity_obj.get_database("default_db")
         db_obj.drop_table("test_sparse_knn_with_index" + suffix, ConflictType.Ignore)


### PR DESCRIPTION
### Summary

`match_sparse` is typed `SparseVector | dict` and both other SDKs accept a plain dict (embedded has a `case dict()` arm, thrift handles dicts in `make_match_sparse_expr`), but the HTTP client called `sparse_data.to_dict()` unconditionally, so dict input crashed client-side with `AttributeError: 'dict' object has no attribute 'to_dict'`.

Now a `SparseVector` is converted with `to_dict()` and a dict is passed through - both serialize to the `{index: value}` JSON object the server parses (`HTTPSearch::ParseSparseVector`). Empty dicts and other types raise a clear `InfinityException` instead of an `AttributeError`.

Fixes #3477

### Testing

- Reproduced on current main (eca7266): dict input raised `AttributeError`; after the fix the dict and `SparseVector` forms build equivalent payloads, and list / empty-dict inputs raise `InfinityException`.
- Added `test_sparse_knn_with_dict` to `python/test_pysdk/test_knn.py`, mirroring `test_sparse_knn` with a dict argument and the same expected frame.
- The full pysdk suite was not run locally (needs a running server); the change is confined to the HTTP client's match_sparse payload builder.