### PR TITLE
Fix Python SDKs lowercasing output expressions (corrupts string literals)

### DIFF
--- a/python/infinity_embedded/local_infinity/query_builder.py
+++ b/python/infinity_embedded/local_infinity/query_builder.py
@@ -451,10 +451,12 @@ class InfinityLocalQueryBuilder(ABC):
         self._columns = columns
         select_list: list[WrapParsedExpr] = []
         for column in columns:
-            if isinstance(column, str):
-                column = column.lower()
+            # match the special output tokens case-insensitively, but keep the
+            # original string for parsing: lowercasing the whole expression
+            # would corrupt string literals inside it
+            key = column.lower() if isinstance(column, str) else column
 
-            match column:
+            match key:
                 case "*":
                     column_expr = WrapColumnExpr()
                     column_expr.star = True

--- a/python/infinity_sdk/infinity/remote_thrift/query_builder.py
+++ b/python/infinity_sdk/infinity/remote_thrift/query_builder.py
@@ -391,10 +391,12 @@ class InfinityThriftQueryBuilder(ABC):
         self._columns = columns
         select_list: list[ParsedExpr] = []
         for column in columns:
-            if isinstance(column, str):
-                column = column.lower()
+            # match the special output tokens case-insensitively, but keep the
+            # original string for parsing: lowercasing the whole expression
+            # would corrupt string literals inside it
+            key = column.lower() if isinstance(column, str) else column
 
-            match column:
+            match key:
                 case "*":
                     column_expr = ColumnExpr(star=True, column_name=[])
                     expr_type = ParsedExprType(column_expr=column_expr)

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,24 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_output_preserves_string_literal_case(self, request):
+        # output() used to lowercase the whole column expression before parsing
+        # it, silently corrupting string literals: output(["'ACTIVE'"]) selected
+        # 'active', and json_extract(data, '$.UserName') would query key
+        # '$.username'. Only the special output tokens (*, _row_id, _score, ...)
+        # are meant to be matched case-insensitively.
+        from infinity.remote_thrift.query_builder import InfinityThriftQueryBuilder
+        qb = InfinityThriftQueryBuilder(None)
+        qb.output(["'ACTIVE'"])
+        assert qb._columns[0].type.constant_expr.str_value == "ACTIVE"
+        qb = InfinityThriftQueryBuilder(None)
+        qb.output(["_SCORE"])
+        assert qb._columns[0].type.function_expr.function_name == "score"
+
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded part needs the embedded engine")
+        from infinity_embedded.local_infinity.query_builder import InfinityLocalQueryBuilder
+        qb = InfinityLocalQueryBuilder(None)
+        qb.output(["'ACTIVE'"])
+        assert qb._columns[0].constant_expr.str_value == "ACTIVE"


### PR DESCRIPTION
### Summary

Both Python SDK query builders lowercased each `output()` column string before parsing it, to match the special output tokens case-insensitively. That also rewrote string literals inside real expressions: `output(["'ACTIVE'"])` silently selected `'active'`, and `json_extract(data, '$.UserName')` (once it parses through the SDKs, see #3463) would query the key `$.username`. The HTTP API forwards the strings untouched, so the same query returned different data per client.

The special tokens are now matched against a lowercased copy while the original string is parsed. Plain identifiers are still lowercased by the `exp.Column` arm, so column-name handling is unchanged; only string literals keep their case.

Fixes #3479

### Testing

- Reproduced on current main (eca7266, sqlglot 30.18.0): before the fix both SDKs built a constant holding `'active'`; after the fix they hold `'ACTIVE'`. `_SCORE` still maps to `score`, `MyCol` still normalizes to `mycol`, `*` still works.
- Added `test_output_preserves_string_literal_case` to `python/test_pysdk/test_condition.py` (thrift builder directly, embedded builder in embedded mode).
- The full pysdk suite was not run locally (needs a running server / built embedded engine); the change is confined to the two `output()` methods.