### PR TITLE
fix(sdk): stop filter() from infinite-recursing on unsupported expressions

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -636,7 +636,7 @@ def traverse_conditions(cons: exp.Condition, fn=None) -> ttypes.ParsedExpr:
         parsed_expr.type = parser_expr_type
         return parsed_expr
     else:
-        return traverse_conditions(cons[1])
+        raise InfinityException(ErrorCode.INVALID_EXPRESSION, f"unknown expression type: {cons}")
 
 
 def parse_expr(expr) -> ttypes.ParsedExpr:

--- a/python/test_pysdk/test_condition.py
+++ b/python/test_pysdk/test_condition.py
@@ -1,5 +1,6 @@
 import infinity
 import pytest
+from infinity.common import InfinityException
 from infinity.errors import ErrorCode
 from infinity.infinity_http import infinity_http
 from infinity.remote_thrift.table import traverse_conditions
@@ -46,3 +47,18 @@ class TestInfinity:
             res = traverse_conditions(cond)
             print(res)
             assert res
+
+    def test_condition_unsupported_expression(self):
+        # Unsupported predicates must fail with a clean InfinityException.
+        # The fallback arm of traverse_conditions used to recurse on
+        # cons[1], a same-class sqlglot copy, so filters like these crashed
+        # the client with RecursionError instead.
+        for cond_str in [
+            "c1 = (select 1)",
+            "(c1, c2) = (1, 2)",
+            "c1 = interval 1 day",
+            "c1[1] = 5",
+            "c1 = any (1)",
+        ]:
+            with pytest.raises(InfinityException, match="unknown expression type"):
+                traverse_conditions(condition(cond_str))


### PR DESCRIPTION
Fixes #3491

## What

`RemoteTable.filter()` crashed with `RecursionError` on unsupported predicate expressions. The fallback arm of `traverse_conditions` recursed on `cons[1]`, but sqlglot's `Expression.__getitem__` returns a copy of the same expression class, so the recursion could never terminate. The arm now raises `InfinityException(ErrorCode.INVALID_EXPRESSION, ...)`, matching how unsupported binary expressions and the embedded SDK's `unknown condition type` path fail.

## Verification

Reproduced on current main before the fix (twice, identical output): each of `c1 = (select 1)`, `(c1, c2) = (1, 2)`, `c1 = interval 1 day`, `c1[1] = 5`, `c1 = any (1)` died with `RecursionError` through the same `traverse_conditions(condition(...))` call `filter()` makes. After the fix all five raise `InfinityException 3069 unknown expression type`, and supported filters (`c1 = 1`, `c1 > 1 and c2 < 2`, `c1 in (1,2,3)`, `c1 like 'a%'`, `sqrt(c1) > 2`) still parse.

## Tests

`python/test_pysdk/test_condition.py::test_condition_unsupported_expression` asserts the clean error for all five inputs. Verified locally against the patched module (passes) and against unpatched main (fails with `RecursionError` for all five). The pysdk suite needs a running server, so it was not run locally; the test body was executed directly instead.