### PR TITLE
Fix embedded SDK truncating floats in mixed int/float arrays and sparse values

### DIFF
--- a/python/infinity_embedded/local_infinity/query_builder.py
+++ b/python/infinity_embedded/local_infinity/query_builder.py
@@ -281,32 +281,37 @@ class InfinityLocalQueryBuilder(ABC):
 
         sparse_expr = WrapConstantExpr()
         match sparse_data:
-            case SparseVector([int(), *_] as indices, [int(), *_] as values):
+            case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                    isinstance(v, int) for v in values):
                 sparse_expr.literal_type = LiteralType.kLongSparseArray
                 sparse_expr.i64_array_idx = indices
                 sparse_expr.i64_array_value = values
-            case SparseVector([int(), *_] as indices, [float(), *_] as values):
+            case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                    isinstance(v, (int, float)) for v in values):
                 sparse_expr.literal_type = LiteralType.kDoubleSparseArray
                 sparse_expr.i64_array_idx = indices
-                sparse_expr.f64_array_value = values
+                sparse_expr.f64_array_value = [float(v) for v in values]
             case SparseVector([int(), *_], None):
                 raise InfinityException(ErrorCode.INVALID_CONSTANT_TYPE,
                                         "No values! Sparse data does not support bool value type now")
             case dict():
                 if len(sparse_data) == 0:
                     raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
-                match next(iter(sparse_data.values())):
-                    case int():
-                        sparse_expr.literal_type = LiteralType.kLongSparseArray
-                        sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
-                        sparse_expr.i64_array_value = [int(vv) for vv in sparse_data.values()]
-                    case float():
-                        sparse_expr.literal_type = LiteralType.kDoubleSparseArray
-                        sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
-                        sparse_expr.f64_array_value = [float(vv) for vv in sparse_data.values()]
-                    case _:
-                        raise InfinityException(ErrorCode.INVALID_EXPRESSION,
-                                                f"Invalid sparse vector value type: {type(next(iter(sparse_data.values())))}")
+                sparse_values = list(sparse_data.values())
+                if all(isinstance(vv, int) for vv in sparse_values):
+                    sparse_expr.literal_type = LiteralType.kLongSparseArray
+                    sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
+                    sparse_expr.i64_array_value = [int(vv) for vv in sparse_values]
+                elif all(isinstance(vv, (int, float)) for vv in sparse_values):
+                    # Any float among the values: store as a double sparse
+                    # array. Dispatching on the first value alone truncated
+                    # floats via int(vv).
+                    sparse_expr.literal_type = LiteralType.kDoubleSparseArray
+                    sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
+                    sparse_expr.f64_array_value = [float(vv) for vv in sparse_values]
+                else:
+                    raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                            f"Invalid sparse vector value type: {type(next(iter(sparse_data.values())))}")
             case _:
                 raise InfinityException(ErrorCode.INVALID_CONSTANT_TYPE,
                                         f"Invalid sparse data type {type(sparse_data)}")

--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -354,18 +354,19 @@ def get_local_constant_expr_from_python_value(value) -> WrapConstantExpr:
             # and lose the fractional part.
             constant_expression.literal_type = LiteralType.kDoubleArray
             constant_expression.f64_array_value = [float(x) for x in value]
-        case [[int(), *_], *_]:
+        case [[int(), *_], *_] if all(isinstance(x, int) for row in value for x in row):
             constant_expression.literal_type = LiteralType.kSubArrayArray
             constant_expression.i64_tensor_value = value
-        case [[float(), *_], *_]:
+        case [[_, *_], *_] if all(isinstance(x, (int, float)) for row in value for x in row):
             constant_expression.literal_type = LiteralType.kSubArrayArray
-            constant_expression.f64_tensor_value = value
-        case [[[int(), *_], *_], *_]:
+            constant_expression.f64_tensor_value = [[float(x) for x in row] for row in value]
+        case [[[int(), *_], *_], *_] if all(isinstance(x, int) for row in value for tensor in row for x in tensor):
             constant_expression.literal_type = LiteralType.kSubArrayArray
             constant_expression.i64_tensor_array_value = value
-        case [[[float(), *_], *_], *_]:
+        case [[[_, *_], *_], *_] if all(isinstance(x, (int, float)) for row in value for tensor in row for x in tensor):
             constant_expression.literal_type = LiteralType.kSubArrayArray
-            constant_expression.f64_tensor_array_value = value
+            constant_expression.f64_tensor_array_value = [[[float(x) for x in tensor] for tensor in row]
+                                                          for row in value]
         case SparseVector([int(), *_] as indices, [*values]) if values and all(
                 isinstance(v, int) for v in values):
             constant_expression.literal_type = LiteralType.kLongSparseArray

