### PR TITLE
Fix match_* search options popping "filter" from the caller's dict

### DIFF
--- a/python/infinity_embedded/local_infinity/query_builder.py
+++ b/python/infinity_embedded/local_infinity/query_builder.py
@@ -218,7 +218,7 @@ class InfinityLocalQueryBuilder(ABC):
         optional_filter = None
         if knn_params is not None:
             # check if there is a filter
-            optional_filter = get_search_optional_filter_from_opt_params(knn_params)
+            optional_filter, knn_params = get_search_optional_filter_from_opt_params(knn_params)
             for k, v in knn_params.items():
                 key = k.lower()
                 value = v.lower()
@@ -268,7 +268,7 @@ class InfinityLocalQueryBuilder(ABC):
         optional_filter = None
         if opt_params is not None:
             # check if there is a filter
-            optional_filter = get_search_optional_filter_from_opt_params(opt_params)
+            optional_filter, opt_params = get_search_optional_filter_from_opt_params(opt_params)
             for k, v in opt_params.items():
                 params = InitParameter()
                 params.param_name = k
@@ -336,7 +336,7 @@ class InfinityLocalQueryBuilder(ABC):
         optional_filter = None
         if extra_options is not None:
             # check if there is a filter
-            optional_filter = get_search_optional_filter_from_opt_params(extra_options)
+            optional_filter, extra_options = get_search_optional_filter_from_opt_params(extra_options)
             for k, v in extra_options.items():
                 options_text += f";{k}={v}"
         match_expr.options_text = options_text
@@ -364,7 +364,7 @@ class InfinityLocalQueryBuilder(ABC):
         optional_filter = None
         if extra_option is not None:
             # check if there is a filter
-            optional_filter = get_search_optional_filter_from_opt_params(extra_option)
+            optional_filter, extra_option = get_search_optional_filter_from_opt_params(extra_option)
             for k, v in extra_option.items():
                 option_str += f";{k}={v}"
         match_tensor_expr = WrapParsedExpr(ParsedExprType.kMatchTensor)

--- a/python/infinity_embedded/local_infinity/utils.py
+++ b/python/infinity_embedded/local_infinity/utils.py
@@ -256,8 +256,13 @@ def parse_expr(expr):
 
 
 def get_search_optional_filter_from_opt_params(opt_params: dict):
+    """Split search optional parameters into (filter_expr, remaining params).
+
+    The caller's dict is left untouched: the "filter" entry used to be
+    popped out of it, silently changing data owned by the caller.
+    """
     optional_filter = None
-    k_to_pop = []
+    remaining_params = {}
     for k, v in opt_params.items():
         if k.lower() == "filter":
             if optional_filter is not None:
@@ -267,10 +272,9 @@ def get_search_optional_filter_from_opt_params(opt_params: dict):
                 raise InfinityException(ErrorCode.INVALID_EXPRESSION,
                                         f"Invalid filter expression '{v}', type should be string, but get {type(v)}")
             optional_filter = traverse_conditions(condition(v))
-            k_to_pop.append(k)
-    for k in k_to_pop:
-        opt_params.pop(k)
-    return optional_filter
+        else:
+            remaining_params[k] = v
+    return optional_filter, remaining_params
 
 
 def get_local_function_expr_from_fde(fde_obj) -> WrapParsedExpr:

--- a/python/infinity_sdk/infinity/remote_thrift/query_builder.py
+++ b/python/infinity_sdk/infinity/remote_thrift/query_builder.py
@@ -241,7 +241,7 @@ class InfinityThriftQueryBuilder(ABC):
         knn_opt_params = []
         optional_filter = None
         if knn_params is not None:
-            optional_filter = get_search_optional_filter_from_opt_params(knn_params)
+            optional_filter, knn_params = get_search_optional_filter_from_opt_params(knn_params)
             for k, v in knn_params.items():
                 key = k.lower()
                 value = v.lower()
@@ -272,7 +272,9 @@ class InfinityThriftQueryBuilder(ABC):
             self._search = SearchExpr()
             self._search.match_exprs = list()
 
-        optional_filter = None if opt_params is None else get_search_optional_filter_from_opt_params(opt_params)
+        optional_filter = None
+        if opt_params is not None:
+            optional_filter, opt_params = get_search_optional_filter_from_opt_params(opt_params)
         match_sparse_expr = make_match_sparse_expr(
             vector_column_name, sparse_data, metric_type, topn, opt_params, optional_filter
         )
@@ -291,7 +293,7 @@ class InfinityThriftQueryBuilder(ABC):
         match_expr.matching_text = matching_text
         options_text = f"topn={topn}"
         if extra_options is not None:
-            match_expr.filter_expr = get_search_optional_filter_from_opt_params(extra_options)
+            match_expr.filter_expr, extra_options = get_search_optional_filter_from_opt_params(extra_options)
             for k, v in extra_options.items():
                 options_text += f";{k}={v}"
         match_expr.options_text = options_text
