### PR TITLE
Fix thrift SDK truncating floats in mixed int/float arrays and sparse values

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/types.py
+++ b/python/infinity_sdk/infinity/remote_thrift/types.py
@@ -645,32 +645,36 @@ def make_match_sparse_expr(vector_column_name: str, sparse_data: SparseVector | 
     query_sparse_expr = ConstantExpr()
 
     match sparse_data:
-        case SparseVector([int(), *_] as indices, [int(), *_] as values):
+        case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                isinstance(v, int) for v in values):
             query_sparse_expr.literal_type = LiteralType.SparseIntegerArray
             query_sparse_expr.i64_array_idx = indices
             query_sparse_expr.i64_array_value = values
-        case SparseVector([int(), *_] as indices, [float(), *_] as values):
+        case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                isinstance(v, (int, float)) for v in values):
             query_sparse_expr.literal_type = LiteralType.SparseDoubleArray
             query_sparse_expr.i64_array_idx = indices
-            query_sparse_expr.f64_array_value = values
+            query_sparse_expr.f64_array_value = [float(v) for v in values]
         case SparseVector([int(), *_], None):
             raise InfinityException(ErrorCode.INVALID_CONSTANT_TYPE,
                                     "No values! Sparse data does not support bool value type now")
         case dict():
             if len(sparse_data) == 0:
                 raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
-            match next(iter(sparse_data.values())):
-                case int():
-                    query_sparse_expr.literal_type = LiteralType.SparseIntegerArray
-                    query_sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
-                    query_sparse_expr.i64_array_value = [int(vv) for vv in sparse_data.values()]
-                case float():
-                    query_sparse_expr.literal_type = LiteralType.SparseDoubleArray
-                    query_sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
-                    query_sparse_expr.f64_array_value = [float(vv) for vv in sparse_data.values()]
-                case _:
-                    raise InfinityException(ErrorCode.INVALID_EXPRESSION,
-                                            f"Invalid sparse vector value type: {type(next(iter(sparse_data.values())))}")
+            sparse_values = list(sparse_data.values())
+            if all(isinstance(vv, int) for vv in sparse_values):
+                query_sparse_expr.literal_type = LiteralType.SparseIntegerArray
+                query_sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
+                query_sparse_expr.i64_array_value = [int(vv) for vv in sparse_values]
+            elif all(isinstance(vv, (int, float)) for vv in sparse_values):
+                # Any float among the values: store as a double sparse array.
+                # Dispatching on the first value alone truncated floats via int(vv).
+                query_sparse_expr.literal_type = LiteralType.SparseDoubleArray
+                query_sparse_expr.i64_array_idx = [int(kk) for kk in sparse_data.keys()]
+                query_sparse_expr.f64_array_value = [float(vv) for vv in sparse_values]
+            else:
+                raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                        f"Invalid sparse vector value type: {type(next(iter(sparse_data.values())))}")
         case _:
             raise InfinityException(ErrorCode.INVALID_CONSTANT_TYPE, f"Invalid sparse data type {type(sparse_data)}")
 

--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -739,51 +739,59 @@ def get_remote_constant_expr_from_python_value(value) -> ttypes.ConstantExpr:
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.Int64, i64_value=value)
         case float():
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.Double, f64_value=value)
-        case [int(), *_]:
+        case [int(), *_] if all(isinstance(x, int) for x in value):
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.IntegerArray,
                                                       i64_array_value=value)
-        case [float(), *_]:
+        case [_, *_] if all(isinstance(x, (int, float)) for x in value):
+            # Any float in the list: store as a double array. Dispatching on
+            # the first element alone would label [1, 2.5] an integer array
+            # and lose the fractional part.
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.DoubleArray,
-                                                      f64_array_value=value)
-        case [[int(), *_], *_]:
+                                                      f64_array_value=[float(x) for x in value])
+        case [[int(), *_], *_] if all(isinstance(x, int) for row in value for x in row):
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.IntegerTensor,
                                                       i64_tensor_value=value)
