### PR TITLE
fix(sdk): render zero-arg functions and IN/BETWEEN filters correctly in to_string()

### DIFF
--- a/python/infinity_sdk/infinity/remote_thrift/utils.py
+++ b/python/infinity_sdk/infinity/remote_thrift/utils.py
@@ -123,20 +123,17 @@ def parsed_expression_to_string(expr: ttypes.ParsedExpr) -> str:
 
     if expr_type.function_expr:
         function_name = expr_type.function_expr.function_name
-        arguments_str = str
-        for index, argument in enumerate(expr_type.function_expr.arguments):
-            arg_str = parsed_expression_to_string(argument)
-            if index == 0:
-                arguments_str = arg_str
-            else:
-                arguments_str = f"{arguments_str}, {arg_str}"
+        arguments_str = ", ".join(
+            parsed_expression_to_string(argument)
+            for argument in expr_type.function_expr.arguments
+        )
         return f"{function_name}({arguments_str})"
 
     if expr_type.between_expr:
         value_str = parsed_expression_to_string(expr_type.between_expr.value)
         upper_bound_str = parsed_expression_to_string(expr_type.between_expr.upper_bound)
         lower_bound_str = parsed_expression_to_string(expr_type.between_expr.lower_bound)
-        return f"between(f{value_str}, f{upper_bound_str}, f{lower_bound_str})"
+        return f"between({value_str}, {lower_bound_str}, {upper_bound_str})"
 
     if expr_type.knn_expr:
         column_expr_str = column_expr_to_string(expr_type.knn_expr.column_expr)
@@ -161,19 +158,16 @@ def parsed_expression_to_string(expr: ttypes.ParsedExpr) -> str:
         return "search()"
 
     if expr_type.in_expr:
-        arguments_str = str
-        for index, argument in enumerate(expr_type.in_expr.arguments):
-            arg_str = parsed_expression_to_string(argument)
-            if index == 0:
-                arguments_str = arg_str
-            else:
-                arguments_str = f"{arguments_str}, {arg_str}"
+        arguments_str = ", ".join(
+            parsed_expression_to_string(argument)
+            for argument in expr_type.in_expr.arguments
+        )
 
         left_expr_str = parsed_expression_to_string(expr_type.in_expr.left_operand)
         if expr_type.in_expr.in_type:
-            return f"{left_expr_str} IN (f{arguments_str})"
+            return f"{left_expr_str} IN ({arguments_str})"
         else:
-            return f"{left_expr_str} NOT IN (f{arguments_str})"
+            return f"{left_expr_str} NOT IN ({arguments_str})"
 
     return ""
 

--- a/python/test_pysdk/test_select.py
+++ b/python/test_pysdk/test_select.py
@@ -2491,3 +2491,28 @@ class TestInfinity:
 
         res = db_obj.drop_table("test_unnest_json_nested" + suffix)
         assert res.error_code == ErrorCode.OK
+
+    @pytest.mark.usefixtures("skip_if_http")
+    def test_to_string_expr_rendering(self, suffix):
+        """
+        Regression test: RemoteTable.to_string() must render function and IN
+        expressions faithfully. Zero-argument functions used to render as
+        "row_id(<class 'str'>)" because arguments_str was initialised to the
+        str builtin, and IN/BETWEEN filters got a stray "f" prefix
+        ("c1 IN (fc2, c3)").
+        """
+        db_obj = self.infinity_obj.get_database("default_db")
+        db_obj.drop_table("test_to_string_expr_rendering" + suffix, ConflictType.Ignore)
+        table = db_obj.create_table("test_to_string_expr_rendering" + suffix, {
+            "c1": {"type": "int", "constraints": ["primary key"]},
+            "c2": {"type": "int"},
+            "c3": {"type": "int"}}, ConflictType.Error)
+        assert table
+
+        res = table.output(["c1"]).filter("row_id() = c2").to_string()
+        assert '"filter": "=(row_id(), c2)"' in res
+
+        res = table.output(["c1"]).filter("c1 in (c2, c3)").to_string()
+        assert '"filter": "c1 IN (c2, c3)"' in res
+
+        db_obj.drop_table("test_to_string_expr_rendering" + suffix, ConflictType.Error)


### PR DESCRIPTION
Fixes #3492

## What

`RemoteTable.to_string()` misrendered three expression shapes in `parsed_expression_to_string`:

- zero-argument functions rendered as `row_id(<class 'str'>)` because `arguments_str` was initialised to the `str` builtin;
- `IN` / `NOT IN` filters got a stray `f` prefix (`c1 IN (fc2, c3)`);
- `BETWEEN` got the same prefix on every operand and printed the lower/upper bounds swapped.

The argument lists are now joined with `", ".join(...)`, the prefixes are gone, and `BETWEEN` prints `(value, lower, upper)`.

## Verification

On current main, via the public `filter()` -> `to_string()` path and via `parsed_expression_to_string` directly (twice, identical output):

- `filter("row_id() = c2")` rendered `"=(row_id(<class 'str'>), c2)"`
- `filter("c1 in (c2, c3)")` rendered `"c1 IN (fc2, c3)"`
- a `BetweenExpr(value=c1, lower_bound=c2, upper_bound=c3)` rendered `between(fc1, fc3, fc2)`

After the fix they render `=(row_id(), c2)`, `c1 IN (c2, c3)`, `between(c1, c2, c3)`.

## Tests

`python/test_pysdk/test_select.py::test_to_string_expr_rendering` covers the function and IN rendering through `to_string()`. It is integration-style and needs a running server (guarded with `skip_if_http`), so it was not executed locally; the exact assertion strings were verified client-side against the patched renderer, and the same assertions fail against unpatched main (`row_id(<class 'str'>)`, `fc2`).