### PR TITLE
Fix HTTP SDK insert() mutating the caller's rows

### DIFF
--- a/python/infinity_sdk/infinity/infinity_http.py
+++ b/python/infinity_sdk/infinity/infinity_http.py
@@ -776,32 +776,42 @@ class table_http:
         else:
             values = [values]
 
+        # Convert to the HTTP API format without mutating the caller's data:
+        # the caller may reuse the same rows (retry, second table, later inserts).
+        converted_values = []
         for value in values:
             if isinstance(value, dict):
+                converted = {}
                 for key in value:
-                    if isinstance(value[key], FDE):
+                    v = value[key]
+                    if isinstance(v, FDE):
                         # Convert FDE object to HTTP API format
-                        fde_obj = value[key]
-                        value[key] = {
+                        converted[key] = {
                             "function": "fde",
-                            "tensor_data": fde_obj.tensor_data,
-                            "target_dimension": fde_obj.target_dimension
+                            "tensor_data": v.tensor_data,
+                            "target_dimension": v.target_dimension
                         }
-                    elif isinstance(value[key],
+                    elif isinstance(v,
                                     np.ndarray):  # trans np array to list since http api can not parse np array
-                        value[key] = value[key].tolist()
-                    elif isinstance(value[key], list):
-                        for idx in range(len(value[key])):
-                            if isinstance(value[key][idx], np.ndarray):
-                                value[key][idx] = value[key][idx].tolist()
-                            elif isinstance(value[key][idx], (np.integer, np.floating, np.longdouble)):
-                                value[key][idx] = value[key][idx].item()
-                    elif isinstance(value[key], SparseVector):
-                        value[key] = value[key].to_dict()
+                        converted[key] = v.tolist()
+                    elif isinstance(v, list):
+                        converted[key] = [
+                            x.tolist() if isinstance(x, np.ndarray)
+                            else x.item() if isinstance(x, (np.integer, np.floating, np.longdouble))
+                            else x
+                            for x in v
+                        ]
+                    elif isinstance(v, SparseVector):
+                        converted[key] = v.to_dict()
+                    else:
+                        converted[key] = v
+                converted_values.append(converted)
+            else:
+                converted_values.append(value)
 
         url = f"databases/{self.database_name}/tables/{self.table_name}/docs"
         h = self.net.set_up_header(["accept", "content-type"])
-        r = self.net.request(url, "post", h, values)
+        r = self.net.request(url, "post", h, converted_values)
         self.net.raise_exception(r)
         return database_result()
 

--- a/python/test_pysdk/test_insert.py
+++ b/python/test_pysdk/test_insert.py
@@ -1120,3 +1120,33 @@ class TestInfinity:
         assert res.error_code == ErrorCode.OK
 
     
+    def test_insert_does_not_mutate_caller_rows(self, http, suffix):
+        # Regression test (HTTP SDK): insert() used to rewrite the caller's row
+        # dicts in place (ndarray -> list, SparseVector -> dict, FDE -> dict,
+        # numpy scalars inside lists -> python scalars), silently corrupting
+        # data the caller may reuse for a retry, a second table, or a diff.
+        if not http:
+            pytest.skip("http-only regression test")
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_insert_no_caller_mutation" + suffix, ConflictType.Ignore)
+        table_obj = db_obj.create_table("test_insert_no_caller_mutation" + suffix, {
+            "c1": {"type": "int"},
+            "c2": {"type": "vector,4,float"},
+            "c3": {"type": "sparse,100,float,int"}}, ConflictType.Error)
+        assert table_obj
+
+        rows = [{"c1": 1,
+                 "c2": np.array([1.0, 2.0, 3.0, 4.0]),
+                 "c3": SparseVector([3, 7], [1.5, 2.5])}]
+        res = table_obj.insert(rows)
+        assert res.error_code == ErrorCode.OK
+
+        # the caller's data must be untouched
+        assert isinstance(rows[0]["c2"], np.ndarray)
+        assert isinstance(rows[0]["c3"], SparseVector)
+        assert rows[0]["c2"].tolist() == [1.0, 2.0, 3.0, 4.0]
+        assert rows[0]["c3"].indices == [3, 7]
+        assert rows[0]["c3"].values == [1.5, 2.5]
+
+        res = db_obj.drop_table("test_insert_no_caller_mutation" + suffix, ConflictType.Error)
+        assert res.error_code == ErrorCode.OK


### PR DESCRIPTION
Fixes #3481

### What problem does this PR solve?

`table_http.insert()` rewrote the caller's row dicts in place: numpy arrays became lists, `SparseVector`/`FDE` objects became plain dicts, and numpy scalars inside list values were replaced with python scalars. Callers reusing the same rows (retry after an error, inserting the same batch into a second table, or holding a reference to their data) silently lost their original objects.

### What changed

`insert()` now builds converted row dicts and posts those, leaving the caller's data untouched. The payload sent to the server is unchanged (verified field-for-field against the pre-fix conversion).

### Tests

- Added `test_insert_does_not_mutate_caller_rows` in `python/test_pysdk/test_insert.py` (http-only): inserts a row with an ndarray vector and a `SparseVector`, then asserts the caller's objects are unchanged.
- Verified fail-before/pass-after locally with a stubbed network layer (the pysdk suite needs a live server, so the new test was not executed here).