--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -345,12 +345,15 @@ def get_local_constant_expr_from_python_value(value) -> WrapConstantExpr:
         case float():
             constant_expression.literal_type = LiteralType.kDouble
             constant_expression.f64_value = value
-        case [int(), *_]:
+        case [int(), *_] if all(isinstance(x, int) for x in value):
             constant_expression.literal_type = LiteralType.kIntegerArray
             constant_expression.i64_array_value = value
-        case [float(), *_]:
+        case [_, *_] if all(isinstance(x, (int, float)) for x in value):
+            # Any float in the list: store as a double array. Dispatching on
+            # the first element alone would label [1, 2.5] an integer array
+            # and lose the fractional part.
             constant_expression.literal_type = LiteralType.kDoubleArray
-            constant_expression.f64_array_value = value
+            constant_expression.f64_array_value = [float(x) for x in value]
         case [[int(), *_], *_]:
             constant_expression.literal_type = LiteralType.kSubArrayArray
             constant_expression.i64_tensor_value = value
@@ -363,29 +366,33 @@ def get_local_constant_expr_from_python_value(value) -> WrapConstantExpr:
         case [[[float(), *_], *_], *_]:
             constant_expression.literal_type = LiteralType.kSubArrayArray
             constant_expression.f64_tensor_array_value = value
-        case SparseVector([int(), *_] as indices, [int(), *_] as values):
+        case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                isinstance(v, int) for v in values):
             constant_expression.literal_type = LiteralType.kLongSparseArray
             constant_expression.i64_array_idx = indices
             constant_expression.i64_array_value = values
-        case SparseVector([int(), *_] as indices, [float(), *_] as values):
+        case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                isinstance(v, (int, float)) for v in values):
             constant_expression.literal_type = LiteralType.kDoubleSparseArray
             constant_expression.i64_array_idx = indices
-            constant_expression.f64_array_value = values
+            constant_expression.f64_array_value = [float(v) for v in values]
         case dict():
             if len(value) == 0:
                 raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