-        case [[float(), *_], *_]:
+        case [[_, *_], *_] if all(isinstance(x, (int, float)) for row in value for x in row):
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.DoubleTensor,
-                                                      f64_tensor_value=value)
-        case [[[int(), *_], *_], *_]:
+                                                      f64_tensor_value=[[float(x) for x in row] for row in value])
+        case [[[int(), *_], *_], *_] if all(isinstance(x, int) for row in value for tensor in row for x in tensor):
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.IntegerTensorArray,
                                                       i64_tensor_array_value=value)
-        case [[[float(), *_], *_], *_]:
+        case [[[_, *_], *_], *_] if all(isinstance(x, (int, float)) for row in value for tensor in row for x in tensor):
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.DoubleTensorArray,
-                                                      f64_tensor_array_value=value)
-        case SparseVector([int(), *_] as indices, [int(), *_] as values):
+                                                      f64_tensor_array_value=[[[float(x) for x in tensor] for tensor in row]
+                                                                              for row in value])
+        case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                isinstance(v, int) for v in values):
             constant_expression = ttypes.ConstantExpr(
                 literal_type=ttypes.LiteralType.SparseIntegerArray,
                 i64_array_idx=indices,
                 i64_array_value=values)
-        case SparseVector([int(), *_] as indices, [float(), *_] as values):
+        case SparseVector([int(), *_] as indices, [*values]) if values and all(
+                isinstance(v, (int, float)) for v in values):
             constant_expression = ttypes.ConstantExpr(
                 literal_type=ttypes.LiteralType.SparseDoubleArray,
                 i64_array_idx=indices,
-                f64_array_value=values)
+                f64_array_value=[float(v) for v in values])
         case dict():
             if len(value) == 0:
                 raise InfinityException(ErrorCode.INVALID_EXPRESSION, "Empty sparse vector")
