### PR TITLE
Fix match_dense crashing on non-string knn_params values

### DIFF
--- a/python/infinity_embedded/local_infinity/query_builder.py
+++ b/python/infinity_embedded/local_infinity/query_builder.py
@@ -221,7 +221,7 @@ class InfinityLocalQueryBuilder(ABC):
             optional_filter = get_search_optional_filter_from_opt_params(knn_params)
             for k, v in knn_params.items():
                 key = k.lower()
-                value = v.lower()
+                value = str(v).lower()
                 tmp_param = InitParameter()
                 tmp_param.param_name = key
                 tmp_param.param_value = value

--- a/python/infinity_sdk/infinity/remote_thrift/query_builder.py
+++ b/python/infinity_sdk/infinity/remote_thrift/query_builder.py
@@ -244,7 +244,7 @@ class InfinityThriftQueryBuilder(ABC):
             optional_filter = get_search_optional_filter_from_opt_params(knn_params)
             for k, v in knn_params.items():
                 key = k.lower()
-                value = v.lower()
+                value = str(v).lower()
                 knn_opt_params.append(InitParameter(key, value))
 
         knn_expr = KnnExpr(
@@ -686,7 +686,7 @@ class InfinityThriftQueryBuilder(ABC):
             optional_filter = get_search_optional_filter_from_opt_params(knn_params)
             for k, v in knn_params.items():
                 key = k.lower()
-                value = v.lower()
+                value = str(v).lower()
                 knn_opt_params.append(InitParameter(key, value))
 
         # Create KnnExpr with FDE function as query_embedding_expr

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,26 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_match_dense_knn_params_non_string_thrift(self):
+        # Regression test (thrift SDK): match_dense crashed with
+        # AttributeError: 'int' object has no attribute 'lower' when a
+        # knn_params value was not a string (e.g. {"ef": 200}).
+        from infinity.remote_thrift.query_builder import InfinityThriftQueryBuilder
+
+        qb = InfinityThriftQueryBuilder(table=None)
+        qb.match_dense("v", [1.0, 2.0], "float", "l2", 5, {"ef": 200})
+        params = qb._search.match_exprs[0].match_vector_expr.opt_params
+        assert [(p.param_name, p.param_value) for p in params] == [("ef", "200")]
+
+    def test_match_dense_knn_params_non_string_embedded(self, request):
+        # Regression test (embedded SDK): same AttributeError on non-string
+        # knn_params values.
+        if not request.config.getoption("--local-infinity"):
+            pytest.skip("embedded-only regression test")
+        from infinity_embedded.local_infinity.query_builder import InfinityLocalQueryBuilder
+
+        qb = InfinityLocalQueryBuilder(table=None)
+        qb.match_dense("v", [1.0, 2.0], "float", "l2", 5, {"ef": 200})
+        params = qb._search.match_exprs[0].knn_expr.opt_params
+        assert [(p.param_name, p.param_value) for p in params] == [("ef", "200")]


### PR DESCRIPTION
Fixes #3484

### What problem does this PR solve?

`match_dense(..., {"ef": 200})` crashed with `AttributeError: 'int' object has no attribute 'lower'` in both the embedded and the thrift SDK: `match_dense` lowercased each `knn_params` value assuming `str`, while every other `match_*` method formats option values without that assumption and the HTTP SDK passes them through untouched.

### What changed

`str(v).lower()` at the three affected sites: the embedded SDK's `match_dense`, the thrift SDK's `match_dense`, and the thrift SDK's `_handle_fde_match_dense`. String values behave exactly as before.

### Tests

- Added `test_match_dense_knn_params_non_string_thrift` and `test_match_dense_knn_params_non_string_embedded` in `python/test_pysdk/test_condition.py`: `{"ef": 200}` is accepted and arrives as `("ef", "200")`.
- Verified fail-before/pass-after locally (the full pysdk suites need a live server / built embedded engine, so they were not run here).