-            match next(iter(value.values())):
-                case int():
-                    constant_expression.literal_type = LiteralType.kLongSparseArray
-                    constant_expression.i64_array_idx = [int(k) for k in value.keys()]
-                    constant_expression.i64_array_value = [int(v) for v in value.values()]
-                case float():
-                    constant_expression.literal_type = LiteralType.kDoubleSparseArray
-                    constant_expression.i64_array_idx = [int(k) for k in value.keys()]
-                    constant_expression.f64_array_value = [float(v) for v in value.values()]
-                case _:
-                    raise InfinityException(ErrorCode.INVALID_EXPRESSION,
-                                            f"Invalid sparse vector value type: {type(next(iter(value.values())))}")
+            dict_values = list(value.values())
+            if all(isinstance(v, int) for v in dict_values):
+                constant_expression.literal_type = LiteralType.kLongSparseArray
+                constant_expression.i64_array_idx = [int(k) for k in value.keys()]
+                constant_expression.i64_array_value = [int(v) for v in dict_values]
+            elif all(isinstance(v, (int, float)) for v in dict_values):
+                # Any float among the values: store as a double sparse array.
+                # Dispatching on the first value alone truncated floats via int(v).
+                constant_expression.literal_type = LiteralType.kDoubleSparseArray
+                constant_expression.i64_array_idx = [int(k) for k in value.keys()]
+                constant_expression.f64_array_value = [float(v) for v in dict_values]
+            else:
+                raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                        f"Invalid sparse vector value type: {type(next(iter(value.values())))}")
         case Array():
             constant_expression.literal_type = LiteralType.kCurlyBracketsArray
             constant_expression.curly_brackets_array = [get_local_constant_expr_from_python_value(child) for child in

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -69,6 +69,19 @@ class TestInfinity:
         assert res.literal_type == LiteralType.kIntegerArray
         assert res.i64_array_value == [1, 2]
 
+        # tensors get the same all-elements dispatch
+        res = get_local_constant_expr_from_python_value([[1, 2.5]])
+        assert res.literal_type == LiteralType.kSubArrayArray
+        assert res.f64_tensor_value == [[1.0, 2.5]]
+
+        res = get_local_constant_expr_from_python_value([[[1, 2.5]]])
+        assert res.literal_type == LiteralType.kSubArrayArray
+        assert res.f64_tensor_array_value == [[[1.0, 2.5]]]
+
+        res = get_local_constant_expr_from_python_value([[1, 2]])
+        assert res.literal_type == LiteralType.kSubArrayArray
+        assert res.i64_tensor_value == [[1, 2]]
+
         res = get_local_constant_expr_from_python_value({1: 5, 2: 0.5})
         assert res.literal_type == LiteralType.kDoubleSparseArray
         assert res.i64_array_idx == [1, 2]

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,60 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_constant_expr_mixed_numeric_lists(self, request):
+        # Regression test (embedded SDK): a mixed int/float list used to be
+        # labeled an integer array (dispatch looked at the first element only),
+        # so 2.5 in [1, 2.5] lost its fractional part. The same first-element
+        # dispatch truncated sparse values: {1: 5, 2: 0.5} and
+        # SparseVector([1, 2], [5, 0.5]) were stored as long-sparse with the
+        # 0.5 truncated to 0 (dict inserts were truncated by int(v) in the SDK
+        # itself).
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.common import SparseVector
+        from infinity_embedded.embedded_infinity_ext import LiteralType
+        from infinity_embedded.local_infinity.utils import get_local_constant_expr_from_python_value
+
+        res = get_local_constant_expr_from_python_value([1, 2.5])
+        assert res.literal_type == LiteralType.kDoubleArray
+        assert res.f64_array_value == [1.0, 2.5]
+
+        res = get_local_constant_expr_from_python_value([1, 2])
+        assert res.literal_type == LiteralType.kIntegerArray
+        assert res.i64_array_value == [1, 2]
+
+        res = get_local_constant_expr_from_python_value({1: 5, 2: 0.5})
+        assert res.literal_type == LiteralType.kDoubleSparseArray
+        assert res.i64_array_idx == [1, 2]
+        assert res.f64_array_value == [5.0, 0.5]
+
+        res = get_local_constant_expr_from_python_value({1: 5, 2: 6})
+        assert res.literal_type == LiteralType.kLongSparseArray
+        assert res.i64_array_value == [5, 6]
+
+        res = get_local_constant_expr_from_python_value(SparseVector([1, 2], [5, 0.5]))
+        assert res.literal_type == LiteralType.kDoubleSparseArray
+        assert res.f64_array_value == [5.0, 0.5]
+
+    def test_match_sparse_mixed_numeric_values(self, request):
+        # Same first-element dispatch in match_sparse: {1: 5, 2: 0.5} became a
+        # long-sparse query vector with 0.5 truncated to 0, silently changing
+        # the scored results.
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.common import SparseVector
+        from infinity_embedded.embedded_infinity_ext import LiteralType
+        from infinity_embedded.local_infinity.query_builder import InfinityLocalQueryBuilder
+
+        qb = InfinityLocalQueryBuilder(table=None)
+        qb.match_sparse("c1", {1: 5, 2: 0.5}, "ip", 3)
+        sparse_expr = qb._search.match_exprs[0].match_sparse_expr.sparse_expr
+        assert sparse_expr.literal_type == LiteralType.kDoubleSparseArray
+        assert sparse_expr.f64_array_value == [5.0, 0.5]
+
+        qb = InfinityLocalQueryBuilder(table=None)
+        qb.match_sparse("c1", SparseVector([1, 2], [5, 0.5]), "ip", 3)
+        sparse_expr = qb._search.match_exprs[0].match_sparse_expr.sparse_expr
+        assert sparse_expr.literal_type == LiteralType.kDoubleSparseArray
+        assert sparse_expr.f64_array_value == [5.0, 0.5]


### PR DESCRIPTION
Fixes #3482

### What problem does this PR solve?

In the embedded SDK, constant-expression and `match_sparse` type dispatch looked at the first element only:

- `insert` with `[1, 2.5]` labeled the value `kIntegerArray`, so `2.5` went into the engine's int64 array field (truncated or rejected).
- `insert` with a sparse dict `{1: 5, 2: 0.5}` was truncated by `int(v)` in the SDK itself: values became `[5, 0]`.
- `match_sparse` with `{1: 5, 2: 0.5}` or `SparseVector([1, 2], [5, 0.5])` was labeled `kLongSparseArray`, dropping the fractional part.

The HTTP SDK sends the same values as JSON and the server stores doubles, so the embedded and HTTP SDKs silently disagreed on the same data.

### What changed

Dispatch now looks at all elements in `get_local_constant_expr_from_python_value` and `match_sparse`: all-int stays an integer/long-sparse array, any float promotes to a double (sparse) array with values float-coerced, anything else still raises `InfinityException`. All-int, all-float, empty, and invalid-input behavior is unchanged.

### Tests

- Added `test_constant_expr_mixed_numeric_lists` and `test_match_sparse_mixed_numeric_values` in `python/test_pysdk/test_condition.py` (embedded-only).
- Verified fail-before/pass-after locally against the expression construction layer (the full pysdk suites need a live server / built embedded engine, so they were not run here).