-            match next(iter(value.values())):
-                case int():
-                    constant_expression = ttypes.ConstantExpr(
-                        literal_type=ttypes.LiteralType.SparseIntegerArray,
-                        i64_array_idx=[int(k) for k in value.keys()],
-                        i64_array_value=[int(v) for v in value.values()])
-                case float():
-                    constant_expression = ttypes.ConstantExpr(
-                        literal_type=ttypes.LiteralType.SparseDoubleArray,
-                        i64_array_idx=[int(k) for k in value.keys()],
-                        f64_array_value=[float(v) for v in value.values()])
-                case _:
-                    raise InfinityException(ErrorCode.INVALID_EXPRESSION,
-                                            f"Invalid sparse vector value type: {type(next(iter(value.values())))}")
+            dict_values = list(value.values())
+            if all(isinstance(v, int) for v in dict_values):
+                constant_expression = ttypes.ConstantExpr(
+                    literal_type=ttypes.LiteralType.SparseIntegerArray,
+                    i64_array_idx=[int(k) for k in value.keys()],
+                    i64_array_value=[int(v) for v in dict_values])
+            elif all(isinstance(v, (int, float)) for v in dict_values):
+                # Any float among the values: store as a double sparse array.
+                # Dispatching on the first value alone truncated floats via int(v).
+                constant_expression = ttypes.ConstantExpr(
+                    literal_type=ttypes.LiteralType.SparseDoubleArray,
+                    i64_array_idx=[int(k) for k in value.keys()],
+                    f64_array_value=[float(v) for v in dict_values])
+            else:
+                raise InfinityException(ErrorCode.INVALID_EXPRESSION,
+                                        f"Invalid sparse vector value type: {type(next(iter(value.values())))}")
         case Array():
             children_list = [get_remote_constant_expr_from_python_value(child) for child in value.elements]
             constant_expression = ttypes.ConstantExpr(literal_type=ttypes.LiteralType.CurlyBracketsArray,

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -46,3 +46,57 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_remote_constant_expr_mixed_numeric_lists(self):
+        # Regression test (thrift SDK): constant-expression and match_sparse
+        # type dispatch looked at the first element only, so a mixed
+        # int/float list like [1, 2.5] became an integer array, a sparse dict
+        # {1: 5, 2: 0.5} was truncated by int(v) in the SDK itself, and
+        # SparseVector([1, 2], [5, 0.5]) became a sparse integer array.
+        from infinity.common import SparseVector
+        from infinity.remote_thrift.infinity_thrift_rpc import ttypes
+        from infinity.remote_thrift.utils import get_remote_constant_expr_from_python_value
+
+        L = ttypes.LiteralType
+        res = get_remote_constant_expr_from_python_value([1, 2.5])
+        assert res.literal_type == L.DoubleArray
+        assert res.f64_array_value == [1.0, 2.5]
+
+        res = get_remote_constant_expr_from_python_value([[1, 2.5]])
+        assert res.literal_type == L.DoubleTensor
+        assert res.f64_tensor_value == [[1.0, 2.5]]
+
+        res = get_remote_constant_expr_from_python_value({1: 5, 2: 0.5})
+        assert res.literal_type == L.SparseDoubleArray
+        assert res.i64_array_idx == [1, 2]
+        assert res.f64_array_value == [5.0, 0.5]
+
+        res = get_remote_constant_expr_from_python_value(SparseVector([1, 2], [5, 0.5]))
+        assert res.literal_type == L.SparseDoubleArray
+        assert res.f64_array_value == [5.0, 0.5]
+
+        # all-int inputs keep their integer types
+        res = get_remote_constant_expr_from_python_value([1, 2])
+        assert res.literal_type == L.IntegerArray
+        assert res.i64_array_value == [1, 2]
+
+        res = get_remote_constant_expr_from_python_value({1: 5, 2: 6})
+        assert res.literal_type == L.SparseIntegerArray
+        assert res.i64_array_value == [5, 6]
+
+    def test_match_sparse_mixed_numeric_values_thrift(self):
+        # Same first-element dispatch in the thrift match_sparse builder:
+        # {1: 5, 2: 0.5} became a sparse-integer query vector with 0.5
+        # truncated to 0.
+        from infinity.common import SparseVector
+        from infinity.remote_thrift.infinity_thrift_rpc import ttypes
+        from infinity.remote_thrift.types import make_match_sparse_expr
+
+        L = ttypes.LiteralType
+        expr = make_match_sparse_expr("c1", {1: 5, 2: 0.5}, "ip", 3)
+        assert expr.query_sparse_expr.literal_type == L.SparseDoubleArray
+        assert expr.query_sparse_expr.f64_array_value == [5.0, 0.5]
+
+        expr = make_match_sparse_expr("c1", SparseVector([1, 2], [5, 0.5]), "ip", 3)
+        assert expr.query_sparse_expr.literal_type == L.SparseDoubleArray
+        assert expr.query_sparse_expr.f64_array_value == [5.0, 0.5]


### PR DESCRIPTION
Fixes #3489

### What problem does this PR solve?

In the thrift SDK, constant-expression and `match_sparse` type dispatch looked at the first element only:

- `insert` with `[1, 2.5]` labeled the value an integer array, so `2.5` went into the engine's int64 array field (truncated or rejected); tensors and tensor arrays had the same first-element dispatch.
- `insert` with a sparse dict `{1: 5, 2: 0.5}` was truncated by `int(v)` in the SDK itself: values became `[5, 0]`.
- `match_sparse` with `{1: 5, 2: 0.5}` or `SparseVector([1, 2], [5, 0.5])` was labeled a sparse integer array, dropping the fractional part.

The HTTP SDK sends the same values as JSON and the server stores doubles, so the thrift and HTTP SDKs silently disagreed on the same data. The embedded SDK had the same dispatch and is fixed separately in #3486.

### What changed

Dispatch now looks at all elements in `get_remote_constant_expr_from_python_value` and `make_match_sparse_expr`: all-int keeps the integer types, any float promotes to the double types with values float-coerced, anything else still raises `InfinityException`. Covers one-dimensional arrays, tensors, tensor arrays, sparse dicts, and `SparseVector` on both the insert path and the `match_sparse` path. All-int, all-float, empty, and invalid-input behavior is unchanged.

### Tests

- Added `test_remote_constant_expr_mixed_numeric_lists` and `test_match_sparse_mixed_numeric_values_thrift` in `python/test_pysdk/test_condition.py` (unit-level, no server needed).
- Verified fail-before/pass-after locally (the full pysdk suites need a live server, so they were not run here).