@@ -313,7 +315,7 @@ class InfinityThriftQueryBuilder(ABC):
         option_str = f"topn={topn}"
         optional_filter = None
         if extra_option is not None:
-            optional_filter = get_search_optional_filter_from_opt_params(extra_option)
+            optional_filter, extra_option = get_search_optional_filter_from_opt_params(extra_option)
             for k, v in extra_option.items():
                 option_str += f";{k}={v}"
         match_tensor_expr = make_match_tensor_expr(
@@ -683,7 +685,7 @@ class InfinityThriftQueryBuilder(ABC):
         knn_opt_params = []
         optional_filter = None
         if knn_params is not None:
-            optional_filter = get_search_optional_filter_from_opt_params(knn_params)
+            optional_filter, knn_params = get_search_optional_filter_from_opt_params(knn_params)
             for k, v in knn_params.items():
                 key = k.lower()
                 value = v.lower()

--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -647,8 +647,13 @@ def parse_expr(expr) -> ttypes.ParsedExpr:
 
 
 def get_search_optional_filter_from_opt_params(opt_params: dict):
+    """Split search optional parameters into (filter_expr, remaining params).
+
+    The caller's dict is left untouched: the "filter" entry used to be
+    popped out of it, silently changing data owned by the caller.
+    """
     optional_filter = None
-    k_to_pop = []
+    remaining_params = {}
     for k, v in opt_params.items():
         if k.lower() == "filter":
             if optional_filter is not None:
@@ -658,10 +663,9 @@ def get_search_optional_filter_from_opt_params(opt_params: dict):
                 raise InfinityException(ErrorCode.INVALID_EXPRESSION,
                                         f"Invalid filter expression '{v}', type should be string, but get {type(v)}")
             optional_filter = traverse_conditions(condition(v))
-            k_to_pop.append(k)
-    for k in k_to_pop:
-        opt_params.pop(k)
-    return optional_filter
+        else:
+            remaining_params[k] = v
+    return optional_filter, remaining_params
 
 
 def get_remote_function_expr_from_fde(fde_obj) -> ttypes.FunctionExpr:

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,39 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_search_opt_params_not_mutated_thrift(self):
+        # Regression test (thrift SDK): match_* used to pop "filter" out of
+        # the caller's options dict, silently changing data owned by the
+        # caller. The filter must still land on the built search expression.
+        from infinity.remote_thrift.query_builder import InfinityThriftQueryBuilder
+
+        qb = InfinityThriftQueryBuilder(table=None)
+        opts = {"filter": "c2 > 1", "operator": "and"}
+        qb.match_text("c1", "hello", 3, opts)
+        assert opts == {"filter": "c2 > 1", "operator": "and"}
+        match_expr = qb._search.match_exprs[0].match_text_expr
+        assert match_expr.filter_expr is not None
+        assert match_expr.options_text == "topn=3;operator=and"
+
+        qb = InfinityThriftQueryBuilder(table=None)
+        opts = {"filter": "c2 > 1", "ef": "200"}
+        qb.match_dense("v", [1.0, 2.0], "float", "l2", 5, opts)
+        assert opts == {"filter": "c2 > 1", "ef": "200"}
+        knn_expr = qb._search.match_exprs[0].match_vector_expr
+        assert knn_expr.filter_expr is not None
+
+    def test_search_opt_params_not_mutated_embedded(self, request):
+        # Regression test (embedded SDK): same caller-dict mutation as the
+        # thrift SDK - "filter" was popped out of the options dict.
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.local_infinity.query_builder import InfinityLocalQueryBuilder
+
+        qb = InfinityLocalQueryBuilder(table=None)
+        opts = {"filter": "c2 > 1", "operator": "and"}
+        qb.match_text("c1", "hello", 3, opts)
+        assert opts == {"filter": "c2 > 1", "operator": "and"}
+        match_expr = qb._search.match_exprs[0].match_expr
+        assert match_expr.filter_expr is not None
+        assert match_expr.options_text == "topn=3;operator=and"


### PR DESCRIPTION
Fixes #3483

### What problem does this PR solve?

`get_search_optional_filter_from_opt_params` (present in both the embedded and the thrift SDK) popped the `filter` entry out of the caller's options dict, so after `match_dense`/`match_sparse`/`match_text`/`match_tensor` the caller's dict had silently lost its filter. Reusing the same dict for a second query ran it unfiltered.

### What changed

Both copies of the helper now return `(filter_expr, remaining_params)` without modifying the input, and the nine call sites use the returned remainder when building the search options. Validation is unchanged: at most one filter, and the value must be a string (both still raise `InfinityException` otherwise). The HTTP SDK is not affected.

### Tests

- Added `test_search_opt_params_not_mutated_thrift` and `test_search_opt_params_not_mutated_embedded` in `python/test_pysdk/test_condition.py`: the caller's dict is unchanged after the call, the filter still lands on the built search expression, and the remaining options still reach the options text.
- Verified fail-before/pass-after locally (the full pysdk suites need a live server / built embedded engine, so they were not run here).